### PR TITLE
fix(search): preserve sticky preview sidebar near tablet breakpoint

### DIFF
--- a/pages/search.html
+++ b/pages/search.html
@@ -488,7 +488,10 @@
             }
 
             .preview-sidebar {
-                position: static;
+                position: sticky;
+                top: 96px;
+                z-index: 5;
+                align-self: start;
             }
         }
 
@@ -530,6 +533,8 @@
             .preview-sidebar {
                 order: -1;
                 display: none;
+                position: static;
+                z-index: auto;
                 padding: 22px 18px;
                 border-radius: 1.5rem;
             }


### PR DESCRIPTION
## Summary
- Search sticky header 제한 수정
- `pages/search.html` 내부 CSS만 수정
- 1180px 이하에서 `.preview-sidebar` sticky가 해제되던 문제 보정
- narrow desktop / tablet 구간 sticky 유지
- 768px 이하 모바일 `display:none` 구조 유지

## Scope confirmation
- 공통 header 미수정
- `css/global.css` 미수정
- DOM 순서 변경 없음
- renderer / adapter / data 파일 미수정
- Search 썸네일 404 이슈 미개입
- main 직접 수정/merge/push 없음

## Validation required after merge
- 실도메인 https://lovebud.pages.dev/ 기준 UI Local 재검증 필요
- 필수 폭: 데스크톱 기준 / 1200px / 1170px / 1024px / 900px / 375px