### PR TITLE
fix(api): guard browse summary cache to GET requests

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -3,6 +3,7 @@ function stripTrailingSlash(value) {
 }
 
 function isBrowseSummaryRequest(request) {
+  if (request.method.toUpperCase() !== 'GET') return false;
   const url = new URL(request.url);
   const path = url.pathname.replace(/\/+$/, '');
   return path === '/api/community/trees' && url.searchParams.get('view') === 'summary';


### PR DESCRIPTION
Restrict browse summary cache handling to GET requests only. Preserve existing GET behavior and allow unsupported methods to return the controlled 405 response. Scope is limited to functions/api/[[path]].js.