### PR TITLE
fix(search): localize preview copy and align initial preview state

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Search Dictionary
- * v20260420-3
+ * v20260420-4
  *
  * 검색/둘러보기 페이지(search.html) 번역 키
  */
@@ -76,6 +76,10 @@
       ko: '다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.',
       en: 'As new moments are added, the emotional path will fill in here.'
     },
+    'search.previewNoRecordsLine': {
+      ko: '{countLabel}지만, {followup}',
+      en: '{countLabel}, and {followup}'
+    },
     'search.previewNewTreeInfo': {
       ko: '새로 시작된 공개 트리입니다',
       en: 'This is a newly started public tree.'
@@ -115,6 +119,10 @@
     'search.previewDefaultTreeName': {
       ko: '러브트리',
       en: 'LoveTree'
+    },
+    'search.previewUnknownRange': {
+      ko: '기록 없음',
+      en: 'No timeline yet'
     },
     'search.previewMoreMoments': {
       ko: '... 그리고 {count}개의 순간 더',

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Search Dictionary
- * v20260420-1
+ * v20260420-2
  *
  * 검색/둘러보기 페이지(search.html) 번역 키
  */
@@ -43,6 +43,74 @@
     'search.previewEmptyBody': {
       ko: '해당 트리의 감정 흐름과 대표 순간을 여기서 미리 볼 수 있어요.',
       en: 'and preview its emotional flow and featured moment here.'
+    },
+    'search.previewNoMomentTitle': {
+      ko: '아직 대표 순간이 없어요.',
+      en: 'There is no featured moment yet.'
+    },
+    'search.previewNoMomentBody': {
+      ko: '첫 입덕 순간이 기록되면 여기에서 바로 미리 볼 수 있어요.',
+      en: 'Once the first fandom moment is recorded, you will be able to preview it here.'
+    },
+    'search.previewStartFromFirstMoment': {
+      ko: '첫 순간부터 감상하기',
+      en: 'Start from the first moment'
+    },
+    'search.previewTimelineHeading': {
+      ko: '어떻게 입덕했을까요?',
+      en: 'How did this fandom begin?'
+    },
+    'search.previewTimelineEmpty': {
+      ko: '아직 기록된 순간이 없어 감정 경로가 비어 있어요.',
+      en: 'No moments have been recorded yet, so the emotional path is still empty.'
+    },
+    'search.previewTimelineEmptyBody': {
+      ko: '첫 순간이 추가되면 이 패널에서 흐름을 바로 미리 볼 수 있어요.',
+      en: 'Once the first moment is added, you will be able to preview the flow in this panel.'
+    },
+    'search.previewNoRecordsYet': {
+      ko: '아직 기록은 0개',
+      en: 'There are still 0 records'
+    },
+    'search.previewNewTreeInfo': {
+      ko: '새로 시작된 공개 트리입니다',
+      en: 'This is a newly started public tree.'
+    },
+    'search.previewJourneyCta': {
+      ko: '카드를 클릭하여 감정 경로를 따라가보세요',
+      en: 'Click a card to follow the emotional path.'
+    },
+    'search.previewMomentCountSuffix': {
+      ko: '개 순간',
+      en: 'moments'
+    },
+    'search.previewDurationPending': {
+      ko: '업데이트 정보 준비 중',
+      en: 'Preparing update info'
+    },
+    'search.previewEmotionTagsLabel': {
+      ko: '감정 태그',
+      en: 'Emotion Tags'
+    },
+    'search.previewTimelineRecentUpdate': {
+      ko: '최근 업데이트',
+      en: 'Recently updated'
+    },
+    'search.previewTimelineLastMoment': {
+      ko: '마지막 순간',
+      en: 'Last moment'
+    },
+    'search.previewTimelineCreated': {
+      ko: '생성',
+      en: 'Created'
+    },
+    'search.previewTimelineUnavailable': {
+      ko: '업데이트 정보 없음',
+      en: 'No update info'
+    },
+    'search.previewDefaultTreeName': {
+      ko: '러브트리',
+      en: 'LoveTree'
     },
 
     // 검색 입력

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Search Dictionary
- * v20260419-1
+ * v20260420-1
  *
  * 검색/둘러보기 페이지(search.html) 번역 키
  */
@@ -16,7 +16,7 @@
     },
     'search.subtitle': {
       ko: '다른 팬들이 정성껏 가꾼 공개 러브트리들을 둘러보고 함께 추억을 나누어 보세요.',
-      en: "Explore public LoveTrees shared by other fans and connect through shared memories."
+      en: 'Explore public LoveTrees shared by other fans and connect through shared memories.'
     },
 
     // 미리보기
@@ -24,9 +24,25 @@
       ko: '러브트리 미리보기',
       en: 'LoveTree Preview'
     },
+    'search.previewBadge': {
+      ko: '대표 순간 보기',
+      en: 'Featured Moment'
+    },
     'search.previewPlaceholder': {
       ko: '트리를 선택하여 감상하기',
-      en: 'Select a tree to view'
+      en: 'Select a tree to preview'
+    },
+    'search.previewDescriptionPlaceholder': {
+      ko: '카드를 선택하면 감정의 흐름과 대표 순간을 미리 볼 수 있어요.',
+      en: 'Select a card to preview the emotional flow and featured moment.'
+    },
+    'search.previewEmptyLead': {
+      ko: '왼쪽 목록에서 공개 러브트리를 선택하면',
+      en: 'Choose a public LoveTree from the list to the left'
+    },
+    'search.previewEmptyBody': {
+      ko: '해당 트리의 감정 흐름과 대표 순간을 여기서 미리 볼 수 있어요.',
+      en: 'and preview its emotional flow and featured moment here.'
     },
 
     // 검색 입력

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Search Dictionary
- * v20260420-2
+ * v20260420-3
  *
  * 검색/둘러보기 페이지(search.html) 번역 키
  */
@@ -72,6 +72,10 @@
       ko: '아직 기록은 0개',
       en: 'There are still 0 records'
     },
+    'search.previewNoRecordsFollowup': {
+      ko: '다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.',
+      en: 'As new moments are added, the emotional path will fill in here.'
+    },
     'search.previewNewTreeInfo': {
       ko: '새로 시작된 공개 트리입니다',
       en: 'This is a newly started public tree.'
@@ -111,6 +115,26 @@
     'search.previewDefaultTreeName': {
       ko: '러브트리',
       en: 'LoveTree'
+    },
+    'search.previewMoreMoments': {
+      ko: '... 그리고 {count}개의 순간 더',
+      en: '... and {count} more moments'
+    },
+    'search.previewSummaryThemeStart': {
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong> 테마로 시작된 공개 러브트리예요.',
+      en: '<strong style="color:var(--on-surface);">{title}</strong> is a public LoveTree that began with the <strong style="color:var(--on-surface);">{theme}</strong> theme.'
+    },
+    'search.previewSummaryStart': {
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 공개 러브트리예요.',
+      en: '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.'
+    },
+    'search.previewSummaryThemeRange': {
+      ko: '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 감정 순간</span>이 <strong>{range}</strong> 동안 기록되었어요.',
+      en: '<strong style="color:var(--on-surface);">{count} emotional moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> were recorded across <strong>{range}</strong>.'
+    },
+    'search.previewSummaryRange': {
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 감정 순간</span>이 <strong>{range}</strong> 동안 기록되었어요.',
+      en: '<strong style="color:var(--on-surface);">{count} emotional moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> were recorded across <strong>{range}</strong>.'
     },
 
     // 검색 입력

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260420-2
+ * v20260420-3
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -8,59 +8,59 @@
  * Dependencies: LoveBudPath (for navigation)
  */
 
- (function() {
-     'use strict';
+(function() {
+    'use strict';
 
-     // ─────────────────────────────────────────────────────────
-     // Security helpers (XSS prevention)
-     // ─────────────────────────────────────────────────────────
+    // ─────────────────────────────────────────────────────────
+    // Security helpers (XSS prevention)
+    // ─────────────────────────────────────────────────────────
 
-     function escapeHtml(value) {
-         return String(value == null ? '' : value)
-             .replace(/&/g, '&amp;')
-             .replace(/</g, '&lt;')
-             .replace(/>/g, '&gt;')
-             .replace(/\"/g, '&quot;')
-             .replace(/'/g, '&#39;');
-     }
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
 
-     function sanitizeUrl(value) {
-         if (!value) return '';
-         const raw = String(value).trim();
-         if (!raw) return '';
-         try {
-             const parsed = new URL(raw, window.location.origin);
-             const protocol = parsed.protocol;
-             if (protocol === 'http:' || protocol === 'https:') {
-                 return parsed.href;
-             }
-             return '';
-         } catch (e) {
-             return '';
-         }
-     }
+    function sanitizeUrl(value) {
+        if (!value) return '';
+        const raw = String(value).trim();
+        if (!raw) return '';
+        try {
+            const parsed = new URL(raw, window.location.origin);
+            const protocol = parsed.protocol;
+            if (protocol === 'http:' || protocol === 'https:') {
+                return parsed.href;
+            }
+            return '';
+        } catch (e) {
+            return '';
+        }
+    }
 
-     function getCurrentLocale() {
-         const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
-         return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
-     }
+    function getCurrentLocale() {
+        const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
 
-     function getSearchCopy(key, fallbackKo, fallbackEn) {
-         const locale = getCurrentLocale();
-         const dict = window.i18nSearch?.[key];
-         if (dict && typeof dict === 'object') {
-             return dict[locale] || dict.ko || dict.en || fallbackKo;
-         }
-         return locale === 'en' ? fallbackEn : fallbackKo;
-     }
+    function getSearchCopy(key, fallbackKo, fallbackEn) {
+        const locale = getCurrentLocale();
+        const dict = window.i18nSearch?.[key];
+        if (dict && typeof dict === 'object') {
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return locale === 'en' ? fallbackEn : fallbackKo;
+    }
 
-     function getPreviewStatsElement() {
-         return _dom?.previewMemoriesCount?.closest?.('#previewTreeStats') || document.getElementById('previewTreeStats');
-     }
+    function getPreviewStatsElement() {
+        return _dom?.previewMemoriesCount?.closest?.('#previewTreeStats') || document.getElementById('previewTreeStats');
+    }
 
-     // ─────────────────────────────────────────────────────────
-     // DOM References (cached on init)
-     // ─────────────────────────────────────────────────────────
+    // ─────────────────────────────────────────────────────────
+    // DOM References (cached on init)
+    // ─────────────────────────────────────────────────────────
 
     let _dom = null;
 
@@ -87,141 +87,145 @@
      * @param {Array} tags 
      * @returns {string} HTML string
      */
-     function renderEmotionTags(tags) {
-         if (!tags || !tags.length) return '';
-         return tags.slice(0, 4).map(tag =>
-             `<span style="padding:8px 14px;background:var(--primary-container);border-radius:99px;font-size:13px;font-weight:700;color:var(--on-primary-container);border:1px solid var(--outline-variant);">#${escapeHtml(tag)}</span>`
-         ).join('');
-     }
+    function renderEmotionTags(tags) {
+        if (!tags || !tags.length) return '';
+        return tags.slice(0, 4).map(tag =>
+            `<span style="padding:8px 14px;background:var(--primary-container);border-radius:99px;font-size:13px;font-weight:700;color:var(--on-primary-container);border:1px solid var(--outline-variant);">#${escapeHtml(tag)}</span>`
+        ).join('');
+    }
 
-     function getTimelineLabel(tree, memories) {
-         const titleHelper = getSearchTitleHelper();
-         const formatDate = titleHelper?.formatShortDate || ((value) => {
-             if (!value) return '';
-             const date = new Date(value);
-             if (Number.isNaN(date.getTime())) return '';
-             return date.toLocaleDateString('ko-KR', {
-                 month: 'short',
-                 day: 'numeric'
-             });
-         });
+    function getTimelineLabel(tree, memories) {
+        const titleHelper = getSearchTitleHelper();
+        const formatDate = titleHelper?.formatShortDate || ((value) => {
+            if (!value) return '';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return '';
+            return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', {
+                month: 'short',
+                day: 'numeric'
+            });
+        });
 
-         const updatedAt = tree.updatedAt || '';
-         const createdAt = tree.createdAt || '';
-         const firstTimestamp = memories[0]?.timestamp || '';
-         const lastTimestamp = memories[memories.length - 1]?.timestamp || '';
+        const updatedAt = tree.updatedAt || '';
+        const createdAt = tree.createdAt || '';
+        const firstTimestamp = memories[0]?.timestamp || '';
+        const lastTimestamp = memories[memories.length - 1]?.timestamp || '';
 
-         const safeUpdated = formatDate(updatedAt);
-         const safeCreated = formatDate(createdAt);
-         const safeFirst = formatDate(firstTimestamp);
-         const safeLast = formatDate(lastTimestamp);
+        const safeUpdated = formatDate(updatedAt);
+        const safeCreated = formatDate(createdAt);
+        const safeFirst = formatDate(firstTimestamp);
+        const safeLast = formatDate(lastTimestamp);
 
-         if (safeUpdated) {
-             return `최근 업데이트 ${safeUpdated}`;
-         }
-         if (safeLast) {
-             return `마지막 순간 ${safeLast}`;
-         }
-         if (safeFirst && safeLast && safeFirst !== safeLast) {
-             return `${safeFirst} ~ ${safeLast}`;
-         }
-         if (safeCreated) {
-             return `${safeCreated} 생성`;
-         }
-         return '업데이트 정보 없음';
-     }
+        if (safeUpdated) {
+            return `${getSearchCopy('search.previewTimelineRecentUpdate', '최근 업데이트', 'Recently updated')} ${safeUpdated}`;
+        }
+        if (safeLast) {
+            return `${getSearchCopy('search.previewTimelineLastMoment', '마지막 순간', 'Last moment')} ${safeLast}`;
+        }
+        if (safeFirst && safeLast && safeFirst !== safeLast) {
+            return `${safeFirst} ~ ${safeLast}`;
+        }
+        if (safeCreated) {
+            return `${safeCreated} ${getSearchCopy('search.previewTimelineCreated', '생성', 'Created')}`;
+        }
+        return getSearchCopy('search.previewTimelineUnavailable', '업데이트 정보 없음', 'No update info');
+    }
 
-     function getSearchTitleHelper() {
-         return window.LoveBudSearchTitleHelper || null;
-     }
+    function getSearchTitleHelper() {
+        return window.LoveBudSearchTitleHelper || null;
+    }
 
-     function getPreviewSummaryCopy(tree, memories) {
-         const titleHelper = getSearchTitleHelper();
-         const displayTitle = titleHelper?.getBrowseDisplayTitle
-             ? titleHelper.getBrowseDisplayTitle(tree)
-             : (String(tree?.title || '').trim() || '러브트리');
-         const themeLabel = titleHelper?.getThemeLabel
-             ? titleHelper.getThemeLabel(tree)
-             : (() => {
-                 const themeRaw = String(tree?.theme || '').trim();
-                 if (!themeRaw || themeRaw === 'LoveTree' || themeRaw === 'Mixed') {
-                     return '';
-                 }
-                 return themeRaw;
-             })();
-         const timeRange = String(tree?.timeRange || '기록 없음').trim();
-         const memoryCount = Number(tree?.memoryCount || 0);
+    function getDefaultTreeName() {
+        return getSearchCopy('search.previewDefaultTreeName', '러브트리', 'LoveTree');
+    }
 
-         if (!memories.length) {
-             if (themeLabel) {
-                 return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 <strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong> 테마로 시작된 공개 러브트리예요.`;
-             }
-             return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 이제 막 시작된 공개 러브트리예요.`;
-         }
+    function getPreviewSummaryCopy(tree, memories) {
+        const titleHelper = getSearchTitleHelper();
+        const displayTitle = titleHelper?.getBrowseDisplayTitle
+            ? titleHelper.getBrowseDisplayTitle(tree)
+            : (String(tree?.title || '').trim() || getDefaultTreeName());
+        const themeLabel = titleHelper?.getThemeLabel
+            ? titleHelper.getThemeLabel(tree)
+            : (() => {
+                const themeRaw = String(tree?.theme || '').trim();
+                if (!themeRaw || themeRaw === 'LoveTree' || themeRaw === 'Mixed') {
+                    return '';
+                }
+                return themeRaw;
+            })();
+        const timeRange = String(tree?.timeRange || '기록 없음').trim();
+        const memoryCount = Number(tree?.memoryCount || 0);
 
-         if (themeLabel) {
-             return `<strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
-         }
+        if (!memories.length) {
+            if (themeLabel) {
+                return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 <strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong> 테마로 시작된 공개 러브트리예요.`;
+            }
+            return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 이제 막 시작된 공개 러브트리예요.`;
+        }
 
-         return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
-     }
+        if (themeLabel) {
+            return `<strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
+        }
 
-     function renderSectionHeading(icon, label) {
-         return `
-             <div style="font-size:11px;font-weight:800;color:var(--on-surface-variant);margin-bottom:12px;text-transform:uppercase;letter-spacing:1px;display:flex;align-items:center;gap:4px;">
-                 <span class="material-symbols-outlined" style="font-size:14px;">${escapeHtml(icon)}</span>
-                 ${escapeHtml(label)}
-             </div>
-         `;
-     }
+        return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
+    }
 
-     function renderInfoCallout(icon, text, variant = 'neutral') {
-         const isPrimary = variant === 'primary';
-         const background = isPrimary ? 'var(--primary-container)' : 'var(--surface-container)';
-         const color = isPrimary ? 'var(--on-primary-container)' : 'var(--on-surface-variant)';
+    function renderSectionHeading(icon, label) {
+        return `
+            <div style="font-size:11px;font-weight:800;color:var(--on-surface-variant);margin-bottom:12px;text-transform:uppercase;letter-spacing:1px;display:flex;align-items:center;gap:4px;">
+                <span class="material-symbols-outlined" style="font-size:14px;">${escapeHtml(icon)}</span>
+                ${escapeHtml(label)}
+            </div>
+        `;
+    }
 
-         return `
-             <div style="margin-top:12px;padding:12px;background:${background};border-radius:0.75rem;font-size:13px;color:${color};font-weight:500;display:flex;align-items:center;gap:8px;">
-                 <span class="material-symbols-outlined" style="font-size:18px;">${escapeHtml(icon)}</span>
-                 ${escapeHtml(text)}
-             </div>
-         `;
-     }
+    function renderInfoCallout(icon, text, variant = 'neutral') {
+        const isPrimary = variant === 'primary';
+        const background = isPrimary ? 'var(--primary-container)' : 'var(--surface-container)';
+        const color = isPrimary ? 'var(--on-primary-container)' : 'var(--on-surface-variant)';
 
-     function renderPathStageBadge(index, title) {
-         return `<span style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;background:var(--surface-container);border-radius:8px;font-size:13px;"><span style="color:var(--primary);font-weight:800;">${index}</span><span>${escapeHtml(title)}</span></span>`;
-     }
+        return `
+            <div style="margin-top:12px;padding:12px;background:${background};border-radius:0.75rem;font-size:13px;color:${color};font-weight:500;display:flex;align-items:center;gap:8px;">
+                <span class="material-symbols-outlined" style="font-size:18px;">${escapeHtml(icon)}</span>
+                ${escapeHtml(text)}
+            </div>
+        `;
+    }
 
-     function renderMoreStagesText(count) {
-         if (!count || count <= 0) return '';
-         return `<div style="margin-top:8px;font-size:12px;color:var(--on-surface-variant);font-style:italic;">... 그리고 ${count}개의 순간 더</div>`;
-     }
+    function renderPathStageBadge(index, title) {
+        return `<span style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;background:var(--surface-container);border-radius:8px;font-size:13px;"><span style="color:var(--primary);font-weight:800;">${index}</span><span>${escapeHtml(title)}</span></span>`;
+    }
+
+    function renderMoreStagesText(count) {
+        if (!count || count <= 0) return '';
+        return `<div style="margin-top:8px;font-size:12px;color:var(--on-surface-variant);font-style:italic;">... 그리고 ${count}개의 순간 더</div>`;
+    }
 
     /**
      * Updates preview details for a tree
      * 
      * @param {Object} tree - Tree view model
      */
-     function updatePreview(tree) {
-         if (!_dom) {
-             console.warn('[LoveBudSearchPreviewRenderer] DOM not initialized');
-             return;
-         }
+    function updatePreview(tree) {
+        if (!_dom) {
+            console.warn('[LoveBudSearchPreviewRenderer] DOM not initialized');
+            return;
+        }
 
-         const memories = Array.isArray(tree.memories) ? tree.memories : [];
+        const memories = Array.isArray(tree.memories) ? tree.memories : [];
         const firstMem = memories[0];
         const hasMemories = memories.length > 0;
         const previewStats = getPreviewStatsElement();
 
-         // ─────────────────────────────────────────────
-         // Video/Iframe container
-         // ─────────────────────────────────────────────
-         
-         if (_dom.previewContainer) {
+        // ─────────────────────────────────────────────
+        // Video/Iframe container
+        // ─────────────────────────────────────────────
+        
+        if (_dom.previewContainer) {
             const titleHelper = getSearchTitleHelper();
             const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
                 ? titleHelper.getBrowseDisplayTitle(tree)
-                : (String(tree?.title || '').trim() || '러브트리');
+                : (String(tree?.title || '').trim() || getDefaultTreeName());
             const safeTreeTitle = escapeHtml(previewDisplayTitle);
 
             if (!hasMemories) {
@@ -230,8 +234,8 @@
                         <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">psychiatry</span>
                         <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${safeTreeTitle}</div>
                         <p style="margin:0;font-size:13px;line-height:1.6;">
-                            아직 대표 순간이 없어요.<br>
-                            첫 입덕 순간이 기록되면 여기에서 바로 미리 볼 수 있어요.
+                            ${escapeHtml(getSearchCopy('search.previewNoMomentTitle', '아직 대표 순간이 없어요.', 'There is no featured moment yet.'))}<br>
+                            ${escapeHtml(getSearchCopy('search.previewNoMomentBody', '첫 입덕 순간이 기록되면 여기에서 바로 미리 볼 수 있어요.', 'Once the first fandom moment is recorded, you will be able to preview it here.'))}
                         </p>
                     </div>
                 `;
@@ -250,7 +254,7 @@
                             allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                             allowfullscreen style="position:absolute;top:0;left:0;"></iframe>
                         <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(0,0,0,0.8),transparent);padding:40px 20px 20px;color:white;text-align:center;">
-                            <div style="font-size:14px;font-weight:700;margin-bottom:8px;opacity:0.9;">첫 순간부터 감상하기</div>
+                            <div style="font-size:14px;font-weight:700;margin-bottom:8px;opacity:0.9;">${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '첫 순간부터 감상하기', 'Start from the first moment'))}</div>
                             <div style="font-size:12px;opacity:0.7;">${safeFirstMemTitle}</div>
                         </div>
                     </div>
@@ -258,49 +262,50 @@
             }
         }
 
-         // ─────────────────────────────────────────
-         // Title
-         // ─────────────────────────────────────────
-         
-         if (_dom.previewTitle) {
-             const titleHelper = getSearchTitleHelper();
-             const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
-                 ? titleHelper.getBrowseDisplayTitle(tree)
-                 : (String(tree?.title || '').trim() || '러브트리');
-             const safeTreeTitle = escapeHtml(previewDisplayTitle);
-             const safeTimeRange = escapeHtml(tree.timeRange || '기록 없음');
+        // ─────────────────────────────────────────
+        // Title
+        // ─────────────────────────────────────────
+        
+        if (_dom.previewTitle) {
+            const titleHelper = getSearchTitleHelper();
+            const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
+                ? titleHelper.getBrowseDisplayTitle(tree)
+                : (String(tree?.title || '').trim() || getDefaultTreeName());
+            const safeTreeTitle = escapeHtml(previewDisplayTitle);
+            const safeTimeRange = escapeHtml(tree.timeRange || '기록 없음');
+            const memoryCountSuffix = getSearchCopy('search.previewMomentCountSuffix', '개 순간', 'moments');
 
-             _dom.previewTitle.innerHTML = `
-                 <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
-                     <span style="font-size:2rem;background:var(--surface-container-low);width:48px;height:48px;display:flex;align-items:center;justify-content:center;border-radius:12px;">${getTreeIcon(tree.stage)}</span>
-                     <div>
-                         <div style="font-size:1.1rem;font-weight:800;color:var(--on-surface);line-height:1.3;">${safeTreeTitle}</div>
-                         <div style="font-size:12px;color:var(--on-surface-variant);margin-top:2px;">${tree.memoryCount}개 순간 · ${safeTimeRange}</div>
-                     </div>
-                 </div>
-             `;
-         }
+            _dom.previewTitle.innerHTML = `
+                <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
+                    <span style="font-size:2rem;background:var(--surface-container-low);width:48px;height:48px;display:flex;align-items:center;justify-content:center;border-radius:12px;">${getTreeIcon(tree.stage)}</span>
+                    <div>
+                        <div style="font-size:1.1rem;font-weight:800;color:var(--on-surface);line-height:1.3;">${safeTreeTitle}</div>
+                        <div style="font-size:12px;color:var(--on-surface-variant);margin-top:2px;">${tree.memoryCount} ${escapeHtml(memoryCountSuffix)} · ${safeTimeRange}</div>
+                    </div>
+                </div>
+            `;
+        }
 
-         // ─────────────────────────────────────────
-         // Description with path visualization
-         // ─────────────────────────────────────────
-         
-         if (_dom.previewDesc) {
+        // ─────────────────────────────────────────
+        // Description with path visualization
+        // ─────────────────────────────────────────
+        
+        if (_dom.previewDesc) {
             if (!hasMemories) {
                 _dom.previewDesc.innerHTML = `
                     <div style="background:var(--surface-container-low);padding:20px;border-radius:1rem;margin-bottom:16px;">
-                        ${renderSectionHeading('route', '어떻게 입덕했을까요?')}
+                        ${renderSectionHeading('route', getSearchCopy('search.previewTimelineHeading', '어떻게 입덕했을까요?', 'How did this fandom begin?'))}
                         <div style="font-size:14px;line-height:1.7;color:var(--on-surface-variant);">
-                            아직 기록된 순간이 없어 감정 경로가 비어 있어요.<br>
-                            첫 순간이 추가되면 이 패널에서 흐름을 바로 미리 볼 수 있어요.
+                            ${escapeHtml(getSearchCopy('search.previewTimelineEmpty', '아직 기록된 순간이 없어 감정 경로가 비어 있어요.', 'No moments have been recorded yet, so the emotional path is still empty.'))}<br>
+                            ${escapeHtml(getSearchCopy('search.previewTimelineEmptyBody', '첫 순간이 추가되면 이 패널에서 흐름을 바로 미리 볼 수 있어요.', 'Once the first moment is added, you will be able to preview the flow in this panel.'))}
                         </div>
                     </div>
 
                     <div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;padding:0 4px;">
                         ${getPreviewSummaryCopy(tree, memories)}
-                        <span style="color:var(--primary);font-weight:700;">아직 기록은 0개</span>지만,
+                        <span style="color:var(--primary);font-weight:700;">${escapeHtml(getSearchCopy('search.previewNoRecordsYet', '아직 기록은 0개', 'There are still 0 records'))}</span>지만,
                         다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.
-                        ${renderInfoCallout('info', '새로 시작된 공개 트리입니다')}
+                        ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '새로 시작된 공개 트리입니다', 'This is a newly started public tree.'))}
                     </div>
                 `;
             } else {
@@ -313,7 +318,7 @@
 
                 _dom.previewDesc.innerHTML = `
                     <div style="background:var(--surface-container-low);padding:20px;border-radius:1rem;margin-bottom:16px;">
-                        ${renderSectionHeading('route', '어떻게 입덕했을까요?')}
+                        ${renderSectionHeading('route', getSearchCopy('search.previewTimelineHeading', '어떻게 입덕했을까요?', 'How did this fandom begin?'))}
                         <div style="display:flex;flex-wrap:wrap;align-items:center;gap:6px;line-height:1.8;">
                             ${pathStages}
                         </div>
@@ -322,36 +327,36 @@
 
                     <div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;padding:0 4px;">
                         ${getPreviewSummaryCopy(tree, memories)}
-                        ${renderInfoCallout('touch_app', '카드를 클릭하여 감정 경로를 따라가보세요', 'primary')}
+                        ${renderInfoCallout('touch_app', getSearchCopy('search.previewJourneyCta', '카드를 클릭하여 감정 경로를 따라가보세요', 'Click a card to follow the emotional path.'), 'primary')}
                     </div>
                 `;
             }
         }
 
-         // ─────────────────────────────────────────
-         // Stats
-         // ─────────────────────────────────────────
+        // ─────────────────────────────────────────
+        // Stats
+        // ─────────────────────────────────────────
 
-         if (previewStats) {
-             previewStats.hidden = false;
-         }
-         
-         if (_dom.previewMemoriesCount) {
-             _dom.previewMemoriesCount.textContent = tree.memoryCount;
-         }
+        if (previewStats) {
+            previewStats.hidden = false;
+        }
+        
+        if (_dom.previewMemoriesCount) {
+            _dom.previewMemoriesCount.textContent = tree.memoryCount;
+        }
 
-         if (_dom.previewTreeDuration) {
-             _dom.previewTreeDuration.textContent = getTimelineLabel(tree, memories);
-         }
+        if (_dom.previewTreeDuration) {
+            _dom.previewTreeDuration.textContent = getTimelineLabel(tree, memories);
+        }
 
-         // ─────────────────────────────────────────
-         // Emotion Tags
-         // ─────────────────────────────────────────
-         
-         if (_dom.previewEmotionTags) {
-             _dom.previewEmotionTags.innerHTML = renderEmotionTags(tree.emotionTags);
-         }
-     }
+        // ─────────────────────────────────────────
+        // Emotion Tags
+        // ─────────────────────────────────────────
+        
+        if (_dom.previewEmotionTags) {
+            _dom.previewEmotionTags.innerHTML = renderEmotionTags(tree.emotionTags);
+        }
+    }
 
     /**
      * Renders placeholder when no tree selected
@@ -438,5 +443,5 @@
         renderEmotionTags: renderEmotionTags
     };
 
-     console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-2');
- })();
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-3');
+})();

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260420-4
+ * v20260420-5
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -73,29 +73,15 @@
 
     let _dom = null;
 
-    /**
-     * Initializes DOM references
-     * @param {Object} domRefs - { previewContainer, previewTitle, previewDesc, previewMemoriesCount, previewTreeDuration, previewEmotionTags }
-     */
     function init(domRefs) {
         _dom = domRefs;
     }
 
-    /**
-     * Gets tree icon by stage
-     * @param {string} stage 
-     * @returns {string} Emoji
-     */
     function getTreeIcon(stage) {
         const icons = { '입덕': '🌱', '성장': '🌿', '최애': '🌳' };
         return icons[stage] || '🌱';
     }
 
-    /**
-     * Renders emotion tags for preview panel
-     * @param {Array} tags 
-     * @returns {string} HTML string
-     */
     function renderEmotionTags(tags) {
         if (!tags || !tags.length) return '';
         return tags.slice(0, 4).map(tag =>
@@ -162,7 +148,7 @@
                 }
                 return themeRaw;
             })();
-        const timeRange = String(tree?.timeRange || '기록 없음').trim();
+        const timeRange = String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '기록 없음', 'No timeline yet')).trim();
         const memoryCount = Number(tree?.memoryCount || 0);
         const safeTitle = escapeHtml(displayTitle);
         const safeTheme = escapeHtml(themeLabel);
@@ -238,11 +224,6 @@
         );
     }
 
-    /**
-     * Updates preview details for a tree
-     * 
-     * @param {Object} tree - Tree view model
-     */
     function updatePreview(tree) {
         if (!_dom) {
             console.warn('[LoveBudSearchPreviewRenderer] DOM not initialized');
@@ -254,10 +235,6 @@
         const hasMemories = memories.length > 0;
         const previewStats = getPreviewStatsElement();
 
-        // ─────────────────────────────────────────────
-        // Video/Iframe container
-        // ─────────────────────────────────────────────
-        
         if (_dom.previewContainer) {
             const titleHelper = getSearchTitleHelper();
             const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
@@ -299,17 +276,13 @@
             }
         }
 
-        // ─────────────────────────────────────────
-        // Title
-        // ─────────────────────────────────────────
-        
         if (_dom.previewTitle) {
             const titleHelper = getSearchTitleHelper();
             const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
                 ? titleHelper.getBrowseDisplayTitle(tree)
                 : (String(tree?.title || '').trim() || getDefaultTreeName());
             const safeTreeTitle = escapeHtml(previewDisplayTitle);
-            const safeTimeRange = escapeHtml(tree.timeRange || '기록 없음');
+            const safeTimeRange = escapeHtml(String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '기록 없음', 'No timeline yet')).trim());
             const memoryCountSuffix = getSearchCopy('search.previewMomentCountSuffix', '개 순간', 'moments');
 
             _dom.previewTitle.innerHTML = `
@@ -323,12 +296,18 @@
             `;
         }
 
-        // ─────────────────────────────────────────
-        // Description with path visualization
-        // ─────────────────────────────────────────
-        
         if (_dom.previewDesc) {
             if (!hasMemories) {
+                const noRecordsLine = formatSearchCopy(
+                    'search.previewNoRecordsLine',
+                    {
+                        countLabel: escapeHtml(getSearchCopy('search.previewNoRecordsYet', '아직 기록은 0개', 'There are still 0 records')),
+                        followup: escapeHtml(getSearchCopy('search.previewNoRecordsFollowup', '다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.', 'As new moments are added, the emotional path will fill in here.'))
+                    },
+                    '{countLabel}지만, {followup}',
+                    '{countLabel}, and {followup}'
+                );
+
                 _dom.previewDesc.innerHTML = `
                     <div style="background:var(--surface-container-low);padding:20px;border-radius:1rem;margin-bottom:16px;">
                         ${renderSectionHeading('route', getSearchCopy('search.previewTimelineHeading', '어떻게 입덕했을까요?', 'How did this fandom begin?'))}
@@ -340,8 +319,7 @@
 
                     <div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;padding:0 4px;">
                         ${getPreviewSummaryCopy(tree, memories)}
-                        <span style="color:var(--primary);font-weight:700;">${escapeHtml(getSearchCopy('search.previewNoRecordsYet', '아직 기록은 0개', 'There are still 0 records'))}</span>
-                        ${escapeHtml(getSearchCopy('search.previewNoRecordsFollowup', '다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.', 'As new moments are added, the emotional path will fill in here.'))}
+                        <span style="color:var(--primary);font-weight:700;">${noRecordsLine}</span>
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '새로 시작된 공개 트리입니다', 'This is a newly started public tree.'))}
                     </div>
                 `;
@@ -370,10 +348,6 @@
             }
         }
 
-        // ─────────────────────────────────────────
-        // Stats
-        // ─────────────────────────────────────────
-
         if (previewStats) {
             previewStats.hidden = false;
         }
@@ -385,20 +359,12 @@
         if (_dom.previewTreeDuration) {
             _dom.previewTreeDuration.textContent = getTimelineLabel(tree, memories);
         }
-
-        // ─────────────────────────────────────────
-        // Emotion Tags
-        // ─────────────────────────────────────────
         
         if (_dom.previewEmotionTags) {
             _dom.previewEmotionTags.innerHTML = renderEmotionTags(tree.emotionTags);
         }
     }
 
-    /**
-     * Renders placeholder when no tree selected
-     * @returns {string} HTML string
-     */
     function renderPlaceholder() {
         const lead = getSearchCopy(
             'search.previewEmptyLead',
@@ -419,9 +385,6 @@
         `;
     }
 
-    /**
-     * Resets preview to placeholder state
-     */
     function resetPreview() {
         if (!_dom || !_dom.previewContainer) return;
 
@@ -466,19 +429,14 @@
         }
     }
 
-    // ─────────────────────────────────────────────────────────
-    // Exports
-    // ─────────────────────────────────────────────────────────
-
     window.LoveBudSearchPreviewRenderer = {
         init: init,
         updatePreview: updatePreview,
         resetPreview: resetPreview,
         renderPlaceholder: renderPlaceholder,
-        // Helpers
         getTreeIcon: getTreeIcon,
         renderEmotionTags: renderEmotionTags
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-4');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-5');
 })();

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260420-3
+ * v20260420-4
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -52,6 +52,15 @@
             return dict[locale] || dict.ko || dict.en || fallbackKo;
         }
         return locale === 'en' ? fallbackEn : fallbackKo;
+    }
+
+    function formatSearchCopy(key, replacements, fallbackKo, fallbackEn) {
+        const template = getSearchCopy(key, fallbackKo, fallbackEn);
+        return String(template).replace(/\{(\w+)\}/g, (_, token) => {
+            return Object.prototype.hasOwnProperty.call(replacements, token)
+                ? String(replacements[token])
+                : '';
+        });
     }
 
     function getPreviewStatsElement() {
@@ -155,19 +164,42 @@
             })();
         const timeRange = String(tree?.timeRange || '기록 없음').trim();
         const memoryCount = Number(tree?.memoryCount || 0);
+        const safeTitle = escapeHtml(displayTitle);
+        const safeTheme = escapeHtml(themeLabel);
+        const safeRange = escapeHtml(timeRange);
 
         if (!memories.length) {
             if (themeLabel) {
-                return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 <strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong> 테마로 시작된 공개 러브트리예요.`;
+                return formatSearchCopy(
+                    'search.previewSummaryThemeStart',
+                    { title: safeTitle, theme: safeTheme },
+                    '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong> 테마로 시작된 공개 러브트리예요.',
+                    '<strong style="color:var(--on-surface);">{title}</strong> is a public LoveTree that began with the <strong style="color:var(--on-surface);">{theme}</strong> theme.'
+                );
             }
-            return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>는 이제 막 시작된 공개 러브트리예요.`;
+            return formatSearchCopy(
+                'search.previewSummaryStart',
+                { title: safeTitle },
+                '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 공개 러브트리예요.',
+                '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.'
+            );
         }
 
         if (themeLabel) {
-            return `<strong style="color:var(--on-surface);">${escapeHtml(themeLabel)}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
+            return formatSearchCopy(
+                'search.previewSummaryThemeRange',
+                { theme: safeTheme, count: memoryCount, range: safeRange },
+                '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 감정 순간</span>이 <strong>{range}</strong> 동안 기록되었어요.',
+                '<strong style="color:var(--on-surface);">{count} emotional moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> were recorded across <strong>{range}</strong>.'
+            );
         }
 
-        return `<strong style="color:var(--on-surface);">${escapeHtml(displayTitle)}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">${memoryCount}개의 감정 순간</span>이 <strong>${escapeHtml(timeRange)}</strong> 동안 기록되었어요.`;
+        return formatSearchCopy(
+            'search.previewSummaryRange',
+            { title: safeTitle, count: memoryCount, range: safeRange },
+            '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 감정 순간</span>이 <strong>{range}</strong> 동안 기록되었어요.',
+            '<strong style="color:var(--on-surface);">{count} emotional moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> were recorded across <strong>{range}</strong>.'
+        );
     }
 
     function renderSectionHeading(icon, label) {
@@ -198,7 +230,12 @@
 
     function renderMoreStagesText(count) {
         if (!count || count <= 0) return '';
-        return `<div style="margin-top:8px;font-size:12px;color:var(--on-surface-variant);font-style:italic;">... 그리고 ${count}개의 순간 더</div>`;
+        return formatSearchCopy(
+            'search.previewMoreMoments',
+            { count },
+            '... 그리고 {count}개의 순간 더',
+            '... and {count} more moments'
+        );
     }
 
     /**
@@ -303,8 +340,8 @@
 
                     <div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;padding:0 4px;">
                         ${getPreviewSummaryCopy(tree, memories)}
-                        <span style="color:var(--primary);font-weight:700;">${escapeHtml(getSearchCopy('search.previewNoRecordsYet', '아직 기록은 0개', 'There are still 0 records'))}</span>지만,
-                        다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.
+                        <span style="color:var(--primary);font-weight:700;">${escapeHtml(getSearchCopy('search.previewNoRecordsYet', '아직 기록은 0개', 'There are still 0 records'))}</span>
+                        ${escapeHtml(getSearchCopy('search.previewNoRecordsFollowup', '다음 순간이 쌓이면 감정 경로가 여기서 채워집니다.', 'As new moments are added, the emotional path will fill in here.'))}
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '새로 시작된 공개 트리입니다', 'This is a newly started public tree.'))}
                     </div>
                 `;
@@ -322,7 +359,7 @@
                         <div style="display:flex;flex-wrap:wrap;align-items:center;gap:6px;line-height:1.8;">
                             ${pathStages}
                         </div>
-                        ${moreStages}
+                        <div style="margin-top:8px;font-size:12px;color:var(--on-surface-variant);font-style:italic;">${escapeHtml(moreStages)}</div>
                     </div>
 
                     <div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;padding:0 4px;">
@@ -443,5 +480,5 @@
         renderEmotionTags: renderEmotionTags
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-3');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-4');
 })();

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260420-1
+ * v20260420-2
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -20,7 +20,7 @@
              .replace(/&/g, '&amp;')
              .replace(/</g, '&lt;')
              .replace(/>/g, '&gt;')
-             .replace(/"/g, '&quot;')
+             .replace(/\"/g, '&quot;')
              .replace(/'/g, '&#39;');
      }
 
@@ -38,6 +38,24 @@
          } catch (e) {
              return '';
          }
+     }
+
+     function getCurrentLocale() {
+         const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
+         return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+     }
+
+     function getSearchCopy(key, fallbackKo, fallbackEn) {
+         const locale = getCurrentLocale();
+         const dict = window.i18nSearch?.[key];
+         if (dict && typeof dict === 'object') {
+             return dict[locale] || dict.ko || dict.en || fallbackKo;
+         }
+         return locale === 'en' ? fallbackEn : fallbackKo;
+     }
+
+     function getPreviewStatsElement() {
+         return _dom?.previewMemoriesCount?.closest?.('#previewTreeStats') || document.getElementById('previewTreeStats');
      }
 
      // ─────────────────────────────────────────────────────────
@@ -193,6 +211,7 @@
          const memories = Array.isArray(tree.memories) ? tree.memories : [];
         const firstMem = memories[0];
         const hasMemories = memories.length > 0;
+        const previewStats = getPreviewStatsElement();
 
          // ─────────────────────────────────────────────
          // Video/Iframe container
@@ -239,7 +258,7 @@
             }
         }
 
-         // ──��──────────────────────────────────────
+         // ─────────────────────────────────────────
          // Title
          // ─────────────────────────────────────────
          
@@ -267,8 +286,6 @@
          // ─────────────────────────────────────────
          
          if (_dom.previewDesc) {
-            const titleHelper = getSearchTitleHelper();
-
             if (!hasMemories) {
                 _dom.previewDesc.innerHTML = `
                     <div style="background:var(--surface-container-low);padding:20px;border-radius:1rem;margin-bottom:16px;">
@@ -314,6 +331,10 @@
          // ─────────────────────────────────────────
          // Stats
          // ─────────────────────────────────────────
+
+         if (previewStats) {
+             previewStats.hidden = false;
+         }
          
          if (_dom.previewMemoriesCount) {
              _dom.previewMemoriesCount.textContent = tree.memoryCount;
@@ -337,9 +358,21 @@
      * @returns {string} HTML string
      */
     function renderPlaceholder() {
+        const lead = getSearchCopy(
+            'search.previewEmptyLead',
+            '왼쪽 목록에서 공개 러브트리를 선택하면',
+            'Choose a public LoveTree from the list to the left'
+        );
+        const body = getSearchCopy(
+            'search.previewEmptyBody',
+            '해당 트리의 감정 흐름과 대표 순간을 여기서 미리 볼 수 있어요.',
+            'and preview its emotional flow and featured moment here.'
+        );
+
         return `
-            <div style="width:100%; height:100%; display:flex; flex-direction: column; align-items:center; justify-content:center; color: var(--on-surface-variant); font-size: 14px; text-align: center; padding: 20px;">
-                <p>카드를 선택하면 감정의 흐름과 대표 순간을 미리 볼 수 있어요.</p>
+            <div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;color:var(--on-surface-variant);font-size:14px;text-align:center;padding:20px;">
+                <p style="margin:0 0 8px;">${escapeHtml(lead)}</p>
+                <p style="margin:0;line-height:1.5;">${escapeHtml(body)}</p>
             </div>
         `;
     }
@@ -349,25 +382,41 @@
      */
     function resetPreview() {
         if (!_dom || !_dom.previewContainer) return;
+
+        const previewStats = getPreviewStatsElement();
+        const placeholderTitle = getSearchCopy(
+            'search.previewPlaceholder',
+            '트리를 선택하여 감상하기',
+            'Select a tree to preview'
+        );
+        const placeholderDescription = getSearchCopy(
+            'search.previewDescriptionPlaceholder',
+            '카드를 선택하면 감정의 흐름과 대표 순간을 미리 볼 수 있어요.',
+            'Select a card to preview the emotional flow and featured moment.'
+        );
         
         if (_dom.previewContainer) {
             _dom.previewContainer.innerHTML = renderPlaceholder();
         }
         
         if (_dom.previewTitle) {
-            _dom.previewTitle.innerHTML = '---';
+            _dom.previewTitle.textContent = placeholderTitle;
         }
         
         if (_dom.previewDesc) {
-            _dom.previewDesc.innerHTML = '<p style="font-style: italic; margin-bottom: 16px;">---</p>';
+            _dom.previewDesc.innerHTML = `<p style="margin-bottom:16px;">${escapeHtml(placeholderDescription)}</p>`;
+        }
+
+        if (previewStats) {
+            previewStats.hidden = true;
         }
         
         if (_dom.previewMemoriesCount) {
-            _dom.previewMemoriesCount.textContent = '-';
+            _dom.previewMemoriesCount.textContent = '0';
         }
         
         if (_dom.previewTreeDuration) {
-            _dom.previewTreeDuration.textContent = '-';
+            _dom.previewTreeDuration.textContent = '';
         }
         
         if (_dom.previewEmotionTags) {
@@ -389,5 +438,5 @@
         renderEmotionTags: renderEmotionTags
     };
 
-     console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-1');
+     console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260420-2');
  })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -489,17 +489,18 @@
                 <div id="previewTreeStats" class="tree-meta" hidden>
                     <span class="tree-meta-item">
                         <span class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle;">account_tree</span>
-                        <span id="previewMemoriesCount">0</span>개 순간
+                        <span id="previewMemoriesCount">0</span>
+                        <span data-i18n="search.previewMomentCountSuffix">개 순간</span>
                     </span>
                     <span class="tree-meta-item">
                         <span class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle;">schedule</span>
-                        <span id="previewTreeDuration">업데이트 정보 준비 중</span>
+                        <span id="previewTreeDuration" data-i18n="search.previewDurationPending">업데이트 정보 준비 중</span>
                     </span>
                 </div>
                 <div>
                     <div class="emotion-tags-label">
                         <span class="material-symbols-outlined" style="font-size: 14px;">tag</span>
-                        감정 태그
+                        <span data-i18n="search.previewEmotionTagsLabel">감정 태그</span>
                     </div>
                     <div id="previewEmotionTags" style="display: flex; flex-wrap: wrap; gap: 8px;">
                         <!-- Populated by JS -->
@@ -518,7 +519,7 @@
     <script src="../js/search-title-helper.js?v=20260420-1"></script>
     <script src="../js/search-data-adapter.js?v=20260418-1"></script>
     <script src="../js/search-card-renderer.js?v=20260420-5"></script>
-    <script src="../js/search-preview-renderer.js?v=20260420-9"></script>
+    <script src="../js/search-preview-renderer.js?v=20260420-10"></script>
     <script src="../js/search.js?v=20260418-1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
@@ -527,7 +528,7 @@
     <script src="../js/i18n/i18n-shared.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260419-2"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260420-1"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260420-2"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260419-2"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -472,21 +472,21 @@
 
         <aside class="preview-sidebar" id="previewSidebar">
             <div class="preview-panel-header">
-                <h3>미리보기</h3>
-                <span class="preview-badge">대표 순간 보기</span>
+                <h3 data-i18n="search.previewTitle">러브트리 미리보기</h3>
+                <span class="preview-badge" data-i18n="search.previewBadge">대표 순간 보기</span>
             </div>
             <div id="previewVideoContainer" class="video-container" style="margin-bottom: 24px;">
                 <div class="preview-empty-state" style="width:100%; height:100%; display:flex; flex-direction: column; align-items:center; justify-content:center; color: var(--on-surface-variant); font-size: 14px; text-align: center; padding: 20px;">
-                    <p style="margin-bottom: 8px;"><strong style="color: var(--primary);">왼쪽 목록</strong>에서 공개 러브트리를 선택하면</p>
-                    <p>해당 트리의 감정 흐름과 대표 순간을<br>여기서 미리 볼 수 있어요.</p>
+                    <p style="margin-bottom: 8px;" data-i18n="search.previewEmptyLead">왼쪽 목록에서 공개 러브트리를 선택하면</p>
+                    <p data-i18n="search.previewEmptyBody">해당 트리의 감정 흐름과 대표 순간을 여기서 미리 볼 수 있어요.</p>
                 </div>
             </div>
             <div id="previewDetails">
-                <div id="previewTitle" class="headline" style="font-size: 1.1rem; margin-bottom: 12px; font-weight: 800; color: var(--on-surface);">---</div>
+                <div id="previewTitle" class="headline" style="font-size: 1.1rem; margin-bottom: 12px; font-weight: 800; color: var(--on-surface);" data-i18n="search.previewPlaceholder">트리를 선택하여 감상하기</div>
                 <div id="previewDesc" style="color: var(--on-surface-variant); font-size: 14px; line-height: 1.5;">
-                    <p style="font-style: italic; margin-bottom: 16px;">---</p>
+                    <p style="margin-bottom: 16px;" data-i18n="search.previewDescriptionPlaceholder">카드를 선택하면 감정의 흐름과 대표 순간을 미리 볼 수 있어요.</p>
                 </div>
-                <div id="previewTreeStats" class="tree-meta">
+                <div id="previewTreeStats" class="tree-meta" hidden>
                     <span class="tree-meta-item">
                         <span class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle;">account_tree</span>
                         <span id="previewMemoriesCount">0</span>개 순간
@@ -518,7 +518,7 @@
     <script src="../js/search-title-helper.js?v=20260420-1"></script>
     <script src="../js/search-data-adapter.js?v=20260418-1"></script>
     <script src="../js/search-card-renderer.js?v=20260420-5"></script>
-    <script src="../js/search-preview-renderer.js?v=20260420-8"></script>
+    <script src="../js/search-preview-renderer.js?v=20260420-9"></script>
     <script src="../js/search.js?v=20260418-1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
@@ -527,7 +527,7 @@
     <script src="../js/i18n/i18n-shared.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260419-2"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260419-2"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260420-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260419-2"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -519,7 +519,7 @@
     <script src="../js/search-title-helper.js?v=20260420-1"></script>
     <script src="../js/search-data-adapter.js?v=20260418-1"></script>
     <script src="../js/search-card-renderer.js?v=20260420-5"></script>
-    <script src="../js/search-preview-renderer.js?v=20260420-10"></script>
+    <script src="../js/search-preview-renderer.js?v=20260420-11"></script>
     <script src="../js/search.js?v=20260418-1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
@@ -528,7 +528,7 @@
     <script src="../js/i18n/i18n-shared.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260419-2"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260420-2"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260420-4"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260419-2"></script>


### PR DESCRIPTION
This PR merges the c-model search surface UI/i18n cleanup into main.

Scope:
- Localize search preview panel copy and summary templates
- Remove initial preview placeholder leakage (---, 0)
- Align pages/search.html initial preview state and asset versions

Files:
- js/i18n/i18n-search.js
- js/search-preview-renderer.js
- pages/search.html

This is intentionally limited to the search surface only.