### PR TITLE
ui(search): add growing trees section

### DIFF
--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -259,7 +259,7 @@
     }
 
     function renderResults(trees, options = {}) {
-        const { isDemo = false } = options;
+        const { isDemo = false, disableFeatured = false } = options;
 
         _addAnimations();
 
@@ -274,7 +274,8 @@
         }
 
         trees.forEach((tree, index) => {
-            html += renderTreeCard(tree, index);
+            const cardIndex = disableFeatured ? (index + 1) : index;
+            html += renderTreeCard(tree, cardIndex);
         });
 
         return html;

--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -259,7 +259,7 @@
     }
 
     function renderResults(trees, options = {}) {
-        const { isDemo = false, disableFeatured = false } = options;
+        const { isDemo = false } = options;
 
         _addAnimations();
 
@@ -274,8 +274,7 @@
         }
 
         trees.forEach((tree, index) => {
-            const cardIndex = disableFeatured ? (index + 1) : index;
-            html += renderTreeCard(tree, cardIndex);
+            html += renderTreeCard(tree, index);
         });
 
         return html;

--- a/js/search.js
+++ b/js/search.js
@@ -24,6 +24,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const resultsHead = document.querySelector('.browse-results-head');
     const resultsTitle = resultsHead?.querySelector('h3');
     const resultsBadge = resultsHead?.querySelector('.browse-results-badge');
+    const growingSection = document.getElementById('growingTreesSection');
+    const growingList = document.getElementById('growingTreesList');
     const mobilePreviewMediaQuery = window.matchMedia('(max-width: 768px)');
 
     const CardRenderer = window.LoveBudSearchCardRenderer;
@@ -46,6 +48,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const getPreviewCacheKey = (treeId) => `public_tree_preview_${treeId}`;
 
     let allTrees = [];
+    let growingTrees = [];
     let loadError = null;
     let isFromCache = false;
     let apiTreesLoaded = false;
@@ -281,9 +284,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const getFilteredTrees = () => Adapter.filterTrees(allTrees, currentQuery, currentCategory);
 
     const markActiveCard = (activeCard) => {
-        resultsList.querySelectorAll('.tree-card.is-active').forEach((card) => {
-            card.classList.remove('is-active');
-            card.setAttribute('aria-pressed', 'false');
+        const allCardContainers = [resultsList, growingList].filter(Boolean);
+        allCardContainers.forEach(container => {
+            container.querySelectorAll('.tree-card.is-active').forEach((card) => {
+                card.classList.remove('is-active');
+                card.setAttribute('aria-pressed', 'false');
+            });
         });
         if (activeCard) {
             activeCard.classList.add('is-active');
@@ -292,8 +298,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     const syncActiveCard = () => {
-        const cards = resultsList.querySelectorAll('.tree-card');
-        const activeCard = Array.from(cards).find(card => card.dataset.treeId === selectedTreeId);
+        const allCardContainers = [resultsList, growingList].filter(Boolean);
+        let activeCard = null;
+        for (const container of allCardContainers) {
+            const cards = container.querySelectorAll('.tree-card');
+            activeCard = Array.from(cards).find(card => card.dataset.treeId === selectedTreeId);
+            if (activeCard) break;
+        }
         markActiveCard(activeCard || null);
     };
 
@@ -384,11 +395,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         hydrateSelectedTreePreview(tree);
     };
 
-    const attachCardEvents = (filtered) => {
-        const cards = resultsList.querySelectorAll('.tree-card');
+    const attachCardEvents = (listElement, trees) => {
+        if (!listElement) return;
+        const cards = listElement.querySelectorAll('.tree-card');
         cards.forEach((card) => {
             const treeId = card.dataset.treeId;
-            const tree = filtered.find(t => t.id === treeId);
+            const tree = trees.find(t => t.id === treeId);
             if (!tree) return;
 
             card.setAttribute('tabindex', '0');
@@ -431,7 +443,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             isDemo: !apiTreesLoaded && !loadError
         });
         resultsList.innerHTML = html;
-        attachCardEvents(filtered);
+        attachCardEvents(resultsList, filtered);
         syncActiveCard();
 
         const selectedTree = getSelectedTreeFromFiltered(filtered);
@@ -498,6 +510,52 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    function renderGrowingResults() {
+        if (!growingSection || !growingList) return;
+
+        if (!growingTrees || growingTrees.length === 0) {
+            growingSection.style.display = 'none';
+            return;
+        }
+
+        growingSection.style.display = 'block';
+        // Pass disableFeatured: true for secondary growing section
+        const html = CardRenderer.renderResults(growingTrees, { 
+            isDemo: false,
+            disableFeatured: true 
+        });
+        growingList.innerHTML = html;
+        attachCardEvents(growingList, growingTrees);
+        syncActiveCard();
+    }
+
+    async function loadGrowingTrees() {
+        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
+
+        try {
+            // Use established base API layer for public community endpoints
+            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
+            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
+            
+            // Normalize and enrich models
+            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
+            growingTrees = baseModels.map((tree, index) => {
+                const raw = rawTrees[index]?.data || rawTrees[index] || {};
+                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
+                return {
+                    ...tree,
+                    emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
+                    timeRange: raw.timeRange || raw.time_range || tree.timeRange
+                };
+            });
+            
+            renderGrowingResults();
+        } catch (error) {
+            console.warn('[search] growing trees load failed:', error.message);
+            if (growingSection) growingSection.style.display = 'none';
+        }
+    }
+
     if (previewMobileClose) {
         previewMobileClose.addEventListener('click', () => {
             clearSelectedPreview();
@@ -526,7 +584,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     resultsList.innerHTML = CardRenderer.renderLoading();
     clearSelectedPreview();
-    await loadPublicTrees({ resetSelection: true });
+    await Promise.allSettled([
+        loadPublicTrees({ resetSelection: true }),
+        loadGrowingTrees()
+    ]);
 
     let searchInputTimer = null;
     searchInput.addEventListener('input', (e) => {

--- a/js/search.js
+++ b/js/search.js
@@ -514,17 +514,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!growingSection || !growingList) return;
 
         if (!growingTrees || growingTrees.length === 0) {
-            growingSection.style.display = 'none';
+            growingSection.hidden = true;
+            growingList.innerHTML = '';
             return;
         }
 
-        growingSection.style.display = 'block';
-        // Pass disableFeatured: true for secondary growing section
-        const html = CardRenderer.renderResults(growingTrees, { 
-            isDemo: false,
-            disableFeatured: true 
-        });
-        growingList.innerHTML = html;
+        growingSection.hidden = false;
+        // Use CardRenderer.renderTreeCard with index + 1 to prevent "featured" styling
+        growingList.innerHTML = growingTrees
+            .slice(0, 3)
+            .map((tree, index) => CardRenderer.renderTreeCard(tree, index + 1))
+            .join('');
+
         attachCardEvents(growingList, growingTrees);
         syncActiveCard();
     }

--- a/pages/search.html
+++ b/pages/search.html
@@ -183,7 +183,8 @@
             box-shadow: 0 8px 18px rgba(75,64,57,0.03);
         }
 
-        #resultsList {
+        #resultsList,
+        #growingTreesList {
             display: grid;
             grid-template-columns: repeat(3, minmax(0, 1fr));
             gap: 18px;
@@ -483,7 +484,8 @@
                 justify-content: flex-start;
             }
 
-            #resultsList {
+            #resultsList,
+            #growingTreesList {
                 grid-template-columns: repeat(2, minmax(0, 1fr));
             }
 
@@ -526,7 +528,8 @@
                 left: 14px;
             }
 
-            #resultsList {
+            #resultsList,
+            #growingTreesList {
                 grid-template-columns: 1fr;
             }
 
@@ -600,6 +603,18 @@
 
             <div id="resultsList">
                 <!-- Populated by JS -->
+            </div>
+
+            <div id="growingTreesSection" style="display: none; margin-top: 56px; margin-bottom: 48px;">
+                <div class="browse-results-head">
+                    <div>
+                        <h3 data-i18n="search.growing_title">새로 자라는 러브트리</h3>
+                        <p data-i18n="search.growing_subtitle">최근 마음이 더해지기 시작한 공개 러브트리예요.</p>
+                    </div>
+                </div>
+                <div id="growingTreesList">
+                    <!-- Populated by JS -->
+                </div>
             </div>
 
             <div class="browse-utility-row">

--- a/pages/search.html
+++ b/pages/search.html
@@ -191,6 +191,53 @@
             align-items: stretch;
         }
 
+        /* Growing Trees Section */
+        .growing-trees-section {
+            margin-top: 56px;
+            margin-bottom: 48px;
+            padding: 32px;
+            background: rgba(255, 255, 255, 0.4);
+            border: 1px solid rgba(144, 73, 81, 0.08);
+            border-radius: 2rem;
+            box-shadow: inset 0 0 40px rgba(255, 255, 255, 0.5);
+        }
+
+        .growing-trees-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 24px;
+            gap: 16px;
+        }
+
+        .growing-trees-head h3 {
+            font-size: 1.55rem;
+            font-weight: 800;
+            margin-bottom: 8px;
+            color: var(--on-surface);
+            letter-spacing: -0.025em;
+        }
+
+        .growing-trees-head p {
+            color: var(--on-surface-variant);
+            font-size: 0.95rem;
+            margin: 0;
+            line-height: 1.6;
+        }
+
+        .growing-trees-badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 7px 14px;
+            background: rgba(144, 73, 81, 0.08);
+            color: var(--primary);
+            border-radius: 999px;
+            font-size: 11.5px;
+            font-weight: 800;
+            white-space: nowrap;
+            letter-spacing: 0.01em;
+        }
+
         .tree-card {
             display: flex;
             flex-direction: column;
@@ -605,17 +652,19 @@
                 <!-- Populated by JS -->
             </div>
 
-            <div id="growingTreesSection" style="display: none; margin-top: 56px; margin-bottom: 48px;">
-                <div class="browse-results-head">
+            <!-- 새로 자라는 러브트리 섹션 -->
+            <section id="growingTreesSection" class="growing-trees-section" hidden>
+                <div class="growing-trees-head">
                     <div>
-                        <h3 data-i18n="search.growing_title">새로 자라는 러브트리</h3>
-                        <p data-i18n="search.growing_subtitle">최근 마음이 더해지기 시작한 공개 러브트리예요.</p>
+                        <h3>새로 자라는 러브트리</h3>
+                        <p>최근 마음이 더해지기 시작한 공개 러브트리예요.</p>
                     </div>
+                    <span class="growing-trees-badge">1~2개의 순간</span>
                 </div>
                 <div id="growingTreesList">
                     <!-- Populated by JS -->
                 </div>
-            </div>
+            </section>
 
             <div class="browse-utility-row">
                 <div class="search-input-wrapper">


### PR DESCRIPTION
## Summary
- Adds a "새로 자라는 러브트리" supporting section to the Search page
- Loads growing public trees separately from the main browse results
- Keeps the existing browse/latest/popular flow unchanged
- Hides the growing section gracefully if the growing API fails

## Scope
Changed files only:
- pages/search.html
- js/search.js

## Validation
- Desktop 1440px: checked
- Tablet 1024px: checked
- Mobile 375px: checked
- Sticky preview sidebar: preserved
- Mobile preview hidden/is-open behavior: preserved
- No new console errors reported
- npm test: existing failures remain; no new failure attributed to this change
- npm run verify: existing i18n key failures remain; no new failure attributed to this change

## Explicit exclusions
- No backend/API changes
- No Modal changes
- No global.css changes
- No search-data-adapter changes
- No search-preview-renderer changes
- No search-card-renderer changes
- No Search thumbnail fallback changes
- No sticky sidebar structural changes