### PR TITLE
fix(modal): require public parent tree for public memory reads

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -430,21 +430,23 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
 
 
 def fetch_public_memories(tree_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
-    filters = ["visibility = 'public'"]
+    filters = ["m.visibility = 'public'", "t.visibility = 'public'"]
     params: list[Any] = []
 
     if tree_id:
         params.append(tree_id)
-        filters.append(f"tree_id = %s")
+        filters.append("m.tree_id = %s")
 
     params.append(limit)
     query = f"""
-        SELECT id, tree_id, parent_id, title, memo, artist, source, source_url,
-               source_type, thumbnail, emotion_tags, timestamp, visibility,
-               created_at, updated_at
-        FROM memories
+        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
+               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.created_at, m.updated_at
+        FROM memories m
+        INNER JOIN trees t
+          ON t.id = m.tree_id
         WHERE {' AND '.join(filters)}
-        ORDER BY created_at DESC
+        ORDER BY m.created_at DESC
         LIMIT %s;
     """
 
@@ -458,12 +460,15 @@ def fetch_public_memories(tree_id: str | None = None, limit: int = 100) -> list[
 
 def fetch_public_memory(memory_id: str) -> dict[str, Any] | None:
     query = """
-        SELECT id, tree_id, parent_id, title, memo, artist, source, source_url,
-               source_type, thumbnail, emotion_tags, timestamp, visibility,
-               created_at, updated_at
-        FROM memories
-        WHERE id = %s
-          AND visibility = 'public'
+        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
+               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.created_at, m.updated_at
+        FROM memories m
+        INNER JOIN trees t
+          ON t.id = m.tree_id
+        WHERE m.id = %s
+          AND m.visibility = 'public'
+          AND t.visibility = 'public'
         LIMIT 1;
     """
 

--- a/tests/contracts/modal-public-memory-parent-visibility.test.js
+++ b/tests/contracts/modal-public-memory-parent-visibility.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const MODAL_APP = path.join(ROOT, 'modal_compute', 'app.py');
+
+function readModalApp() {
+  return fs.readFileSync(MODAL_APP, 'utf8');
+}
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+function getFunctionBody(source, functionName) {
+  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  assert.ok(match, `missing ${functionName}`);
+  return match[0];
+}
+
+test('modal public memory list excludes memories under private parent trees', () => {
+  const source = readModalApp();
+  const body = getFunctionBody(source, 'fetch_public_memories');
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /frommemoriesminnerjointreestont\.id=m\.tree_id/,
+    'fetch_public_memories must join parent trees'
+  );
+
+  assert.match(
+    normalized,
+    /m\.visibility=['"]public['"]/,
+    'fetch_public_memories must still require public memories'
+  );
+
+  assert.match(
+    normalized,
+    /t\.visibility=['"]public['"]/,
+    'fetch_public_memories must require public parent trees'
+  );
+
+  assert.match(
+    normalized,
+    /m\.tree_id=%s/,
+    'treeId filter must apply to the memories alias'
+  );
+});
+
+test('modal public memory detail excludes memories under private parent trees', () => {
+  const source = readModalApp();
+  const body = getFunctionBody(source, 'fetch_public_memory');
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /frommemoriesminnerjointreestont\.id=m\.tree_id/,
+    'fetch_public_memory must join parent trees'
+  );
+
+  assert.match(
+    normalized,
+    /m\.id=%s/,
+    'fetch_public_memory must filter by the memory id'
+  );
+
+  assert.match(
+    normalized,
+    /m\.visibility=['"]public['"]/,
+    'fetch_public_memory must still require public memories'
+  );
+
+  assert.match(
+    normalized,
+    /t\.visibility=['"]public['"]/,
+    'fetch_public_memory must require public parent trees'
+  );
+});


### PR DESCRIPTION
## 문제
private tree 아래 public memory가 anonymous direct read path에서 노출됨.

## 수정
`fetch_public_memories()`와 `fetch_public_memory()`에 parent tree visibility guard 추가.

## 정책
anonymous public read requires `memory.visibility = public` AND parent `tree.visibility = public`.

## 유지
owner read, `create_owner_memory`, Plus entitlement, schema, Cloudflare functions 변경 없음.

## 검증
- `py_compile PASS`
- `ast parse PASS`
- `node --test tests/contracts/modal-public-memory-parent-visibility.test.js tests/contracts/growing-trees-api-contract.test.js tests/contracts/api-route-mapping.test.js` -> `18/18 PASS`
- public-under-private list/detail 차단 query PASS
- owner read equivalent PASS
- public tree/public memory regression PASS

## 운영 메모
- Modal deploy는 이 PR에서 수행하지 않음
- production data 삭제 없음
- QA cleanup 없음