### PR TITLE
ui(api): preserve backend error codes and response body

### DIFF
--- a/js/api/base-api-fetch.js
+++ b/js/api/base-api-fetch.js
@@ -105,13 +105,25 @@
 
     if (!response.ok) {
       let errorMsg = `HTTP Error ${response.status}`;
+      let errorData = null;
       try {
-        const errorData = await response.json();
-        errorMsg = errorData.error || errorMsg;
+        errorData = await response.json();
+        if (errorData) {
+          errorMsg = errorData.error || errorMsg;
+        }
       } catch (e) {}
+
       const error = new Error(errorMsg);
       error.status = response.status;
       error.statusCode = response.status;
+
+      if (errorData) {
+        error.data = errorData;
+        if (errorData.code) {
+          error.code = errorData.code;
+        }
+      }
+
       throw error;
     }
 


### PR DESCRIPTION
## Summary

- Preserve backend API error response bodies in client-side errors
- Preserve stable API error codes such as `PLUS_REQUIRED_PRIVATE_STORAGE` on `error.code`
- Keep existing `message`, `status`, and `statusCode` behavior unchanged

## Scope

Changed files:

- `js/api/base-api-fetch.js`

## Explicit non-changes

- No backend/API/runtime changes
- No auth module changes
- No docs changes
- No i18n changes
- No UI page changes
- No createTree payload changes
- No visibility toggle changes
- No My Trees / Editor / Settings / Search / Detail behavior changes

## Error shape

Before:

```js
{ message, status, statusCode }
```

After:

```js
{ message, status, statusCode, data?, code? }
```

Where:

- `data` preserves the full parsed JSON response body when available
- `code` preserves `data.code` when provided by the backend

## Verification

- Branch created from latest `main` at `a47b035f1e235d40e1a16c8c36e50921b889d22b`
- `git diff --name-only main..HEAD` confirmed one changed file
- Accidental `netlify/functions/_lib/http.js` change was reverted before commit
- Existing 401/403 retry and redirect logic should remain unchanged
- JSON parse failure / non-JSON error body falls back to existing behavior