### PR TITLE
ui(search-detail): quiet-first public experience polish

### DIFF
--- a/js/i18n/i18n-detail.js
+++ b/js/i18n/i18n-detail.js
@@ -243,72 +243,72 @@
       en: 'Error occurred while saving the record'
     },
     'empty_memo_kicker': {
-      ko: '남겨진 마음',
-      en: 'Feeling left behind'
+      ko: '그때의 마음',
+      en: 'Feeling then'
     },
     'empty_memo_quote': {
       ko: '짧게 남은 장면 하나도 오래 머무는 마음이 될 수 있어요.',
       en: 'Even a brief scene can become a feeling that stays for a long time.'
     },
     'empty_memo_title': {
-      ko: '아직 길게 남겨진 메모는 없지만, 이 순간의 여운은 그대로 머물러 있어요.',
-      en: 'There may not be a long memo yet, but the afterglow of this moment still remains.'
+      ko: '아직 긴 메모는 없어요.',
+      en: 'No long note yet.'
     },
     'empty_memo_desc': {
-      ko: '짧은 장면 하나만으로도 시작되는 감정이 있어요. 이 러브트리는 그 조용한 시작까지 함께 감상하는 공간이에요.',
-      en: 'Some feelings begin with just a brief scene. This LoveTree is also a space for staying with that quiet beginning.'
+      ko: '이 장면의 여운이 남아 있어요.',
+      en: 'The afterglow of this scene remains.'
     },
     'connected_empty_kicker': {
-      ko: '이어질 다음 장면',
-      en: 'The next scene to follow'
+      ko: '이어진 순간들',
+      en: 'Connected moments'
     },
     'connected_empty_title': {
-      ko: '지금은 이 순간이 가장 또렷하게 남아 있어요.',
-      en: 'For now, this is the moment that remains most clearly.'
+      ko: '지금은 이 순간이 남아 있어요.',
+      en: 'For now, this moment remains.'
     },
     'connected_empty_desc': {
-      ko: '아직 같은 흐름의 다른 순간은 보이지 않지만, 이 장면 하나만으로도 트리의 분위기를 천천히 느껴볼 수 있어요.',
-      en: 'Other moments in the same flow may not appear yet, but this scene alone can still carry the mood of the tree.'
+      ko: '이어진 순간은 아직 없어요.',
+      en: 'No connected moments yet.'
     },
     'connected_single_moment_title': {
-      ko: '지금은 이 한 순간을 중심으로 감상하고 있어요.',
-      en: 'Right now, you are staying with this single moment.'
+      ko: '이 순간에서 시작된 마음',
+      en: 'The feeling that began here'
     },
     'connected_single_moment_desc': {
-      ko: '아직 트리 전체 흐름은 보이지 않지만, 이 장면 하나만으로도 남겨진 마음을 조용히 따라가 볼 수 있어요.',
-      en: 'The whole tree flow is not visible yet, but this one scene still lets you quietly follow the feeling left behind.'
+      ko: '이 장면에 남은 마음을 따라가고 있어요.',
+      en: 'Following the feeling left in this scene.'
     },
     'connected_temporarily_unavailable_title': {
-      ko: '이어진 다른 순간은 잠시 후 다시 또렷해질 거예요.',
-      en: 'The connected moments may become clear again shortly.'
+      ko: '이어진 순간을 불러오는 중이에요.',
+      en: 'Loading connected moments.'
     },
     'connected_temporarily_unavailable_desc': {
-      ko: '지금은 현재 장면을 중심으로 감상하고 있어요. 연결된 흐름은 잠시 후 다시 이어서 볼 수 있을 거예요.',
-      en: 'For now, stay with the current scene. The connected flow should return shortly.'
+      ko: '지금은 이 순간을 먼저 보고 있어요.',
+      en: 'For now, stay with this moment first.'
     },
     'connected_path_missing_title': {
-      ko: '아직 이 순간과 이어진 트리 흐름은 보이지 않아요.',
-      en: 'The tree flow connected to this moment is not visible yet.'
+      ko: '이어진 흐름이 아직 보이지 않아요.',
+      en: 'The connected flow is not visible yet.'
     },
     'connected_path_missing_desc': {
-      ko: '그래도 지금 보고 있는 장면 하나만으로도 이 러브트리의 분위기를 천천히 느껴볼 수 있어요.',
-      en: 'Even so, this single scene still lets you take in the mood of this LoveTree.'
+      ko: '지금은 이 장면부터 감상해요.',
+      en: 'Start with this scene for now.'
     },
     'connected_missing_cards_title': {
-      ko: '이 트리의 다른 순간은 아직 여기서 또렷하게 펼쳐지지 않았어요.',
-      en: 'The other moments in this tree are not fully unfolding here yet.'
+      ko: '이어진 순간들',
+      en: 'Connected moments'
     },
     'connected_missing_cards_desc_suffix': {
-      ko: '개의 순간이 이 트리에 남아 있지만, 지금은 현재 장면을 중심으로 감정의 흐름을 읽고 있어요.',
-      en: ' moments remain in this tree, but right now you are reading the flow around the current scene.'
+      ko: '개의 순간이 남아 있어요.',
+      en: ' moments remain.'
     },
     'connected_partial_tree_title': {
-      ko: '지금은 이 순간 주변의 흐름만 조용히 감상하고 있어요.',
-      en: 'For now, you are quietly viewing only the flow around this moment.'
+      ko: '이 순간 주변의 흐름',
+      en: 'Flow around this moment'
     },
     'connected_partial_tree_desc': {
-      ko: '트리 전체 맥락은 아직 흐릿하지만, 지금 보이는 장면과 이어질 감정의 여운은 차분히 따라가 볼 수 있어요.',
-      en: 'The full tree context is still blurred, but you can gently stay with the scene you have now and the feeling it leaves behind.'
+      ko: '지금 보이는 장면부터 따라가요.',
+      en: 'Follow from the scene visible now.'
     },
     'connected_relation_previous': {
       ko: '이전에 남겨진 순간',
@@ -335,16 +335,16 @@
       en: 'Continue with the original video'
     },
     'public_tree_view_chip': {
-      ko: '공개 러브트리 감상',
-      en: 'Viewing a public LoveTree'
+      ko: '러브트리 감상',
+      en: 'Viewing LoveTree'
     },
     'single_moment_view_chip': {
       ko: '한 순간 감상',
       en: 'Viewing a single moment'
     },
     'moment_centered_view_chip': {
-      ko: '지금은 이 순간 중심 감상',
-      en: 'Moment-centered viewing'
+      ko: '이 순간 감상',
+      en: 'Viewing this moment'
     },
     'public_tree_kicker': {
       ko: '공개 러브트리',
@@ -355,128 +355,128 @@
       en: 'A single preserved moment'
     },
     'moment_centered_kicker': {
-      ko: '지금은 이 순간 중심 감상',
+      ko: '이 순간 감상',
       en: 'Staying with this moment'
     },
     'public_tree_fallback_title': {
-      ko: '누군가의 러브트리를 감상하고 있어요',
-      en: 'You are viewing someone\'s LoveTree'
+      ko: '이 순간에서 시작된 마음',
+      en: 'The feeling that began here'
     },
     'public_tree_fallback_title_with_artist_suffix': {
-      ko: '에게 마음이 닿기 시작한 순간을 감상하고 있어요',
-      en: ' is the artist whose moment you are viewing as your heart begins to connect'
+      ko: '에서 시작된 마음',
+      en: ' is where this feeling began'
     },
     'single_moment_fallback_title': {
-      ko: '이 순간에 남겨진 마음을 감상하고 있어요',
-      en: 'You are staying with the feeling left in this moment'
+      ko: '이 순간에서 시작된 마음',
+      en: 'The feeling that began here'
     },
     'public_tree_desc_join': {
       ko: ' 안에서',
       en: ' contains '
     },
     'public_tree_desc_suffix': {
-      ko: '개의 순간으로 이어진 감정의 흐름을 따라가고 있어요.',
-      en: ' connected moments in an emotional flow.'
+      ko: '개의 이어진 장면들',
+      en: ' connected scenes.'
     },
     'public_tree_desc_fallback_with_memory_suffix': {
-      ko: '에서 시작된 마음을 따라가고 있어요.',
+      ko: '에서 시작된 마음',
       en: ' is where this feeling began.'
     },
     'single_moment_hero_desc': {
-      ko: '하나에 남겨진 감정을 따라가고 있어요.',
-      en: 'You are following the feeling left in this one moment.'
+      ko: '이어진 장면들',
+      en: 'Connected scenes'
     },
     'single_moment_hero_desc_fallback': {
-      ko: '지금 남아 있는 이 장면 하나를 중심으로 감상하고 있어요.',
-      en: 'You are staying with this single scene for now.'
+      ko: '이어진 장면들',
+      en: 'Connected scenes'
     },
     'tree_partial_hero_desc': {
-      ko: '지금 남아 있는 이 순간을 중심으로 감정의 결을 보고 있어요.',
-      en: 'You are staying with the emotional texture of the moment that remains here.'
+      ko: '이어진 장면들',
+      en: 'Connected scenes'
     },
     'public_tree_context_desc': {
       ko: '이 트리 안에서 남겨진 순간을 감상하고 있어요.',
       en: 'You are viewing a moment within this tree.'
     },
     'current_moment_kicker': {
-      ko: '지금 감상 중인 순간',
-      en: 'Current moment'
+      ko: '그때의 마음',
+      en: 'Feeling then'
     },
     'current_moment_side_summary': {
-      ko: '순간에 남겨진 마음을 천천히 읽어보세요.',
-      en: 'Take a moment to read the feeling left in this memory.'
+      ko: '그때의 마음을 읽어보세요.',
+      en: 'Read the feeling from then.'
     },
     'current_moment_side_summary_fallback': {
-      ko: '지금 이 순간에 남겨진 마음을 천천히 읽어보세요.',
-      en: 'Take a moment to read the feeling left here.'
+      ko: '그때의 마음을 읽어보세요.',
+      en: 'Read the feeling from then.'
     },
     'connected_flow_kicker': {
-      ko: '이어진 흐름',
-      en: 'Connected flow'
+      ko: '이어진 순간들',
+      en: 'Connected moments'
     },
     'single_moment_connected_kicker': {
       ko: '지금 머무는 장면',
       en: 'The scene you are staying with'
     },
     'connected_flow_title': {
-      ko: '이 트리의 이어진 기억',
-      en: 'More moments in this tree'
+      ko: '이어진 순간들',
+      en: 'Connected moments'
     },
     'single_moment_connected_title': {
-      ko: '지금은 이 순간을 중심으로 감상 중이에요',
-      en: 'Right now, you are staying with this moment'
+      ko: '이어진 순간들',
+      en: 'Connected moments'
     },
     'connected_flow_summary': {
-      ko: '이 공개 러브트리 안에서 함께 이어지는 순간을 따라가 보세요.',
-      en: 'Follow the connected moments that continue in this public LoveTree.'
+      ko: '함께 이어지는 순간들',
+      en: 'Connected moments'
     },
     'connected_flow_count_suffix': {
-      ko: '개의 순간 가운데 지금 장면과 함께 읽히는 기억을 이어서 살펴보세요.',
-      en: ' moments are part of this tree. Continue with the memories that read together with this scene.'
+      ko: '개의 순간이 이어져 있어요.',
+      en: ' moments are connected.'
     },
     'connected_flow_count_pending_suffix': {
-      ko: '개의 순간이 이 트리에 남아 있어요. 지금은 현재 장면을 중심으로 감정의 흐름을 읽고 있어요.',
-      en: ' moments remain in this tree. Right now you are reading the emotional flow around the current scene.'
+      ko: '개의 순간이 남아 있어요.',
+      en: ' moments remain.'
     },
     'connected_flow_empty_summary': {
-      ko: '지금은 이 순간이 가장 먼저 또렷하게 열려 있어요.',
-      en: 'For now, this moment is what opens most clearly.'
+      ko: '지금은 이 순간이 먼저 열려 있어요.',
+      en: 'For now, this moment opens first.'
     },
     'connected_flow_single_summary': {
-      ko: '지금은 이 장면 하나를 중심으로 감상하고 있어요.',
-      en: 'For now, you are staying with this one scene.'
+      ko: '지금은 이 장면 하나를 보고 있어요.',
+      en: 'For now, stay with this one scene.'
     },
     'single_moment_connected_summary': {
-      ko: '지금 남아 있는 이 장면과 마음부터 따라가 볼 수 있어요.',
-      en: 'You can begin with the scene and feeling that remain here.'
+      ko: '이 장면과 마음부터 따라가요.',
+      en: 'Start with this scene and feeling.'
     },
     'connected_flow_temporarily_unavailable_summary': {
-      ko: '지금은 이 순간 하나를 중심으로 감상하고 있어요.',
-      en: 'For now, you are staying with this single moment.'
+      ko: '지금은 이 순간을 먼저 보고 있어요.',
+      en: 'For now, stay with this moment first.'
     },
     'connected_flow_partial_tree_summary': {
-      ko: '지금 보이는 이 장면을 중심으로 감정의 결을 따라가고 있어요.',
-      en: 'You are following the emotional texture around the scene you have now.'
+      ko: '지금 보이는 장면부터 따라가요.',
+      en: 'Follow from the scene visible now.'
     },
     'public_tree_growth_label': {
-      ko: '공개 트리 감상 중',
-      en: 'Viewing public tree'
+      ko: '감정이 자라는 중',
+      en: 'Feeling growing'
     },
     'my_tree_growth_label': {
-      ko: '내 트리를 다시 감상 중',
-      en: 'Revisiting my tree'
+      ko: '감정이 자라는 중',
+      en: 'Feeling growing'
     },
     'editor_tree_growth_label': {
-      ko: '편집 트리를 감상 모드로 확인 중',
-      en: 'Reviewing edited tree in view mode'
+      ko: '감정이 자라는 중',
+      en: 'Feeling growing'
     },
     'single_moment_growth_label': {
-      ko: '한 순간 감상 중',
-      en: 'Viewing a single moment'
+      ko: '감정이 자라는 중',
+      en: 'Feeling growing'
     },
     'moment_centered_growth_label': {
-      ko: '지금은 이 순간 중심 감상 중',
-      en: 'Moment-centered viewing'
+      ko: '감정이 자라는 중',
+      en: 'Feeling growing'
     },
     'back_to_browse_soft': {
       ko: '둘러보기로 돌아가기',

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -14,8 +14,8 @@
       en: 'Browse LoveTrees'
     },
     'search.subtitle': {
-      ko: '다른 팬이 남긴 순간과 흐름을 따라가 보세요.',
-      en: 'Follow the moments and paths shared by other fans.'
+      ko: '조용히 자라는 마음들',
+      en: 'Quietly growing feelings'
     },
     'search.intentNote': {
       ko: '트리를 고르면 감상 허브가 바로 열립니다.',
@@ -36,71 +36,71 @@
       en: 'Choose a card to open it here.'
     },
     'search.previewPlaceholder': {
-      ko: '트리를 골라 감상하기',
-      en: 'Choose a tree to view'
+      ko: '아직 선택한 러브트리가 없어요.',
+      en: 'No LoveTree selected yet.'
     },
     'search.previewDescriptionPlaceholder': {
-      ko: '트리를 고르면 대표 순간과 이어진 감정이 이곳에 열립니다.',
-      en: 'Choose a tree to open the featured moment and connected feelings here.'
+      ko: '마음이 닿는 트리를 골라보세요.',
+      en: 'Choose a tree that draws you in.'
     },
     'search.previewEmptyLead': {
-      ko: '트리를 고르면',
-      en: 'When you choose a tree,'
+      ko: '아직 선택한 러브트리가 없어요.',
+      en: 'No LoveTree selected yet.'
     },
     'search.previewEmptyBody': {
-      ko: '대표 순간과 이어진 감정이 이곳에 열립니다.',
-      en: 'the featured moment and connected feelings open here.'
+      ko: '마음이 닿는 트리를 골라보세요.',
+      en: 'Choose a tree that draws you in.'
     },
     'search.previewNoMomentTitle': {
       ko: '아직 대표 순간이 또렷하게 남아 있지 않아요.',
       en: 'There is no clearly featured moment yet.'
     },
     'search.previewNoMomentBody': {
-      ko: '시작 순간이 더해지면 이 감상 허브에서 가장 먼저 열어볼 수 있어요.',
-      en: 'Once the starting moment is added, you will be able to open it here first.'
+      ko: '첫 순간이 더해지면 이곳에 열려요.',
+      en: 'It will open here once the first moment is added.'
     },
     'search.previewStartFromFirstMoment': {
       ko: '대표 순간부터 감상하기',
       en: 'Start from the featured moment'
     },
     'search.previewTimelineHeading': {
-      ko: '대표 순간에서 이어진 흐름',
-      en: 'Flow connected from the featured moment'
+      ko: '이어진 흐름',
+      en: 'Connected flow'
     },
     'search.previewTimelineEmpty': {
-      ko: '아직 시작 순간이 남아 있지 않아 흐름이 비어 있어요.',
-      en: 'The flow is still empty because the starting moment has not been saved yet.'
+      ko: '아직 이어진 순간이 없어요.',
+      en: 'No connected moments yet.'
     },
     'search.previewTimelineEmptyBody': {
-      ko: '첫 순간이 더해지면 이 패널에서 대표 순간과 흐름을 바로 볼 수 있어요.',
-      en: 'Once the first moment is added, you will be able to see the featured moment and flow in this panel.'
+      ko: '첫 순간이 더해지면 이곳에 흐름이 놓여요.',
+      en: 'The flow will appear here once the first moment is added.'
     },
     'search.previewNoRecordsYet': {
       ko: '아직 남아 있는 순간은 없지만',
       en: 'There are no saved moments yet, but'
     },
     'search.previewNoRecordsFollowup': {
-      ko: '다음 순간이 이어지면 이곳에서 흐름이 함께 열려요.',
-      en: 'when the next moment is added, the flow will open here together.'
+      ko: '다음 순간이 이어지면 이곳에서 흐름이 열려요.',
+      en: 'when the next moment is added, the flow will open here.'
     },
     'search.previewNoRecordsLine': {
       ko: '{countLabel} {followup}',
       en: '{countLabel} {followup}'
     },
     'search.previewNewTreeInfo': {
-      ko: '이제 막 감상이 시작될 공개 러브트리예요.',
-      en: 'This public LoveTree is just about to begin.'
+      ko: '막 자라기 시작한 러브트리예요.',
+      en: 'This LoveTree has just begun to grow.'
     },
     'search.previewJourneyCta': {
-      ko: '이곳에서 대표 순간과 이어진 감정을 훑어보고, 마음이 머무는 순간으로 들어가 보세요.',
-      en: 'Scan the featured moment and connected feelings here, then open the moment that draws you in.'
+      ko: '마음이 머무는 순간으로 들어가 보세요.',
+      en: 'Open the moment that draws you in.'
     },
     'search.previewMomentCountSuffix': {
       ko: '개의 순간',
       en: ' moments'
     },
     'search.previewDurationPending': {
-      ko: '시작 순간을 기다리는 중',
+      ko: '첫 순간을 기다리는 중',
       en: 'Waiting for the first moment'
     },
     'search.previewStatsPending': {
@@ -128,7 +128,7 @@
       en: 'First saved on'
     },
     'search.previewTimelineUnavailable': {
-      ko: '아직 시작 순간을 기다리는 중이에요',
+      ko: '아직 첫 순간을 기다리는 중이에요',
       en: 'Still waiting for the first moment'
     },
     'search.previewDefaultTreeName': {
@@ -148,12 +148,12 @@
       en: 'Open this tree'
     },
     'search.previewSummaryThemeStart': {
-      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 공개 러브트리예요.',
-      en: '<strong style="color:var(--on-surface);">{title}</strong> is a public LoveTree that has just begun with <strong style="color:var(--on-surface);">{theme}</strong>.'
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 러브트리예요.',
+      en: '<strong style="color:var(--on-surface);">{title}</strong> has just begun with <strong style="color:var(--on-surface);">{theme}</strong>.'
     },
     'search.previewSummaryStart': {
-      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 공개 러브트리예요.',
-      en: '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.'
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 러브트리예요.',
+      en: '<strong style="color:var(--on-surface);">{title}</strong> has just begun.'
     },
     'search.previewSummaryThemeRange': {
       ko: '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 <strong>{range}</strong>에 걸쳐 이어졌어요.',
@@ -164,40 +164,40 @@
       en: '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> continued across <strong>{range}</strong>.'
     },
     'search.previewLoadingLead': {
-      ko: '이 트리의 대표 순간과 이어진 감정을 불러오는 중이에요.',
-      en: 'Loading the featured moment and connected feelings of this tree.'
+      ko: '이 트리의 대표 순간을 불러오는 중이에요.',
+      en: 'Loading the featured moment of this tree.'
     },
     'search.previewLoadingHeading': {
       ko: '감상 허브를 여는 중',
       en: 'Opening the preview hub'
     },
     'search.previewLoadingBody': {
-      ko: '선택한 트리의 대표 순간과 이어진 감정을 이곳에서 먼저 보여드릴게요.',
-      en: 'The featured moment and connected feelings of this tree will appear here first.'
+      ko: '선택한 트리의 대표 순간이 이곳에 열려요.',
+      en: 'The featured moment of this tree will open here.'
     },
 
     // 검색 입력
     'search.placeholder': {
-      ko: '예: 첫 설렘 · 아티스트명 · 감정 태그',
-      en: 'e.g., first spark, artist, emotion tag'
+      ko: '아티스트, 첫 순간, 감정으로 찾아보기',
+      en: 'Search by artist, first moment, or feeling'
     },
 
     // 필터
     'search.filter.all': {
-      ko: '전체 경로',
-      en: 'All Paths'
+      ko: '전체',
+      en: 'All'
     },
     'search.filter.newbie': {
-      ko: '시작 순간 중심',
-      en: 'Starting Moments'
+      ko: '첫 순간',
+      en: 'First moment'
     },
     'search.filter.growing': {
-      ko: '이어진 감정',
-      en: 'Connected Feelings'
+      ko: '이어진 마음',
+      en: 'Connected feelings'
     },
     'search.filter.fan': {
       ko: '깊어진 마음',
-      en: 'Deepened Affection'
+      en: 'Deepened feelings'
     },
 
     // 기타

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -18,8 +18,8 @@
       en: 'Quietly growing feelings'
     },
     'search.intentNote': {
-      ko: '트리를 고르면 감상 허브가 바로 열립니다.',
-      en: 'Choose a tree to open the viewing hub.'
+      ko: '트리를 고르면 열려요.',
+      en: 'Choose a tree to open it.'
     },
 
     // 미리보기
@@ -32,8 +32,8 @@
       en: 'Selected Tree'
     },
     'search.previewKicker': {
-      ko: '카드를 고르면 이곳에서 바로 감상할 수 있어요.',
-      en: 'Choose a card to open it here.'
+      ko: '트리를 고르면 열려요.',
+      en: 'Choose a tree to open it.'
     },
     'search.previewPlaceholder': {
       ko: '아직 선택한 러브트리가 없어요.',
@@ -52,12 +52,12 @@
       en: 'Choose a tree that draws you in.'
     },
     'search.previewNoMomentTitle': {
-      ko: '아직 대표 순간이 또렷하게 남아 있지 않아요.',
-      en: 'There is no clearly featured moment yet.'
+      ko: '아직 대표 순간이 없어요.',
+      en: 'No featured moment yet.'
     },
     'search.previewNoMomentBody': {
-      ko: '첫 순간이 더해지면 이곳에 열려요.',
-      en: 'It will open here once the first moment is added.'
+      ko: '첫 순간이 더해지면 열려요.',
+      en: 'It opens once the first moment is added.'
     },
     'search.previewStartFromFirstMoment': {
       ko: '대표 순간부터 감상하기',
@@ -72,16 +72,16 @@
       en: 'No connected moments yet.'
     },
     'search.previewTimelineEmptyBody': {
-      ko: '첫 순간이 더해지면 이곳에 흐름이 놓여요.',
-      en: 'The flow will appear here once the first moment is added.'
+      ko: '첫 순간이 더해지면 놓여요.',
+      en: 'The flow appears once the first moment is added.'
     },
     'search.previewNoRecordsYet': {
-      ko: '아직 남아 있는 순간은 없지만',
+      ko: '아직 남은 순간은 없지만',
       en: 'There are no saved moments yet, but'
     },
     'search.previewNoRecordsFollowup': {
-      ko: '다음 순간이 이어지면 이곳에서 흐름이 열려요.',
-      en: 'when the next moment is added, the flow will open here.'
+      ko: '다음 순간이 이어지면 열려요.',
+      en: 'when the next moment is added, it opens here.'
     },
     'search.previewNoRecordsLine': {
       ko: '{countLabel} {followup}',
@@ -92,8 +92,8 @@
       en: 'This LoveTree has just begun to grow.'
     },
     'search.previewJourneyCta': {
-      ko: '마음이 머무는 순간으로 들어가 보세요.',
-      en: 'Open the moment that draws you in.'
+      ko: '마음이 닿는 순간으로',
+      en: 'To the moment that draws you in'
     },
     'search.previewMomentCountSuffix': {
       ko: '개의 순간',
@@ -104,8 +104,8 @@
       en: 'Waiting for the first moment'
     },
     'search.previewStatsPending': {
-      ko: '대표 순간이 열리면 함께 보여드릴게요',
-      en: 'This will appear once the featured moment opens.'
+      ko: '열리면 함께 보여요',
+      en: 'Appears when it opens.'
     },
     'search.previewEmotionTagsLabel': {
       ko: '이어진 감정',
@@ -113,7 +113,7 @@
     },
     'search.previewNoEmotionTags': {
       ko: '아직 이어진 감정은 없어요.',
-      en: 'There are no clearly saved emotions yet.'
+      en: 'No saved emotions yet.'
     },
     'search.previewTimelineRecentUpdate': {
       ko: '최근에 이어진 감정',
@@ -164,16 +164,16 @@
       en: '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> continued across <strong>{range}</strong>.'
     },
     'search.previewLoadingLead': {
-      ko: '이 트리의 대표 순간을 불러오는 중이에요.',
-      en: 'Loading the featured moment of this tree.'
+      ko: '대표 순간을 불러오는 중이에요.',
+      en: 'Loading the featured moment.'
     },
     'search.previewLoadingHeading': {
       ko: '감상 허브를 여는 중',
       en: 'Opening the preview hub'
     },
     'search.previewLoadingBody': {
-      ko: '선택한 트리의 대표 순간이 이곳에 열려요.',
-      en: 'The featured moment of this tree will open here.'
+      ko: '대표 순간이 열려요.',
+      en: 'The featured moment opens here.'
     },
 
     // 검색 입력

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -43,7 +43,7 @@
             gap: 6px;
             padding: 8px 14px;
             border-radius: 999px;
-            background: rgba(255,255,255,0.78);
+            background: rgba(255,255,255,0.74);
             border: 1px solid rgba(144, 73, 81, 0.08);
             color: var(--on-surface-variant);
             font-size: 12px;
@@ -58,13 +58,13 @@
         .detail-hero {
             display: flex;
             flex-direction: column;
-            gap: 10px;
+            gap: 8px;
             margin-bottom: 16px;
-            padding: 18px 22px;
-            border-radius: 1.35rem;
-            background: linear-gradient(135deg, rgba(255,255,255,0.92), rgba(249,245,242,0.94));
-            border: 1px solid rgba(144, 73, 81, 0.08);
-            box-shadow: 0 10px 24px rgba(75, 64, 57, 0.04);
+            padding: 16px 20px;
+            border-radius: 1.3rem;
+            background: linear-gradient(135deg, rgba(255,255,255,0.88), rgba(249,245,242,0.9));
+            border: 1px solid rgba(144, 73, 81, 0.07);
+            box-shadow: 0 8px 18px rgba(75, 64, 57, 0.035);
         }
 
         .detail-hero-kicker {
@@ -80,16 +80,16 @@
 
         .detail-hero-title {
             margin: 0;
-            font-size: 1.95rem;
+            font-size: 1.9rem;
             line-height: 1.15;
             color: var(--on-surface);
         }
 
         .detail-hero-desc {
             margin: 0;
-            max-width: 680px;
-            font-size: 0.94rem;
-            line-height: 1.62;
+            max-width: 620px;
+            font-size: 0.93rem;
+            line-height: 1.5;
             color: var(--on-surface-variant);
         }
 
@@ -114,6 +114,7 @@
             flex-direction: column;
             gap: 12px;
             padding: 6px 0 0;
+            min-width: 0;
         }
 
         .detail-side-kicker {
@@ -140,6 +141,7 @@
 
         .detail-main-media {
             margin-bottom: 0;
+            min-width: 0;
         }
 
         .video-main {
@@ -148,7 +150,7 @@
             background: #000;
             border-radius: 2rem;
             overflow: hidden;
-            box-shadow: 0 28px 72px -20px rgba(0,0,0,0.18);
+            box-shadow: 0 22px 54px -22px rgba(0,0,0,0.16);
             margin-bottom: 16px;
         }
 
@@ -180,10 +182,10 @@
         }
 
         .diary-container {
-            background: white;
-            padding: 34px 38px;
+            background: rgba(255,255,255,0.94);
+            padding: 32px 36px;
             border-radius: 1.8rem;
-            box-shadow: 0 14px 40px rgba(0,0,0,0.04);
+            box-shadow: 0 12px 32px rgba(0,0,0,0.035);
             border: 1px solid rgba(144,73,81,0.06);
             position: relative;
             overflow: hidden;
@@ -194,15 +196,16 @@
             position: absolute;
             top: 16px;
             left: 24px;
-            font-size: 104px;
+            font-size: 88px;
             font-family: var(--font-heading);
             color: var(--primary);
-            opacity: 0.05;
+            opacity: 0.04;
             line-height: 1;
         }
 
         .connected-section {
             margin-top: 10px;
+            min-width: 0;
         }
 
         .connected-section.is-empty .growth-visualization,
@@ -228,7 +231,7 @@
 
         .connected-section h3 {
             margin: 0;
-            font-size: 1.6rem;
+            font-size: 1.55rem;
             font-weight: 800;
             line-height: 1.18;
         }
@@ -236,27 +239,28 @@
         .connected-summary {
             margin: 0;
             color: var(--on-surface-variant);
-            font-size: 0.92rem;
-            line-height: 1.55;
-            max-width: 620px;
+            font-size: 0.9rem;
+            line-height: 1.48;
+            max-width: 560px;
         }
 
         .moment-card {
-            background: white;
+            background: rgba(255,255,255,0.94);
             padding: 18px;
             border-radius: 1.55rem;
             border: 1px solid rgba(0,0,0,0.03);
-            box-shadow: 0 10px 28px rgba(0,0,0,0.02);
+            box-shadow: 0 9px 24px rgba(0,0,0,0.018);
             display: flex;
             gap: 18px;
             align-items: center;
             margin-bottom: 16px;
             transition: all 0.3s;
             cursor: pointer;
+            min-width: 0;
         }
 
         .moment-card:hover {
-            transform: translateY(-4px);
+            transform: translateY(-2px);
             border-color: var(--outline-variant);
             box-shadow: var(--shadow-whisper);
         }
@@ -265,13 +269,13 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            margin-top: 30px;
+            margin-top: 28px;
         }
 
         .growth-line {
-            width: 4px; height: 48px;
+            width: 4px; height: 44px;
             background: linear-gradient(to bottom, var(--primary), var(--secondary));
-            opacity: 0.18;
+            opacity: 0.16;
             border-radius: 99px;
             margin-bottom: 10px;
         }
@@ -294,9 +298,9 @@
         @media (max-width: 768px) {
             .detail-page-shell { padding: 16px 16px 30px; }
             .detail-topbar { align-items: flex-start; flex-direction: column; margin-bottom: 12px; }
-            .detail-hero { padding: 16px 16px; border-radius: 1.2rem; margin-bottom: 14px; gap: 8px; }
-            .detail-hero-title { font-size: 1.55rem; line-height: 1.2; }
-            .detail-hero-desc { font-size: 0.9rem; line-height: 1.55; }
+            .detail-hero { padding: 15px 16px; border-radius: 1.2rem; margin-bottom: 14px; gap: 7px; }
+            .detail-hero-title { font-size: 1.5rem; line-height: 1.2; }
+            .detail-hero-desc { font-size: 0.88rem; line-height: 1.5; }
             .detail-layout { gap: 22px; }
             .detail-title-block { gap: 10px; }
             .detail-title-main { font-size: 1.85rem; line-height: 1.16; }
@@ -305,7 +309,7 @@
             .moment-card { padding: 14px; gap: 14px; }
             .moment-card img { width: 60px !important; height: 60px !important; }
             .growth-visualization { margin-top: 24px; }
-            #connectedFragments { grid-template-columns: 1fr !important; gap: 14px !important; }
+            #connectedFragments { grid-template-columns: 1fr !important; gap: 14px !important; min-width: 0; }
         }
     </style>
 </head>
@@ -327,8 +331,8 @@
 
         <section id="detailHero" class="detail-hero">
             <div id="detailHeroKicker" class="detail-hero-kicker">&nbsp;</div>
-            <h2 id="detailHeroTitle" class="headline detail-hero-title">...</h2>
-            <p id="detailHeroDesc" class="detail-hero-desc">...</p>
+            <h2 id="detailHeroTitle" class="headline detail-hero-title">이 순간에서 시작된 마음</h2>
+            <p id="detailHeroDesc" class="detail-hero-desc">이어진 장면들</p>
             <div id="treeContext"></div>
         </section>
 
@@ -350,7 +354,7 @@
 
                 <section class="diary-section">
                     <div class="detail-title-block">
-                        <p id="detailSubtitle" class="detail-side-kicker">&nbsp;</p>
+                        <p id="detailSubtitle" class="detail-side-kicker">그때의 마음</p>
                         <h1 class="headline detail-title-main" id="memoryTitle">&nbsp;</h1>
                         <div class="detail-tag-row">
                             <div class="tags-container" id="tagsContainer"></div>
@@ -368,7 +372,7 @@
                 <div class="connected-section">
                     <div class="connected-heading">
                         <span id="connectedKicker" class="connected-kicker">&nbsp;</span>
-                        <h3 id="connectedTitle" class="headline">&nbsp;</h3>
+                        <h3 id="connectedTitle" class="headline">이어진 순간들</h3>
                         <p id="connectedSummary" class="connected-summary">&nbsp;</p>
                     </div>
                     <div id="connectedFragments" style="display: grid; grid-template-columns: 1fr; gap: 16px;"></div>
@@ -377,7 +381,7 @@
                 <div class="growth-visualization">
                     <div class="growth-line"></div>
                     <div class="growth-dot"></div>
-                    <p id="growthLabel" style="margin-top: 14px; font-weight: 800; color: var(--primary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;">&nbsp;</p>
+                    <p id="growthLabel" style="margin-top: 14px; font-weight: 800; color: var(--primary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;">감정이 자라는 중</p>
                 </div>
             </aside>
         </main>

--- a/pages/search.html
+++ b/pages/search.html
@@ -12,14 +12,14 @@
         .search-container {
             max-width: var(--page-work-max);
             margin: 0 auto;
-            padding: 30px 40px 60px;
+            padding: 28px 40px 58px;
             display: grid;
             grid-template-columns: minmax(0, 1.62fr) 420px;
-            gap: 36px;
+            gap: 34px;
         }
 
         .browse-curation-shell {
-            margin-bottom: 24px;
+            margin-bottom: 20px;
             padding: 0;
             background: transparent;
             border: 0;
@@ -27,7 +27,7 @@
         }
 
         .search-panel-header {
-            margin-bottom: 14px;
+            margin-bottom: 10px;
         }
 
         .search-panel-eyebrow {
@@ -45,18 +45,18 @@
         }
 
         .search-panel-header h2 {
-            font-size: clamp(2.4rem, 4.4vw, 3.55rem);
-            margin-bottom: 10px;
+            font-size: clamp(2.28rem, 4.2vw, 3.4rem);
+            margin-bottom: 8px;
             line-height: 1.04;
             letter-spacing: -0.035em;
         }
 
         .search-panel-header p {
             color: var(--on-surface-variant);
-            font-size: 1rem;
+            font-size: 0.98rem;
             font-weight: 400;
-            line-height: 1.7;
-            max-width: 460px;
+            line-height: 1.55;
+            max-width: 420px;
             margin: 0;
         }
 
@@ -65,10 +65,12 @@
             margin-bottom: 0;
             max-width: 420px;
             flex: 1 1 auto;
+            min-width: 0;
         }
 
         .search-input {
             width: 100%;
+            box-sizing: border-box;
             padding: 15px 18px 15px 48px;
             border-radius: 999px;
             border: 1px solid rgba(144, 73, 81, 0.09);
@@ -130,6 +132,7 @@
             margin-bottom: 0;
             flex-wrap: wrap;
             justify-content: flex-end;
+            min-width: 0;
         }
 
         .browse-utility-row {
@@ -138,6 +141,7 @@
             justify-content: space-between;
             gap: 16px;
             margin-top: 18px;
+            min-width: 0;
         }
 
         .browse-guidance-strip {
@@ -189,40 +193,41 @@
             grid-template-columns: repeat(3, minmax(0, 1fr));
             gap: 18px;
             align-items: stretch;
+            min-width: 0;
         }
 
         /* Growing Trees Section */
         .growing-trees-section {
-            margin-top: 56px;
-            margin-bottom: 48px;
-            padding: 32px;
-            background: rgba(255, 255, 255, 0.4);
-            border: 1px solid rgba(144, 73, 81, 0.08);
+            margin-top: 50px;
+            margin-bottom: 44px;
+            padding: 28px;
+            background: rgba(255, 255, 255, 0.34);
+            border: 1px solid rgba(144, 73, 81, 0.07);
             border-radius: 2rem;
-            box-shadow: inset 0 0 40px rgba(255, 255, 255, 0.5);
+            box-shadow: inset 0 0 32px rgba(255, 255, 255, 0.42);
         }
 
         .growing-trees-head {
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 24px;
+            margin-bottom: 22px;
             gap: 16px;
         }
 
         .growing-trees-head h3 {
-            font-size: 1.55rem;
+            font-size: 1.5rem;
             font-weight: 800;
-            margin-bottom: 8px;
+            margin-bottom: 6px;
             color: var(--on-surface);
             letter-spacing: -0.025em;
         }
 
         .growing-trees-head p {
             color: var(--on-surface-variant);
-            font-size: 0.95rem;
+            font-size: 0.94rem;
             margin: 0;
-            line-height: 1.6;
+            line-height: 1.48;
         }
 
         .growing-trees-badge {
@@ -250,7 +255,8 @@
             cursor: pointer;
             position: relative;
             overflow: hidden;
-            box-shadow: 0 18px 36px rgba(75, 64, 57, 0.05);
+            box-shadow: 0 16px 32px rgba(75, 64, 57, 0.045);
+            min-width: 0;
         }
 
         .tree-card::before {
@@ -266,14 +272,14 @@
         }
 
         .tree-card:hover {
-            transform: translateY(-4px);
+            transform: translateY(-2px);
             border-color: rgba(144,73,81,0.14);
-            box-shadow: 0 24px 44px rgba(144, 73, 81, 0.08);
+            box-shadow: 0 20px 38px rgba(144, 73, 81, 0.07);
         }
 
         .tree-card.is-active {
             border-color: rgba(144, 73, 81, 0.18);
-            box-shadow: 0 24px 48px rgba(144, 73, 81, 0.12);
+            box-shadow: 0 22px 42px rgba(144, 73, 81, 0.10);
         }
 
         .tree-card:hover::before,
@@ -333,6 +339,7 @@
             gap: 10px;
             padding: 4px 6px 6px;
             height: 100%;
+            min-width: 0;
         }
 
         .tree-title {
@@ -391,11 +398,12 @@
             position: sticky;
             top: 96px;
             height: fit-content;
-            background: rgba(255,255,255,0.9);
-            padding: 28px 24px;
+            background: rgba(255,255,255,0.88);
+            padding: 26px 22px;
             border-radius: 2rem;
-            border: 1px solid rgba(144, 73, 81, 0.10);
-            box-shadow: 0 22px 54px rgba(75, 64, 57, 0.08);
+            border: 1px solid rgba(144, 73, 81, 0.09);
+            box-shadow: 0 18px 42px rgba(75, 64, 57, 0.06);
+            min-width: 0;
         }
 
         .preview-sidebar h3 {
@@ -413,10 +421,11 @@
             align-items: center;
             justify-content: space-between;
             margin-bottom: 10px;
+            min-width: 0;
         }
 
         .preview-panel-header h3 {
-            font-size: 1.76rem;
+            font-size: 1.68rem;
             font-weight: 900;
             color: var(--on-surface);
             margin: 0;
@@ -427,6 +436,7 @@
             display: flex;
             align-items: center;
             gap: 10px;
+            min-width: 0;
         }
 
         .preview-mobile-close {
@@ -456,6 +466,7 @@
             background: rgba(144, 73, 81, 0.08);
             padding: 6px 11px;
             border-radius: 99px;
+            white-space: nowrap;
         }
 
         .preview-empty-state {
@@ -551,17 +562,17 @@
             }
 
             .browse-curation-shell {
-                margin-bottom: 18px;
+                margin-bottom: 16px;
             }
 
             .search-panel-header h2 {
-                font-size: 2.05rem;
+                font-size: 2.0rem;
                 line-height: 1.08;
-                margin-bottom: 8px;
+                margin-bottom: 7px;
             }
 
             .search-panel-header p {
-                font-size: 0.95rem;
+                font-size: 0.94rem;
                 max-width: 100%;
             }
 
@@ -578,6 +589,18 @@
             #resultsList,
             #growingTreesList {
                 grid-template-columns: 1fr;
+            }
+
+            .growing-trees-section {
+                padding: 22px 16px;
+                margin-top: 40px;
+                border-radius: 1.6rem;
+            }
+
+            .growing-trees-head {
+                flex-direction: column;
+                margin-bottom: 18px;
+                gap: 10px;
             }
 
             .preview-sidebar {
@@ -604,7 +627,7 @@
             }
 
             .preview-panel-header h3 {
-                font-size: 1.45rem;
+                font-size: 1.42rem;
             }
 
             .preview-mobile-close {
@@ -644,7 +667,7 @@
             <div class="browse-curation-shell">
                 <div class="search-panel-header">
                     <h2 class="headline" data-i18n="search.title">러브트리 둘러보기</h2>
-                    <p data-i18n="search.subtitle">다른 팬이 남긴 첫 순간을 살펴보세요.</p>
+                    <p data-i18n="search.subtitle">조용히 자라는 마음들</p>
                 </div>
             </div>
 
@@ -657,9 +680,9 @@
                 <div class="growing-trees-head">
                     <div>
                         <h3>새로 자라는 러브트리</h3>
-                        <p>최근 마음이 더해지기 시작한 공개 러브트리예요.</p>
+                        <p>막 자라기 시작한 마음들</p>
                     </div>
-                    <span class="growing-trees-badge">1~2개의 순간</span>
+                    <span class="growing-trees-badge">자라는 중</span>
                 </div>
                 <div id="growingTreesList">
                     <!-- Populated by JS -->
@@ -669,13 +692,13 @@
             <div class="browse-utility-row">
                 <div class="search-input-wrapper">
                     <span class="material-symbols-outlined search-icon">search</span>
-                    <input type="text" id="searchInput" class="search-input" placeholder="예: 첫 설렘 · 아티스트명 · 감정 태그" required>
+                    <input type="text" id="searchInput" class="search-input" placeholder="아티스트, 첫 순간, 감정으로 찾아보기" required>
                 </div>
 
                 <div class="filter-row" aria-label="감상 보조 필터">
                     <span class="tag-chip active" data-category="전체">전체</span>
-                    <span class="tag-chip" data-category="입덕">시작 순간 중심</span>
-                    <span class="tag-chip" data-category="성장">이어진 감정</span>
+                    <span class="tag-chip" data-category="입덕">첫 순간</span>
+                    <span class="tag-chip" data-category="성장">이어진 마음</span>
                     <span class="tag-chip" data-category="최애">깊어진 마음</span>
                 </div>
             </div>
@@ -693,19 +716,19 @@
             </div>
             <div id="previewVideoContainer" class="video-container" style="margin-bottom: 24px;">
                 <div class="preview-empty-state" style="width:100%; height:100%; display:flex; flex-direction: column; align-items:center; justify-content:center; color: var(--on-surface-variant); font-size: 14px; text-align: center; padding: 20px;">
-                    <p>왼쪽 카드 하나를 고르면 대표 순간이 열려요.</p>
+                    <p>마음이 닿는 트리를 골라보세요.</p>
                 </div>
             </div>
             <div id="previewDetails">
-                <div id="previewTitle" class="headline" style="font-size: 1.18rem; margin-bottom: 12px; font-weight: 800; color: var(--on-surface);">카드를 선택해 대표 순간을 확인하세요</div>
+                <div id="previewTitle" class="headline" style="font-size: 1.18rem; margin-bottom: 12px; font-weight: 800; color: var(--on-surface);">아직 선택한 러브트리가 없어요.</div>
                 <div id="previewDesc" style="color: var(--on-surface-variant); font-size: 14px; line-height: 1.6;">
-                    <p style="margin-bottom: 16px;">선택한 러브트리의 순간과 이어진 감정을 이곳에서 먼저 볼 수 있어요.</p>
+                    <p style="margin-bottom: 16px;">마음이 닿는 트리를 골라보세요.</p>
                 </div>
                 <div id="previewTreeStats" class="tree-meta" hidden>
                     <span class="tree-meta-item">
                         <span class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle;">account_tree</span>
                         <span id="previewMemoriesCount"></span>
-                        <span>카드를 선택하면 대표 순간과 이어진 흐름을 보여드려요</span>
+                        <span>이어진 순간들</span>
                     </span>
                     <span class="tree-meta-item">
                         <span class="material-symbols-outlined" style="font-size: 14px; vertical-align: middle;">schedule</span>


### PR DESCRIPTION
## Summary
- Reduce Search/Detail default copy according to the quiet-first direction
- Shorten Search preview, growing section, filter, and placeholder copy
- Shorten Detail hero, diary, connected, and growth i18n copy
- Lower visual density with minimal page-local CSS adjustments only

## Scope
Changed files only:
- `pages/search.html`
- `pages/detail.html`
- `js/i18n/i18n-search.js`
- `js/i18n/i18n-detail.js`

## Explicit exclusions
- No `global.css` changes
- No `js/search.js` changes
- No `js/detail.js` changes
- No renderer/adapter changes
- No API/backend/runtime changes
- No editor changes
- No prototype changes
- No untracked assets
- No mode toggle / guide mode
- No policy docs

## Verification status
- Static diff confirmed against `main`
- Browser dynamic verification not yet completed
- UI Local verification required before merge decision

## Notes
- Main merge is not approved by this PR creation step.
- Additional commits require separate UI Lead approval.