### PR TITLE
docs: align public-first plus private policy direction

### DIFF
--- a/docs/backend/backend.md
+++ b/docs/backend/backend.md
@@ -17,15 +17,16 @@ Auth: Firebase ID Token verified in each protected function via `requireUser(eve
 netlify/
 ├── functions/
 │   ├── _lib/
-│   │   ├── auth.js       ← Firebase token verification (from 133)
-│   │   ├── db.js         ← Neon PostgreSQL Pool (from 133)
-│   │   ├── http.js       ← CORS / response helpers (from 133)
-│   │   └── doc-store.js  ← LoveBud data access layer (NEW)
+│   │   ├── auth.js       ← Firebase token verification
+│   │   ├── db.js         ← Neon PostgreSQL Pool
+│   │   ├── http.js       ← CORS / response helpers
+│   │   └── doc-store.js  ← LoveBud data access layer
 │   ├── trees.js          ← GET/POST  /api/trees
-│   ├── tree-detail.js    ← GET       /api/trees/:treeId
+│   ├── tree-detail.js    ← GET/PUT/DELETE /api/trees/:treeId
 │   ├── memories.js       ← GET/POST  /api/memories
 │   ├── memory-detail.js  ← GET/PATCH/DELETE /api/memories/:memoryId
-│   └── community-memories.js ← GET   /api/community/memories
+│   ├── community-trees.js ← GET /api/community/trees
+│   └── community-memories.js ← GET /api/community/memories
 ├── sql/
 │   └── 001_initial_schema.sql
 └── toml (netlify.toml routes /api/* → function files)
@@ -35,24 +36,26 @@ netlify/
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | /api/trees | optional | List user's trees (auth) or public trees (anon) |
+| GET | /api/trees | required | List user's trees |
 | POST | /api/trees | required | Create a new tree |
 | GET | /api/trees/:treeId | required* | Get tree + memories (*private requires owner) |
-| GET | /api/community/memories | none | Public memories from all trees (no auth required) |
+| PUT | /api/trees/:treeId | required | Update tree metadata / visibility |
+| DELETE | /api/trees/:treeId | required | Delete tree |
+| GET | /api/community/trees | none | Browse public tree summaries |
+| GET | /api/community/memories | none | Public memories by treeId or community scope |
 | GET | /api/memories | required | List memories (filter by treeId, parentId) |
 | POST | /api/memories | required | Create a new memory |
-| GET | /api/memories/:memoryId | required | Get single memory |
+| GET | /api/memories/:memoryId | required* | Get single memory (*public anyone / private owner) |
 | PATCH | /api/memories/:memoryId | required | Update memory fields |
 | DELETE | /api/memories/:memoryId | required | Delete memory |
 
-## Auth Pattern (per-function)
+## Auth Pattern
 ```javascript
 const { requireUser } = require('./_lib/auth');
-// In handler:
-const user = await requireUser(event); // throws 401 if not authenticated
+const user = await requireUser(event);
 ```
 
-## Environment Variables (Netlify)
+## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -64,77 +67,190 @@ const user = await requireUser(event); // throws 401 if not authenticated
 
 | Package | Version | Why |
 |---------|---------|-----|
-| `firebase-admin` | ^12.0.0 | `_lib/auth.js` calls `require('firebase-admin')` to verify ID tokens in protected functions |
-| `pg` | ^8.12.0 | `_lib/db.js` calls `require('pg')` for Neon PostgreSQL connection pool |
+| `firebase-admin` | ^12.0.0 | Firebase ID token verification |
+| `pg` | ^8.12.0 | Neon PostgreSQL connection pool |
 
-Both are **server-side only** (Netlify Functions) — never bundled into the browser.
-Netlify auto-installs `package.json` dependencies during build.
+Both are server-side only.
 
-## Netlify 배포 설정
+---
 
-**package.json**: 루트에 위치하며 Netlify Functions 빌드 시 의존성 자동 설치  
-**netlify.toml**: `[functions]` 섹션으로 Functions 디렉토리 지정, `[[redirects]]` 순서는 `/api/*` → `/*` (SPA fallback은 항상 마지막)  
-빌드 에러 시 확인: Functions 로그에서 "Cannot find module" 오류 → package.json 의존성 누락 확인
+## Visibility / private storage policy
+
+### Current implementation
+
+Current main implementation remains private-first.
+
+- `POST /api/trees` defaults new tree visibility to `private`.
+- `POST /api/trees` rejects `visibility: 'public'` with 409.
+- `PUT /api/trees/:treeId` allows owner visibility update.
+- private → public currently requires at least 3 public memories.
+- public → private currently has no Plus entitlement guard.
+- Existing private trees are stored as ordinary `visibility: 'private'` rows.
+
+### Target policy
+
+CTO-approved direction is public-first + Plus private.
+
+- New trees should transition to public-first.
+- Existing private trees must not be automatically made public.
+- Existing private trees are grandfathered private.
+- Private creation and public → private transition require Plus entitlement after the entitlement source is defined.
+- Public visibility and browse display eligibility are separate concepts.
+- Netlify and Modal policy must be changed together.
+
+### Create tree policy
+
+Current:
+
+- Backend accepts `title` and optional `visibility`.
+- Default visibility is `private`.
+- `visibility: 'public'` is rejected.
+
+Target:
+
+- Default visibility becomes `public`.
+- `visibility: 'private'` requires Plus entitlement.
+- Entitlement source is not yet defined, so this is not implementable yet.
+- Frontend create payload must not be changed alone.
+
+Decision-needed:
+
+- User plan source of truth
+- DB schema or provider for entitlement
+- Error status and response body for Plus-required private creation
+- Grandfathered private marking strategy, if needed beyond existing visibility value
+
+### Toggle visibility policy
+
+Current:
+
+- Owner can request visibility update through `/api/trees/:treeId`.
+- private → public has a 3-public-memory publication guard.
+- public → private is allowed for owner without plan check.
+
+Target:
+
+- public → private requires Plus entitlement unless the tree is grandfathered private or another CTO-approved exception applies.
+- private → public should be treated as publishing or grandfathered-private release.
+- Browse display eligibility remains separate from visibility.
+
+Recommended target behavior:
+
+| Transition | Target backend behavior |
+|------------|--------------------------|
+| public → private | require Plus entitlement |
+| private → public | allow owner, then evaluate browse eligibility separately |
+| grandfathered private → private | keep allowed for owner |
+| grandfathered private → public | allow owner, no automatic re-private without entitlement unless approved |
+
+### Browse display filter
+
+Browse summary should not become a raw list of all public trees.
+
+Recommended browse summary conditions:
+
+- tree visibility is `public`
+- public memory count meets display threshold, currently 3+
+- browse quality filter passes
+
+Public visibility means accessible public state. Browse display means curated/eligible for browse surfaces.
+
+---
 
 ## Current Status
 
 **Implemented:**
-- Browser-side fetch client (js/postgres-client.js) — API-first with mock fallback
-- `_lib/` (auth, db, http, doc-store) — full CRUD scaffold
+- Browser-side fetch client (`js/postgres-client.js`) — API-first with fallback
+- `_lib/` auth, db, http, doc-store
 - `trees.js` — GET/POST with auth
-- `tree-detail.js` — GET with access control
+- `tree-detail.js` — GET/PUT/DELETE with access control and visibility update
 - `memories.js` — GET/POST with auth + ownership enforcement
 - `memory-detail.js` — GET/PATCH/DELETE with ownership check
-- `community-memories.js` — public read (no auth)
-- SQL schema (netlify/sql/001_initial_schema.sql)
+- `community-trees.js` — browse public summaries
+- `community-memories.js` — public read path
+- SQL schema scaffold
 
-**GET 정책 (모두 인증 필수):**
-- `/api/memories` GET: 인증된 사용자의 own trees 메모리만 조회 (treeId 지정 시 해당 tree 소유권 검증)
-- `/api/memories/:memoryId` GET: 인증 필수. public memory는 anyone이 조회 가능, private memory는 owner만 조회 가능
+**GET 정책:**
+- `/api/memories` GET: authenticated user's own tree memories only
+- `/api/memories/:memoryId` GET: public memory can be viewed publicly; private memory requires owner
+- `/api/trees/:treeId` GET: public tree can be viewed; private tree requires owner
 
-**Ownership 검증 완료:**
-- memories.js GET: 사용자가 소유한 트리의 메모리만 반환
-- memories.js POST: body.treeId가 본인 소유 트리인지 검증 후 생성
+**Ownership 검증:**
+- memories.js GET: returns memories for user's own trees
+- memories.js POST: verifies body.treeId ownership before creation
 - memory-detail.js GET: public anyone / private owner only
-- memory-detail.js PATCH/DELETE: memory가 속한 tree의 owner만 수정/삭제 가능
+- memory-detail.js PATCH/DELETE: owner only
+- tree-detail.js PUT/DELETE: owner only
 
 **입력값 검증 규칙:**
-- 필수 필드(treeId 등) 누락 → 400 error
-- 빈 문자열/공백 → trim 후 빈 값이면 400 error  
-- UUID 파라미터(treeId, memoryId, parentId) → UUID 형식 검증
-- limit 파라미터 → 1~100 범위로 제한 (기본 20)
-- visibility → 'public' 또는 'private'만 허용
-- sourceType → 'youtube', 'soundcloud', 'bandcamp', 'spotify', 'apple', 'other'
-- 문자열 필드 길이 제한: title(200), memo(5000), artist(100), source(200), sourceUrl(1000), thumbnail(500), timestamp(100)
-- emotionTags → 배열, 최대 20개, 빈 문자열不允许
+- 필수 필드 누락 → 400
+- UUID 파라미터 → UUID 형식 검증
+- limit 파라미터 → bounded range
+- visibility → `public` 또는 `private`만 허용
+- sourceType → `youtube`, `soundcloud`, `bandcamp`, `spotify`, `apple`, `other`
+- 문자열 필드 길이 제한 적용
+- emotionTags → 배열, 최대 20개
 
-**Frontend 연결 상태:**
-- `search.html` — `window.apiClient.getCommunityMemories()` API 우선 + mock fallback 적용 완료
-- `js/postgres-client.js` — 모든 메서드 API 우선, 실패 시 mock fallback
+---
 
-**Not yet implemented:**
-- Neon PostgreSQL actual database + schema run
-- detail.html API 연결 (postgres-client.js는 준비됨)
-- editor.html API 연결 — createMemory, getMemoriesByTree 구현 완료
+## Public-first transition TODO
 
-**Next step:**
-1. Run `001_initial_schema.sql` against Neon PostgreSQL
-2. Run `002_seed_demo_data.sql` for demo content (optional but recommended for public browsing)
-3. Update Netlify environment variables (`FIREBASE_SERVICE_ACCOUNT_JSON`, `NETLIFY_DATABASE_URL`)
+Before code changes:
 
-**시드 데이터 (Verified Seed Data):**
-- `002_seed_demo_data.sql` — **실제 공식 YouTube 채널에서 확인 가능한 공개 콘텐츠만** 포함
-- 2개 public trees (BTS, Hearts2Hearts 샘플)
-- **5개 검증된 public memories**
-  - BTS: 봄날, Dynamite, Butter, Permission to Dance (4개 — BTS Official YouTube)
-  - Hearts2Hearts: The Chase MV (1개 — @hearts2hearts.official 공식 채널, 2025.02.24 데뷔)
-- `ON CONFLICT` 구문으로 재실행 시 업데이트 가능 (단, owner_id는 유지됨)
-- Neon 콘솔 또는 `psql`로 실행: `\i netlify/sql/002_seed_demo_data.sql`
+1. Update API contract and tests.
+2. Define Plus entitlement source.
+3. Define grandfathered private behavior.
+4. Update Netlify and Modal policy together.
+5. Separate visibility change from browse display eligibility.
+6. Prepare frontend UX copy and error handling.
 
-**참고**: Hearts2Hearts 공식 채널(@hearts2hearts.official)에 Butterflies, RUDE!, STYLE 등 추가 콘텐츠가 있으며, 확인 후 확장 가능합니다.
+Implementation split:
 
-**Detail 화면 API 연결 방법:**
-- `apiClient.getMemory(memoryId)` — GET `/api/memories/:memoryId` 직접 호출
-- `apiClient.getMemoriesByTree(treeId)` — GET `/api/memories?treeId=...` 호출
-- `apiClient.getFirstTree()` — GET `/api/trees` 후 첫 번째 선택
-- 모든 메서드는 API 실패 시 자동으로 mock-data.js fallback
+### Backend workstream
+
+- Change `POST /api/trees` default visibility to public.
+- Remove public-create 409 only when Modal equivalent is ready.
+- Add entitlement guard for private creation.
+- Add entitlement guard for public → private toggle.
+- Preserve grandfathered private owner access.
+- Keep browse summary filter separate.
+
+### Modal workstream
+
+- Mirror create tree policy.
+- Mirror private endpoint entitlement policy.
+- Keep browse latest/growing filters public-only.
+
+### Frontend workstream
+
+- Do not change createTree payload until backend/Modal are ready.
+- Update My Trees create modal after API policy is ready.
+- Update Editor visibility badge and toggle copy.
+- Add Plus-required UX only after error contract is fixed.
+
+---
+
+## Not yet implemented / decision-needed
+
+- Public-first create tree implementation
+- Plus entitlement source
+- Plus private backend guard
+- Grandfathered private metadata strategy
+- Entitlement error code/status contract
+- User-facing copy for Plus private after payment policy is confirmed
+
+---
+
+## Seed data note
+
+Seed/demo data remains public sample content and is not a private storage policy reference.
+
+---
+
+## Detail/API integration note
+
+- `apiClient.getMemory(memoryId)` — GET `/api/memories/:memoryId`
+- `apiClient.getMemoriesByTree(treeId)` — GET `/api/memories?treeId=...`
+- `apiClient.getFirstTree()` — GET `/api/trees` then first item
+
+Visibility policy changes must update the API client only after backend and Modal contracts are aligned.

--- a/docs/engineering/API_CONTRACT.md
+++ b/docs/engineering/API_CONTRACT.md
@@ -1,7 +1,7 @@
 # LoveBud API 응답 계약
 
-> **버전:** 1.3  
-> **최종 갱신:** 2026-04-22  
+> **버전:** 1.4  
+> **최종 갱신:** 2026-04-25  
 > **관련 커밋:** `0230475`, `bb9741b`, `bb9e663`
 
 ---
@@ -76,26 +76,13 @@ interface Memory {
 }
 ```
 
-**핵심 필드 매핑:**
-- `tree_id` (snake_case) → `treeId` (camelCase)
-- `parent_id` → `parentId`
-- `source_url` → `sourceUrl`
-- `source_type` → `sourceType`
-- `emotion_tags` → `emotionTags`
-- `created_at` → `createdAt`
-- `updated_at` → `updatedAt`
-
 ### 2.2 Memory 목록
 
 ```typescript
 type MemoryList = Memory[];
 ```
 
-**직렬화:** `serializeMemoryList(items)`
-
 ### 2.3 Tree 단건
-
-**파일:** `netlify/functions/_lib/serializers.js:serializeTree`
 
 ```typescript
 interface Tree {
@@ -107,11 +94,9 @@ interface Tree {
   updatedAt: string | null;
   nodeCount: number;
   payload: {
-    // 확장 필드
     description?: string;
     coverImage?: string;
-    // ... 기타 payload 필드
-    nodes?: Memory[]; // tree-detail용
+    nodes?: Memory[];
   };
 }
 ```
@@ -122,41 +107,141 @@ interface Tree {
 type TreeList = Tree[];
 ```
 
-**직렬화:** `serializeTreeList(items)`
-
-### 2.5 Tree Detail (with memories)
-
-Tree 응답에 `payload.nodes`가 포함된 형태입니다.
+### 2.5 Tree Detail
 
 ```typescript
 interface TreeDetail extends Tree {
   payload: {
     nodes: Memory[];
-    // ... 기타 payload
   };
 }
 ```
 
 ---
 
-## 3. Browse 전용 계약
+## 3. Visibility / private storage 전환 계약
 
-> 현재 browse는 **summary 목록 우선 → 선택 후 treeId 기준 preview hydrate** 구조입니다.
-> 구현 기준 파일:
-> - `netlify/functions/community-trees.js`
-> - `netlify/functions/community-memories.js`
-> - `js/search.js`
-> - `js/api/public-tree-adapter.js`
+### 3.1 현재 구현 계약
 
-### 3.1 Browse Summary Contract
+현재 main 구현은 아직 private-first입니다.
+
+- `POST /api/trees`는 새 tree 생성 시 `visibility` 기본값을 `private`으로 처리합니다.
+- `POST /api/trees`에 `visibility: 'public'`이 들어오면 현재 구현은 409를 반환합니다.
+- `PUT /api/trees/:treeId`는 private → public 전환 시 공개 memory 3개 이상 조건을 확인합니다.
+- public → private 전환에 Plus entitlement 검증은 아직 없습니다.
+- Modal private tree 생성도 동일하게 private-first이며 public 생성 요청을 차단합니다.
+
+### 3.2 목표 정책 계약
+
+CTO 결정 기준 목표 정책은 **public-first + Plus private**입니다.
+
+- 신규 tree는 public-first 방향으로 전환합니다.
+- 기존 private tree는 자동 public 전환하지 않고 grandfathered private으로 유지합니다.
+- private 생성/전환은 Plus entitlement source 확정 후 backend에서 검증합니다.
+- `public visibility`와 `browse 노출 조건`은 분리합니다.
+- createTree payload만 단독으로 public 변경하는 것은 금지합니다.
+- Netlify와 Modal create/toggle 정책은 반드시 동기화합니다.
+
+### 3.3 public visibility와 browse 노출 분리
+
+`visibility: 'public'`은 접근 가능 상태입니다.
+
+browse 노출은 별도 display/quality filter입니다.
+
+```typescript
+interface VisibilityPolicyState {
+  visibility: 'public' | 'private';
+  browseEligible: boolean;
+  browseEligibilityReason?: 'min_public_memories_not_met' | 'private_tree' | 'quality_filter_pending' | null;
+}
+```
+
+현재 browse 기본 노출 조건:
+
+- tree visibility가 `public`
+- public memory가 최소 3개 이상
+- browse summary filter 통과
+
+따라서 public tree라도 public memory가 3개 미만이면 public 접근은 가능하지만 browse summary에는 노출되지 않을 수 있습니다.
+
+### 3.4 create tree 전환 계약
+
+현재:
+
+```typescript
+interface CreateTreeRequestCurrent {
+  title?: string;
+  visibility?: 'private';
+}
+```
+
+목표:
+
+```typescript
+interface CreateTreeRequestTarget {
+  title?: string;
+  visibility?: 'public' | 'private';
+}
+```
+
+목표 정책:
+
+- visibility 생략 시 신규 tree는 `public`으로 생성합니다.
+- `visibility: 'private'` 생성은 Plus entitlement 필요 대상입니다.
+- entitlement source 확정 전에는 private 생성 허용/차단을 구현하지 않습니다.
+- frontend만 먼저 public payload로 바꾸지 않습니다.
+
+### 3.5 toggle visibility 전환 계약
+
+목표 정책:
+
+```typescript
+interface UpdateTreeVisibilityRequest {
+  visibility: 'public' | 'private';
+}
+```
+
+전환 규칙:
+
+- `public -> private`: Plus entitlement 필요
+- `private -> public`: grandfathered private 해제 또는 publish 성격으로 허용 후보
+- `private -> public` 시 browse 노출 조건은 별도 판단
+- public 전환 자체와 browse summary 노출을 같은 guard로 묶지 않습니다.
+
+### 3.6 decision-needed: entitlement error contract
+
+아직 미확정입니다.
+
+후보:
+
+```typescript
+interface PlusRequiredError {
+  error: true;
+  code: 'PLUS_REQUIRED_PRIVATE_STORAGE';
+  message: string;
+}
+```
+
+HTTP status 후보:
+
+- `403`: 현재 auth/permission 계열과 일관됨
+- `402`: 의미상 결제 필요에 가깝지만 운영 관행이 불균일함
+
+결정 필요:
+
+- Plus entitlement source of truth
+- status code
+- error body shape
+- grandfathered private 예외 처리
+
+---
+
+## 4. Browse 전용 계약
+
+### 4.1 Browse Summary Contract
 
 **Endpoint**
 - `GET /api/community/trees?view=summary&sort=latest&limit=3`
-
-**Query params**
-- `view=summary` : browse summary 응답 활성화
-- `sort=latest` : 현재 구현상 최신순 정렬
-- `limit=3` : 현재 browse 초기 목록 기본 개수
 
 **Response shape**
 
@@ -179,85 +264,29 @@ type BrowseTreeSummaryList = BrowseTreeSummary[];
 ```
 
 **현재 구현 의미**
-- summary는 tree 목록 자체가 아니라, public tree와 public memory를 합쳐 만든 **browse 카드 요약 모델**입니다.
-- `representativeThumbnail`, `memoryCount`, `emotionTags`, `stage`, `theme`, `timeRange`는 summary view에서 서버가 계산합니다.
-- 현재 구현상 `representativeThumbnail`은 정렬된 메모리 흐름의 **첫 memory thumbnail** 우선입니다.
+- summary는 tree 목록 자체가 아니라, public tree와 public memory를 합쳐 만든 browse 카드 요약 모델입니다.
+- public-first 전환 후에도 browse summary는 `browseEligible` 조건을 통과한 public tree만 반환해야 합니다.
+- visibility가 public이어도 memory/quality 조건이 부족하면 summary에서 제외될 수 있습니다.
 
-**Fallback rules**
-- `representativeThumbnail`이 없으면 빈 문자열 허용
-- `theme`가 비면 `'LoveTree'`
-- `timeRange`가 비면 빈 문자열 또는 browse renderer 기본 문구 사용
-- summary 응답은 browse 첫 렌더용이므로 `memories` 배열은 포함하지 않음
-
-**Backward compatibility rule**
-- 서버 정식 계약은 flat camelCase입니다.
-- 다만 browse adapter는 이행기 동안 아래를 수용합니다.
-  - legacy `{ data }` wrapper
-  - `created_at`, `updated_at`
-  - `owner_id`
-  - `representative_thumbnail`
-  - `memory_count`
-- browse 경로 외 신규 UI는 이 fallback에 의존하지 않습니다.
-
-### 3.2 Preview Hydration Contract
+### 4.2 Preview Hydration Contract
 
 **Endpoint**
 - `GET /api/community/memories?treeId=<treeId>`
-
-**Query params**
-- `treeId=<treeId>` : 선택된 browse tree id
-- `limit` : 현재 browse hydrate 경로에서는 명시하지 않음. 서버 기본 상한 사용
-
-**Response shape**
 
 ```typescript
 type BrowseHydrationMemoryList = Memory[];
 ```
 
-**클라이언트 hydration 결과 shape**
+- hydrate는 public memories만 반환합니다.
+- public tree라도 private memory는 browse hydrate에 포함하지 않습니다.
+- private/grandfathered tree는 browse hydrate 대상이 아닙니다.
 
-```typescript
-interface HydratedBrowseTree extends BrowseTreeSummary {
-  memories: Memory[];
-  memoryCount: number;
-  emotionTags: string[];
-  timeRange: string;
-  representativeThumbnail: string;
-  theme: string;
-  stage: string;
-}
-```
+### 4.3 Future Modal Snapshot Contract
 
-**현재 구현 의미**
-- summary 목록 선택 후 `js/search.js`가 `treeId`로 public memories를 다시 조회합니다.
-- `js/api/public-tree-adapter.js`가 tree summary + memory list를 합쳐 preview용 hydrated model을 만듭니다.
-- 현재 preview는 **tree detail 전체 응답**가 아니라, `treeId` 기준 memories hydrate 결과를 사용합니다.
+예정 endpoint 후보:
 
-**Fallback rules**
-- hydrate 실패 시 summary 목록은 유지하고 preview만 reset 가능
-- preview hydrate가 실패해도 browse list는 재렌더 가능해야 함
-- `memories`가 비어도 summary의 `memoryCount`, `stage`, `theme`, `representativeThumbnail` 기본값은 유지 가능
-- adapter는 memory 응답에서도 이행기 snake_case / `{data}` wrapper를 임시 수용함
-
-**Backward compatibility rule**
-- browse hydrate는 camelCase-only를 목표로 하지만, adapter 내부에서만 snake_case와 wrapper fallback 허용
-- `treeId`, `createdAt`, `sourceUrl`, `emotionTags`는 장기적으로 camelCase-only로 고정
-
-### 3.3 Future Modal Snapshot Contract
-
-> 이 계약은 **예정 상태**입니다. 현재 main에는 구현되어 있지 않습니다.
-> 목적은 browse 카드 선택 시 preview hydrate 전체 memories를 계속 쓰는 대신,
-> Modal에서 필요한 최소 snapshot만 별도 계약으로 고정하는 것입니다.
-
-**예정 endpoint 방향**
-- 후보 1: `GET /api/community/trees/<treeId>/snapshot`
-- 후보 2: `GET /api/community/trees?view=snapshot&treeId=<treeId>`
-
-**예정 query params**
-- `treeId` 또는 path param 기반 tree 식별자
-- 필요 시 `limit`, `cursor`, `include=preview|flow` 같은 확장 파라미터 추가 가능
-
-**예정 response shape (초안)**
+- `GET /api/community/trees/<treeId>/snapshot`
+- `GET /api/community/trees?view=snapshot&treeId=<treeId>`
 
 ```typescript
 interface BrowseTreeSnapshot {
@@ -277,30 +306,11 @@ interface BrowseTreeSnapshot {
 }
 ```
 
-**Snapshot contract 원칙**
-- Modal snapshot은 **browse summary의 확장 계약**이어야지, tree detail 계약 재사용이 아닙니다.
-- snapshot은 Modal 오픈에 필요한 최소 데이터만 포함합니다.
-- full memory list 전체를 강제하지 않습니다.
-- detail/editor 계약과 분리된 browse 전용 응답으로 유지합니다.
+Snapshot도 browse 노출 조건을 통과한 public tree를 기본 대상으로 합니다.
 
-**Migration 방향**
-1. 현재 browse summary contract 고정
-2. 현재 preview hydrate contract 고정
-3. Modal snapshot 응답 shape를 별도 snapshot 테스트로 고정
-4. Modal 오픈 시 `/community/memories?treeId=` 직접 hydrate 대신 snapshot 우선 사용
-5. 이후 필요 시 preview hydrate는 snapshot 보조 fallback으로만 축소
+---
 
-**Backward compatibility rule**
-- snapshot 도입 전까지 현재 summary + hydrate 조합이 정식 지원 경로입니다.
-- snapshot 도입 초기에도 browse adapter는 기존 summary/hydrate 경로를 fallback으로 유지해야 합니다.
-- snapshot 계약이 고정되기 전에는 기존 `/community/memories?treeId=` 경로를 제거하지 않습니다.
-
-### 3.4 HOT / 추천 / 좋아요 확장 계약 (예정)
-
-> 이 계약도 **예정 상태**입니다. 현재 main에는 구현되어 있지 않습니다.
-> 목적은 browse/detail 구조를 깨지 않고, HOT / 추천 / 반응 확장을 위한 최소 필드만 선고정하는 것입니다.
-
-#### 3.4.1 Browse summary에 바로 붙일 수 있는 최소 후보 필드
+## 5. HOT / 추천 / 좋아요 확장 계약 예정
 
 ```typescript
 interface BrowseTreeSummaryExtension {
@@ -312,329 +322,105 @@ interface BrowseTreeSummaryExtension {
 }
 ```
 
-**지금 바로 필요한 필드**
-- `badgeLabel?`
-- `hotScore?`
-- `likeCount?`
+원칙:
 
-**후순위 필드**
-- `bookmarkCount?`
-- `reactionCount?`
-
-**summary 포함 원칙**
-- summary에는 **카드 정렬/배지/간단 수치 노출에 직접 필요한 aggregate 필드만** 허용
-- `likedByMe`, `recommendedReason`, `reactionBreakdown` 같은 개인화/설명형 필드는 summary에 넣지 않음
-
-#### 3.4.2 HOT용 최소 필드
-
-```typescript
-interface HotRankingFields {
-  hotScore: number;
-  recentViewCount7d?: number | null;
-  recentLikeCount7d?: number | null;
-  recentBookmarkCount7d?: number | null;
-  trendingWindow?: '24h' | '7d' | '30d' | null;
-}
-```
-
-**지금 바로 필요한 필드**
-- `hotScore`
-
-**후순위 필드**
-- `recentViewCount7d`
-- `recentLikeCount7d`
-- `recentBookmarkCount7d`
-- `trendingWindow`
-
-**배치 원칙**
-- HOT 정렬/배지 판단용으로는 `hotScore`만 summary에 붙일 수 있음
-- 세부 근거 수치는 snapshot 또는 ranking 전용 endpoint로 분리
-
-#### 3.4.3 추천용 최소 필드
-
-```typescript
-interface RecommendationFields {
-  recommendationKey?: string | null;
-  recommendationReasonCode?:
-    | 'similar_theme'
-    | 'similar_emotion'
-    | 'similar_artist'
-    | 'popular_with_similar_taste'
-    | null;
-  recommendationScore?: number | null;
-}
-```
-
-**지금 바로 필요한 필드**
-- 없음
-- 추천은 summary에 바로 붙이기보다 **별도 query 또는 snapshot 확장**으로 시작하는 것을 기본값으로 둠
-
-**후순위 필드**
-- `recommendationReasonCode`
-- `recommendationScore`
-- `recommendationKey`
-
-**배치 원칙**
-- 추천 결과 목록이 필요하면 endpoint query 수준에서 분리
-  - 예: `GET /api/community/trees?view=summary&sort=recommended`
-- 추천 이유 문구는 summary가 아니라 snapshot 또는 별도 recommendation endpoint에서 제공
-
-#### 3.4.4 좋아요 / 북마크 / 반응용 최소 필드
-
-```typescript
-interface ReactionAggregateFields {
-  likeCount?: number | null;
-  bookmarkCount?: number | null;
-  reactionCount?: number | null;
-}
-
-interface ReactionUserStateFields {
-  likedByMe?: boolean | null;
-  bookmarkedByMe?: boolean | null;
-  reactedByMe?: boolean | null;
-}
-```
-
-**지금 바로 필요한 필드**
-- aggregate: `likeCount`
-
-**후순위 필드**
-- aggregate: `bookmarkCount`, `reactionCount`
-- user-state: `likedByMe`, `bookmarkedByMe`, `reactedByMe`
-
-**배치 원칙**
-- aggregate 수치는 summary에 붙일 수 있음
-- user-state 필드는 인증/개인화가 필요하므로 summary 기본 계약에 넣지 않음
-- `likedByMe` 류는 snapshot 또는 별도 user-state endpoint에서만 허용
-
-#### 3.4.5 snapshot 전용 필드
-
-```typescript
-interface BrowseTreeSnapshotExtension {
-  recommendedReasonText?: string | null;
-  reactionBreakdown?: Record<string, number> | null;
-  socialProofText?: string | null;
-  likedByMe?: boolean | null;
-  bookmarkedByMe?: boolean | null;
-}
-```
-
-**snapshot 전용 원칙**
-- 추천 이유 설명
-- 반응 세부 분해
-- 개인화 상태
-- social proof 문구
-는 summary가 아니라 snapshot 또는 별도 endpoint로 분리
-
-#### 3.4.6 별도 endpoint 방향
-
-**ranking 전용 방향**
-- `GET /api/community/trees?view=summary&sort=hot`
-- `GET /api/community/trees?view=summary&sort=recommended`
-
-**user-state 전용 방향**
-- `GET /api/community/trees/<treeId>/viewer-state`
-- 또는 snapshot 응답에 인증 사용자 상태를 조건부 포함
-
-**reaction write 방향 (후순위)**
-- `POST /api/community/trees/<treeId>/like`
-- `POST /api/community/trees/<treeId>/bookmark`
-- `POST /api/community/trees/<treeId>/reactions`
-
-> 쓰기 endpoint는 이번 문서 범위에서 shape만 예고하며, 현재 구현 계약에는 포함하지 않음
-
-#### 3.4.7 backward compatibility rule
-
-- 기존 browse summary 필드는 유지
-- HOT / 추천 / 반응 확장 필드는 **optional additive fields**로만 추가
-- 현재 `js/api/public-tree-adapter.js`와 browse renderer는 새 필드가 없어도 동작해야 함
-- snapshot 도입 전에는 개인화 필드(`likedByMe`)를 summary 기본 계약에 넣지 않음
-- detail 계약에는 HOT/추천용 필드를 강제로 주입하지 않음
-
-#### 3.4.8 단계별 rollout 방향
-
-1. **Phase 1 — summary additive fields**
-   - `hotScore?`
-   - `badgeLabel?`
-   - `likeCount?`
-2. **Phase 2 — hot/recommended sort query**
-   - `sort=hot`
-   - `sort=recommended`
-3. **Phase 3 — snapshot extension**
-   - `recommendedReasonText`
-   - `socialProofText`
-   - `likedByMe`
-   - `bookmarkedByMe`
-4. **Phase 4 — reaction write / viewer-state**
-   - 별도 write endpoint 또는 viewer-state endpoint
+- 확장 필드는 optional additive field로만 추가합니다.
+- user-state 필드는 summary 기본 계약에 넣지 않습니다.
+- `likedByMe`, `bookmarkedByMe` 등은 snapshot 또는 별도 viewer-state endpoint로 분리합니다.
 
 ---
 
-## 4. 프론트엔드 원칙
+## 6. 프론트엔드 원칙
 
-### 4.1 절대 금지
+### 6.1 절대 금지
 
 ```javascript
-// ❌ 금지: {id, data} 접근
 const title = memory.data?.title;
 const treeId = memory.data?.tree_id;
-
-// ❌ 금지: 믹스드 접근
-const title = memory.data?.title || memory.title;
 ```
 
-### 4.2 필수 사용
+### 6.2 필수 사용
 
 ```javascript
-// ✅ 표준: flat camelCase 직접 접근
 const title = memory.title;
 const treeId = memory.treeId;
-
-// ✅ 표준: normalizeMemory 공통 유틸
 const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 ```
 
-### 4.3 snake_case 이행기 호환 (Migration-Only)
+### 6.3 visibility 정책 관련 금지
 
-**원칙:** 신규 코드와 서버 응답은 flat camelCase만 사용해야 합니다.
-
-**이행기 호환:** 클라이언트 런타임이 아직 legacy snake_case 및 `{id, data}` 형태를 수용하는 것은 이행기 기간 동안만 허용됩니다.
-
-**제거 조건:** `/community/trees`, `/community/memories` 및 주요 API가 flat camelCase만 반환하는 것이 확인되면, `js/utils/normalize.js`와 `js/postgres-client.js`의 transitional fallback을 제거합니다.
-
-```javascript
-// js/utils/normalize.js - transitional fallback block
-// Accept legacy snake_case fields during migration only.
-// New code and server responses must prefer flat camelCase only.
-function normalizeMemory(mem) {
-  if (!mem || typeof mem !== 'object') return mem;
-
-  return {
-    id: mem.id,
-    treeId: mem.treeId || mem.tree_id || null,  // TODO: remove || mem.tree_id after migration
-    parentId: mem.parentId ?? mem.parent_id ?? null,  // TODO: remove ?? mem.parent_id
-    // ...
-  };
-}
-```
+- frontend만 createTree payload를 public으로 변경하지 않습니다.
+- frontend-only Plus lock으로 정책 완료를 선언하지 않습니다.
+- public visibility를 browse 노출과 같은 의미로 표시하지 않습니다.
 
 ---
 
-## 5. 백엔드 원칙
+## 7. 백엔드 원칙
 
-### 5.1 직렬화기 사용 의무
+### 7.1 직렬화기 사용 의무
 
-**모든 API 응답은 반드시 serializers를 거쳐야 합니다.**
+모든 API 응답은 반드시 serializers를 거칩니다.
 
-```javascript
-// netlify/functions/memory-detail.js
-const { serializeMemory } = require('./_lib/serializers');
+### 7.2 visibility guard 원칙
 
-const existingFlat = serializeMemory(existing);
-return ok(existingFlat);
-```
-
-### 5.2 허용되는 함수
-
-- `serializeMemory(input)` - Memory 단건
-- `serializeMemoryList(items)` - Memory 목록
-- `serializeTree(input, options)` - Tree 단건
-- `serializeTreeList(items)` - Tree 목록
-
-### 5.3 내부 저장소와 API 응답 분리
-
-```javascript
-// 내부 저장소 (doc-store)
-const internal = {
-  id: "tree_123",
-  data: {
-    title: "My Tree",
-    tree_id: "tree_123"
-  }
-};
-
-// API 응답 (flat camelCase)
-const response = serializeTree(internal);
-// { id: "tree_123", title: "My Tree" }
-```
+- create tree 정책은 Netlify와 Modal에서 동기화해야 합니다.
+- private 생성/전환 guard는 entitlement source 확정 후 backend에서 강제해야 합니다.
+- 기존 private tree grandfathering을 고려해야 합니다.
+- browse display filter는 public visibility와 별도로 유지합니다.
 
 ---
 
-## 6. 관련 파일
+## 8. 관련 파일
 
 | 파일 | 역할 |
 |------|------|
 | `netlify/functions/_lib/serializers.js` | API 응답 직렬화기 |
-| `js/utils/normalize.js` | 프론트 정규화 유틸 |
-| `js/detail.js` | flat camelCode 사용 예시 |
-| `js/editor.js` | flat camelCase 사용 예시 |
-| `js/search.js` | flat camelCase 사용 예시 |
-| `js/api/public-tree-adapter.js` | browse summary/hydrate 이행기 adapter |
+| `netlify/functions/trees.js` | create tree / list trees |
+| `netlify/functions/tree-detail.js` | tree detail / visibility update |
 | `netlify/functions/community-trees.js` | browse summary 서버 계약 |
 | `netlify/functions/community-memories.js` | browse hydration 서버 계약 |
+| `modal_compute/app.py` | Modal public/private tree 계약 |
+| `js/utils/normalize.js` | 프론트 정규화 유틸 |
+| `js/api/public-tree-adapter.js` | browse summary/hydrate adapter |
 
 ---
 
-## 7. 장기 TODO
+## 9. 장기 TODO
 
-### 7.1 snake_case fallback 완전 제거 검토
+### 9.1 public-first backend 전환
 
-**현재:** 직렬화기와 normalize에서 snake_case/camelCase 병행 지원 (이행기 호환)
-**목표:** 백엔드는 camelCase만, 프론트는 별도 변환 불필요
+- Netlify create tree public-first 전환
+- Modal create tree public-first 전환
+- create payload 단독 변경 금지 원칙 유지
+- API 계약 테스트 추가
 
-**제거 조건 (완료 기준):**
-1. `/community/trees`, `/community/memories` 엔드포인트가 flat camelCase만 반환
-2. `/api/trees/*`, `/api/memories/*` 엔드포인트가 flat camelCase만 반환
-3. mock-data.js, cache 저장 데이터가 flat camelCase로 정리됨
-4. 관련 테스트 스냅샷이 flat camelCase 기준으로 고정됨
+### 9.2 Plus private entitlement
 
-**제거 대상 파일 및 코드:**
-- `js/utils/normalize.js`: snake_case fallback 블록
-- `js/postgres-client.js`: `getPublicTrees()` 내 `{id,data}` wrapper 및 snake_case fallback
-- `js/api/public-tree-adapter.js`: browse 전용 legacy fallback 블록
+- entitlement source of truth 확정
+- plan 저장 위치 확정
+- backend guard 추가
+- frontend 안내와 API error 처리 동기화
 
-**목표 시점:** 위 제거 조건 충족 후 즉시 진행 (마일스톤: TBD)
+### 9.3 browse 노출 조건 고정
 
-### 7.2 normalizeMemory 역할 축소
-
-**현재:** snake_case → camelCase 보정
-**목표:** 백엔드에서 완전히 처리되면 normalizeMemory는 단순 검증/기본값 처리만
-
-### 7.3 browse snapshot 계약 고정
-
-**현재:** summary + memories hydrate 조합
-**목표:** Modal open용 snapshot contract 별도 고정
-
-**완료 기준:**
-1. summary contract 문서 고정
-2. preview hydration contract 문서 고정
-3. snapshot response shape 테스트 추가
-4. Modal snapshot 도입 후 hydrate fallback 범위 재정의
-
-### 7.4 HOT / 추천 / 반응 필드 고정
-
-**현재:** 관련 필드 없음
-**목표:** additive optional field로만 확장
-
-**완료 기준:**
-1. summary용 최소 aggregate field 고정
-2. snapshot/user-state 전용 field 분리
-3. hot / recommended sort query 방향 고정
-4. reaction write 계약 방향 별도 분리
+- public visibility와 browseEligible 분리
+- public memory 3개 이상 조건 유지 여부 최종 확인
+- snapshot 계약에 browseEligibility metadata 포함 여부 검토
 
 ---
 
-## 8. 위반 시 대응
+## 10. 위반 시 대응
 
 | 위반 유형 | 대응 |
 |-----------|------|
 | 새 코드에 `{id, data}` 접근 | PR reject |
 | API 응답에 직렬화기 미사용 | PR reject |
-| snake_case 필드 노출 | 버그로 처리, serializers 보강 |
-| 프론트에서 직접 snake_case 보정 | normalize.js로 이관 후 제거 |
-| browse snapshot 없이 detail/tree payload를 Modal에 재사용 | 계약 위반으로 처리 |
-| user-state 필드를 summary 기본 계약에 직접 주입 | 계약 위반으로 처리 |
+| createTree payload만 public으로 단독 변경 | PR reject |
+| Netlify와 Modal visibility 정책 불일치 | PR reject |
+| Plus private을 frontend-only로 잠금 | PR reject |
+| 기존 private tree 자동 public 전환 | PR reject |
+| public visibility를 browse 노출로 설명 | 정책 위반으로 수정 |
 
 ---
 
-**문서 유지보수:** API 응답 구조 변경 시 이 문서를 반드시 갱신할 것
+**문서 유지보수:** API 응답 구조 또는 visibility 정책 변경 시 이 문서를 반드시 갱신할 것

--- a/docs/ops/MODAL_BROWSE_RUNTIME.md
+++ b/docs/ops/MODAL_BROWSE_RUNTIME.md
@@ -2,14 +2,16 @@
 
 LoveBud browse/public summary 경로에서 Modal을 1순위 읽기/계산 계층으로 유지하기 위한 운영 기준입니다.
 
+---
+
 ## 1. 현재 기준 경로
 
 - Cloudflare Pages 프런트(`https://lovebud.pages.dev`)는 browse 진입 시 직접 Modal을 호출하지 않습니다.
 - 프런트는 same-origin `/api/community/trees?view=summary&sort=latest&limit=3`를 호출합니다.
-- Cloudflare Pages `functions/api/[[path]].js`가 `view=summary` 요청을 받으면 **먼저 Modal**의 `/modal/browse/latest?limit=<n>`를 호출합니다.
+- Cloudflare Pages `functions/api/[[path]].js`가 `view=summary` 요청을 받으면 먼저 Modal의 `/modal/browse/latest?limit=<n>`를 호출합니다.
 - Modal 응답이 실패하거나 비어 있으면 Cloudflare Pages route가 Vercel upstream으로 fallback 합니다.
 
-즉, 현재 주경로는 아래와 같습니다.
+현재 주경로:
 
 1. 브라우저 → `https://lovebud.pages.dev/api/community/trees?view=summary&sort=latest&limit=3`
 2. Cloudflare Pages `functions/api/[[path]].js`
@@ -17,9 +19,12 @@ LoveBud browse/public summary 경로에서 Modal을 1순위 읽기/계산 계층
 4. 실패 시 Vercel upstream fallback
 
 중요:
-- 현재 main 기준 browse summary의 same-origin entry는 **Cloudflare Pages `/api/community/trees`** 입니다.
+
+- 현재 main 기준 browse summary의 same-origin entry는 Cloudflare Pages `/api/community/trees`입니다.
 - Vercel은 브라우저의 직접 진입점이 아니라 upstream / secondary 계층입니다.
-- Netlify는 legacy / fallback 계층입니다.
+- Netlify는 fallback / legacy 계층입니다.
+
+---
 
 ## 2. main 기준 Modal browse 계약
 
@@ -27,6 +32,15 @@ LoveBud browse/public summary 경로에서 Modal을 1순위 읽기/계산 계층
 
 - `GET /modal/health`
 - `GET /modal/browse/latest?limit=1..60&sort=latest|popular`
+- `GET /modal/browse/growing?limit=3..12`
+- `GET /modal/community/memories`
+- `GET /modal/memories/{memory_id}`
+- `GET /modal/trees/{tree_id}`
+- `GET /modal/private/trees`
+- `POST /modal/private/trees`
+- `GET /modal/private/trees/{tree_id}`
+- `GET /modal/private/memories`
+- `POST /modal/private/memories`
 
 Modal browse summary는 아래 key를 flat camelCase로 반환합니다.
 
@@ -43,21 +57,86 @@ Modal browse summary는 아래 key를 flat camelCase로 반환합니다.
 - `timeRange`
 - `representativeMemorySourceUrl`
 
-## 3. 품질 가드와 publication guard 구분
+---
+
+## 3. Visibility / private storage 정책
+
+### 3.1 현재 Modal 구현
+
+현재 Modal private owner write path는 private-first입니다.
+
+- `/modal/private/trees` POST는 tree visibility 기본값을 `private`으로 처리합니다.
+- `/modal/private/trees` POST에 `visibility: public`이 들어오면 현재 구현은 409를 반환합니다.
+- `/modal/private/memories` POST는 memory visibility 기본값을 `private`으로 처리합니다.
+- Plus entitlement 검증은 아직 없습니다.
+
+### 3.2 목표 정책
+
+CTO 결정 기준 목표 정책은 **public-first + Plus private**입니다.
+
+- 신규 tree는 public-first 방향으로 전환합니다.
+- 기존 private tree는 자동 public 전환하지 않고 grandfathered private으로 유지합니다.
+- private 생성/전환은 Plus entitlement source 확정 후 backend에서 검증합니다.
+- public visibility와 browse 노출 조건은 분리합니다.
+- createTree payload만 단독으로 public 변경하는 것은 금지합니다.
+- Netlify와 Modal 정책은 반드시 동기화합니다.
+
+### 3.3 Modal 전환 원칙
+
+Modal은 Netlify/API 정책과 동시에 바뀌어야 합니다.
+
+금지:
+
+- Netlify는 public-first인데 Modal은 private-first로 남기는 상태
+- Modal은 public-first인데 Netlify는 private-first로 남기는 상태
+- Cloudflare route가 Modal/Netlify 차이를 숨기도록 방치하는 상태
+- Plus entitlement 없이 Modal private write만 frontend에서 숨기는 상태
+
+전환 시 필요한 항목:
+
+- `/modal/private/trees` POST default visibility 변경 여부
+- private 생성 시 entitlement check
+- public → private toggle endpoint가 Modal에 추가될 경우 동일 entitlement check
+- grandfathered private owner read 유지
+- public browse filters 유지
+
+Decision-needed:
+
+- Modal이 user plan을 직접 조회할지, upstream/API layer에서 검증할지
+- Modal secret/env로 entitlement source에 접근할지
+- Modal private endpoint의 Plus-required error contract
+
+---
+
+## 4. 품질 가드와 publication guard 구분
 
 Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강제합니다.
 
 - `trees.visibility = 'public'`
 - public memories `HAVING count(*) >= 3`
 
-따라서 browse latest summary는 **공개 순간 3개 이상**인 공개 트리만 반환해야 합니다.
+따라서 browse latest summary는 공개 순간 3개 이상인 공개 트리만 반환해야 합니다.
 
 중요:
-- 이 문서에서 설명하는 조건은 **browse summary display filter / quality filter** 맥락입니다.
-- 트리를 public으로 전환할 수 있는지 결정하는 **publication guard**와 혼동하지 않습니다.
-- publication guard 운영 기준은 `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`를 따릅니다.
 
-## 4. CORS 기준
+- 이 조건은 **browse summary display filter / quality filter**입니다.
+- `visibility: public` 자체와 같은 의미가 아닙니다.
+- public-first 전환 후에도 public tree가 곧바로 browse에 노출되는 것은 아닙니다.
+- publication/visibility 전환 guard와 browse display filter를 혼동하지 않습니다.
+
+전환 후 권장 해석:
+
+| 개념 | 의미 | Modal browse 영향 |
+|------|------|-------------------|
+| public visibility | 공개 접근 가능한 tree 상태 | 필요 조건 |
+| browseEligible | 둘러보기 카드 노출 가능 상태 | summary 반환 조건 |
+| public memory count | 공개 memory 개수 | 품질 threshold |
+| grandfathered private | 기존 private 유지 상태 | browse 제외 |
+| Plus private | 유료 private 보관 상태 | browse 제외 |
+
+---
+
+## 5. CORS 기준
 
 `modal_compute/app.py` 기본 허용 origin 예시:
 
@@ -67,24 +146,38 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 
 운영에서는 필요 시 `CORS_ALLOWED_ORIGINS`로 덮어씁니다.
 
-## 5. 필수 운영 환경 변수
+---
+
+## 6. 필수 운영 환경 변수
 
 ### Cloudflare Pages
+
 - `MODAL_BASE_URL`
   - Cloudflare Pages `functions/api/[[path]].js`가 browse summary용 Modal upstream으로 사용
 - `LOVEBUD_UPSTREAM_ORIGIN`
   - Modal 실패 시 fallback upstream origin으로 사용
 
 ### Modal secret/runtime
+
 - `DATABASE_URL`
   - Modal secret `lovebud-db`에서 주입
 
 ### Optional
+
 - `CORS_ALLOWED_ORIGINS`
   - 콤마 구분 문자열
   - 기본값이 있더라도 운영에서는 명시 설정 권장
 
-## 6. 운영 체크리스트
+### Decision-needed for Plus private
+
+- Plus entitlement source env/secret
+- plan lookup endpoint or DB table
+- entitlement cache policy
+- Plus-required error code/status
+
+---
+
+## 7. 운영 체크리스트
 
 1. Cloudflare Pages 운영 환경에 `MODAL_BASE_URL`가 설정되어 있는지 확인
 2. Cloudflare Pages 운영 환경에 `LOVEBUD_UPSTREAM_ORIGIN`가 설정되어 있는지 확인
@@ -92,22 +185,67 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 4. `/modal/browse/latest?limit=3`가 배열을 반환하는지 확인
 5. 각 item에 browse 카드가 기대하는 key가 모두 있는지 확인
 6. Modal 장애 시 Cloudflare Pages route가 Vercel fallback으로 계속 browse를 살리는지 확인
+7. public-first 전환 시 Netlify와 Modal create policy가 같은지 확인
+8. Plus private 적용 시 Modal private write path가 entitlement를 검증하는지 확인
+9. grandfathered private tree가 browse에 노출되지 않는지 확인
 
-## 7. 데이터 shape 메모
+---
+
+## 8. 데이터 shape 메모
 
 현재 main 기준으로 browse 첫 렌더에 꼭 필요한 shape는 충족합니다.
-다만 아래 필드는 운영 점검 시 함께 봅니다.
+
+운영 점검 필드:
 
 - `representativeThumbnail`: 가능한 한 시각 카드에 바로 쓸 수 있는 값이어야 함
 - `emotionTags`: browse chip/preview에 바로 쓸 수 있는 문자열 배열이어야 함
 - `theme`: 현재 고정값이면 후속 개선 후보
 - `timeRange`: 현재 비어 있으면 후속 개선 후보
+- `visibility`: public이어야 browse summary 대상
 
-## 8. 역할 분리
+---
+
+## 9. 역할 분리
 
 - Modal: browse summary 읽기/집계 1순위 계층
 - Cloudflare Pages: same-origin entry + API 라우터
 - Vercel: upstream / secondary entry 유지
 - Netlify: fallback / legacy 유지
 
-이 원칙은 유지하되, 프런트가 직접 Modal URL이나 Vercel/Netlify URL에 강결합되지 않도록 현재 구조를 기본값으로 둡니다.
+Visibility 정책 전환 후에도 프런트가 직접 Modal URL이나 Vercel/Netlify URL에 강결합되지 않도록 현재 구조를 기본값으로 둡니다.
+
+---
+
+## 10. public-first 전환 전 금지 사항
+
+- createTree payload만 public으로 변경
+- Modal만 public-first로 변경
+- Netlify만 public-first로 변경
+- 기존 private tree 자동 public 전환
+- Plus entitlement 없이 private write를 정책상 완료로 선언
+- browse latest filter에서 public memory threshold를 암묵적으로 제거
+
+---
+
+## 11. 이후 작업 분리
+
+### Modal/backend 작업
+
+- public-first create policy 반영
+- private create entitlement guard
+- public/private visibility transition 정책 반영
+- grandfathered private 유지
+- browse summary filter 유지
+
+### Cloudflare/API routing 작업
+
+- Modal failure fallback이 visibility 정책 불일치를 숨기지 않도록 점검
+- API response/error contract 동기화
+
+### Frontend 작업
+
+- public-first UX copy
+- Plus private 안내
+- browse 노출 조건 설명
+
+이 문서는 코드 변경 지시가 아니라 운영/정책 정합성 기준입니다.

--- a/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
+++ b/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
@@ -2,266 +2,282 @@
 
 이 문서는 LoveBud / LoveTree의 공개, 비공개, 둘러보기 소개 UX 정책을 정리합니다.
 
-목적은 사용자가 생성 단계에서 공개 범위 설정을 고르는 부담을 느끼지 않고, 좋아하는 순간을 남기며 둘러보기에 소개될 수 있는 트리로 키우는 흐름을 이해하도록 하는 것입니다.
+현재 CTO 결정에 따라 제품 방향은 **public-first + Plus private**으로 전환합니다. 단, 코드 수정 전 단계에서는 기존 private-first 구현을 즉시 변경하지 않고, 문서상 목표 정책과 전환 가드레일을 먼저 고정합니다.
 
-이 문서는 UX 정책 문서입니다. 결제, 권한, backend, API, DB 변경을 제안하거나 확정하지 않습니다.
-
----
-
-## 1. 정책 요약
-
-1. 새 트리는 처음부터 `public`으로 생성하지 않습니다.
-2. 공개 전환은 공개 순간 3개 이상이 된 뒤 가능해야 합니다.
-3. 생성 단계에서는 public/private 선택 부담을 주지 않습니다.
-4. 기본 흐름은 **둘러보기에 소개될 트리로 키우기**입니다.
-5. 사용자는 공개 설정을 고르는 것이 아니라, 트리를 키우는 목표를 이해해야 합니다.
-6. 프라이빗 보관은 향후 Plus 또는 유료 혜택으로 분리될 가능성이 있지만, 이번 정책은 결제/권한/backend 변경을 포함하지 않습니다.
+이 문서는 UX/제품 정책 문서입니다. 결제, 권한, backend, API, DB 변경을 직접 구현하거나 확정하지 않습니다. 실제 구현은 별도 frontend/backend 작업으로 분리합니다.
 
 ---
 
-## 2. 제품 해석
+## 1. 확정 정책 요약
 
-LoveBud / LoveTree는 일반 설정 중심 도구가 아닙니다.
-
-- 핵심 경험은 팬의 첫 순간과 좋아하는 기억을 쌓는 것입니다.
-- 공개는 생성 시점의 설정값이 아니라, 트리가 충분히 자란 뒤 선택할 수 있는 소개 단계입니다.
-- 둘러보기는 게시판이 아니라 다른 러브트리를 감상하는 공간입니다.
-- 새 트리 생성은 공개 범위 선택보다 감정 기록 시작에 집중해야 합니다.
-
-따라서 생성 UX는 공개/비공개 선택 UI가 아니라, 다음 목표를 안내하는 흐름이어야 합니다.
-
-> 좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요.
+1. 신규 tree는 장기적으로 `public-first` 방향으로 전환합니다.
+2. 기존 private tree는 자동 public 전환하지 않고 **grandfathered private**으로 유지합니다.
+3. private 생성/전환은 Plus entitlement source가 확정된 뒤 backend에서 검증합니다.
+4. `public visibility`와 `browse 노출 조건`은 분리합니다.
+5. createTree payload만 단독으로 `public` 변경하는 것은 금지합니다.
+6. Netlify와 Modal visibility 정책은 반드시 동기화합니다.
+7. 결제/권한 로직 확정 전에는 Plus private을 확정 기능처럼 과도하게 노출하지 않습니다.
 
 ---
 
-## 3. UX 원칙
+## 2. 현재 구현 상태
 
-### 3.1. 생성 단계에서 공개 설정을 전면에 두지 않는다
+현재 main 구현은 아직 private-first입니다.
 
-생성 모달은 사용자가 새 트리를 시작하는 순간입니다.
+- My Trees 생성 모달은 `visibility: private` payload를 보냅니다.
+- backend create tree API는 public 생성 요청을 차단합니다.
+- Editor의 visibility toggle은 public/private 전환을 허용하지만 Plus 권한 검증은 없습니다.
+- Settings의 `프라이빗 보관` 문구는 `Plus에서 준비 중` 수준의 보조 안내입니다.
 
-이 단계에서 `public/private` 선택을 직접 요구하면 다음 문제가 생깁니다.
+따라서 본 문서는 목표 정책을 정의하되, 현재 코드 동작과 혼동하지 않도록 다음을 명시합니다.
 
-1. backend publication guard와 충돌할 수 있음
-2. 사용자가 설정을 먼저 이해해야 하는 부담이 생김
-3. LoveTree를 키우는 감정 흐름보다 공개 범위 선택이 앞에 나옴
-4. public 선택 후 409가 발생하는 UX가 부정적으로 느껴질 수 있음
-
-따라서 생성 단계에서는 공개 범위 라디오를 제거하고, 시작 목표 카드로 대체합니다.
-
-### 3.2. 비공개를 무료 기본 선택지처럼 강하게 학습시키지 않는다
-
-현재 backend 생성 payload는 항상 private이어야 하지만, UX에서 이를 강하게 노출하지 않습니다.
-
-- `비공개 기본값`을 전면 문구로 쓰지 않습니다.
-- `공개/비공개 선택`을 생성 단계의 핵심 액션으로 만들지 않습니다.
-- private은 backend 안전 상태이며, 사용자-facing 목표는 둘러보기 소개 준비입니다.
-
-### 3.3. 순간 3개 이상을 성장 목표로 보여준다
-
-공개 전환 조건은 사용자가 이해할 수 있는 성장 목표로 표현합니다.
-
-권장 해석:
-
-- 공개 순간 0/3: 아직 준비 전
-- 공개 순간 1/3: 첫 순간을 남김
-- 공개 순간 2/3: 거의 준비됨
-- 공개 순간 3/3 이상: 둘러보기에 소개 가능
-
-사용자는 설정을 고르는 것이 아니라, 러브트리를 키워서 소개 가능 상태에 도달한다고 이해해야 합니다.
-
-### 3.4. 둘러보기 소개는 공개 전환과 분리해 설명한다
-
-둘러보기 소개는 사용자-facing UX 목표입니다.
-
-반면 publication guard는 server-side 정책입니다.
-
-문서와 UI에서 다음을 혼동하지 않습니다.
-
-- publication guard: public 전환 가능 여부를 막는 서버 정책
-- browse display filter: 둘러보기에 어떤 트리를 보여줄지 결정하는 표시 정책
-
-상세 개념 분리는 [`BROWSE_FILTER_VS_PUBLICATION_GUARD.md`](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md)를 따릅니다.
+> 코드 전환은 frontend 단독으로 진행하지 않습니다. create tree, toggle visibility, Netlify, Modal, 권한 검증 정책을 함께 설계한 뒤 단계적으로 반영합니다.
 
 ---
 
-## 4. 화면별 가이드
+## 3. 제품 해석
 
-### 4.1. 생성 모달
+LoveBud / LoveTree의 공개 정책은 다음 두 개념을 분리해야 합니다.
 
-생성 모달의 목표는 공개 범위 선택이 아니라 새 트리 시작입니다.
+### 3.1. public visibility
 
-#### 해야 할 것
+`public visibility`는 해당 tree 또는 memory가 링크/공개 접근 가능한 상태인지 나타내는 저장 상태입니다.
 
-- 공개/비공개 라디오를 제거합니다.
-- 시작 목표 카드를 표시합니다.
-- 생성 payload는 항상 `visibility: private`으로 보냅니다.
-- public 선택지를 생성 단계에서 직접 제공하지 않습니다.
+public-first 전환 후 신규 tree는 기본적으로 public visibility를 갖는 방향입니다.
 
-#### 권장 카드 문구
+### 3.2. browse 노출 조건
 
-제목:
+`browse 노출`은 둘러보기 화면에 소개될 수 있는 표시 조건입니다.
 
-> 둘러보기에 소개될 트리로 키우기
+public tree라고 해서 즉시 둘러보기에 노출되는 것은 아닙니다. 둘러보기 노출은 품질/성장 조건을 별도로 따릅니다.
 
-설명:
+권장 기본 조건:
 
-> 좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요.
+- tree visibility가 `public`
+- public memory가 최소 3개 이상
+- browse summary/display filter를 통과
 
-보조 설명 후보:
-
-> 먼저 조용히 시작하고, 충분히 자라면 소개할 수 있어요.
-
-#### 피해야 할 UX
-
-- `공개/비공개` 라디오
-- `지금 바로 공개` 버튼
-- public 선택 후 backend 409 노출
-- `비공개 기본값`을 주요 안내로 강조
-
-### 4.2. 에디터
-
-에디터는 트리를 키우는 공간입니다.
-
-공개 상태 설정을 크게 배치하기보다, 작은 progress card로 둘러보기 소개 준비 상태를 보여줍니다.
-
-#### 권장 컴포넌트
-
-- 작은 `둘러보기 소개 준비` progress card
-- 공개 순간 카운트 표시
-- 3개 이상일 때 별도 소개 가능 CTA
-
-#### 상태별 예시
-
-| 공개 순간 수 | 상태 문구 | UX 방향 |
-|--------------|-----------|---------|
-| 0/3 | 아직 소개 준비 전이에요 | 첫 공개 순간 남기기 유도 |
-| 1/3 | 첫 순간이 준비됐어요 | 다음 순간 추가 유도 |
-| 2/3 | 거의 준비됐어요 | 하나 더 남기기 유도 |
-| 3/3 이상 | 둘러보기에 소개할 수 있어요 | 소개 가능 CTA 제공 |
-
-#### CTA 예시
-
-- `둘러보기 소개 준비 보기`
-- `둘러보기에 소개하기`
-- `소개 가능 상태 확인하기`
-
-### 4.3. 설정
-
-설정 화면에서도 공개 범위 라디오를 기본 구조로 두지 않습니다.
-
-#### 해야 할 것
-
-- 기본 공개 범위 라디오를 제거합니다.
-- 둘러보기 소개 안내로 대체합니다.
-- 소개 가능 조건과 현재 상태를 설명합니다.
-- 프라이빗 보관/Plus 준비 중은 작게 보조 카드로만 표현할 수 있습니다.
-
-#### 권장 문구
-
-제목:
-
-> 둘러보기 소개
-
-설명:
-
-> 좋아하는 순간을 3개 이상 남기면 이 트리를 둘러보기에 소개할 수 있어요.
-
-보조 카드:
-
-> 프라이빗 보관은 Plus에서 준비 중이에요.
-
-단, Plus 보조 카드는 결제, 권한, backend 제한이 실제 구현되기 전까지는 안내 수준으로만 둡니다.
+이 분리는 사용자가 `공개 = 바로 둘러보기 노출`로 오해하지 않게 하기 위한 핵심 정책입니다.
 
 ---
 
-## 5. 유료화 가드레일
+## 4. 기존 private tree grandfathering
 
-프라이빗 보관은 향후 Plus 또는 유료 혜택으로 분리될 수 있습니다.
+기존 private tree는 자동으로 public 전환하지 않습니다.
 
-다만 현재 정책 문서에서는 다음을 금지합니다.
+이유:
 
-1. 실제 결제 UX 제안
-2. 권한 제한 구현 제안
-3. backend 제한 변경 제안
-4. DB schema 변경 제안
-5. 생성 모달에서 `비공개는 유료입니다`를 강하게 노출
+1. 기존 사용자는 private-first UX 아래에서 tree를 만들었습니다.
+2. 자동 public 전환은 사용자 기대와 신뢰를 훼손할 수 있습니다.
+3. production 데이터 visibility 일괄 변경은 별도 승인 없이 금지합니다.
 
-현재 무료 사용자 경험은 다음처럼 느껴져야 합니다.
+권장 처리:
 
-- 새 트리를 자연스럽게 시작한다.
-- 좋아하는 순간을 남긴다.
-- 3개 이상이 되면 둘러보기에 소개할 수 있다는 목표를 본다.
-- 프라이빗 보관/Plus는 보조 정보로만 접한다.
-
----
-
-## 6. backend 정합성
-
-### 6.1. 새 트리 생성
-
-backend 기준 새 트리는 처음부터 public으로 생성하지 않습니다.
-
-따라서 생성 모달에서 public 선택지를 제공하지 않고, 생성 payload는 항상 private으로 보내는 것이 UX와 backend 정책 모두에 맞습니다.
-
-### 6.2. 공개 전환
-
-비공개 트리를 public으로 전환하려면 공개 순간이 3개 이상이어야 합니다.
-
-이 조건은 server-side publication guard입니다.
-
-UI는 이를 에러로 처음 경험하게 하기보다, progress card와 소개 가능 CTA로 미리 설명해야 합니다.
-
-### 6.3. browse display filter와 publication guard 구분
-
-둘러보기 노출 기준과 public 전환 가능 조건은 같은 개념이 아닙니다.
-
-- browse display filter: 둘러보기에서 어떤 트리를 보여줄지 결정하는 표시 정책
-- publication guard: public 전환 가능 여부를 결정하는 서버 정책
-
-상세 기준은 [`BROWSE_FILTER_VS_PUBLICATION_GUARD.md`](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md)를 참조합니다.
+- 기존 private tree는 owner에게 계속 private으로 보입니다.
+- 기존 private tree는 `grandfathered private` 상태로 유지합니다.
+- 사용자가 명시적으로 public 전환할 수 있는 UX는 별도 승인 후 제공합니다.
+- free user가 기존 private tree를 public으로 전환하는 것은 허용 가능 후보입니다.
+- free user가 public tree를 private으로 전환하는 것은 Plus entitlement 확정 후 제한합니다.
 
 ---
 
-## 7. 금지 표현 / 권장 표현
+## 5. UX 원칙
 
-### 7.1. 금지 또는 최소화 표현
+### 5.1. 신규 tree 생성
 
-| 표현 | 이유 |
+목표 정책은 public-first입니다.
+
+다만 구현 전환 전까지는 현재 private-first payload를 단독으로 바꾸면 안 됩니다. public-first 전환은 다음이 함께 준비된 뒤 진행합니다.
+
+- frontend 생성 UX
+- Netlify create tree 정책
+- Modal create tree 정책
+- browse display filter 정합성
+- Plus entitlement source
+- 기존 private tree grandfathering 처리
+
+전환 후 권장 생성 UX:
+
+- 기본 안내: `새 러브트리는 공개 상태로 시작해요.`
+- 보조 안내: `둘러보기에는 충분히 자란 뒤 소개돼요.`
+- private 선택지는 Plus private storage로 분리하되, 결제/권한 확정 전에는 강한 판매 문구를 쓰지 않습니다.
+
+### 5.2. 무료 사용자의 private 선택
+
+Plus entitlement source가 확정되기 전:
+
+- private 선택을 확정 기능처럼 노출하지 않습니다.
+- `프라이빗 보관은 Plus에서 준비 중이에요.` 수준으로 안내합니다.
+
+Plus entitlement source가 확정된 뒤:
+
+- 무료 사용자가 private 생성/전환을 선택하면 Plus 필요 안내를 보여줍니다.
+- frontend 안내와 backend 권한 검증을 함께 적용합니다.
+
+권장 문구 후보:
+
+> 비공개 보관은 Plus에서 사용할 수 있어요.
+
+> 지금은 공개 상태로 시작하고, 둘러보기 소개 여부는 조건을 채운 뒤 따로 정리할 수 있어요.
+
+### 5.3. Editor badge
+
+현재 Editor의 `비공개 러브트리` badge는 단순 visibility 상태입니다.
+
+public-first 전환 후에는 다음 의미를 분리해야 합니다.
+
+| 상태 | 의미 |
 |------|------|
-| 공개 범위 | 설정 중심으로 느껴짐 |
-| 공개/비공개 선택 | 생성 단계에서 선택 부담을 만듦 |
-| 지금 바로 공개 | backend publication guard와 충돌 가능 |
-| 비공개 기본값 | 무료 기본 경험을 비공개로 학습시킴 |
+| 공개 러브트리 | public visibility 상태 |
+| 둘러보기 준비 중 | public이지만 browse 노출 조건 미충족 |
+| 둘러보기 소개 가능 | public이며 browse 노출 조건 충족 |
+| 비공개 보관 | Plus private 또는 grandfathered private |
 
-### 7.2. 권장 표현
+### 5.4. 공개/비공개 전환 버튼 위치
 
-| 표현 | 사용 위치 |
-|------|----------|
-| 둘러보기에 소개될 트리로 키우기 | 생성 모달 시작 목표 카드 |
-| 좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요 | 생성 모달 / 에디터 / 설정 안내 |
-| 둘러보기 소개 준비 | 에디터 progress card |
-| 프라이빗 보관 | Plus 보조 카드 |
-| Plus에서 준비 중 | 유료화 예고 보조 문구 |
+공개/비공개 전환은 기본 작업 흐름을 방해하지 않는 위치에 둡니다.
+
+권장 위치:
+
+- Editor sidebar의 접힌 설정 패널
+- My Trees card overflow menu
+
+기본 Editor 작업 화면에 visibility 설명을 과도하게 노출하지 않습니다.
+
+### 5.5. Settings
+
+Settings에서 기본 공개 범위 설정을 즉시 부활시키는 것은 보류합니다.
+
+권장 방향:
+
+- Settings는 정책 설명과 private storage 안내 중심으로 유지합니다.
+- `기본 공개 범위` 라디오는 Plus entitlement와 backend enforcement가 준비된 뒤 재검토합니다.
+- 사용자가 바꿀 수 없는 정책값을 설정처럼 노출하지 않습니다.
 
 ---
 
-## 8. 이후 UI 구현 기준
+## 6. API/backend 정합성 원칙
 
-이 문서를 기준으로 이후 UI Web은 다음 방향으로 구현할 수 있습니다.
+### 6.1. create tree
 
-1. 생성 모달에서 공개/비공개 라디오 제거
-2. 시작 목표 카드 추가
-3. 생성 payload를 항상 `visibility: private`으로 유지
-4. 에디터에 `둘러보기 소개 준비` progress card 추가
-5. 공개 순간 수 0/3, 1/3, 2/3, 3/3 이상 상태 표현
-6. 3개 이상일 때 별도 소개 가능 CTA 표시
-7. 설정 화면에서 기본 공개 범위 라디오를 둘러보기 소개 안내로 대체
-8. Plus/프라이빗 보관은 작고 보조적인 준비 중 카드로만 표현
+목표 정책:
 
-주의:
+- 신규 tree는 public-first 방향으로 전환합니다.
+- 단, frontend payload만 단독 변경하지 않습니다.
+- Netlify와 Modal create 정책을 동시에 동기화합니다.
 
-- 이 문서는 코드 변경 지시가 아닙니다.
-- 실제 구현은 별도 UI Web 작업으로 분리합니다.
-- backend publication guard 변경은 포함하지 않습니다.
-- 결제/권한/Plus 구현은 포함하지 않습니다.
+현재 구현:
+
+- Netlify create tree는 public 생성 요청을 차단합니다.
+- Modal create tree도 public 생성 요청을 차단합니다.
+
+전환 조건:
+
+- API 계약 문서 개정
+- backend create guard 개정
+- Modal create guard 개정
+- frontend 생성 UX 개정
+- entitlement 미확정 상태에서 private 선택지를 어떻게 처리할지 결정
+
+### 6.2. toggle visibility
+
+목표 정책:
+
+- public → private 전환은 Plus private 기능으로 잠급니다.
+- private → public 전환은 grandfathered private 해제 또는 publish 흐름으로 취급합니다.
+- Plus entitlement source가 확정되기 전에는 backend enforcement를 구현하지 않습니다.
+
+현재 구현:
+
+- private → public 전환은 공개 memory 3개 이상 조건을 요구합니다.
+- public → private 전환에는 Plus 권한 검증이 없습니다.
+
+전환 시 재정의 필요:
+
+- public-first 이후에도 private → public 전환에 공개 memory 3개 조건을 둘지
+- 또는 visibility 전환과 browse 소개 조건을 완전히 분리할지
+
+권장 방향:
+
+- visibility 전환과 browse 노출 조건은 분리합니다.
+- public 전환 자체는 접근성/공개 상태입니다.
+- browse 노출은 public memory 3개 이상 display filter로 관리합니다.
+
+---
+
+## 7. Plus entitlement decision-needed
+
+아래 항목은 아직 미확정입니다.
+
+- Plus entitlement source of truth
+- plan 정보를 저장할 DB 위치
+- free/plus 판정 API
+- frontend에서 Plus 상태를 읽는 방식
+- backend에서 private 생성/전환을 차단할 때 사용할 HTTP status/code
+- 기존 grandfathered private tree를 Plus 없이 계속 private 유지할 기간
+- 결제 UX 도입 시점
+
+권장 API error code 후보:
+
+```text
+PLUS_REQUIRED_PRIVATE_STORAGE
+```
+
+권장 사용자 문구 후보:
+
+> 비공개 보관은 Plus에서 사용할 수 있어요.
+
+---
+
+## 8. 금지 사항
+
+- createTree payload만 단독으로 `public`으로 바꾸지 않습니다.
+- Netlify만 바꾸고 Modal을 방치하지 않습니다.
+- Modal만 바꾸고 Netlify를 방치하지 않습니다.
+- 기존 private tree를 자동 public 전환하지 않습니다.
+- Plus entitlement 없이 frontend-only lock으로 정책 완료를 선언하지 않습니다.
+- 결제/권한 로직 확정 전 Plus private을 확정 기능처럼 과도하게 홍보하지 않습니다.
+
+---
+
+## 9. 이후 구현 분리
+
+### Frontend 작업
+
+- My Trees 생성 모달 public-first copy/IA
+- private 선택 Plus 안내
+- Editor badge 상태 분리
+- Editor/My Trees visibility action 재배치
+- Settings private storage 안내 조정
+- i18n key 정리
+
+### Backend 작업
+
+- Netlify create tree policy 전환
+- Netlify toggle visibility entitlement guard
+- Modal create tree policy 전환
+- Modal private endpoint entitlement guard
+- API error contract 고정
+- grandfathered private 처리 정책 반영
+
+### Docs 작업
+
+- API contract update
+- backend.md update
+- Modal runtime update
+- browse filter/public visibility 용어 정리
+
+---
+
+## 10. 현재 문서의 적용 상태
+
+이 문서는 정책 전환 기준 문서입니다.
+
+현재 main 코드가 이미 public-first로 바뀌었다는 의미가 아닙니다. 코드 반영 전에는 다음 현재 구현 사실을 유지합니다.
+
+- createTree payload는 private-first입니다.
+- backend create guard는 public 생성 요청을 차단합니다.
+- Modal create guard도 public 생성 요청을 차단합니다.
+- Plus entitlement enforcement는 없습니다.
+
+CTO 승인 후 별도 frontend/backend 작업에서 public-first 전환을 구현합니다.


### PR DESCRIPTION
## Summary

- Align product/API/backend/Modal docs with staged public-first + Plus private direction
- Preserve current implementation truth: production code remains private-first
- Clarify public visibility and browse listing separation
- Document grandfathering for existing private trees
- Keep Plus entitlement source as unresolved decision

## Scope

Changed docs only:

- `docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
- `docs/engineering/API_CONTRACT.md`
- `docs/backend/backend.md`
- `docs/ops/MODAL_BROWSE_RUNTIME.md`

## Explicit exclusions

- No code changes
- No UI changes
- No API/runtime behavior changes
- No backend implementation changes
- No createTree payload change
- No Modal implementation change
- No entitlement or payment implementation
- No production data migration

## Important note

This PR documents the intended staged policy direction only.
It does not implement public-first behavior.
After merge, production behavior remains private-first until separate frontend/backend PRs are approved and merged.

## Remaining decisions

- Plus entitlement source of truth
- Plan storage/provider
- Free/Plus decision API
- 403 vs 402 status for Plus-required private storage
- Error code/body shape
- Grandfathered private tree exception display
- Whether public transition itself requires 3 public memories or whether that guard moves only to browse listing
- Settings default visibility controls
- Modal entitlement verification boundary