### PR TITLE
ui(editor): polish editor card surfaces

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -172,16 +172,16 @@ body {
     top: 50%;
     transform: translate(-50%, -50%);
     width: min(390px, calc(100% - 48px));
-    padding: 22px 22px 20px;
-    border-radius: 26px;
-    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.95));
-    border: 1px solid rgba(144,73,81,0.10);
-    box-shadow: 0 24px 54px rgba(75,64,57,0.10);
+    padding: 24px 24px 22px;
+    border-radius: 28px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(252,248,246,0.94));
+    border: 1px solid rgba(144,73,81,0.12);
+    box-shadow: 0 20px 48px rgba(75,64,57,0.08);
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 9px;
+    gap: 10px;
     z-index: 3;
 }
 
@@ -236,11 +236,11 @@ body {
 }
 
 .editor-add-card {
-    padding: 14px;
-    border-radius: 18px;
-    background: white;
-    box-shadow: 0 4px 16px rgba(75, 64, 57, 0.04);
-    border: 1px solid rgba(144, 73, 81, 0.06);
+    padding: 16px;
+    border-radius: 20px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96));
+    box-shadow: 0 6px 20px rgba(75, 64, 57, 0.06);
+    border: 1px solid rgba(144, 73, 81, 0.10);
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -286,6 +286,11 @@ body {
 .node-card {
     width: 102px;
     margin: 0 auto;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 16px;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    box-shadow: 0 4px 12px rgba(75, 64, 57, 0.06);
+    transition: all 0.3s ease;
 }
 
 .node-img-wrapper {
@@ -377,9 +382,9 @@ body {
 
 .memory-node:hover .node-card,
 .memory-node.selected .node-card {
-    transform: scale(1.05);
-    border-color: var(--primary);
-    box-shadow: 0 25px 50px rgba(144, 73, 81, 0.18);
+    transform: scale(1.03);
+    border-color: rgba(144, 73, 81, 0.4);
+    box-shadow: 0 18px 40px rgba(144, 73, 81, 0.12);
 }
 
 .new-node-highlight .node-card {
@@ -581,8 +586,16 @@ body {
     font-weight: 700;
 }
 
-.tag-primary { background: var(--primary); color: white; }
-.tag-secondary { background: var(--secondary-container); color: var(--on-secondary-container); }
+.tag-primary {
+    background: rgba(144, 73, 81, 0.12);
+    color: var(--primary);
+    border: 1px solid rgba(144, 73, 81, 0.18);
+}
+.tag-secondary {
+    background: rgba(144, 73, 81, 0.08);
+    color: var(--on-surface-variant);
+    border: 1px solid rgba(144, 73, 81, 0.12);
+}
 
 .diary-note {
     background: var(--surface-container-low);


### PR DESCRIPTION
## Summary

- Polish editor card/form surfaces with CSS-only changes
- Soften memory node card, selected/current emphasis, tag pill, empty guide, add memory form
- Keep editor DOM/JS/runtime behavior unchanged

## Scope

Changed files only:
- `css/editor.css`

## Explicit exclusions

- No `js/i18n/i18n-editor.js` changes
- No `pages/editor.html` changes
- No `js/editor.js` changes
- No `js/editor/*` changes
- No `css/global.css` changes
- No API/backend/runtime changes
- No `modal_compute/*` changes
- No `pages/gpt-v2/*` changes
- No `pages/gpt-svg-tree/*` changes
- No untracked assets
- No reference image full transplant
- No GPT-v2 direct transplant
- No tree/SVG structure changes
- No canvas coordinate changes
- No DOM/id changes
- No save/edit/delete logic changes

## Verification status

- Local static visual check completed
- 1440px / 1024px / 375px checked
- Horizontal overflow: none
- Local `/api/trees` 404 is local API-not-running issue, unrelated to CSS change
- Cloudflare Preview or test slot visual verification required before merge decision