### PR TITLE
docs: clarify Cloudflare Modal runtime and Netlify legacy status

### DIFF
--- a/docs/backend/backend.md
+++ b/docs/backend/backend.md
@@ -1,19 +1,53 @@
-# LoveBud MVP — Backend Functions
+# LoveBud Backend Runtime Notes
 
-## Overview
-Netlify Functions backend for LoveBud MVP. Data stored in Neon PostgreSQL.
+## Current production/test slot runtime truth
 
-## Architecture
+Current `lovebud.pages.dev` production/test slot API runtime is not Netlify Functions.
+
+Observed production / test1 / test2 / test3 route matrix:
+
+- `/api/trees`: `x-lovebud-upstream: modal`
+- `/api/memories`: `x-lovebud-upstream: modal`
+- `modal-function-call-id` exists
+- `server: cloudflare`
+- `cf-cache-status: DYNAMIC`
+- No Netlify Functions invocation evidence was observed
+
+Current active runtime path:
+
+```text
+Browser
+→ Cloudflare Pages same-origin /api/*
+→ Cloudflare Pages Functions under functions/api/*
+→ Modal
+→ Neon PostgreSQL
 ```
+
+`netlify/functions/*` is a legacy artifact only. It is not the current production backend for `lovebud.pages.dev`. Do not implement new backend policy in `netlify/functions/*` unless CTO explicitly reactivates Netlify runtime.
+
+PR #38 was closed because it targeted legacy `netlify/functions/*` rather than the active Cloudflare/Modal runtime.
+
+---
+
+## Legacy Netlify Functions artifact
+
+The following section documents the legacy Netlify Functions implementation that remains in the repository for reference and pending archive decision.
+
+It must not be read as the active production backend.
+
+## Legacy Architecture
+
+```text
 Browser → Firebase Auth (login)
-        → Netlify Functions (this folder)
-        → Neon PostgreSQL (actual data)
+        → Netlify Functions (legacy artifact only)
+        → Neon PostgreSQL
 ```
 
 Auth: Firebase ID Token verified in each protected function via `requireUser(event)`.
 
-## File Structure
-```
+## Legacy File Structure
+
+```text
 netlify/
 ├── functions/
 │   ├── _lib/
@@ -21,21 +55,23 @@ netlify/
 │   │   ├── db.js         ← Neon PostgreSQL Pool
 │   │   ├── http.js       ← CORS / response helpers
 │   │   └── doc-store.js  ← LoveBud data access layer
-│   ├── trees.js          ← GET/POST  /api/trees
-│   ├── tree-detail.js    ← GET/PUT/DELETE /api/trees/:treeId
-│   ├── memories.js       ← GET/POST  /api/memories
-│   ├── memory-detail.js  ← GET/PATCH/DELETE /api/memories/:memoryId
-│   ├── community-trees.js ← GET /api/community/trees
-│   └── community-memories.js ← GET /api/community/memories
+│   ├── trees.js          ← legacy GET/POST  /api/trees
+│   ├── tree-detail.js    ← legacy GET/PUT/DELETE /api/trees/:treeId
+│   ├── memories.js       ← legacy GET/POST  /api/memories
+│   ├── memory-detail.js  ← legacy GET/PATCH/DELETE /api/memories/:memoryId
+│   ├── community-trees.js ← legacy GET /api/community/trees
+│   └── community-memories.js ← legacy GET /api/community/memories
 ├── sql/
 │   └── 001_initial_schema.sql
-└── toml (netlify.toml routes /api/* → function files)
+└── toml (netlify.toml legacy routes /api/* → function files)
 ```
 
-## API Endpoints
+## Legacy API Endpoints
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
+These endpoint mappings describe the legacy Netlify implementation. The current `lovebud.pages.dev` runtime uses Cloudflare Pages Functions and Modal instead.
+
+| Method | Path | Auth | Legacy description |
+|--------|------|------|--------------------|
 | GET | /api/trees | required | List user's trees |
 | POST | /api/trees | required | Create a new tree |
 | GET | /api/trees/:treeId | required* | Get tree + memories (*private requires owner) |
@@ -49,21 +85,22 @@ netlify/
 | PATCH | /api/memories/:memoryId | required | Update memory fields |
 | DELETE | /api/memories/:memoryId | required | Delete memory |
 
-## Auth Pattern
+## Legacy Auth Pattern
+
 ```javascript
 const { requireUser } = require('./_lib/auth');
 const user = await requireUser(event);
 ```
 
-## Environment Variables
+## Legacy Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `FIREBASE_SERVICE_ACCOUNT_JSON` | Yes | Firebase Admin service account |
-| `NETLIFY_DATABASE_URL` | Yes | Neon PostgreSQL connection string |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | Yes | Firebase Admin service account for legacy Netlify runtime |
+| `NETLIFY_DATABASE_URL` | Yes | Neon PostgreSQL connection string for legacy Netlify runtime |
 | `CORS_ALLOWED_ORIGINS` | No | Comma-separated allowed origins |
 
-## Top-level Dependencies
+## Legacy Top-level Dependencies
 
 | Package | Version | Why |
 |---------|---------|-----|
@@ -74,122 +111,52 @@ Both are server-side only.
 
 ---
 
-## Visibility / private storage policy
+## Visibility / private storage policy note
 
-### Current implementation
+The public-first + Plus private policy must be implemented against the active runtime, not this legacy artifact.
 
-Current main implementation remains private-first.
+Active implementation targets:
 
-- `POST /api/trees` defaults new tree visibility to `private`.
-- `POST /api/trees` rejects `visibility: 'public'` with 409.
-- `PUT /api/trees/:treeId` allows owner visibility update.
-- private → public currently requires at least 3 public memories.
-- public → private currently has no Plus entitlement guard.
-- Existing private trees are stored as ordinary `visibility: 'private'` rows.
+- `functions/api/*` Cloudflare Pages Functions
+- Modal private/public/community endpoints
+- Modal/Neon data flow
+
+Do not implement new visibility/private-storage behavior in `netlify/functions/*` unless Netlify runtime is explicitly reactivated.
+
+### Current active behavior status
+
+Current production behavior must be verified against Cloudflare/Modal runtime.
+
+The legacy Netlify code may still describe older private-first behavior, but it is not authoritative for `lovebud.pages.dev` production/test slots.
 
 ### Target policy
 
 CTO-approved direction is public-first + Plus private.
 
-- New trees should transition to public-first.
+- New trees should transition to public-first in the active runtime.
 - Existing private trees must not be automatically made public.
 - Existing private trees are grandfathered private.
 - Private creation and public → private transition require Plus entitlement after the entitlement source is defined.
 - Public visibility and browse display eligibility are separate concepts.
-- Netlify and Modal policy must be changed together.
-
-### Create tree policy
-
-Current:
-
-- Backend accepts `title` and optional `visibility`.
-- Default visibility is `private`.
-- `visibility: 'public'` is rejected.
-
-Target:
-
-- Default visibility becomes `public`.
-- `visibility: 'private'` requires Plus entitlement.
-- Entitlement source is not yet defined, so this is not implementable yet.
-- Frontend create payload must not be changed alone.
-
-Decision-needed:
-
-- User plan source of truth
-- DB schema or provider for entitlement
-- Error status and response body for Plus-required private creation
-- Grandfathered private marking strategy, if needed beyond existing visibility value
-
-### Toggle visibility policy
-
-Current:
-
-- Owner can request visibility update through `/api/trees/:treeId`.
-- private → public has a 3-public-memory publication guard.
-- public → private is allowed for owner without plan check.
-
-Target:
-
-- public → private requires Plus entitlement unless the tree is grandfathered private or another CTO-approved exception applies.
-- private → public should be treated as publishing or grandfathered-private release.
-- Browse display eligibility remains separate from visibility.
-
-Recommended target behavior:
-
-| Transition | Target backend behavior |
-|------------|--------------------------|
-| public → private | require Plus entitlement |
-| private → public | allow owner, then evaluate browse eligibility separately |
-| grandfathered private → private | keep allowed for owner |
-| grandfathered private → public | allow owner, no automatic re-private without entitlement unless approved |
-
-### Browse display filter
-
-Browse summary should not become a raw list of all public trees.
-
-Recommended browse summary conditions:
-
-- tree visibility is `public`
-- public memory count meets display threshold, currently 3+
-- browse quality filter passes
-
-Public visibility means accessible public state. Browse display means curated/eligible for browse surfaces.
+- Cloudflare/Modal policy must be changed together.
 
 ---
 
 ## Current Status
 
-**Implemented:**
-- Browser-side fetch client (`js/postgres-client.js`) — API-first with fallback
-- `_lib/` auth, db, http, doc-store
-- `trees.js` — GET/POST with auth
-- `tree-detail.js` — GET/PUT/DELETE with access control and visibility update
-- `memories.js` — GET/POST with auth + ownership enforcement
-- `memory-detail.js` — GET/PATCH/DELETE with ownership check
-- `community-trees.js` — browse public summaries
-- `community-memories.js` — public read path
-- SQL schema scaffold
+**Active production/test slot backend:**
 
-**GET 정책:**
-- `/api/memories` GET: authenticated user's own tree memories only
-- `/api/memories/:memoryId` GET: public memory can be viewed publicly; private memory requires owner
-- `/api/trees/:treeId` GET: public tree can be viewed; private tree requires owner
+- Cloudflare Pages `functions/api/trees.js`
+- Cloudflare Pages `functions/api/memories.js`
+- Cloudflare Pages `functions/api/trees/[id].js` where applicable
+- Cloudflare Pages `functions/api/[[path]].js`
+- Modal `/modal/*` endpoints
 
-**Ownership 검증:**
-- memories.js GET: returns memories for user's own trees
-- memories.js POST: verifies body.treeId ownership before creation
-- memory-detail.js GET: public anyone / private owner only
-- memory-detail.js PATCH/DELETE: owner only
-- tree-detail.js PUT/DELETE: owner only
+**Legacy artifact still present:**
 
-**입력값 검증 규칙:**
-- 필수 필드 누락 → 400
-- UUID 파라미터 → UUID 형식 검증
-- limit 파라미터 → bounded range
-- visibility → `public` 또는 `private`만 허용
-- sourceType → `youtube`, `soundcloud`, `bandcamp`, `spotify`, `apple`, `other`
-- 문자열 필드 길이 제한 적용
-- emotionTags → 배열, 최대 20개
+- `netlify/functions/*`
+- `netlify.toml`
+- Netlify route contract tests and docs references pending transition
 
 ---
 
@@ -197,21 +164,20 @@ Public visibility means accessible public state. Browse display means curated/el
 
 Before code changes:
 
-1. Update API contract and tests.
+1. Update active Cloudflare/Modal API contract and tests.
 2. Define Plus entitlement source.
 3. Define grandfathered private behavior.
-4. Update Netlify and Modal policy together.
+4. Update Cloudflare and Modal policy together.
 5. Separate visibility change from browse display eligibility.
 6. Prepare frontend UX copy and error handling.
 
 Implementation split:
 
-### Backend workstream
+### Active backend workstream
 
-- Change `POST /api/trees` default visibility to public.
-- Remove public-create 409 only when Modal equivalent is ready.
-- Add entitlement guard for private creation.
-- Add entitlement guard for public → private toggle.
+- Change active tree create behavior in Cloudflare/Modal path.
+- Add entitlement guard for private creation in the active runtime.
+- Add entitlement guard for public → private toggle in the active runtime.
 - Preserve grandfathered private owner access.
 - Keep browse summary filter separate.
 
@@ -230,27 +196,8 @@ Implementation split:
 
 ---
 
-## Not yet implemented / decision-needed
+## Archive note
 
-- Public-first create tree implementation
-- Plus entitlement source
-- Plus private backend guard
-- Grandfathered private metadata strategy
-- Entitlement error code/status contract
-- User-facing copy for Plus private after payment policy is confirmed
+Immediate archive is not performed in the Netlify legacy deprecation documentation PR.
 
----
-
-## Seed data note
-
-Seed/demo data remains public sample content and is not a private storage policy reference.
-
----
-
-## Detail/API integration note
-
-- `apiClient.getMemory(memoryId)` — GET `/api/memories/:memoryId`
-- `apiClient.getMemoriesByTree(treeId)` — GET `/api/memories?treeId=...`
-- `apiClient.getFirstTree()` — GET `/api/trees` then first item
-
-Visibility policy changes must update the API client only after backend and Modal contracts are aligned.
+Archive requires tests/docs reference transition first. In particular, `netlify.toml` and Netlify route contract tests still reference this legacy tree.

--- a/docs/engineering/API_CONTRACT.md
+++ b/docs/engineering/API_CONTRACT.md
@@ -1,8 +1,35 @@
 # LoveBud API 응답 계약
 
-> **버전:** 1.4  
+> **버전:** 1.5  
 > **최종 갱신:** 2026-04-25  
 > **관련 커밋:** `0230475`, `bb9741b`, `bb9e663`
+
+---
+
+## 0. Runtime source of truth
+
+Current production/test slot API runtime is:
+
+```text
+Cloudflare Pages same-origin /api/*
+→ Cloudflare Pages Functions under functions/api/*
+→ Modal
+```
+
+Production / test1 / test2 / test3 route matrix observation:
+
+- `/api/trees`: `x-lovebud-upstream: modal`
+- `/api/memories`: `x-lovebud-upstream: modal`
+- `modal-function-call-id` exists
+- `server: cloudflare`
+- `cf-cache-status: DYNAMIC`
+- No Netlify Functions invocation evidence was observed
+
+`netlify/functions/*` is a legacy artifact only. It is not the current production backend for `lovebud.pages.dev`. Do not implement new backend policy in `netlify/functions/*` unless CTO explicitly reactivates Netlify runtime.
+
+PR #38 was closed because it targeted legacy `netlify/functions/*` rather than the active Cloudflare/Modal runtime.
+
+Archive is not performed by this documentation update. Archive requires tests/docs reference transition first.
 
 ---
 
@@ -54,7 +81,14 @@
 
 ### 2.1 Memory 단건
 
-**파일:** `netlify/functions/_lib/serializers.js:serializeMemory`
+Active runtime contract source:
+
+- Cloudflare Pages Functions under `functions/api/*`
+- Modal `/modal/*` endpoints
+
+Legacy reference only:
+
+- `netlify/functions/_lib/serializers.js:serializeMemory`
 
 ```typescript
 interface Memory {
@@ -121,15 +155,17 @@ interface TreeDetail extends Tree {
 
 ## 3. Visibility / private storage 전환 계약
 
-### 3.1 현재 구현 계약
+### 3.1 현재 active runtime 계약
 
-현재 main 구현은 아직 private-first입니다.
+Current active runtime is Cloudflare Pages Functions → Modal.
 
-- `POST /api/trees`는 새 tree 생성 시 `visibility` 기본값을 `private`으로 처리합니다.
-- `POST /api/trees`에 `visibility: 'public'`이 들어오면 현재 구현은 409를 반환합니다.
-- `PUT /api/trees/:treeId`는 private → public 전환 시 공개 memory 3개 이상 조건을 확인합니다.
-- public → private 전환에 Plus entitlement 검증은 아직 없습니다.
-- Modal private tree 생성도 동일하게 private-first이며 public 생성 요청을 차단합니다.
+Current production behavior must be verified against that active route, not `netlify/functions/*`.
+
+Current document baseline:
+
+- `POST /api/trees` and `GET /api/trees` route through `functions/api/trees.js` to Modal `/modal/private/trees`.
+- `POST /api/memories` and `GET /api/memories` route through `functions/api/memories.js` to Modal `/modal/private/memories`.
+- `netlify/functions/*` may still contain older private-first code, but it is not authoritative for `lovebud.pages.dev` production/test slots.
 
 ### 3.2 목표 정책 계약
 
@@ -140,7 +176,8 @@ CTO 결정 기준 목표 정책은 **public-first + Plus private**입니다.
 - private 생성/전환은 Plus entitlement source 확정 후 backend에서 검증합니다.
 - `public visibility`와 `browse 노출 조건`은 분리합니다.
 - createTree payload만 단독으로 public 변경하는 것은 금지합니다.
-- Netlify와 Modal create/toggle 정책은 반드시 동기화합니다.
+- Cloudflare Pages Functions와 Modal create/toggle 정책은 반드시 동기화합니다.
+- `netlify/functions/*`에는 신규 backend 정책을 구현하지 않습니다. Netlify runtime 재활성화가 명시 승인된 경우만 예외입니다.
 
 ### 3.3 public visibility와 browse 노출 분리
 
@@ -166,13 +203,12 @@ interface VisibilityPolicyState {
 
 ### 3.4 create tree 전환 계약
 
-현재:
+현재 active path:
 
-```typescript
-interface CreateTreeRequestCurrent {
-  title?: string;
-  visibility?: 'private';
-}
+```text
+/api/trees
+→ functions/api/trees.js
+→ Modal /modal/private/trees
 ```
 
 목표:
@@ -190,6 +226,7 @@ interface CreateTreeRequestTarget {
 - `visibility: 'private'` 생성은 Plus entitlement 필요 대상입니다.
 - entitlement source 확정 전에는 private 생성 허용/차단을 구현하지 않습니다.
 - frontend만 먼저 public payload로 바꾸지 않습니다.
+- Cloudflare/Modal path가 함께 준비되어야 합니다.
 
 ### 3.5 toggle visibility 전환 계약
 
@@ -243,6 +280,10 @@ HTTP status 후보:
 **Endpoint**
 - `GET /api/community/trees?view=summary&sort=latest&limit=3`
 
+**Active route**
+- Cloudflare Pages `functions/api/[[path]].js`
+- Modal `/modal/browse/latest`
+
 **Response shape**
 
 ```typescript
@@ -272,6 +313,10 @@ type BrowseTreeSummaryList = BrowseTreeSummary[];
 
 **Endpoint**
 - `GET /api/community/memories?treeId=<treeId>`
+
+**Active route**
+- Cloudflare Pages `functions/api/[[path]].js`
+- Modal `/modal/community/memories`
 
 ```typescript
 type BrowseHydrationMemoryList = Memory[];
@@ -359,14 +404,15 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 ### 7.1 직렬화기 사용 의무
 
-모든 API 응답은 반드시 serializers를 거칩니다.
+모든 API 응답은 active Cloudflare/Modal runtime에서 flat camelCase contract를 유지해야 합니다.
 
 ### 7.2 visibility guard 원칙
 
-- create tree 정책은 Netlify와 Modal에서 동기화해야 합니다.
-- private 생성/전환 guard는 entitlement source 확정 후 backend에서 강제해야 합니다.
+- create tree 정책은 Cloudflare Pages Functions와 Modal에서 동기화해야 합니다.
+- private 생성/전환 guard는 entitlement source 확정 후 active backend에서 강제해야 합니다.
 - 기존 private tree grandfathering을 고려해야 합니다.
 - browse display filter는 public visibility와 별도로 유지합니다.
+- `netlify/functions/*`에 신규 visibility/private-storage 정책을 구현하지 않습니다.
 
 ---
 
@@ -374,14 +420,14 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 | 파일 | 역할 |
 |------|------|
-| `netlify/functions/_lib/serializers.js` | API 응답 직렬화기 |
-| `netlify/functions/trees.js` | create tree / list trees |
-| `netlify/functions/tree-detail.js` | tree detail / visibility update |
-| `netlify/functions/community-trees.js` | browse summary 서버 계약 |
-| `netlify/functions/community-memories.js` | browse hydration 서버 계약 |
-| `modal_compute/app.py` | Modal public/private tree 계약 |
+| `functions/api/trees.js` | active `/api/trees` Cloudflare route-specific handler |
+| `functions/api/memories.js` | active `/api/memories` Cloudflare route-specific handler |
+| `functions/api/trees/[id].js` | active tree detail Cloudflare handler where applicable |
+| `functions/api/[[path]].js` | active Cloudflare catch-all handler for recognized read/community routes |
+| `modal_compute/app.py` | active Modal API/backend target |
 | `js/utils/normalize.js` | 프론트 정규화 유틸 |
 | `js/api/public-tree-adapter.js` | browse summary/hydrate adapter |
+| `netlify/functions/*` | legacy artifact only, not current production backend |
 
 ---
 
@@ -389,8 +435,7 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 ### 9.1 public-first backend 전환
 
-- Netlify create tree public-first 전환
-- Modal create tree public-first 전환
+- Cloudflare/Modal create tree public-first 전환
 - create payload 단독 변경 금지 원칙 유지
 - API 계약 테스트 추가
 
@@ -398,7 +443,7 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 - entitlement source of truth 확정
 - plan 저장 위치 확정
-- backend guard 추가
+- active backend guard 추가
 - frontend 안내와 API error 처리 동기화
 
 ### 9.3 browse 노출 조건 고정
@@ -407,6 +452,12 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 - public memory 3개 이상 조건 유지 여부 최종 확인
 - snapshot 계약에 browseEligibility metadata 포함 여부 검토
 
+### 9.4 Netlify legacy transition
+
+- tests/docs reference transition
+- `netlify.toml` treatment decision
+- archive decision after CTO approval
+
 ---
 
 ## 10. 위반 시 대응
@@ -414,12 +465,13 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 | 위반 유형 | 대응 |
 |-----------|------|
 | 새 코드에 `{id, data}` 접근 | PR reject |
-| API 응답에 직렬화기 미사용 | PR reject |
+| active API 응답에 flat camelCase 계약 미준수 | PR reject |
 | createTree payload만 public으로 단독 변경 | PR reject |
-| Netlify와 Modal visibility 정책 불일치 | PR reject |
+| Cloudflare와 Modal visibility 정책 불일치 | PR reject |
 | Plus private을 frontend-only로 잠금 | PR reject |
 | 기존 private tree 자동 public 전환 | PR reject |
 | public visibility를 browse 노출로 설명 | 정책 위반으로 수정 |
+| 신규 backend policy를 `netlify/functions/*`에 구현 | PR reject unless Netlify runtime is explicitly reactivated |
 
 ---
 

--- a/docs/ops/DEPLOYED_ENTRY_MAP.md
+++ b/docs/ops/DEPLOYED_ENTRY_MAP.md
@@ -6,10 +6,12 @@
 
 - **공식 주소**: `https://lovebud.pages.dev/`
 - **Deprecated transitional fallback under audit**: `https://lovebud.vercel.app/`
-- **Legacy fallback pending audit**: `https://lovebud.netlify.app/`
+- **Legacy artifact / not current production backend**: `https://lovebud.netlify.app/`, `netlify/functions/*`
 
 주의:
 - 문서와 운영 안내에서 `lovebud.vercel.app`, `lovebud.netlify.app`를 주서비스처럼 설명하지 않습니다.
+- `netlify/functions/*`는 현재 `lovebud.pages.dev` production/test slot의 active backend가 아닙니다.
+- 새 backend 정책 구현은 Netlify runtime 재활성화가 명시 승인되지 않는 한 `netlify/functions/*`에 추가하지 않습니다.
 
 ## 2. URL 노출 경로 (Cloudflare Pages)
 
@@ -22,7 +24,26 @@
 - `/editor.html`
 - `/my-trees.html`
 
-## 3. API 엔드포인트 맵 (`/api/*`)
+## 3. API runtime source of truth
+
+현재 production / test1 / test2 / test3 route matrix 실측 기준:
+
+- `/api/trees`: `x-lovebud-upstream: modal`
+- `/api/memories`: `x-lovebud-upstream: modal`
+- `modal-function-call-id` 존재
+- `server: cloudflare`
+- `cf-cache-status: DYNAMIC`
+- Netlify Functions 호출 흔적 없음
+
+현재 API runtime 경로:
+
+```text
+Cloudflare Pages same-origin /api/*
+→ Cloudflare Pages Functions under functions/api/*
+→ Modal
+```
+
+## 4. API 엔드포인트 맵 (`/api/*`)
 
 모든 브라우저 API 호출은 Cloudflare Pages same-origin 경로를 먼저 탑니다.
 
@@ -30,34 +51,50 @@
 | :--- | :--- | :--- |
 | `/api/trees` | `functions/api/trees.js` | Route-specific Cloudflare Function -> `GET`/`POST` -> Modal `/modal/private/trees`; response marker `x-lovebud-upstream: modal` |
 | `/api/memories` | `functions/api/memories.js` | Route-specific Cloudflare Function -> `GET`/`POST` -> Modal `/modal/private/memories`; response marker `x-lovebud-upstream: modal` |
-| `/api/community/trees` | `functions/api/[[path]].js` | Catch-all fallback; 일부 Modal read route 가능 -> Vercel deprecated transitional fallback under audit |
-| `/api/community/memories` | `functions/api/[[path]].js` | Catch-all fallback; 일부 Modal read route 가능 -> Vercel deprecated transitional fallback under audit |
-| `/api/trees/*` | `functions/api/trees/[id].js` 또는 `functions/api/[[path]].js` | `GET` detail route 일부 확인; non-GET/PATCH/DELETE는 production route matrix pending |
-| `/api/memories/*` | `functions/api/[[path]].js` | detail route 및 non-GET/PATCH/DELETE는 production route matrix pending |
-| 기타 `/api/*` | `functions/api/[[path]].js` | route-specific function이 없는 요청의 catch-all fallback; Vercel deprecated transitional fallback 위험 audit 중 |
+| `/api/community/trees` | `functions/api/[[path]].js` | Catch-all Cloudflare Function -> Modal browse/community route where recognized |
+| `/api/community/memories` | `functions/api/[[path]].js` | Catch-all Cloudflare Function -> Modal community memories route where recognized |
+| `/api/trees/*` | `functions/api/trees/[id].js` 또는 `functions/api/[[path]].js` | Cloudflare Function -> Modal private/public tree detail path where recognized |
+| `/api/memories/*` | `functions/api/[[path]].js` | Cloudflare Function -> Modal memory detail path where recognized |
+| 기타 `/api/*` | `functions/api/[[path]].js` | route-specific function이 없는 요청의 catch-all 처리. recognized route가 아니면 Cloudflare 404/405 계열 응답 |
 
-## 4. 계층 역할 요약
+## 5. 계층 역할 요약
 
 ### Modal
+- active API/backend target
+- private tree/memory owner routes
+- public/community read routes
 - browse summary
-- public/community/private read
 - representative snapshot / preview 계산
 
 ### Cloudflare Pages
 - 공식 프런트 엔트리
 - static asset 서빙
 - same-origin API router
+- production/test slot runtime entry
 
 ### Vercel
 - deprecated transitional fallback under audit
 - primary production runtime으로 취급하지 않음
 - production route matrix가 의존성 없음 또는 대체 경로 확정을 증명하기 전 제거 금지
 
-### Netlify
-- legacy fallback pending audit
-- 일부 기존 CRUD / legacy 경로 보존/폐기 판단 필요
+### Netlify / `netlify/functions/*`
+- legacy artifact only
+- current production backend for `lovebud.pages.dev`가 아님
+- production/test slot API route matrix에서 호출 흔적 없음
+- Netlify runtime을 명시 재활성화하지 않는 한 신규 backend 정책 구현 위치가 아님
 
-## 5. 실제 자산 로드 기준
+## 6. PR #38 기록
+
+PR #38은 active Cloudflare/Modal runtime이 아니라 legacy `netlify/functions/*`를 대상으로 backend 정책을 구현했기 때문에 close되었습니다.
+
+해당 close는 Netlify Functions 코드를 즉시 삭제하거나 archive했다는 뜻이 아닙니다. 현재 판단은 다음과 같습니다.
+
+- active runtime 구현 대상: `functions/api/*` + Modal
+- legacy reference: `netlify/functions/*`
+- archive: 이 PR에서 수행하지 않음
+- archive 전제: tests/docs reference transition 완료 후 별도 승인 필요
+
+## 7. 실제 자산 로드 기준
 
 - static 자산은 `https://lovebud.pages.dev/` 환경에서 직접 서빙됩니다.
 - 핵심 프런트 자산 예시:
@@ -66,14 +103,14 @@
   - `/js/postgres-client.js`
   - `/js/search.js`
 
-## 6. 운영 메모
+## 8. 운영 메모
 
 현재 구조는 완전 제거 상태가 아니라 전이기 구조입니다.
 
 - 공식 주소는 Cloudflare Pages
 - `/api/trees`, `/api/memories`의 `GET`/`POST`는 route-specific Cloudflare Function을 통해 Modal private endpoint로 전달
 - same-origin entry는 Cloudflare Pages
-- `functions/api/[[path]].js`는 route-specific function이 없는 `/api/*` 요청의 catch-all fallback
+- `functions/api/[[path]].js`는 route-specific function이 없는 `/api/*` 요청의 catch-all handler
 - Vercel은 deprecated transitional fallback under audit
-- Netlify는 legacy fallback pending audit
-- detail route, community route, PATCH/DELETE 계열은 production route matrix 완료 전까지 pending
+- Netlify Functions는 legacy artifact이며 active production backend가 아님
+- detail route, community route, PATCH/DELETE 계열은 active route matrix 기준으로 계속 검증 필요

--- a/docs/ops/OPERATIONS.md
+++ b/docs/ops/OPERATIONS.md
@@ -4,20 +4,20 @@
 
 LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 
-> **Hierarchy: Modal > Cloudflare Pages > Vercel > Netlify**
+> **Hierarchy: Cloudflare Pages Entry + Modal Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact**
 
 | 계층 | 역할 | 현재 책임 범위 | 상태 |
 | :--- | :--- | :--- | :--- |
-| **Modal** | **Primary Read / Compute Layer** | browse summary, public read aggregation, 대표 카드 계산, read-heavy snapshot 계산 | 1순위 |
-| **Cloudflare Pages** | **Primary Entry Layer** | 실서비스 진입점, 정적 프런트 서빙, same-origin `/api/*` 라우팅 | 1순위 |
-| **Vercel** | **Secondary Upstream Layer** | upstream origin, proxy fallback, 전이기 보조 계층 | 보조 |
-| **Netlify** | **Legacy Write / Fallback Layer** | 기존 Functions 유지, 일부 CRUD / legacy fallback | 보조 |
+| **Cloudflare Pages** | **Primary Entry / API Router** | 실서비스 진입점, 정적 프런트 서빙, same-origin `/api/*` 라우팅, `functions/api/*` 실행 | 1순위 |
+| **Modal** | **Active API / Backend Target** | `/api/trees`, `/api/memories`, browse/community/private read/write target, 대표 카드 계산 | 1순위 |
+| **Vercel** | **Deprecated Transitional Fallback** | 일부 fallback / 전이기 보조 계층 | audit 중 |
+| **Netlify** | **Legacy Artifact Only** | `netlify/functions/*`, `netlify.toml` legacy reference. 현재 `lovebud.pages.dev` production/test slot active backend 아님 | 신규 구현 금지 |
 
 핵심 원칙:
 - 실서비스 주소는 **반드시 `https://lovebud.pages.dev/`** 기준으로 본다.
-- browse summary 계열은 **Modal을 먼저** 본다.
-- Cloudflare Pages는 공식 사용자-facing entry 이다.
-- Vercel과 Netlify는 보조 / 전이기 계층으로 본다.
+- browser-facing API entry는 **Cloudflare Pages same-origin `/api/*`** 기준으로 본다.
+- active backend target은 **Cloudflare Pages Functions → Modal** 경로 기준으로 본다.
+- `netlify/functions/*`는 현재 active production backend가 아니며, Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend 정책 구현 대상이 아니다.
 
 ---
 
@@ -26,46 +26,60 @@ LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 - **공식 서비스 주소**: `https://lovebud.pages.dev/`
 - **Cloudflare Pages 프로젝트(운영 기준)**: `lovebud.pages.dev`
 - **Modal 앱**: `lovebud-browse-snapshot`
-- **Vercel 주소(보조/Upstream)**: `https://lovebud.vercel.app/`
-- **Netlify 주소(보조/Fallback)**: `https://lovebud.netlify.app/`
+- **Vercel 주소(Deprecated transitional fallback)**: `https://lovebud.vercel.app/`
+- **Netlify 주소 / Functions(Legacy artifact only)**: `https://lovebud.netlify.app/`, `netlify/functions/*`
 
 주의:
 - Vercel과 Netlify 주소는 현재 공식 사용자-facing 대표 주소가 아닙니다.
 - 운영 문서에서 `lovebud.vercel.app`, `lovebud.netlify.app`를 주서비스처럼 설명하지 않습니다.
+- Netlify Functions를 현재 `lovebud.pages.dev` production/test slot backend처럼 설명하지 않습니다.
 
 ---
 
 ## 3. 실제 요청 경로
 
-### 3.1 브라우즈 summary
+### 3.1 `/api/trees`
+
+현재 production/test slot route matrix 실측 기준:
+
+1. 브라우저 → `https://lovebud.pages.dev/api/trees`
+2. Cloudflare Pages `functions/api/trees.js`
+3. Modal `/modal/private/trees`
+4. 응답 marker: `x-lovebud-upstream: modal`
+5. `modal-function-call-id` 존재
+6. `server: cloudflare`, `cf-cache-status: DYNAMIC`
+
+### 3.2 `/api/memories`
+
+현재 production/test slot route matrix 실측 기준:
+
+1. 브라우저 → `https://lovebud.pages.dev/api/memories`
+2. Cloudflare Pages `functions/api/memories.js`
+3. Modal `/modal/private/memories`
+4. 응답 marker: `x-lovebud-upstream: modal`
+5. `modal-function-call-id` 존재
+6. `server: cloudflare`, `cf-cache-status: DYNAMIC`
+
+### 3.3 브라우즈 summary
 
 현재 browse summary의 주경로는 아래입니다.
 
 1. 브라우저 → `https://lovebud.pages.dev/api/community/trees?view=summary&sort=latest&limit=3`
 2. Cloudflare Pages `functions/api/[[path]].js`
 3. `MODAL_BASE_URL` 기준 Modal `/modal/browse/latest?limit=3` 우선 호출
-4. Modal 실패 시 Vercel upstream fallback
-5. 필요 시 그 뒤의 legacy 계층이 보조적으로 관여 가능
+4. recognized route는 Modal 응답을 기준으로 처리
 
-즉, browse summary의 운영 우선순위는 아래와 같습니다.
-
-- **Modal first**
-- **Cloudflare Pages entry**
-- **Vercel fallback second**
-
-### 3.2 브라우즈 memories hydrate
+### 3.4 브라우즈 memories hydrate
 
 현재 preview hydrate 경로는 아래입니다.
 
 1. 브라우저 → `https://lovebud.pages.dev/api/community/memories?treeId=<id>`
 2. Cloudflare Pages `functions/api/[[path]].js`
 3. Modal `/modal/community/memories` 우선 호출
-4. Modal 실패 시 Vercel upstream fallback
 
-### 3.3 기타 `/api/*`
+### 3.5 기타 `/api/*`
 
-기타 `/api/*` 경로는 Cloudflare Pages `functions/api/[[path]].js`가 `LOVEBUD_UPSTREAM_ORIGIN`를 기준으로 upstream proxy를 수행합니다.
-기본값은 `https://lovebud.vercel.app` 입니다.
+기타 `/api/*` 경로는 Cloudflare Pages `functions/api/[[path]].js`가 recognized route를 Modal로 전달하거나, unhandled route에 대해 Cloudflare 404/405 계열 응답을 반환합니다.
 
 ---
 
@@ -76,13 +90,13 @@ LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 현재 Cloudflare Pages 라우터가 직접 참조하는 핵심 변수:
 
 - `MODAL_BASE_URL`
-  - browse summary 및 private/community read 계열 Modal upstream
+  - browse summary 및 private/community read/write 계열 Modal upstream
 - `LOVEBUD_UPSTREAM_ORIGIN`
-  - fallback upstream origin
+  - deprecated fallback 계층 audit 중인 origin
 
 기본 원칙:
 - `MODAL_BASE_URL`는 **반드시 실제 live Modal 배포 주소**를 가리켜야 한다.
-- `LOVEBUD_UPSTREAM_ORIGIN`은 현재 전이기 구조에서는 `https://lovebud.vercel.app`를 가리킬 수 있다.
+- `/api/trees`, `/api/memories` active path는 Cloudflare Pages Functions가 Modal로 전달한다.
 
 ### 4.2 Modal
 
@@ -96,18 +110,19 @@ Modal runtime 핵심 변수:
 
 ### 4.3 Vercel / Netlify
 
-Vercel은 현재 upstream / fallback 보조 계층입니다.
-Netlify는 현재 legacy/fallback 계층입니다.
-다만 운영 설명에서는 두 계층 모두 **주경로**로 표현하지 않습니다.
+Vercel은 deprecated transitional fallback입니다.
+Netlify Functions는 legacy artifact입니다.
+
+운영 설명에서는 두 계층 모두 **주경로**로 표현하지 않습니다.
 
 ---
 
 ## 5. fallback 운영 원칙
 
 - Modal browse summary가 실패해도 browse 전체가 멈추면 안 된다.
-- 이 경우 Cloudflare Pages `functions/api/[[path]].js`가 Vercel upstream fallback을 수행한다.
 - fallback은 유지하되, 성능 및 요약 품질 기준은 Modal이 우선이다.
-- 점진적 제거 대상은 “Vercel/Netlify 주경로 설명”이지, fallback 자체가 아니다.
+- 점진적 제거 대상은 “Vercel/Netlify 주경로 설명”이지, 모든 fallback 문구의 즉시 삭제가 아니다.
+- Netlify Functions는 현재 active fallback으로 확인되지 않았으므로 legacy artifact로만 표기한다.
 
 ---
 
@@ -117,27 +132,42 @@ Netlify는 현재 legacy/fallback 계층입니다.
 
 정리 순서:
 1. 실서비스 주소는 Cloudflare Pages로 고정
-2. browse summary는 Modal 우선으로 고정
-3. Cloudflare Pages는 same-origin entry로 유지
-4. Vercel은 upstream / 보조 entry로 유지
-5. Netlify는 legacy fallback / write로 축소
-6. 이후 Vercel / Netlify 의존 범위를 점진적으로 더 줄인다
+2. Cloudflare Pages same-origin `/api/*`를 runtime entry로 고정
+3. `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal로 고정
+4. browse summary는 Modal 우선으로 고정
+5. Vercel은 deprecated transitional fallback으로 축소
+6. Netlify Functions는 legacy artifact로 축소
+7. tests/docs reference transition 완료 후 Netlify archive 여부를 별도 승인한다
 
 ---
 
-## 7. 운영 체크포인트
+## 7. PR #38 운영 기록
+
+PR #38은 active runtime이 아닌 `netlify/functions/*`에 backend 정책을 구현했기 때문에 close되었습니다.
+
+해당 판단은 다음 기준을 따른다.
+
+- active production/test slot runtime: Cloudflare Pages Functions → Modal
+- legacy artifact: `netlify/functions/*`
+- archive: 이번 문서 정리 PR에서 수행하지 않음
+- Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend policy를 `netlify/functions/*`에 구현하지 않음
+
+---
+
+## 8. 운영 체크포인트
 
 - `https://lovebud.pages.dev/`가 공식 주소로 안내되고 있는가
-- browse summary 요청이 `/api/community/trees?view=summary`를 통해 나가는가
-- preview hydrate 요청이 `/api/community/memories?treeId=...`를 통해 나가는가
-- Cloudflare Pages env에 `MODAL_BASE_URL`, `LOVEBUD_UPSTREAM_ORIGIN`이 설정되어 있는가
+- `/api/trees` 응답에 `x-lovebud-upstream: modal`이 있는가
+- `/api/memories` 응답에 `x-lovebud-upstream: modal`이 있는가
+- Modal 응답에 `modal-function-call-id`가 있는가
+- 응답 server가 Cloudflare인지 확인했는가
+- Cloudflare Pages env에 `MODAL_BASE_URL`이 설정되어 있는가
 - Modal `/modal/health`가 정상 응답하는가
-- Modal `/modal/browse/latest?limit=3`가 정상 응답하는가
-- Modal 실패 시 Vercel fallback이 동작하는가
+- `netlify/functions/*`를 새 backend 구현 대상으로 오해하지 않았는가
 
 ---
 
-## 8. 관리자 운영 메모
+## 9. 관리자 운영 메모
 
 확인용 핵심 URL:
 - 메인: `https://lovebud.pages.dev/`

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -22,15 +22,25 @@
 
 ## 현재 상태 스냅샷
 
-- 기준일: 2026-04-24
-- 기준 main 커밋: `8f13e484dcd66d1817f0f476863add4fe0cfbd35`
+- 기준일: 2026-04-25
+- 기준 main 커밋: `440b3de75e9c567aa5128ec7e34fc844e94eefb7`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
-| 문서 TF | 완료 | PR #8, PR #10 | project 운영 문서 및 검증 기준 문서 main 반영 완료. 추가 수정 없음 |
+| 문서 TF | 완료 | PR #8, PR #10, PR #32, PR #33 | project 운영 문서, 검증 기준, public-first 정책, Tree/Memory/Visibility/Delete QA matrix main 반영 완료 |
+| Runtime routing truth | 진행 중 | production/test1/test2/test3 route matrix | `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal 경로로 실측. Netlify Functions 호출 흔적 없음. Netlify legacy deprecation 문서 정리 진행 중 |
 | UI TF | 완료 | PR #9 `ui: polish public search and detail copy` | main 병합 완료 (Commit: `d5eee446`). production 검증 완료. UI TF 종료 승인 |
 | 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. merged 아님. 정식 기능 아님. navigation 연결 금지. 최신 main 반영 가능성 확인 필요 |
+
+---
+
+## Runtime / Backend 상태 메모
+
+- Current production/test slot runtime: `Cloudflare Pages same-origin /api/* → Cloudflare Pages Functions → Modal`.
+- `netlify/functions/*`는 legacy artifact only이며 현재 `lovebud.pages.dev` production/test slot active backend가 아닙니다.
+- PR #38은 active Cloudflare/Modal runtime이 아니라 legacy `netlify/functions/*`를 대상으로 했기 때문에 close되었습니다.
+- Netlify archive는 즉시 수행하지 않습니다. tests/docs reference transition 후 별도 승인 필요합니다.
 
 ---
 
@@ -38,6 +48,9 @@
 
 | 작업 | 상태 | 메모 |
 |------|------|------|
+| Netlify Functions legacy deprecation 문서 PR | 진행 중 | active runtime truth 고정. 코드 이동/삭제 없음 |
+| Active Cloudflare/Modal public-first backend 설계 | 대기 | Netlify legacy deprecation 정리 후 별도 브랜치 필요 |
+| PR #36 / #38 계열 backend 방향 재정렬 | 대기 | 신규 backend policy는 `netlify/functions/*`가 아닌 active Cloudflare/Modal runtime 대상으로 재설계 필요 |
 | Search에 “새로 자라는 러브트리” 보조 섹션 설계 | 대기 | 설계 승인 후 별도 브랜치에서 진행 |
 | PR #7 재동기화 가능성 확인 | 대기 | prototype 상태 유지. main 병합 대상 아님 |
 | Search 보조 섹션 UI 구현 | 대기 | 설계 승인 이후 UI 구현 브랜치 분리 |
@@ -46,6 +59,9 @@
 
 ## 작업 이력 (Task History)
 
+- 2026-04-25: production/test1/test2/test3 route matrix 기준 `/api/trees`, `/api/memories` active upstream이 Modal임을 확인. Netlify Functions는 legacy artifact로 정리 필요
+- 2026-04-25: PR #32 public-first + Plus private policy direction 문서 반영 완료
+- 2026-04-25: PR #33 Tree / Memory / Visibility / Delete QA Matrix 문서 반영 완료
 - 2026-04-24: PR #9 production 검증 완료 및 UI TF 종료
 - 2026-04-24: `feature/search-growing-trees-api` 운영 quick check 통과 및 기능 TF 종료
 - 2026-04-24: project 운영 및 검증 기준 문서 동기화


### PR DESCRIPTION
## Summary

- Document current production/test slot API runtime as Cloudflare Pages Functions → Modal
- Mark netlify/functions as legacy artifact only
- Clarify that new backend policy must not target netlify/functions unless Netlify runtime is explicitly reactivated
- Record PR #38 close reason
- Preserve archive as future work requiring tests/docs reference transition

## Explicit exclusions

- No code changes
- No netlify/functions changes
- No netlify.toml changes
- No tests changes
- No API/runtime behavior changes
- No archive/move/delete