### PR TITLE
fix(api): block Vercel fallback for Modal-owned GET routes

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -130,6 +130,26 @@ function withUpstreamHeader(response, upstream) {
   });
 }
 
+function isModalOwnedGetRoute(request, env) {
+  if (request.method.toUpperCase() !== 'GET') return false;
+  const modalUrl = buildModalUrl(request, env || {});
+  return modalUrl !== null;
+}
+
+function buildModalUnavailableResponse() {
+  return new Response(
+    JSON.stringify({ error: 'Modal backend unavailable' }),
+    {
+      status: 503,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'x-lovebud-upstream': 'modal',
+        'x-lovebud-degraded': 'modal-unavailable'
+      }
+    }
+  );
+}
+
 async function tryModalRead(request, env) {
   if (request.method.toUpperCase() !== 'GET') return null;
 
@@ -166,6 +186,7 @@ export async function onRequest(context) {
   const { request, env } = context;
   const upstreamUrl = buildUpstreamUrl(request, env || {});
   const method = request.method.toUpperCase();
+  const isModalOwned = isModalOwnedGetRoute(request, env || {});
 
   if (isBrowseSummaryRequest(request)) {
     const cache = caches.default;
@@ -185,6 +206,10 @@ export async function onRequest(context) {
       }
       if (modalResponse) return modalResponse;
     } catch (error) {
+      if (isModalOwned) {
+        console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);
+        return buildModalUnavailableResponse();
+      }
       console.warn('[LoveBudCloudflareProxy] Modal read failed before response, falling back to Vercel', error);
     }
   } else {
@@ -192,6 +217,10 @@ export async function onRequest(context) {
       const modalResponse = await tryModalRead(request, env || {});
       if (modalResponse) return modalResponse;
     } catch (error) {
+      if (isModalOwned) {
+        console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);
+        return buildModalUnavailableResponse();
+      }
       console.warn('[LoveBudCloudflareProxy] Modal read failed before response, falling back to Vercel', error);
     }
   }


### PR DESCRIPTION
## Summary
- Prevents Modal-owned GET routes from silently falling back to Vercel when Modal is unavailable
- Returns explicit 503 JSON response with x-lovebud-upstream: modal and x-lovebud-degraded: modal-unavailable
- Preserves existing fallback behavior for unknown /api/* routes and non-GET catch-all requests
- Keeps summary cache-hit behavior unchanged

## Scope
Changed files only:
- unctions/api/[[path]].js

## Validation
- npm test executed
- Cloudflare proxy growing-trees tests passed
- Existing unrelated failures, if any, are not caused by this change

## Explicit exclusions
- No Modal backend changes
- No Netlify changes
- No Vercel changes
- No Cloudflare Dashboard env changes
- No docs changes
- No UI changes
- No global CSS changes