### PR TITLE
fix(search): reduce first-paint fallback flash

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -112,8 +112,8 @@
       en: 'Connected Feelings'
     },
     'search.previewNoEmotionTags': {
-      ko: '아직 이어진 감정은 없어요.',
-      en: 'No saved emotions yet.'
+      ko: '감정의 결이 이곳에 놓여요.',
+      en: 'The feeling tone appears here.'
     },
     'search.previewTimelineRecentUpdate': {
       ko: '최근에 이어진 감정',

--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260422-3
+ * v20260422-4
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -249,13 +249,34 @@
         `;
     }
 
-    function renderLoading() {
+    function renderSkeletonCard(index) {
         return `
-            <div style="grid-column:1 / -1;text-align: center; padding: 80px 24px; color: var(--on-surface-variant);">
-                <span class="material-symbols-outlined" style="font-size: 48px; opacity: 0.4; margin-bottom: 16px; display: block; animation: spin 1s linear infinite;">sync</span>
-                <p style="font-size: 1.1rem; font-weight: 500;">공개 러브트리를 불러오는 중...</p>
+            <div class="tree-card search-skeleton-card" aria-hidden="true" style="animation-delay:${index * 0.04}s;pointer-events:none;">
+                <div class="tree-card-media search-skeleton-block" style="min-height:${index === 0 ? 210 : 182}px;"></div>
+                <div class="tree-card-body">
+                    <div class="search-skeleton-line search-skeleton-title"></div>
+                    <div class="search-skeleton-line search-skeleton-copy"></div>
+                    <div class="tree-meta-row">
+                        <div class="tree-meta-left">
+                            <span class="tree-meta-chip search-skeleton-chip"></span>
+                        </div>
+                        <div class="tree-meta-right">
+                            <span class="search-skeleton-line search-skeleton-count"></span>
+                        </div>
+                    </div>
+                </div>
             </div>
         `;
+    }
+
+    function renderSkeletonGrid(options = {}) {
+        _addAnimations();
+        const count = Math.max(1, Math.min(Number(options.count || 6), 8));
+        return Array.from({ length: count }, (_, index) => renderSkeletonCard(index)).join('');
+    }
+
+    function renderLoading(options = {}) {
+        return renderSkeletonGrid(options);
     }
 
     function renderResults(trees, options = {}) {
@@ -288,7 +309,29 @@
         style.textContent = `
             @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
             @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+            @keyframes searchSkeletonPulse { 0%, 100% { opacity: 0.58; } 50% { opacity: 1; } }
             .results-fade-in { animation: fadeIn 0.3s ease-out; }
+            .search-skeleton-card { cursor: default; box-shadow: 0 16px 32px rgba(75, 64, 57, 0.035); }
+            .search-skeleton-card::before { opacity: 0; }
+            .search-skeleton-block,
+            .search-skeleton-line,
+            .search-skeleton-chip {
+                display: block;
+                border-radius: 999px;
+                background: linear-gradient(90deg, rgba(144,73,81,0.07), rgba(255,255,255,0.72), rgba(122,139,110,0.07));
+                background-size: 220% 100%;
+                animation: searchSkeletonPulse 1.35s ease-in-out infinite;
+            }
+            .search-skeleton-block { border-radius: 1.35rem; width: 100%; }
+            .search-skeleton-title { width: 72%; height: 18px; }
+            .search-skeleton-copy { width: 92%; height: 13px; opacity: 0.75; }
+            .search-skeleton-chip { width: 96px; height: 28px; }
+            .search-skeleton-count { width: 82px; height: 13px; }
+            @media (prefers-reduced-motion: reduce) {
+                .search-skeleton-block,
+                .search-skeleton-line,
+                .search-skeleton-chip { animation: none; }
+            }
         `;
         document.head.appendChild(style);
     }
@@ -298,6 +341,7 @@
         renderTreeCard: renderTreeCard,
         renderResults: renderResults,
         renderLoading: renderLoading,
+        renderSkeletonGrid: renderSkeletonGrid,
         renderNoTreesState: renderNoTreesState,
         renderEmptySearchState: renderEmptySearchState,
         renderDemoBadge: renderDemoBadge,
@@ -312,5 +356,5 @@
         }
     };
 
-     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260422-3');
+     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260422-4');
  })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
     <style>
         .search-container {
             max-width: var(--page-work-max);
@@ -16,6 +16,27 @@
             display: grid;
             grid-template-columns: minmax(0, 1.62fr) 420px;
             gap: 34px;
+        }
+
+        .search-container .material-symbols-outlined {
+            font-family: 'Material Symbols Outlined';
+            font-weight: normal;
+            font-style: normal;
+            line-height: 1;
+            letter-spacing: normal;
+            text-transform: none;
+            white-space: nowrap;
+            word-wrap: normal;
+            direction: ltr;
+            -webkit-font-feature-settings: 'liga';
+            font-feature-settings: 'liga';
+            -webkit-font-smoothing: antialiased;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 1em;
+            min-width: 1em;
+            overflow: hidden;
         }
 
         .browse-curation-shell {
@@ -300,6 +321,7 @@
             background:
                 radial-gradient(circle at 20% 15%, rgba(255, 245, 246, 0.95), rgba(255,255,255,0.18) 46%),
                 linear-gradient(135deg, rgba(144, 73, 81, 0.13), rgba(122, 139, 110, 0.14));
+            isolation: isolate;
         }
 
         .tree-card-media img {
@@ -325,8 +347,11 @@
             align-items: center;
             justify-content: center;
             color: var(--primary);
-            font-size: 42px;
+            font-size: 34px;
             font-weight: 900;
+            background:
+                radial-gradient(circle at 18% 16%, rgba(255, 245, 246, 0.96), rgba(255,255,255,0.18) 48%),
+                linear-gradient(135deg, rgba(144, 73, 81, 0.11), rgba(122, 139, 110, 0.13));
         }
 
         .tree-card-media-fallback[hidden] {

--- a/pages/search.html
+++ b/pages/search.html
@@ -217,6 +217,63 @@
             min-width: 0;
         }
 
+        .search-skeleton-card {
+            pointer-events: none;
+            cursor: default;
+            box-shadow: 0 16px 32px rgba(75, 64, 57, 0.035);
+        }
+
+        .search-skeleton-card::before {
+            opacity: 0;
+        }
+
+        .search-skeleton-block,
+        .search-skeleton-line,
+        .search-skeleton-chip {
+            display: block;
+            border-radius: 999px;
+            background: linear-gradient(90deg, rgba(144,73,81,0.07), rgba(255,255,255,0.72), rgba(122,139,110,0.07));
+            background-size: 220% 100%;
+            animation: searchSkeletonPulse 1.35s ease-in-out infinite;
+        }
+
+        .search-skeleton-block {
+            border-radius: 1.35rem;
+            width: 100%;
+        }
+
+        .search-skeleton-title {
+            width: 72%;
+            height: 18px;
+        }
+
+        .search-skeleton-copy {
+            width: 92%;
+            height: 13px;
+            opacity: 0.75;
+        }
+
+        .search-skeleton-chip {
+            width: 96px;
+            height: 28px;
+        }
+
+        .search-skeleton-count {
+            width: 82px;
+            height: 13px;
+        }
+
+        @keyframes searchSkeletonPulse {
+            0%, 100% { opacity: 0.58; }
+            50% { opacity: 1; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .search-skeleton-block,
+            .search-skeleton-line,
+            .search-skeleton-chip { animation: none; }
+        }
+
         /* Growing Trees Section */
         .growing-trees-section {
             margin-top: 50px;
@@ -697,7 +754,39 @@
             </div>
 
             <div id="resultsList">
-                <!-- Populated by JS -->
+                <div class="tree-card tree-card-featured search-skeleton-card" aria-hidden="true">
+                    <div class="tree-card-media search-skeleton-block" style="min-height:210px;"></div>
+                    <div class="tree-card-body">
+                        <div class="search-skeleton-line search-skeleton-title"></div>
+                        <div class="search-skeleton-line search-skeleton-copy"></div>
+                        <div class="tree-meta-row">
+                            <div class="tree-meta-left"><span class="tree-meta-chip search-skeleton-chip"></span></div>
+                            <div class="tree-meta-right"><span class="search-skeleton-line search-skeleton-count"></span></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tree-card search-skeleton-card" aria-hidden="true">
+                    <div class="tree-card-media search-skeleton-block"></div>
+                    <div class="tree-card-body">
+                        <div class="search-skeleton-line search-skeleton-title"></div>
+                        <div class="search-skeleton-line search-skeleton-copy"></div>
+                        <div class="tree-meta-row">
+                            <div class="tree-meta-left"><span class="tree-meta-chip search-skeleton-chip"></span></div>
+                            <div class="tree-meta-right"><span class="search-skeleton-line search-skeleton-count"></span></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tree-card search-skeleton-card" aria-hidden="true">
+                    <div class="tree-card-media search-skeleton-block"></div>
+                    <div class="tree-card-body">
+                        <div class="search-skeleton-line search-skeleton-title"></div>
+                        <div class="search-skeleton-line search-skeleton-copy"></div>
+                        <div class="tree-meta-row">
+                            <div class="tree-meta-left"><span class="tree-meta-chip search-skeleton-chip"></span></div>
+                            <div class="tree-meta-right"><span class="search-skeleton-line search-skeleton-count"></span></div>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- 새로 자라는 러브트리 섹션 -->


### PR DESCRIPTION
## Summary

- Reduce Search page first-paint fallback flash
- Replace the initial loading state with a tree-card-like skeleton grid
- Reduce raw Material Symbols ligature text exposure during icon font loading
- Align one preview fallback copy with the Search static fallback tone

## Scope

Changed files expected:

- `pages/search.html`
- `js/i18n/i18n-search.js`
- `js/search-card-renderer.js`

## Explicit non-changes

- No backend/API changes
- No Modal changes
- No `css/global.css` changes
- No `js/shared-header.js` changes
- No `js/search.js` orchestration changes
- No Search thumbnail 404 fix
- No Detail page changes

## Verification plan

This PR is for Cloudflare Pages Preview visual verification.

Required before merge:

1. Open Cloudflare PR Preview
2. Compare with production `https://lovebud.pages.dev/pages/search`
3. Check first paint under normal network
4. Check first paint once with Slow 3G or Disable cache
5. Confirm `account_tree`, `schedule`, `favorite` raw ligature text is reduced/not visible
6. Confirm card skeleton to final card transition is smoother
7. Confirm card click and preview sidebar still work
8. Confirm no new console errors except existing thumbnail 404 noise

## Merge status

- Merge is blocked until preview visual verification passes
- This PR is not related to PR #38 Backend/API v2