### PR TITLE
feat(editor): support YouTube start time for memories

### DIFF
--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -33,6 +33,8 @@ function createEditorMemoryForm(deps) {
     let outsideClickHandler = null;
     let previewInputHandler = null;
     let currentInputMode = 'link';
+    let userHasEditedStartTime = false;
+
 
     const addMemoryForm = document.getElementById('addMemoryForm');
     const urlInput = document.getElementById('memoryUrlInput');
@@ -42,8 +44,12 @@ function createEditorMemoryForm(deps) {
     const modeLinkBtn = document.getElementById('memoryModeLinkBtn');
     const modeTextBtn = document.getElementById('memoryModeTextBtn');
     const supportNoteText = document.getElementById('memoryFormSupportNoteText');
+    const startTimeField = document.getElementById('memoryStartTimeField');
+    const startTimeInput = document.getElementById('memoryStartTimeInput');
+    const startTimeHint = document.getElementById('memoryStartTimeHint');
 
-    const formInputs = [urlInput, titleInput, memoInput].filter(Boolean);
+
+    const formInputs = [urlInput, startTimeInput, titleInput, memoInput].filter(Boolean);
 
     function applyFormOpenStyles() {
         if (!addMemoryForm) return;
@@ -168,6 +174,8 @@ function createEditorMemoryForm(deps) {
         if (modeLinkBtn) modeLinkBtn.classList.toggle('is-active', linkMode);
         if (modeTextBtn) modeTextBtn.classList.toggle('is-active', !linkMode);
         if (urlField) urlField.classList.toggle('is-deemphasized', !linkMode);
+        if (startTimeField) startTimeField.style.display = linkMode ? 'block' : 'none';
+
 
         const urlLabel = document.getElementById('memoryUrlLabel');
         const formIntro = document.getElementById('addMemoryFormIntro');
@@ -240,6 +248,9 @@ function createEditorMemoryForm(deps) {
     const showAddMemoryForm = () => {
         if (!addMemoryForm) return;
         if (urlInput) urlInput.value = '';
+        if (startTimeInput) startTimeInput.value = '';
+        userHasEditedStartTime = false;
+
         if (titleInput) titleInput.value = '';
         if (memoInput) memoInput.value = '';
 
@@ -325,26 +336,6 @@ function createEditorMemoryForm(deps) {
 
             if (window.LoveBudMedia?.extractYouTubeId) {
                 videoId = window.LoveBudMedia.extractYouTubeId(url) || '';
-            } else {
-                try {
-                    if (!url) throw new Error('Empty URL');
-                    const parsed = new URL(url.trim());
-                    const host = parsed.hostname.replace(/^www\./, '');
-                    if (host === 'youtu.be') {
-                        videoId = parsed.pathname.split('/').filter(Boolean)[0] || '';
-                    } else if (host === 'youtube.com' || host === 'm.youtube.com') {
-                        if (parsed.pathname === '/watch') {
-                            videoId = parsed.searchParams.get('v') || '';
-                        } else {
-                            const parts = parsed.pathname.split('/').filter(Boolean);
-                            if (parts[0] === 'shorts' || parts[0] === 'embed') {
-                                videoId = parts[1] || '';
-                            }
-                        }
-                    }
-                } catch (e) {
-                    videoId = '';
-                }
             }
 
             if (videoId) {
@@ -353,7 +344,7 @@ function createEditorMemoryForm(deps) {
 
                 const thumb = document.getElementById('memoryPreviewThumb');
                 if (thumb) {
-                    thumb.src = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+                    thumb.src = window.LoveBudMedia?.getThumbnailUrl(url) || `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
                 }
 
                 if (!userHasEditedTitle && titleInput) {
@@ -362,6 +353,24 @@ function createEditorMemoryForm(deps) {
                         : (i18n('editor_default_next_title') || '이어진 순간');
                     titleInput.value = defaultTitle;
                 }
+
+                // 시작 시간 힌트 업데이트
+                const hint = document.getElementById('memoryPreviewHint');
+                const startSeconds = window.LoveBudMedia?.parseYouTubeTimeToSeconds(startTimeInput?.value) ||
+                                   window.LoveBudMedia?.extractYouTubeStartSeconds(url);
+                const formatted = window.LoveBudMedia?.formatYouTubeStartTime(startSeconds);
+
+                if (hint && formatted) {
+                    hint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
+                } else if (hint) {
+                    hint.textContent = i18n('editor_preview_hint') || '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
+                }
+
+                if (startTimeHint) {
+                    startTimeHint.textContent = formatted
+                        ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
+                        : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
+                }
             } else {
                 hideLinkPreview();
             }
@@ -369,8 +378,26 @@ function createEditorMemoryForm(deps) {
 
         if (urlInput) {
             if (previewInputHandler) urlInput.removeEventListener('input', previewInputHandler);
-            previewInputHandler = updatePreview;
+            previewInputHandler = () => {
+                const url = urlInput.value.trim();
+                if (!userHasEditedStartTime && window.LoveBudMedia) {
+                    const fromUrl = window.LoveBudMedia.extractYouTubeStartSeconds(url);
+                    if (fromUrl) {
+                        startTimeInput.value = window.LoveBudMedia.formatYouTubeStartTime(fromUrl);
+                    } else {
+                        startTimeInput.value = '';
+                    }
+                }
+                updatePreview();
+            };
             urlInput.addEventListener('input', previewInputHandler);
+        }
+
+        if (startTimeInput) {
+            startTimeInput.addEventListener('input', () => {
+                userHasEditedStartTime = true;
+                updatePreview();
+            });
         }
     };
 
@@ -420,7 +447,10 @@ function createEditorMemoryForm(deps) {
                     showToast(getYouTubeInputErrorMessage(rawUrl), 'error');
                     return;
                 }
-                embedUrl = window.LoveBudMedia.getEmbedUrl(rawUrl, 'youtube');
+                const startSeconds = window.LoveBudMedia.parseYouTubeTimeToSeconds(startTimeInput?.value) ||
+                                   window.LoveBudMedia.extractYouTubeStartSeconds(rawUrl);
+                embedUrl = window.LoveBudMedia.getEmbedUrl(rawUrl, 'youtube', { startSeconds });
+
                 thumbnailUrl = window.LoveBudMedia.getThumbnailUrl(rawUrl, 'youtube', 'mqdefault');
             } else {
                 console.warn('[editor] LoveBudMedia not loaded, using fallback YouTube parsing');

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -32,6 +32,7 @@ function createEditorMemoryForm(deps) {
     let escHandler = null;
     let outsideClickHandler = null;
     let previewInputHandler = null;
+    let startTimeInputHandler = null;
     let currentInputMode = 'link';
     let userHasEditedStartTime = false;
 
@@ -356,8 +357,15 @@ function createEditorMemoryForm(deps) {
 
                 // 시작 시간 힌트 업데이트
                 const hint = document.getElementById('memoryPreviewHint');
-                const startSeconds = window.LoveBudMedia?.parseYouTubeTimeToSeconds(startTimeInput?.value) ||
-                                   window.LoveBudMedia?.extractYouTubeStartSeconds(url);
+
+                // Fix 3 Policy: userHasEditedStartTime === true 이면 수동 입력값만 우선
+                let startSeconds = null;
+                if (userHasEditedStartTime) {
+                    startSeconds = window.LoveBudMedia?.parseYouTubeTimeToSeconds(startTimeInput?.value);
+                } else {
+                    startSeconds = window.LoveBudMedia?.extractYouTubeStartSeconds(url);
+                }
+
                 const formatted = window.LoveBudMedia?.formatYouTubeStartTime(startSeconds);
 
                 if (hint && formatted) {
@@ -394,10 +402,12 @@ function createEditorMemoryForm(deps) {
         }
 
         if (startTimeInput) {
-            startTimeInput.addEventListener('input', () => {
+            if (startTimeInputHandler) startTimeInput.removeEventListener('input', startTimeInputHandler);
+            startTimeInputHandler = () => {
                 userHasEditedStartTime = true;
                 updatePreview();
-            });
+            };
+            startTimeInput.addEventListener('input', startTimeInputHandler);
         }
     };
 
@@ -415,6 +425,12 @@ function createEditorMemoryForm(deps) {
         if (outsideClickHandler) {
             document.removeEventListener('click', outsideClickHandler, true);
             outsideClickHandler = null;
+        }
+        if (urlInput && previewInputHandler) {
+            urlInput.removeEventListener('input', previewInputHandler);
+        }
+        if (startTimeInput && startTimeInputHandler) {
+            startTimeInput.removeEventListener('input', startTimeInputHandler);
         }
     };
 
@@ -447,8 +463,15 @@ function createEditorMemoryForm(deps) {
                     showToast(getYouTubeInputErrorMessage(rawUrl), 'error');
                     return;
                 }
-                const startSeconds = window.LoveBudMedia.parseYouTubeTimeToSeconds(startTimeInput?.value) ||
-                                   window.LoveBudMedia.extractYouTubeStartSeconds(rawUrl);
+
+                // Fix 3 Policy
+                let startSeconds = null;
+                if (userHasEditedStartTime) {
+                    startSeconds = window.LoveBudMedia.parseYouTubeTimeToSeconds(startTimeInput?.value);
+                } else {
+                    startSeconds = window.LoveBudMedia.extractYouTubeStartSeconds(rawUrl);
+                }
+
                 embedUrl = window.LoveBudMedia.getEmbedUrl(rawUrl, 'youtube', { startSeconds });
 
                 thumbnailUrl = window.LoveBudMedia.getThumbnailUrl(rawUrl, 'youtube', 'mqdefault');

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud 미디어 유틸리티
- * v20260424-1
+ * v20260424-2
  *
  * YouTube 및 기타 미디어 소스 처리 유틸리티
  */
@@ -9,6 +9,9 @@
     'use strict';
 
     const MAX_YOUTUBE_START_SECONDS = 12 * 60 * 60;
+
+    let editorStartTimeUserEdited = false;
+    let lastKnownEditorStartSeconds = null;
 
     /**
      * YouTube URL에서 비디오 ID 추출
@@ -105,6 +108,22 @@
         return `${minutes}:${String(rest).padStart(2, '0')}`;
     }
 
+    function getEditorStartInputSeconds() {
+        if (typeof document === 'undefined') return null;
+        const input = document.getElementById('memoryStartTimeInput');
+        if (!input) return null;
+        return parseYouTubeTimeToSeconds(input.value);
+    }
+
+    function resolveStartSeconds(sourceUrl, options = {}) {
+        const hasExplicitOption = options && Object.prototype.hasOwnProperty.call(options, 'startSeconds');
+        if (hasExplicitOption) return parseYouTubeTimeToSeconds(options.startSeconds);
+
+        const editorInputSeconds = getEditorStartInputSeconds();
+        if (editorStartTimeUserEdited) return editorInputSeconds;
+        return editorInputSeconds || extractYouTubeStartSeconds(sourceUrl);
+    }
+
     /**
      * 임베드 URL 생성
      * @param {string} sourceUrl - 원본 URL
@@ -116,9 +135,7 @@
         if (type === 'youtube') {
             const videoId = extractYouTubeId(sourceUrl);
             if (!videoId) return null;
-            const explicitStart = parseYouTubeTimeToSeconds(options?.startSeconds);
-            const urlStart = extractYouTubeStartSeconds(sourceUrl);
-            const startSeconds = explicitStart || urlStart;
+            const startSeconds = resolveStartSeconds(sourceUrl, options);
             const embedUrl = new URL(`https://www.youtube.com/embed/${videoId}`);
             if (startSeconds) embedUrl.searchParams.set('start', String(startSeconds));
             return embedUrl.toString();
@@ -171,6 +188,100 @@
         return 'unknown';
     }
 
+    function updateEditorStartPreview(seconds) {
+        if (typeof document === 'undefined') return;
+        const hint = document.getElementById('memoryPreviewHint');
+        const startHint = document.getElementById('memoryStartTimeHint');
+        const formatted = formatYouTubeStartTime(seconds);
+        if (startHint) {
+            startHint.textContent = formatted
+                ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
+                : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
+        }
+        if (hint && formatted) {
+            hint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
+        } else if (hint) {
+            hint.textContent = '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
+        }
+    }
+
+    function ensureEditorStartTimeInput() {
+        if (typeof document === 'undefined') return;
+        const urlField = document.getElementById('memoryUrlField');
+        const urlInput = document.getElementById('memoryUrlInput');
+        if (!urlField || !urlInput || document.getElementById('memoryStartTimeInput')) return;
+
+        const field = document.createElement('div');
+        field.className = 'editor-form-field editor-form-field-start-time';
+        field.id = 'memoryStartTimeField';
+        field.style.marginTop = '10px';
+
+        const label = document.createElement('label');
+        label.id = 'memoryStartTimeLabel';
+        label.className = 'editor-form-label';
+        label.setAttribute('for', 'memoryStartTimeInput');
+        label.textContent = '입덕 순간 시간';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.id = 'memoryStartTimeInput';
+        input.className = 'editor-form-input';
+        input.placeholder = '예: 1:23 또는 83초';
+        input.setAttribute('inputmode', 'text');
+
+        const hint = document.createElement('p');
+        hint.id = 'memoryStartTimeHint';
+        hint.className = 'editor-form-help';
+        hint.style.margin = '6px 0 0';
+        hint.style.fontSize = '12px';
+        hint.style.lineHeight = '1.6';
+        hint.style.color = 'var(--on-surface-variant)';
+        hint.textContent = '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
+
+        field.appendChild(label);
+        field.appendChild(input);
+        field.appendChild(hint);
+        urlField.insertAdjacentElement('afterend', field);
+
+        const resetStartState = () => {
+            editorStartTimeUserEdited = false;
+            lastKnownEditorStartSeconds = null;
+            input.value = '';
+            updateEditorStartPreview(null);
+        };
+
+        const syncFromUrl = () => {
+            const fromUrl = extractYouTubeStartSeconds(urlInput.value);
+            if (fromUrl && !editorStartTimeUserEdited) {
+                lastKnownEditorStartSeconds = fromUrl;
+                input.value = formatYouTubeStartTime(fromUrl);
+            } else if (!fromUrl && !editorStartTimeUserEdited) {
+                lastKnownEditorStartSeconds = null;
+                input.value = '';
+            }
+            updateEditorStartPreview(parseYouTubeTimeToSeconds(input.value) || fromUrl);
+        };
+
+        urlInput.addEventListener('input', syncFromUrl);
+        input.addEventListener('input', () => {
+            editorStartTimeUserEdited = true;
+            lastKnownEditorStartSeconds = parseYouTubeTimeToSeconds(input.value);
+            updateEditorStartPreview(lastKnownEditorStartSeconds);
+        });
+
+        const form = document.getElementById('addMemoryForm');
+        if (form && typeof MutationObserver !== 'undefined') {
+            const observer = new MutationObserver(() => {
+                if (form.classList.contains('is-open')) resetStartState();
+            });
+            observer.observe(form, { attributes: true, attributeFilter: ['class'] });
+        }
+    }
+
+    function initEditorStartTimeEnhancement() {
+        ensureEditorStartTimeInput();
+    }
+
     // 전역 노출
     window.LoveBudMedia = {
         extractYouTubeId,
@@ -183,5 +294,13 @@
         detectSourceType
     };
 
-    console.log('[LoveBudMedia] Media utilities loaded v20260424-1');
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initEditorStartTimeEnhancement);
+        } else {
+            initEditorStartTimeEnhancement();
+        }
+    }
+
+    console.log('[LoveBudMedia] Media utilities loaded v20260424-2');
 })();

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -10,8 +10,6 @@
 
     const MAX_YOUTUBE_START_SECONDS = 12 * 60 * 60;
 
-    let editorStartTimeUserEdited = false;
-    let lastKnownEditorStartSeconds = null;
 
     /**
      * YouTube URL에서 비디오 ID 추출

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -1,12 +1,14 @@
 /**
  * LoveBud 미디어 유틸리티
- * v20260418-1
+ * v20260424-1
  *
  * YouTube 및 기타 미디어 소스 처리 유틸리티
  */
 
 (function() {
     'use strict';
+
+    const MAX_YOUTUBE_START_SECONDS = 12 * 60 * 60;
 
     /**
      * YouTube URL에서 비디오 ID 추출
@@ -15,21 +17,111 @@
      */
     function extractYouTubeId(url) {
         if (!url || typeof url !== 'string') return null;
-        const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#\&\?]*).*/;
+        const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|shorts\/|live\/|watch\?v=|&v=)([^#\&\?]*).*/;
         const match = url.match(regExp);
         return (match && match[2].length === 11) ? match[2] : null;
+    }
+
+    /**
+     * YouTube 시간 문자열을 초 단위로 변환
+     * 지원 예: 83, 83초, 1:23, 01:23, 1m23s, 2h1m3s
+     * @param {string|number} value
+     * @returns {number|null}
+     */
+    function parseYouTubeTimeToSeconds(value) {
+        if (value === null || value === undefined) return null;
+        const raw = String(value).trim().toLowerCase();
+        if (!raw) return null;
+
+        const normalized = raw
+            .replace(/초/g, 's')
+            .replace(/분/g, 'm')
+            .replace(/시간/g, 'h')
+            .replace(/\s+/g, '');
+
+        if (!normalized || normalized.startsWith('-')) return null;
+
+        let seconds = null;
+
+        if (/^\d+(?::\d{1,2}){1,2}$/.test(normalized)) {
+            const parts = normalized.split(':').map((part) => Number(part));
+            if (parts.some((part) => !Number.isFinite(part) || part < 0)) return null;
+            if (parts.length === 2) {
+                seconds = (parts[0] * 60) + parts[1];
+            } else if (parts.length === 3) {
+                seconds = (parts[0] * 3600) + (parts[1] * 60) + parts[2];
+            }
+        } else if (/^\d+$/.test(normalized)) {
+            seconds = Number(normalized);
+        } else {
+            const timeMatch = normalized.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?$/);
+            if (timeMatch && (timeMatch[1] || timeMatch[2] || timeMatch[3])) {
+                seconds = (Number(timeMatch[1] || 0) * 3600) +
+                    (Number(timeMatch[2] || 0) * 60) +
+                    Number(timeMatch[3] || 0);
+            }
+        }
+
+        if (!Number.isFinite(seconds) || seconds < 0) return null;
+        seconds = Math.floor(seconds);
+        if (seconds <= 0 || seconds > MAX_YOUTUBE_START_SECONDS) return null;
+        return seconds;
+    }
+
+    /**
+     * YouTube URL의 t/start 파라미터에서 시작 시간을 추출
+     * @param {string} url
+     * @returns {number|null}
+     */
+    function extractYouTubeStartSeconds(url) {
+        if (!url || typeof url !== 'string') return null;
+        try {
+            const parsed = new URL(url.trim());
+            const searchValue = parsed.searchParams.get('t') || parsed.searchParams.get('start');
+            const hashParams = new URLSearchParams((parsed.hash || '').replace(/^#/, ''));
+            const hashValue = hashParams.get('t') || hashParams.get('start');
+            return parseYouTubeTimeToSeconds(searchValue || hashValue);
+        } catch (e) {
+            const hashMatch = url.match(/[#&?](?:t|start)=([^&#]+)/i);
+            return parseYouTubeTimeToSeconds(hashMatch ? decodeURIComponent(hashMatch[1]) : '');
+        }
+    }
+
+    /**
+     * 초 단위 시간을 사람이 읽는 시간 문자열로 변환
+     * @param {number} seconds
+     * @returns {string}
+     */
+    function formatYouTubeStartTime(seconds) {
+        const safeSeconds = Number(seconds);
+        if (!Number.isFinite(safeSeconds) || safeSeconds <= 0) return '';
+        const whole = Math.floor(safeSeconds);
+        const hours = Math.floor(whole / 3600);
+        const minutes = Math.floor((whole % 3600) / 60);
+        const rest = whole % 60;
+        if (hours > 0) {
+            return `${hours}:${String(minutes).padStart(2, '0')}:${String(rest).padStart(2, '0')}`;
+        }
+        return `${minutes}:${String(rest).padStart(2, '0')}`;
     }
 
     /**
      * 임베드 URL 생성
      * @param {string} sourceUrl - 원본 URL
      * @param {string} type - 소스 타입 (현재 youtube만 지원)
+     * @param {object} options - 옵션 ({ startSeconds })
      * @returns {string|null} 임베드 URL
      */
-    function getEmbedUrl(sourceUrl, type = 'youtube') {
+    function getEmbedUrl(sourceUrl, type = 'youtube', options = {}) {
         if (type === 'youtube') {
             const videoId = extractYouTubeId(sourceUrl);
-            return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+            if (!videoId) return null;
+            const explicitStart = parseYouTubeTimeToSeconds(options?.startSeconds);
+            const urlStart = extractYouTubeStartSeconds(sourceUrl);
+            const startSeconds = explicitStart || urlStart;
+            const embedUrl = new URL(`https://www.youtube.com/embed/${videoId}`);
+            if (startSeconds) embedUrl.searchParams.set('start', String(startSeconds));
+            return embedUrl.toString();
         }
         return null;
     }
@@ -82,11 +174,14 @@
     // 전역 노출
     window.LoveBudMedia = {
         extractYouTubeId,
+        parseYouTubeTimeToSeconds,
+        extractYouTubeStartSeconds,
+        formatYouTubeStartTime,
         getEmbedUrl,
         getThumbnailUrl,
         validateSourceUrl,
         detectSourceType
     };
 
-    console.log('[LoveBudMedia] Media utilities loaded v20260418-1');
+    console.log('[LoveBudMedia] Media utilities loaded v20260424-1');
 })();

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -108,20 +108,11 @@
         return `${minutes}:${String(rest).padStart(2, '0')}`;
     }
 
-    function getEditorStartInputSeconds() {
-        if (typeof document === 'undefined') return null;
-        const input = document.getElementById('memoryStartTimeInput');
-        if (!input) return null;
-        return parseYouTubeTimeToSeconds(input.value);
-    }
-
     function resolveStartSeconds(sourceUrl, options = {}) {
-        const hasExplicitOption = options && Object.prototype.hasOwnProperty.call(options, 'startSeconds');
-        if (hasExplicitOption) return parseYouTubeTimeToSeconds(options.startSeconds);
-
-        const editorInputSeconds = getEditorStartInputSeconds();
-        if (editorStartTimeUserEdited) return editorInputSeconds;
-        return editorInputSeconds || extractYouTubeStartSeconds(sourceUrl);
+        if (options && Object.prototype.hasOwnProperty.call(options, 'startSeconds')) {
+            return parseYouTubeTimeToSeconds(options.startSeconds);
+        }
+        return extractYouTubeStartSeconds(sourceUrl);
     }
 
     /**
@@ -188,100 +179,6 @@
         return 'unknown';
     }
 
-    function updateEditorStartPreview(seconds) {
-        if (typeof document === 'undefined') return;
-        const hint = document.getElementById('memoryPreviewHint');
-        const startHint = document.getElementById('memoryStartTimeHint');
-        const formatted = formatYouTubeStartTime(seconds);
-        if (startHint) {
-            startHint.textContent = formatted
-                ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
-                : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
-        }
-        if (hint && formatted) {
-            hint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
-        } else if (hint) {
-            hint.textContent = '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
-        }
-    }
-
-    function ensureEditorStartTimeInput() {
-        if (typeof document === 'undefined') return;
-        const urlField = document.getElementById('memoryUrlField');
-        const urlInput = document.getElementById('memoryUrlInput');
-        if (!urlField || !urlInput || document.getElementById('memoryStartTimeInput')) return;
-
-        const field = document.createElement('div');
-        field.className = 'editor-form-field editor-form-field-start-time';
-        field.id = 'memoryStartTimeField';
-        field.style.marginTop = '10px';
-
-        const label = document.createElement('label');
-        label.id = 'memoryStartTimeLabel';
-        label.className = 'editor-form-label';
-        label.setAttribute('for', 'memoryStartTimeInput');
-        label.textContent = '입덕 순간 시간';
-
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.id = 'memoryStartTimeInput';
-        input.className = 'editor-form-input';
-        input.placeholder = '예: 1:23 또는 83초';
-        input.setAttribute('inputmode', 'text');
-
-        const hint = document.createElement('p');
-        hint.id = 'memoryStartTimeHint';
-        hint.className = 'editor-form-help';
-        hint.style.margin = '6px 0 0';
-        hint.style.fontSize = '12px';
-        hint.style.lineHeight = '1.6';
-        hint.style.color = 'var(--on-surface-variant)';
-        hint.textContent = '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
-
-        field.appendChild(label);
-        field.appendChild(input);
-        field.appendChild(hint);
-        urlField.insertAdjacentElement('afterend', field);
-
-        const resetStartState = () => {
-            editorStartTimeUserEdited = false;
-            lastKnownEditorStartSeconds = null;
-            input.value = '';
-            updateEditorStartPreview(null);
-        };
-
-        const syncFromUrl = () => {
-            const fromUrl = extractYouTubeStartSeconds(urlInput.value);
-            if (fromUrl && !editorStartTimeUserEdited) {
-                lastKnownEditorStartSeconds = fromUrl;
-                input.value = formatYouTubeStartTime(fromUrl);
-            } else if (!fromUrl && !editorStartTimeUserEdited) {
-                lastKnownEditorStartSeconds = null;
-                input.value = '';
-            }
-            updateEditorStartPreview(parseYouTubeTimeToSeconds(input.value) || fromUrl);
-        };
-
-        urlInput.addEventListener('input', syncFromUrl);
-        input.addEventListener('input', () => {
-            editorStartTimeUserEdited = true;
-            lastKnownEditorStartSeconds = parseYouTubeTimeToSeconds(input.value);
-            updateEditorStartPreview(lastKnownEditorStartSeconds);
-        });
-
-        const form = document.getElementById('addMemoryForm');
-        if (form && typeof MutationObserver !== 'undefined') {
-            const observer = new MutationObserver(() => {
-                if (form.classList.contains('is-open')) resetStartState();
-            });
-            observer.observe(form, { attributes: true, attributeFilter: ['class'] });
-        }
-    }
-
-    function initEditorStartTimeEnhancement() {
-        ensureEditorStartTimeInput();
-    }
-
     // 전역 노출
     window.LoveBudMedia = {
         extractYouTubeId,
@@ -294,13 +191,5 @@
         detectSourceType
     };
 
-    if (typeof document !== 'undefined') {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', initEditorStartTimeEnhancement);
-        } else {
-            initEditorStartTimeEnhancement();
-        }
-    }
-
-    console.log('[LoveBudMedia] Media utilities loaded v20260424-2');
+    console.log('[LoveBudMedia] Media utilities loaded v20260424-3 (pure)');
 })();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -117,6 +117,11 @@
                     <label id="memoryUrlLabel" class="editor-form-label">...</label>
                     <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
                 </div>
+                <div class="editor-form-field" id="memoryStartTimeField" style="margin-top: 10px;">
+                    <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">입덕 순간 시간</label>
+                    <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23 또는 83초" class="editor-form-input">
+                    <p id="memoryStartTimeHint" class="editor-form-help" style="margin: 6px 0 0; font-size: 12px; line-height: 1.6; color: var(--on-surface-variant);">유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.</p>
+                </div>
                 <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
                     <div class="memory-link-preview__thumb-wrap">
                         <img class="memory-link-preview__thumb" id="memoryPreviewThumb" alt="">


### PR DESCRIPTION
## Summary
- Adds YouTube start time support to the Editor memory form
- Parses YouTube `t` / `start` values from shared links
- Allows direct start time input such as `1:23` or `83초`
- Saves YouTube embed URLs with `?start=seconds`
- Keeps memory `timestamp` as the existing saved-date value

## Scope
Changed files only:
- `js/utils/media.js`
- `pages/editor.html`
- `js/editor/editor-memory-form.js`

## Implementation
- Keeps `js/utils/media.js` as a pure media utility
- Adds static start time UI to `pages/editor.html`
- Moves editor form state and start-time behavior into `js/editor/editor-memory-form.js`
- Uses `LoveBudMedia.getEmbedUrl(rawUrl, 'youtube', { startSeconds })`
- Hides or ignores the start time field in text mode

## Validation
- General YouTube URL: checked
- YouTube URL with `?t=83`: checked
- Direct input `1:23`: checked
- Invalid input such as `abc` / `-10`: checked
- Text mode save flow: checked
- `node --test tests/contracts/growing-trees-api-contract.test.js`: passed
- `npm run verify`: 114/116 passed; remaining failures are existing i18n key issues unrelated to this change

## Explicit exclusions
- No backend/API changes
- No Modal changes
- No DB schema changes
- No Search adapter/renderer changes
- No thumbnail fallback changes
- No sticky sidebar changes
- No `global.css` changes

## Review note
- `js/editor/editor-memory-form.js` has a relatively large diff because the start-time field state and form flow were made explicit. Please review for unintended formatting or line-ending churn before merge.