### PR TITLE
Filter default record tag from browse surfaces

### DIFF
--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -143,7 +143,7 @@ function createEditorMemoryForm(deps) {
             timestamp: dateStr,
             sourceUrl: embedUrl,
             sourceType: 'youtube',
-            emotionTags: [i18n('tag_record') || '기록'],
+            emotionTags: [],
             parentId: resolveParentIdForCreate(getSelectedNodeId(), getCanonicalRootId()),
             thumbnail: thumbnailUrl,
             artist: '',

--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260421-1
+ * v20260421-2
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -131,6 +131,7 @@
          const safeTags = (Array.isArray(tags) ? tags : [])
              .map(tag => titleHelper?.sanitizeBrowseLabel ? titleHelper.sanitizeBrowseLabel(tag) : String(tag || '').trim())
              .filter(Boolean)
+             .filter(tag => tag !== '기록' && tag !== 'tag_record')
              .slice(0, 3);
 
          if (!safeTags.length) return '';
@@ -403,5 +404,5 @@
         getBasePath: getBasePath
     };
 
-     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260421-1');
+     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260421-2');
  })();

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260421-1
+ * v20260421-2
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -99,6 +99,7 @@
         const safeTags = (Array.isArray(tags) ? tags : [])
             .map(tag => titleHelper?.sanitizeBrowseLabel ? titleHelper.sanitizeBrowseLabel(tag) : String(tag || '').trim())
             .filter(Boolean)
+            .filter(tag => tag !== '기록' && tag !== 'tag_record')
             .slice(0, 4);
 
         if (!safeTags.length) return '';
@@ -451,5 +452,5 @@
         renderEmotionTags: renderEmotionTags
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260421-1');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260421-2');
 })();

--- a/js/search-title-helper.js
+++ b/js/search-title-helper.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Title Helper
- * v20260421-1
+ * v20260421-2
  * 
  * Shared helper for browse/search title formatting.
  * Used by: search-card-renderer.js, search-preview-renderer.js
@@ -53,7 +53,9 @@
         const tags = Array.isArray(tree?.emotionTags) ? tree.emotionTags : [];
         for (const tag of tags) {
             const safeTag = sanitizeBrowseLabel(tag);
-            if (safeTag) return safeTag;
+            if (!safeTag) continue;
+            if (safeTag === '기록' || safeTag === 'tag_record') continue;
+            return safeTag;
         }
         return '';
     }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -190,7 +190,7 @@
     <script src="../js/editor/editor-rename-ui.js?v=20260420-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260421-3"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260419-1"></script>
-    <script src="../js/editor/editor-memory-form.js?v=20260419-1"></script>
+    <script src="../js/editor/editor-memory-form.js?v=20260421-2"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260420-2"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -516,10 +516,10 @@
 <script src="../js/api/public-tree-adapter.js?v=20260421-2"></script>
 <script src="../js/postgres-client.js?v=20260420-1"></script>
     <!-- Search modules -->
-    <script src="../js/search-title-helper.js?v=20260421-1"></script>
+    <script src="../js/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search-data-adapter.js?v=20260418-1"></script>
-    <script src="../js/search-card-renderer.js?v=20260421-1"></script>
-    <script src="../js/search-preview-renderer.js?v=20260421-1"></script>
+    <script src="../js/search-card-renderer.js?v=20260421-2"></script>
+    <script src="../js/search-preview-renderer.js?v=20260421-2"></script>
     <script src="../js/search.js?v=20260418-1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>


### PR DESCRIPTION
## Summary
- stop auto-saving the default record tag on new editor memories
- filter `기록` / `tag_record` from browse title generation and browse tag rendering
- bump affected browse/editor asset references

## Scope
- `js/editor/editor-memory-form.js`
- `js/search-title-helper.js`
- `js/search-card-renderer.js`
- `js/search-preview-renderer.js`
- `pages/search.html`
- `pages/editor.html`

## Notes
- This clean PR excludes the unrelated editor/public-tree-adapter changes from the earlier branch.
