### PR TITLE
docs(policy): define public-first visibility and browse eligibility

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -14,9 +14,13 @@
 - private storage는 Plus entitlement가 필요합니다.
 - memory visibility가 생략되면 parent tree visibility를 상속합니다.
 - explicit memory visibility는 backend policy가 허용하는 범위에서만 상속값을 override할 수 있습니다.
+- private tree 아래 explicit public memory는 저장될 수 있습니다.
+- stored memory visibility 와 anonymous public exposure 는 다른 개념입니다.
+- anonymous public read 는 `memory.visibility = public` 과 `parent tree.visibility = public` 을 모두 요구합니다.
 - public visibility 와 Browse/Search eligibility 는 다른 개념입니다.
 - Browse/Search introduction 은 `publicMomentCount >= 3` 이 필요합니다.
-- private tree 아래 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 확인해야 합니다.
+- Browse/Search introduction, community memories list, public memory detail read 는 parent tree visibility guard 를 함께 확인해야 합니다.
+- owner/private read 는 private access policy 에 따라 private tree 아래 public/private memory 를 조회할 수 있습니다.
 
 ---
 
@@ -31,7 +35,7 @@
 5. `./design/UI_DESIGN_SYSTEM.md`
 6. 요청 범위에 맞는 문서군 인덱스
 
-Visibility, private storage, Browse/Search eligibility 판단이 필요하면 아래를 추가로 읽습니다.
+Visibility, private storage, anonymous public exposure, Browse/Search eligibility 판단이 필요하면 아래를 추가로 읽습니다.
 
 - `./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
 - `./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
@@ -53,7 +57,7 @@ Visibility, private storage, Browse/Search eligibility 판단이 필요하면 �
 - [PRODUCT_BRIEF.md](./product/PRODUCT_BRIEF.md) - 현재 실행 기준 제품 개요
 - [PRODUCT_IDENTITY.md](./product/PRODUCT_IDENTITY.md) - 제품 정체성 source of truth 및 public-first 감상 공간 원칙
 - [BRAND_EXPERIENCE.md](./product/BRAND_EXPERIENCE.md) - 브랜드 감성 / UX 표현 원칙 source of truth
-- [PUBLICATION_AND_PRIVACY_UX_POLICY.md](./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md) - public-first visibility, Plus private storage, memory visibility inheritance, Browse/Search eligibility 정책
+- [PUBLICATION_AND_PRIVACY_UX_POLICY.md](./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md) - public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책
 - [UI_COPY_DIET_GUIDE.md](./product/UI_COPY_DIET_GUIDE.md) - UI 카피 다이어트 운영 기준
 - [MVP_SCOPE.md](./product/MVP_SCOPE.md) - MVP 범위
 - [USER_FLOW.md](./product/USER_FLOW.md) - 사용자 흐름
@@ -75,7 +79,7 @@ Visibility, private storage, Browse/Search eligibility 판단이 필요하면 �
 
 - **index**: [engineering_index.md](./engineering/engineering_index.md)
 - [API_CONTRACT.md](./engineering/API_CONTRACT.md) - flat camelCase API 계약
-- [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - visibility/access policy, Browse/Search eligibility, Browse display filter 개념 분리
+- [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 - [RECENT_REFACTORING.md](./engineering/RECENT_REFACTORING.md) - 최근 리팩터링 기록

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -10,7 +10,13 @@
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
 - Netlify는 주경로가 아니라 fallback 또는 단계적 제거 대상입니다.
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 제품/브랜드/UI 판단의 source of truth 입니다.
-- browse display filter 와 publication guard 는 다른 개념입니다.
+- 신규 tree의 정책상 기본 visibility는 `public`입니다.
+- private storage는 Plus entitlement가 필요합니다.
+- memory visibility가 생략되면 parent tree visibility를 상속합니다.
+- explicit memory visibility는 backend policy가 허용하는 범위에서만 상속값을 override할 수 있습니다.
+- public visibility 와 Browse/Search eligibility 는 다른 개념입니다.
+- Browse/Search introduction 은 `publicMomentCount >= 3` 이 필요합니다.
+- private tree 아래 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 확인해야 합니다.
 
 ---
 
@@ -24,6 +30,11 @@
 4. `./product/BRAND_EXPERIENCE.md`
 5. `./design/UI_DESIGN_SYSTEM.md`
 6. 요청 범위에 맞는 문서군 인덱스
+
+Visibility, private storage, Browse/Search eligibility 판단이 필요하면 아래를 추가로 읽습니다.
+
+- `./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
+- `./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
 
 운영/배포 판단이 필요하면 아래를 추가로 읽습니다.
 
@@ -40,9 +51,9 @@
 
 - **index**: [product_index.md](./product/product_index.md)
 - [PRODUCT_BRIEF.md](./product/PRODUCT_BRIEF.md) - 현재 실행 기준 제품 개요
-- [PRODUCT_IDENTITY.md](./product/PRODUCT_IDENTITY.md) - 제품 정체성 source of truth
+- [PRODUCT_IDENTITY.md](./product/PRODUCT_IDENTITY.md) - 제품 정체성 source of truth 및 public-first 감상 공간 원칙
 - [BRAND_EXPERIENCE.md](./product/BRAND_EXPERIENCE.md) - 브랜드 감성 / UX 표현 원칙 source of truth
-- [PUBLICATION_AND_PRIVACY_UX_POLICY.md](./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md) - 공개/비공개/둘러보기 소개 UX 정책
+- [PUBLICATION_AND_PRIVACY_UX_POLICY.md](./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md) - public-first visibility, Plus private storage, memory visibility inheritance, Browse/Search eligibility 정책
 - [UI_COPY_DIET_GUIDE.md](./product/UI_COPY_DIET_GUIDE.md) - UI 카피 다이어트 운영 기준
 - [MVP_SCOPE.md](./product/MVP_SCOPE.md) - MVP 범위
 - [USER_FLOW.md](./product/USER_FLOW.md) - 사용자 흐름
@@ -64,7 +75,7 @@
 
 - **index**: [engineering_index.md](./engineering/engineering_index.md)
 - [API_CONTRACT.md](./engineering/API_CONTRACT.md) - flat camelCase API 계약
-- [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 개념 분리
+- [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - visibility/access policy, Browse/Search eligibility, Browse display filter 개념 분리
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 - [RECENT_REFACTORING.md](./engineering/RECENT_REFACTORING.md) - 최근 리팩터링 기록

--- a/docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md
+++ b/docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md
@@ -1,152 +1,305 @@
 # Browse Display Filter vs. Publication Guard
 
-LoveBud의 browse 노출 정책은 **same-origin browse read path**와 **server-side publication guard**를 서로 다른 책임으로 분리해 관리합니다.
+LoveBud의 공개 정책은 **visibility/access policy**와 **Browse/Search introduction eligibility**를 분리해 관리합니다.
 
-이 문서는 아래 두 개념을 혼동하지 않기 위해 작성합니다.
+이 문서는 아래 개념을 혼동하지 않기 위해 작성합니다.
 
-- **Browse Display Filter**: 공개된 트리 중 무엇을 browse에서 먼저, 어떤 품질 기준으로 보여줄지 정하는 read-path 품질 필터
-- **Publication Guard**: 트리를 공개 상태로 만들 수 있는지, 비공개 데이터를 읽을 수 있는지 정하는 server-side 보안/정책 가드
+- **Visibility / Access Policy**: tree 또는 memory가 public/private 중 어떤 공개 상태를 갖는지, 누가 읽을 수 있는지, private storage가 Plus entitlement를 요구하는지 결정하는 server-side hard policy
+- **Browse/Search Introduction Eligibility**: 이미 public인 tree 중 무엇을 Browse/Search 화면에서 소개할 수 있는지 결정하는 read-path eligibility policy
+- **Browse Display Filter**: eligible tree를 어떤 정렬, summary, quality 기준으로 보여줄지 정하는 read-path display filter
+
+핵심 원칙:
+
+```text
+public visibility != Browse/Search eligibility
+```
 
 ---
 
-## 1. 현재 browse read path (main 기준)
+## 1. Canonical policy
+
+### 1.1 New trees default to public
+
+정책상 신규 tree의 기본 visibility는 `public`입니다.
+
+단, 이 정책은 frontend payload만 단독으로 바꿔 구현하지 않습니다. create tree API, backend/runtime guard, private storage entitlement, 기존 private tree grandfathering을 함께 정렬해야 합니다.
+
+### 1.2 Private storage requires Plus entitlement
+
+다음 동작은 Plus entitlement가 필요합니다.
+
+- private tree 생성
+- public tree를 private으로 전환
+- 신규 private memory/storage 사용
+
+canonical entitlement field:
+
+```text
+users/{uid}.privateStorageEnabled
+```
+
+### 1.3 Memory visibility inheritance
+
+Memory visibility가 payload에서 생략되면 parent tree visibility를 상속합니다.
+
+```text
+parent tree visibility = public
+memory visibility omitted
+=> effective memory visibility = public
+```
+
+```text
+parent tree visibility = private
+memory visibility omitted
+=> effective memory visibility = private
+```
+
+명시적 memory visibility는 backend policy가 허용하는 경우에만 상속값을 override할 수 있습니다. 이 override는 parent tree access policy 또는 Plus private storage guard를 우회하지 못합니다.
+
+### 1.4 Browse/Search introduction requires publicMomentCount >= 3
+
+Browse/Search 소개 조건은 visibility 저장 조건과 다릅니다.
+
+Browse/Search introduction의 canonical minimum condition:
+
+```text
+parent tree visibility === 'public'
+AND publicMomentCount >= 3
+AND browse/search display guard passes
+```
+
+따라서 public tree라도 `publicMomentCount < 3`이면 직접 공개 접근은 가능할 수 있지만 Browse/Search 소개 대상은 아닙니다.
+
+### 1.5 Private parent tree remains a browse/search blocker
+
+private tree 아래에 public memory가 가능한 정책/구현이 있더라도, child memory visibility만으로 Browse/Search 노출을 허용하지 않습니다.
+
+Browse/Search 노출은 반드시 함께 확인합니다.
+
+```text
+parent tree visibility
+AND publicMomentCount
+AND browse/search guard
+```
+
+parent tree가 private이면 public child memory가 있더라도 Browse/Search introduction 대상이 아닙니다.
+
+---
+
+## 2. Current browse read path
 
 현재 browse 페이지의 클라이언트는 외부 호스트를 직접 호출하지 않습니다.
 
 - `js/search.js`
-  - browse 리스트는 `window.apiClient.getPublicTrees({ view: 'summary', sort: 'latest', limit: 3 })`로 로드
+  - browse 리스트는 `window.apiClient.getPublicTrees({ view: 'summary', sort, limit })`로 로드
   - 카드 선택 후 preview hydrate는 `window.apiClient.getPublicTreePreview(tree)`로 로드
 - `js/postgres-client.js`
   - browse summary list는 `/community/trees`
   - preview hydrate는 `/community/memories`
 - `js/api/base-api-fetch.js`
-  - 실제 fetch는 항상 `fetch(`/api${endpoint}`)` 형태의 **same-origin `/api`** 호출
+  - 실제 fetch는 항상 same-origin `/api/*` 형태로 호출
 
-즉, 브라우저 기준 browse read path는 아래와 같습니다.
+브라우저 기준 browse read path:
 
-### summary list
-`search.js` → `window.apiClient.getPublicTrees()` → `/api/community/trees?view=summary&sort=latest&limit=3`
+```text
+search.js
+→ window.apiClient.getPublicTrees()
+→ /api/community/trees?view=summary&sort=...&limit=...
+```
 
-### preview hydrate
-`search.js` → `window.apiClient.getPublicTreePreview()` → `/api/community/memories?treeId=...`
+preview hydrate path:
 
-중요:
-- **오래된 Netlify 직접 호출 설명은 더 이상 현재 main 설명이 아닙니다.**
-- 클라이언트는 `lovebud.vercel.app` 같은 현재 origin 안에서 `/api/...`만 호출합니다.
-
----
-
-## 2. Modal > Vercel > Netlify 우선순위가 browse에서 실제로 어떻게 적용되는가
-
-계층 자체는 `Modal > Vercel > Netlify`가 맞지만, browse의 모든 read path가 동일한 우선순위를 쓰는 것은 아닙니다.
-
-### 2.1 browse summary list (`/api/community/trees?view=summary`)
-위치: `api/community/trees.js`
-
-현재 main 구현:
-1. **Vercel same-origin API**가 요청을 받음
-2. `view=summary`이면 **Modal** `/modal/browse/latest`를 먼저 호출
-3. Modal 데이터가 있으면 그대로 반환
-4. Modal 실패 또는 빈 응답이면 **Netlify** `/community/trees?...`로 fallback
-
-즉, summary browse list의 실제 우선순위는:
-
-**브라우저 → Vercel `/api/community/trees` → Modal 우선 → Netlify fallback**
-
-### 2.2 preview hydrate (`/api/community/memories`)
-위치: `api/community/memories.js`
-
-현재 main 구현:
-1. **Vercel same-origin API**가 요청을 받음
-2. `treeId`가 있으면 **Modal** `/modal/browse/latest`를 먼저 조회
-3. 해당 treeId에 맞는 representative preview memory를 만들 수 있으면 바로 반환
-4. Modal preview를 만들 수 없으면 **Netlify** `/community/memories?...`로 fallback
-5. treeId preview 경로에서 upstream 오류가 나면 degraded preview(`[]`)를 반환할 수 있음
-
-즉, preview hydrate의 현재 우선순위는:
-
-**브라우저 → Vercel `/api/community/memories` → Modal representative preview 우선 → Netlify fallback**
+```text
+search.js
+→ window.apiClient.getPublicTreePreview(tree)
+→ /api/community/memories?treeId=...
+```
 
 중요:
-- browse 전체를 한 줄로 `Modal > Vercel > Netlify`라고만 쓰면 과장될 수 있습니다.
-- **summary list와 preview hydrate 모두 Modal 우선 시도를 가지지만, 방식은 다릅니다.**
-- summary list는 Modal browse list를 직접 사용하고,
-- preview hydrate는 Modal summary에서 representative preview를 구성한 뒤 fallback 합니다.
+
+- 브라우저가 Netlify API를 직접 호출한다고 설명하지 않습니다.
+- 브라우저는 same-origin `/api/*` contract를 기준으로 동작합니다.
+- Cloudflare Pages Functions / Modal / legacy fallback 여부는 runtime 계층에서 관리합니다.
 
 ---
 
-## 3. Publication Guard (보안/정책 계층)
+## 3. Visibility / Access Policy
 
-Publication Guard는 browse 카드 품질 필터가 아니라 **server-side policy**입니다.
+Visibility / Access Policy는 Browse card 품질 필터가 아니라 server-side policy입니다.
 
-### 3.1 read guard
-위치: `netlify/functions/tree-detail.js`
+역할:
 
-- 공개 트리는 누구나 읽을 수 있음
-- 비공개 트리는 owner만 읽을 수 있음
-- 비공개 트리의 memories도 owner가 아니면 읽을 수 없음
+- tree visibility 저장값 결정
+- memory effective visibility 결정
+- private tree/storage Plus entitlement 검증
+- public/private read access 검증
+- existing private tree grandfathering 처리
 
-즉, visibility 자체는 server-side에서 강제됩니다.
+정책 기준:
 
-### 3.2 write/publication guard
-위치:
-- `netlify/functions/trees.js` POST
-- `netlify/functions/tree-detail.js` PUT
+- 신규 tree는 public default
+- private storage는 Plus entitlement 필요
+- memory visibility omitted 시 parent tree visibility 상속
+- explicit memory visibility override는 backend policy가 허용한 경우에만 가능
+- 기존 private tree는 자동 public 전환하지 않음
 
-현재 main 구현:
-- 새 트리를 처음부터 `public`으로 만드는 것은 차단됨
-- 비공개 트리를 공개로 전환할 때는 **공개 순간(public memories) 3개 이상**이 필요함
+Visibility / Access Policy가 하지 않는 것:
 
-즉, `3개 이상 공개 순간` 규칙은 browse 카드 정렬용 힌트가 아니라 **공개 전환 정책 가드**입니다.
+- Browse/Search에 소개할 카드 개수 또는 정렬 결정
+- public tree가 충분히 자랐는지 판단
+- Browse/Search summary quality 보정
 
 ---
 
-## 4. Browse Display Filter (read-path 품질 계층)
+## 4. Browse/Search Introduction Eligibility
 
-Browse Display Filter는 공개 가능 여부를 결정하지 않습니다.
+Browse/Search Introduction Eligibility는 public tree 중 Browse/Search에서 소개할 수 있는 tree를 고릅니다.
 
-역할은 아래와 같습니다.
+역할:
 
-- browse에서 어떤 공개 트리를 먼저 보여줄지 결정
-- summary 카드에 필요한 최소 정보만 빠르게 공급
-- representative thumbnail, emotion tags, memoryCount 같은 browse summary 품질을 보정
-- browse 첫 화면을 감상 허브처럼 유지
+- public tree 중 Browse/Search 소개 가능한 tree 선별
+- publicMomentCount 기준 적용
+- private parent tree 차단
+- 감상 허브 품질 기준 유지
 
-현재 main 기준 browse display filter는 아래 두 층에서 작동합니다.
+canonical 조건:
 
-1. **Modal summary browse query**
-   - `view=summary` 경로에서 browse 후보를 먼저 정제
-2. **Vercel adapter / client summary enrichment**
-   - `api/community/trees.js`와 `js/postgres-client.js` summary adapter에서 browse 카드용 필드를 정리
+```text
+isBrowseSearchEligible(tree) =
+  tree.visibility === 'public'
+  && tree.publicMomentCount >= 3
+  && passesBrowseSearchGuard(tree)
+```
 
 중요:
-- Display Filter는 **browse에 무엇을 보여줄지** 결정합니다.
-- Publication Guard는 **무엇을 공개 상태로 만들 수 있는지 / 누가 읽을 수 있는지**를 결정합니다.
-- 둘은 서로 대체하지 않습니다.
+
+- `publicMomentCount >= 3`은 Browse/Search introduction eligibility입니다.
+- 이 기준을 public visibility 전환 guard로 재사용하지 않습니다.
+- public visibility와 Browse/Search introduction은 사용자-facing copy에서도 분리합니다.
 
 ---
 
-## 5. 운영/문서 작성 시 금지할 설명
+## 5. Browse Display Filter
 
-아래 설명은 현재 main 기준으로 부정확합니다.
+Browse Display Filter는 eligible tree를 어떻게 보여줄지 정하는 read-path 품질 계층입니다.
 
+역할:
+
+- Browse/Search에서 어떤 공개 tree를 먼저 보여줄지 결정
+- summary card에 필요한 최소 정보만 빠르게 공급
+- representative thumbnail, emotion tags, memoryCount 같은 browse summary 필드 보정
+- Browse 첫 화면을 게시판/검색엔진이 아니라 감상 허브처럼 유지
+
+Display Filter는 다음을 결정하지 않습니다.
+
+- tree가 public/private 중 무엇인지
+- private storage를 사용할 수 있는지
+- private tree owner가 누구인지
+- memory visibility inheritance가 어떻게 계산되는지
+
+---
+
+## 6. Correct examples
+
+### Example A: public tree, 2 public moments
+
+```text
+tree.visibility = public
+publicMomentCount = 2
+```
+
+결과:
+
+```text
+public read 가능 후보
+Browse/Search introduction 불가
+```
+
+### Example B: public tree, 3 public moments
+
+```text
+tree.visibility = public
+publicMomentCount = 3
+```
+
+결과:
+
+```text
+public read 가능 후보
+Browse/Search introduction 가능 후보
+```
+
+단, display guard 또는 quality filter를 통과해야 실제 노출됩니다.
+
+### Example C: private tree, public child memory exists
+
+```text
+tree.visibility = private
+child memory visibility = public
+publicMomentCount >= 3
+```
+
+결과:
+
+```text
+parent tree가 private이므로 Browse/Search introduction 불가
+```
+
+child memory visibility만으로 parent tree browse/search eligibility를 만들 수 없습니다.
+
+### Example D: memory visibility omitted
+
+```text
+tree.visibility = public
+memory visibility omitted
+```
+
+결과:
+
+```text
+memory effective visibility = public
+```
+
+```text
+tree.visibility = private
+memory visibility omitted
+```
+
+결과:
+
+```text
+memory effective visibility = private
+```
+
+---
+
+## 7. Documentation guardrails
+
+금지할 설명:
+
+- "public tree는 항상 Browse/Search에 노출된다"
+- "3개 이상 공개 순간은 public 전환 조건이다"
+- "publicMomentCount는 visibility guard다"
+- "private tree 아래 public memory가 있으면 browse에 소개할 수 있다"
+- "memory visibility 생략은 항상 public이다"
+- "private storage는 frontend UI lock만으로 충분하다"
 - "브라우저가 Netlify API를 직접 호출한다"
-- "browse 전체가 Modal 직통 read path다"
-- "3개 이상 규칙은 browse 화면 display filter일 뿐이다"
-- "publication guard는 아직 없다"
-- "preview hydrate는 Vercel → Netlify만 탄다"
 
-현재 main 기준 더 정확한 설명은 아래입니다.
+정확한 설명:
 
-- browse 클라이언트는 **same-origin `/api`**만 호출한다
-- summary browse list는 **Modal 우선, Netlify fallback**이다
-- preview hydrate는 **Modal representative preview 우선, Netlify fallback**이다
-- `3개 이상 공개 순간`은 **publication guard**이며 browse display filter와 별개다
+- 신규 tree의 정책상 기본 visibility는 public이다.
+- private storage는 Plus entitlement가 필요하다.
+- memory visibility 생략 시 parent tree visibility를 상속한다.
+- explicit memory visibility override는 backend policy가 허용할 때만 가능하다.
+- public visibility와 Browse/Search introduction eligibility는 별개다.
+- Browse/Search introduction은 `publicMomentCount >= 3`이 필요하다.
+- private parent tree는 public child memory가 있어도 Browse/Search introduction 대상이 아니다.
+- 브라우저는 same-origin `/api/*`를 호출한다.
 
 ---
 
-## 6. 한 줄 요약
+## 8. One-line summary
 
-- **Browse Display Filter**: browse read-path 품질과 카드 정제를 담당하는 soft filter
-- **Publication Guard**: 공개 가능 여부와 읽기 권한을 강제하는 server-side hard guard
-- **same-origin browse 구조**: 브라우저는 직접 Netlify를 호출하지 않고, 항상 Vercel `/api`를 통해 읽는다
+```text
+Visibility decides who can access a tree or memory; Browse/Search eligibility decides whether a public tree is mature enough to be introduced.
+```

--- a/docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md
+++ b/docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md
@@ -1,16 +1,19 @@
 # Browse Display Filter vs. Publication Guard
 
-LoveBud의 공개 정책은 **visibility/access policy**와 **Browse/Search introduction eligibility**를 분리해 관리합니다.
+LoveBud의 공개 정책은 **visibility/access policy**, **stored memory visibility**, **anonymous public exposure**, **Browse/Search introduction eligibility**를 분리해 관리합니다.
 
 이 문서는 아래 개념을 혼동하지 않기 위해 작성합니다.
 
-- **Visibility / Access Policy**: tree 또는 memory가 public/private 중 어떤 공개 상태를 갖는지, 누가 읽을 수 있는지, private storage가 Plus entitlement를 요구하는지 결정하는 server-side hard policy
-- **Browse/Search Introduction Eligibility**: 이미 public인 tree 중 무엇을 Browse/Search 화면에서 소개할 수 있는지 결정하는 read-path eligibility policy
+- **Stored Visibility**: tree 또는 memory row에 저장되는 visibility 값
+- **Visibility / Access Policy**: 누가 tree 또는 memory를 읽을 수 있는지, private storage가 Plus entitlement를 요구하는지 결정하는 server-side hard policy
+- **Anonymous Public Exposure**: 비로그인/anonymous public read path에서 실제로 외부에 노출 가능한지 결정하는 public read guard
+- **Browse/Search Introduction Eligibility**: 이미 public exposure 가능한 tree 중 무엇을 Browse/Search 화면에서 소개할 수 있는지 결정하는 read-path eligibility policy
 - **Browse Display Filter**: eligible tree를 어떤 정렬, summary, quality 기준으로 보여줄지 정하는 read-path display filter
 
 핵심 원칙:
 
 ```text
+stored memory visibility != anonymous public exposure
 public visibility != Browse/Search eligibility
 ```
 
@@ -38,25 +41,52 @@ canonical entitlement field:
 users/{uid}.privateStorageEnabled
 ```
 
-### 1.3 Memory visibility inheritance
+### 1.3 Memory visibility inheritance and explicit override
 
 Memory visibility가 payload에서 생략되면 parent tree visibility를 상속합니다.
 
 ```text
 parent tree visibility = public
 memory visibility omitted
-=> effective memory visibility = public
+=> stored/effective memory visibility = public
 ```
 
 ```text
 parent tree visibility = private
 memory visibility omitted
-=> effective memory visibility = private
+=> stored/effective memory visibility = private
 ```
 
-명시적 memory visibility는 backend policy가 허용하는 경우에만 상속값을 override할 수 있습니다. 이 override는 parent tree access policy 또는 Plus private storage guard를 우회하지 못합니다.
+명시적 memory visibility는 backend policy가 허용하는 경우에만 상속값을 override할 수 있습니다. backend policy가 허용하면 private tree 아래에 explicit public memory가 저장될 수 있습니다.
 
-### 1.4 Browse/Search introduction requires publicMomentCount >= 3
+그러나 stored memory visibility와 anonymous public exposure는 별개입니다.
+
+Canonical 문구:
+
+```text
+Stored memory visibility and anonymous public exposure are separate. A memory may be stored as public under a private tree when backend policy allows it, but anonymous public read paths must require both memory.visibility = public and parent tree.visibility = public.
+```
+
+### 1.4 Anonymous public read requires parent tree public visibility
+
+Anonymous public read path는 다음을 모두 요구해야 합니다.
+
+```text
+memory.visibility === 'public'
+AND parentTree.visibility === 'public'
+```
+
+따라서 `memory.visibility = public` alone은 anonymous public read에 충분하지 않습니다.
+
+parent tree visibility guard가 필요한 경로:
+
+- Browse/Search introduction
+- community memories list
+- public memory detail read
+
+Owner/private read path는 기존 private access policy를 따릅니다. owner는 private tree 아래 public/private memory를 조회할 수 있습니다.
+
+### 1.5 Browse/Search introduction requires publicMomentCount >= 3
 
 Browse/Search 소개 조건은 visibility 저장 조건과 다릅니다.
 
@@ -69,20 +99,6 @@ AND browse/search display guard passes
 ```
 
 따라서 public tree라도 `publicMomentCount < 3`이면 직접 공개 접근은 가능할 수 있지만 Browse/Search 소개 대상은 아닙니다.
-
-### 1.5 Private parent tree remains a browse/search blocker
-
-private tree 아래에 public memory가 가능한 정책/구현이 있더라도, child memory visibility만으로 Browse/Search 노출을 허용하지 않습니다.
-
-Browse/Search 노출은 반드시 함께 확인합니다.
-
-```text
-parent tree visibility
-AND publicMomentCount
-AND browse/search guard
-```
-
-parent tree가 private이면 public child memory가 있더라도 Browse/Search introduction 대상이 아닙니다.
 
 ---
 
@@ -130,9 +146,11 @@ Visibility / Access Policy는 Browse card 품질 필터가 아니라 server-side
 역할:
 
 - tree visibility 저장값 결정
-- memory effective visibility 결정
+- memory stored/effective visibility 결정
+- explicit memory visibility override 허용 여부 결정
 - private tree/storage Plus entitlement 검증
 - public/private read access 검증
+- anonymous public exposure guard 적용
 - existing private tree grandfathering 처리
 
 정책 기준:
@@ -141,6 +159,7 @@ Visibility / Access Policy는 Browse card 품질 필터가 아니라 server-side
 - private storage는 Plus entitlement 필요
 - memory visibility omitted 시 parent tree visibility 상속
 - explicit memory visibility override는 backend policy가 허용한 경우에만 가능
+- explicit public memory가 private tree 아래 저장될 수 있어도 anonymous public exposure는 parent tree public 여부를 함께 확인
 - 기존 private tree는 자동 public 전환하지 않음
 
 Visibility / Access Policy가 하지 않는 것:
@@ -151,7 +170,36 @@ Visibility / Access Policy가 하지 않는 것:
 
 ---
 
-## 4. Browse/Search Introduction Eligibility
+## 4. Anonymous Public Exposure Guard
+
+Anonymous Public Exposure Guard는 비로그인/anonymous public read path에서 memory 또는 tree가 외부 사용자에게 실제로 노출될 수 있는지 결정합니다.
+
+memory anonymous public read 조건:
+
+```text
+canAnonymousReadMemory(memory, parentTree) =
+  memory.visibility === 'public'
+  && parentTree.visibility === 'public'
+```
+
+경로별 적용:
+
+| 경로 | parent tree visibility guard |
+|------|------------------------------|
+| Browse/Search introduction | 필요 |
+| community memories list | 필요 |
+| public memory detail read | 필요 |
+
+중요:
+
+- private tree 아래 explicit public memory는 저장될 수 있습니다.
+- 그러나 parent tree가 private이면 anonymous public read에서 노출하지 않습니다.
+- `memory.visibility = public` alone은 anonymous public read 조건이 아닙니다.
+- owner/private read는 이 guard와 별개로 기존 private access policy를 따릅니다.
+
+---
+
+## 5. Browse/Search Introduction Eligibility
 
 Browse/Search Introduction Eligibility는 public tree 중 Browse/Search에서 소개할 수 있는 tree를 고릅니다.
 
@@ -176,10 +224,11 @@ isBrowseSearchEligible(tree) =
 - `publicMomentCount >= 3`은 Browse/Search introduction eligibility입니다.
 - 이 기준을 public visibility 전환 guard로 재사용하지 않습니다.
 - public visibility와 Browse/Search introduction은 사용자-facing copy에서도 분리합니다.
+- private tree 아래 public memory가 있더라도 parent tree가 private이면 Browse/Search introduction 대상이 아닙니다.
 
 ---
 
-## 5. Browse Display Filter
+## 6. Browse Display Filter
 
 Browse Display Filter는 eligible tree를 어떻게 보여줄지 정하는 read-path 품질 계층입니다.
 
@@ -196,10 +245,11 @@ Display Filter는 다음을 결정하지 않습니다.
 - private storage를 사용할 수 있는지
 - private tree owner가 누구인지
 - memory visibility inheritance가 어떻게 계산되는지
+- anonymous public read에서 parent tree visibility를 생략해도 되는지
 
 ---
 
-## 6. Correct examples
+## 7. Correct examples
 
 ### Example A: public tree, 2 public moments
 
@@ -211,7 +261,7 @@ publicMomentCount = 2
 결과:
 
 ```text
-public read 가능 후보
+anonymous public read 가능 후보
 Browse/Search introduction 불가
 ```
 
@@ -225,7 +275,7 @@ publicMomentCount = 3
 결과:
 
 ```text
-public read 가능 후보
+anonymous public read 가능 후보
 Browse/Search introduction 가능 후보
 ```
 
@@ -242,10 +292,14 @@ publicMomentCount >= 3
 결과:
 
 ```text
-parent tree가 private이므로 Browse/Search introduction 불가
+stored child memory visibility는 public일 수 있음
+anonymous community memories list 노출 불가
+anonymous public memory detail read 불가
+Browse/Search introduction 불가
+owner/private read 가능
 ```
 
-child memory visibility만으로 parent tree browse/search eligibility를 만들 수 없습니다.
+child memory visibility만으로 anonymous public exposure 또는 parent tree browse/search eligibility를 만들 수 없습니다.
 
 ### Example D: memory visibility omitted
 
@@ -257,7 +311,7 @@ memory visibility omitted
 결과:
 
 ```text
-memory effective visibility = public
+memory stored/effective visibility = public
 ```
 
 ```text
@@ -268,12 +322,12 @@ memory visibility omitted
 결과:
 
 ```text
-memory effective visibility = private
+memory stored/effective visibility = private
 ```
 
 ---
 
-## 7. Documentation guardrails
+## 8. Documentation guardrails
 
 금지할 설명:
 
@@ -281,6 +335,8 @@ memory effective visibility = private
 - "3개 이상 공개 순간은 public 전환 조건이다"
 - "publicMomentCount는 visibility guard다"
 - "private tree 아래 public memory가 있으면 browse에 소개할 수 있다"
+- "private tree 아래 public memory가 있으면 community memories list에 anonymous 노출할 수 있다"
+- "memory.visibility = public이면 anonymous public detail read가 가능하다"
 - "memory visibility 생략은 항상 public이다"
 - "private storage는 frontend UI lock만으로 충분하다"
 - "브라우저가 Netlify API를 직접 호출한다"
@@ -291,15 +347,18 @@ memory effective visibility = private
 - private storage는 Plus entitlement가 필요하다.
 - memory visibility 생략 시 parent tree visibility를 상속한다.
 - explicit memory visibility override는 backend policy가 허용할 때만 가능하다.
-- public visibility와 Browse/Search introduction eligibility는 별개다.
+- private tree 아래 explicit public memory는 저장될 수 있다.
+- stored memory visibility와 anonymous public exposure는 별개다.
+- anonymous public read는 `memory.visibility = public`과 `parent tree.visibility = public`을 모두 요구한다.
 - Browse/Search introduction은 `publicMomentCount >= 3`이 필요하다.
-- private parent tree는 public child memory가 있어도 Browse/Search introduction 대상이 아니다.
+- parent tree가 private이면 public child memory가 있어도 Browse/Search, community memories list, public memory detail read에 anonymous 노출하지 않는다.
+- owner/private read는 private access policy에 따라 private tree 아래 public/private memory를 조회할 수 있다.
 - 브라우저는 same-origin `/api/*`를 호출한다.
 
 ---
 
-## 8. One-line summary
+## 9. One-line summary
 
 ```text
-Visibility decides who can access a tree or memory; Browse/Search eligibility decides whether a public tree is mature enough to be introduced.
+Stored visibility decides what is saved; anonymous public exposure decides what public readers can see; Browse/Search eligibility decides whether a public tree is mature enough to be introduced.
 ```

--- a/docs/product/PRODUCT_IDENTITY.md
+++ b/docs/product/PRODUCT_IDENTITY.md
@@ -27,36 +27,47 @@ LoveTree는 아래 조건에 해당하는 팬을 위해 설계되었습니다:
 1. **First Moment First**: "입덕"의 그 순간, 가장 강렬했던 첫 기억을 가장 소중하게 다룹니다.
 2. **Connected Love Path**: 순간들을 파편화하지 않고, 나뭇가지처럼 유기적으로 흐르는 경로(Path)로 연결합니다.
 3. **Emotion Over Archive**: 단순한 저장보다는 '왜 이 시점이 좋았는지'에 대한 감정 메모를 핵심 콘텐츠로 처리합니다.
-4. **Private First, Share Second**: 나의 소중한 공간으로서의 가치를 먼저 확립한 뒤, 선택적으로 공유하여 팬덤 내에서 긍정적인 영향력을 전파합니다.
+4. **Public-first, Carefully Introduced**: 새 러브트리는 공개 상태로 시작하지만, 둘러보기에는 충분한 공개 순간이 쌓인 뒤 조용히 소개됩니다.
 
-## 5. UX Direction
+## 5. Visibility and Community Principle
+LoveTree는 감정을 숨기는 도구가 아니라, 감정의 경로가 자연스럽게 공유될 수 있는 조용한 공개 공간을 지향합니다.
+
+- 신규 LoveTree는 정책상 `public`으로 시작합니다.
+- 비공개 보관은 Plus private storage 기능으로 분리합니다.
+- memory visibility가 생략되면 parent tree visibility를 상속합니다.
+- public visibility와 Browse/Search 소개 가능 여부는 별개입니다.
+- Browse/Search 소개는 `publicMomentCount >= 3`을 기준으로 합니다.
+- private tree 아래 public memory가 있더라도 parent tree가 private이면 Browse/Search에 소개하지 않습니다.
+
+## 6. UX Direction
 * **Warm & Organic**: 나뭇가지 같은 곡선, 부드러운 그림자, 따뜻한 색감을 사용하여 사용자의 감정을 보호합니다.
 * **Tactile Experience**: 디지털 공간이지만 아날로그 다이어리를 꾸미는 듯한 종이 질감과 여백의 미를 추구합니다.
 * **Emotional Flow**: 기술적인 플로우차트 스타일을 배격하고, 감정의 흐름을 닮은 자연스러운 인터페이스를 제공합니다.
 
-## 6. Mobile vs Desktop Role
+## 7. Mobile vs Desktop Role
 | 환경 | 주요 역할 | 사용자 경험 (UX) |
 | :--- | :--- | :--- |
 | **Mobile** | **빠른 기록 & 감상** | 이동 중에도 영상의 특정 시점과 짧은 감정 메모를 즉시 남기는 'Snap' 경험. |
 | **Desktop** | **연결 구조 & 편집** | 넓은 화면에서 기억들의 관계를 정립하고 트리 구조를 재배치하는 'Curation' 경험. |
 
-## 7. Decision Checklist (의사결정 기준)
+## 8. Decision Checklist (의사결정 기준)
 새로운 기능이나 디자인을 제안할 때 아래 질문에 답할 수 있어야 합니다.
 1. 이 기능이 팬의 **첫 순간**을 기록하는 데 도움이 되는가?
 2. 이 디자인이 **따뜻한 스크랩북**의 느낌을 유지하고 있는가?
 3. 이것이 데이터의 나열인가, 아니면 **감정의 흐름**인가?
 4. IT 관리 툴(Admin)처럼 차갑게 느껴지지는 않는가?
+5. 공개 상태와 Browse/Search 소개 가능 여부를 혼동시키지는 않는가?
 
-## 8. Community Principle (커뮤니티 원칙)
+## 9. Community Principle (커뮤니티 원칙)
 LoveTree는 팬덤 커뮤니티의 **감정 공유 공간**으로서 가치를 합니다.
 
-- **입덕 경로의 가이딩**: 완성된 LoveTree를 공유하여, 다른 팬들에게 "이렇게 입덕할 수 있다"는 길을 제시합니다.
+- **입덕 경로의 가이딩**: 충분히 자란 LoveTree를 공유하여, 다른 팬들에게 "이렇게 입덕할 수 있다"는 길을 제시합니다.
 - **Positive Energy Only**: 비판이나 부정보다 각자의 감정과 경험을 존중하는 분위기를 유지합니다.
 - **돌봄의 연쇄**: 하나의 감정 기록이 다른 팬에게 감동이 되고, 그 감동이 또 다른 기록의 이유가 됩니다.
 
 > LoveTree의 커뮤니티는 **"게시판"이 아니라 "러브트리 감상 공간"**입니다.
 
-## 9. Design Guardrails
+## 10. Design Guardrails
 - **No Hard Edges**: 모든 컴포넌트에 부드러운 곡선을 적용하여 따뜻한 느낌을 유지합니다.
 - **No Cold Palette**: 차가운 색상 대비를 지양하고, 감정을 보호하는 웜톤 톤을 기본으로 합니다.
 - **No Mechanical Flow**: 노드 간의 연결은 자연스러운 감정의 흐름을 반영합니다.
@@ -78,6 +89,9 @@ LoveTree/LoveBud는 정보를 정리하는 서비스가 아니라, 감정의 흐
 공개 영역은 피드, 게시판, 검색 결과 화면처럼 보이면 안 된다.  
 LoveTree의 browse 경험은 누군가의 첫 순간과 이어진 감정을 조용히 따라가는 감상 허브여야 한다.
 
+공개 상태와 browse 소개는 같은 뜻이 아니다.  
+새 러브트리는 공개 상태로 시작할 수 있지만, browse/search에는 공개 순간이 충분히 쌓인 뒤 조용히 소개되어야 한다.
+
 편집 경험도 일반 생산성 도구의 어조를 그대로 가져오면 안 된다.  
 editor는 입력 폼을 채우는 곳이 아니라, 첫 순간을 심고 다음 순간을 이어 붙이는 공간이어야 한다.
 
@@ -94,6 +108,7 @@ LoveTree/LoveBud의 모든 화면은 아래 원칙을 공유한다.
 3. 수치, 상태, 설정, 관리 액션은 감상 흐름을 해치지 않는 수준으로만 노출한다.
 4. placeholder와 빈 상태 문구도 제품 톤 안에서 작성한다.
 5. 게시판, 관리툴, 대시보드처럼 보이는 표현은 기본값으로 두지 않는다.
+6. 공개 여부와 Browse/Search 소개 가능 여부를 같은 상태처럼 표현하지 않는다.
 
 ---
 

--- a/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
+++ b/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
@@ -1,283 +1,300 @@
 # Publication and Privacy UX Policy
 
-이 문서는 LoveBud / LoveTree의 공개, 비공개, 둘러보기 소개 UX 정책을 정리합니다.
+이 문서는 LoveBud / LoveTree의 공개, 비공개, memory visibility, Browse/Search 소개 UX 정책을 정리합니다.
 
-현재 CTO 결정에 따라 제품 방향은 **public-first + Plus private**으로 전환합니다. 단, 코드 수정 전 단계에서는 기존 private-first 구현을 즉시 변경하지 않고, 문서상 목표 정책과 전환 가드레일을 먼저 고정합니다.
+현재 CTO 확정 정책은 **public-first visibility + Plus private storage + separate browse eligibility**입니다. 이 문서는 제품/UX 정책의 canonical source이며, 코드 구현은 별도 frontend/backend 작업으로 분리합니다.
 
-이 문서는 UX/제품 정책 문서입니다. 결제, 권한, backend, API, DB 변경을 직접 구현하거나 확정하지 않습니다. 실제 구현은 별도 frontend/backend 작업으로 분리합니다.
-
----
-
-## 1. 확정 정책 요약
-
-1. 신규 tree는 장기적으로 `public-first` 방향으로 전환합니다.
-2. 기존 private tree는 자동 public 전환하지 않고 **grandfathered private**으로 유지합니다.
-3. private 생성/전환은 Plus entitlement source가 확정된 뒤 backend에서 검증합니다.
-4. `public visibility`와 `browse 노출 조건`은 분리합니다.
-5. createTree payload만 단독으로 `public` 변경하는 것은 금지합니다.
-6. Netlify와 Modal visibility 정책은 반드시 동기화합니다.
-7. 결제/권한 로직 확정 전에는 Plus private을 확정 기능처럼 과도하게 노출하지 않습니다.
+중요: 이 문서는 현재 main 코드가 이미 public-first로 동작한다는 의미가 아닙니다. 코드 변경 전에는 현재 구현 상태를 별도로 확인해야 합니다.
 
 ---
 
-## 2. 현재 구현 상태
+## 1. Canonical policy summary
 
-현재 main 구현은 아직 private-first입니다.
+1. **New trees default to public.**
+   - 신규 tree의 정책상 기본 visibility는 `public`입니다.
+   - frontend payload만 단독으로 바꾸지 않고, frontend/backend/runtime 정책을 함께 전환합니다.
 
-- My Trees 생성 모달은 `visibility: private` payload를 보냅니다.
-- backend create tree API는 public 생성 요청을 차단합니다.
-- Editor의 visibility toggle은 public/private 전환을 허용하지만 Plus 권한 검증은 없습니다.
-- Settings의 `프라이빗 보관` 문구는 `Plus에서 준비 중` 수준의 보조 안내입니다.
+2. **Private storage requires Plus entitlement.**
+   - private tree 생성, public tree의 private 전환, 신규 private memory/storage 사용은 Plus entitlement가 필요합니다.
+   - canonical entitlement field는 `users/{uid}.privateStorageEnabled`입니다.
 
-따라서 본 문서는 목표 정책을 정의하되, 현재 코드 동작과 혼동하지 않도록 다음을 명시합니다.
+3. **Memory visibility omitted inherits parent tree visibility.**
+   - memory create/update payload에서 visibility가 생략되면 parent tree visibility를 상속합니다.
 
-> 코드 전환은 frontend 단독으로 진행하지 않습니다. create tree, toggle visibility, Netlify, Modal, 권한 검증 정책을 함께 설계한 뒤 단계적으로 반영합니다.
+4. **Explicit memory visibility may override inheritance when backend policy allows it.**
+   - 명시적 memory visibility는 backend policy가 허용하는 범위에서만 상속값을 override할 수 있습니다.
+   - override가 허용되더라도 parent tree 접근 권한과 private storage guard를 우회할 수 없습니다.
 
----
+5. **Public visibility and Browse/Search eligibility are separate.**
+   - `visibility: public`은 공개 접근 가능 상태입니다.
+   - Browse/Search 소개 가능 여부는 별도 eligibility 조건입니다.
 
-## 3. 제품 해석
+6. **Browse/Search introduction requires `publicMomentCount >= 3`.**
+   - public tree라도 공개 순간 수가 3개 미만이면 Browse/Search 소개 대상이 아닙니다.
+   - 직접 링크/공개 접근 가능성과 Browse/Search 소개는 같은 뜻이 아닙니다.
 
-LoveBud / LoveTree의 공개 정책은 다음 두 개념을 분리해야 합니다.
-
-### 3.1. public visibility
-
-`public visibility`는 해당 tree 또는 memory가 링크/공개 접근 가능한 상태인지 나타내는 저장 상태입니다.
-
-public-first 전환 후 신규 tree는 기본적으로 public visibility를 갖는 방향입니다.
-
-### 3.2. browse 노출 조건
-
-`browse 노출`은 둘러보기 화면에 소개될 수 있는 표시 조건입니다.
-
-public tree라고 해서 즉시 둘러보기에 노출되는 것은 아닙니다. 둘러보기 노출은 품질/성장 조건을 별도로 따릅니다.
-
-권장 기본 조건:
-
-- tree visibility가 `public`
-- public memory가 최소 3개 이상
-- browse summary/display filter를 통과
-
-이 분리는 사용자가 `공개 = 바로 둘러보기 노출`로 오해하지 않게 하기 위한 핵심 정책입니다.
+7. **Child memory visibility does not by itself make a private tree browseable.**
+   - private tree 아래에 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 봅니다.
+   - parent tree가 private이면 child public memory만으로 Browse/Search 소개 대상이 될 수 없습니다.
 
 ---
 
-## 4. 기존 private tree grandfathering
+## 2. Current implementation note
+
+현재 main 구현은 정책 전환 중간 상태일 수 있습니다. 문서의 canonical policy와 실제 코드 동작이 다를 수 있으므로 구현 작업 전에는 관련 frontend/backend/runtime 파일을 다시 확인해야 합니다.
+
+기존 확인 기준:
+
+- My Trees 생성 모달은 과거 private-first payload를 사용했습니다.
+- backend create tree guard는 과거 public 생성 요청을 제한했습니다.
+- Editor visibility toggle은 public/private 전환 UI를 제공하되 Plus entitlement guard가 완전히 연결되지 않았을 수 있습니다.
+- Settings의 private storage 문구는 정책/결제 구현 상태에 따라 별도 조정이 필요합니다.
+
+정책 전환은 다음을 함께 맞춘 뒤 진행합니다.
+
+- tree create payload / API contract
+- Cloudflare Pages Functions route policy
+- Modal backend visibility policy
+- entitlement check
+- memory visibility inheritance
+- existing private tree grandfathering
+- Browse/Search eligibility filter
+
+---
+
+## 3. Visibility model
+
+### 3.1. Tree visibility
+
+Tree visibility는 해당 tree 자체가 공개 접근 가능한지 결정하는 저장 상태입니다.
+
+정책:
+
+- 신규 tree 기본값은 `public`입니다.
+- 기존 private tree는 자동 public 전환하지 않습니다.
+- `public -> private` 전환은 Plus private storage entitlement가 필요합니다.
+- `private -> public` 전환은 사용자의 명시적 publish/visibility action으로 처리합니다.
+
+### 3.2. Memory visibility inheritance
+
+Memory visibility는 다음 순서로 결정합니다.
+
+1. payload에 explicit visibility가 있고 backend policy가 허용하면 그 값을 사용합니다.
+2. payload visibility가 생략되면 parent tree visibility를 상속합니다.
+3. parent tree access policy와 private storage policy를 우회하는 explicit override는 허용하지 않습니다.
+
+예시:
+
+```text
+parent tree visibility = public
+memory visibility omitted
+=> effective memory visibility = public
+```
+
+```text
+parent tree visibility = private
+memory visibility omitted
+=> effective memory visibility = private
+```
+
+```text
+parent tree visibility = private
+memory visibility = public
+=> backend policy가 허용한 경우에만 public memory가 될 수 있음
+=> 그래도 parent tree가 private이면 Browse/Search 소개 대상은 아님
+```
+
+---
+
+## 4. Browse/Search eligibility
+
+Browse/Search eligibility는 공개 접근 가능 여부가 아니라 **소개 가능 여부**입니다.
+
+Browse/Search introduction 조건:
+
+- parent tree visibility가 `public`
+- `publicMomentCount >= 3`
+- Browse/Search display filter 또는 quality filter를 통과
+
+따라서 다음을 명확히 구분합니다.
+
+| 상태 | 의미 |
+|------|------|
+| public visibility | direct/public read policy상 공개 접근 가능한 상태 |
+| browse/search eligible | Browse/Search 화면에서 소개될 수 있는 상태 |
+| publicMomentCount | Browse/Search 소개 기준으로 계산된 공개 순간 수 |
+
+중요 원칙:
+
+- public tree라고 해서 즉시 Browse/Search에 노출되지 않습니다.
+- `publicMomentCount >= 3`은 Browse/Search introduction guard입니다.
+- `publicMomentCount >= 3`을 tree visibility 전환 조건으로 사용하지 않습니다.
+- private tree 아래 public memory가 있더라도 parent tree가 private이면 Browse/Search에 노출하지 않습니다.
+
+---
+
+## 5. Existing private tree grandfathering
 
 기존 private tree는 자동으로 public 전환하지 않습니다.
 
 이유:
 
-1. 기존 사용자는 private-first UX 아래에서 tree를 만들었습니다.
+1. 기존 사용자는 private-first UX 아래에서 tree를 만들었을 수 있습니다.
 2. 자동 public 전환은 사용자 기대와 신뢰를 훼손할 수 있습니다.
 3. production 데이터 visibility 일괄 변경은 별도 승인 없이 금지합니다.
 
-권장 처리:
+정책:
 
 - 기존 private tree는 owner에게 계속 private으로 보입니다.
-- 기존 private tree는 `grandfathered private` 상태로 유지합니다.
-- 사용자가 명시적으로 public 전환할 수 있는 UX는 별도 승인 후 제공합니다.
-- free user가 기존 private tree를 public으로 전환하는 것은 허용 가능 후보입니다.
-- free user가 public tree를 private으로 전환하는 것은 Plus entitlement 확정 후 제한합니다.
+- 기존 private tree는 grandfathered private으로 유지할 수 있습니다.
+- non-Plus grandfathered owner는 기존 private content를 열람/수정할 수 있습니다.
+- non-Plus grandfathered owner의 신규 private storage 사용은 Plus entitlement가 필요합니다.
+- grandfathered private tree를 public으로 전환하는 UX는 별도 승인 후 제공합니다.
 
 ---
 
-## 5. UX 원칙
+## 6. UX copy guidance
 
-### 5.1. 신규 tree 생성
+사용자-facing 문구는 공개 접근과 Browse/Search 소개를 혼동시키지 않아야 합니다.
 
-목표 정책은 public-first입니다.
+권장 문구:
 
-다만 구현 전환 전까지는 현재 private-first payload를 단독으로 바꾸면 안 됩니다. public-first 전환은 다음이 함께 준비된 뒤 진행합니다.
+> 새 러브트리는 공개 상태로 시작해요.
 
-- frontend 생성 UX
-- Netlify create tree 정책
-- Modal create tree 정책
-- browse display filter 정합성
-- Plus entitlement source
-- 기존 private tree grandfathering 처리
+> 공개 상태여도 바로 둘러보기에 소개되지는 않아요.
 
-전환 후 권장 생성 UX:
-
-- 기본 안내: `새 러브트리는 공개 상태로 시작해요.`
-- 보조 안내: `둘러보기에는 충분히 자란 뒤 소개돼요.`
-- private 선택지는 Plus private storage로 분리하되, 결제/권한 확정 전에는 강한 판매 문구를 쓰지 않습니다.
-
-### 5.2. 무료 사용자의 private 선택
-
-Plus entitlement source가 확정되기 전:
-
-- private 선택을 확정 기능처럼 노출하지 않습니다.
-- `프라이빗 보관은 Plus에서 준비 중이에요.` 수준으로 안내합니다.
-
-Plus entitlement source가 확정된 뒤:
-
-- 무료 사용자가 private 생성/전환을 선택하면 Plus 필요 안내를 보여줍니다.
-- frontend 안내와 backend 권한 검증을 함께 적용합니다.
-
-권장 문구 후보:
+> 공개된 순간이 3개 이상 쌓이면 둘러보기에서 소개될 수 있어요.
 
 > 비공개 보관은 Plus에서 사용할 수 있어요.
 
-> 지금은 공개 상태로 시작하고, 둘러보기 소개 여부는 조건을 채운 뒤 따로 정리할 수 있어요.
+> 순간의 공개 범위를 따로 고르지 않으면, 러브트리의 공개 상태를 따라가요.
 
-### 5.3. Editor badge
+> 공개는 링크로 볼 수 있는 상태이고, 둘러보기 소개는 충분히 자란 러브트리를 조용히 보여주는 기준이에요.
 
-현재 Editor의 `비공개 러브트리` badge는 단순 visibility 상태입니다.
+짧은 UI label 후보:
 
-public-first 전환 후에는 다음 의미를 분리해야 합니다.
+- 공개로 시작
+- 둘러보기 소개 준비 중
+- 공개 순간 3개부터 소개 가능
+- 비공개 보관은 Plus 기능
+
+---
+
+## 7. Editor / My Trees state labels
+
+Visibility badge와 Browse/Search eligibility badge는 분리합니다.
 
 | 상태 | 의미 |
 |------|------|
-| 공개 러브트리 | public visibility 상태 |
-| 둘러보기 준비 중 | public이지만 browse 노출 조건 미충족 |
-| 둘러보기 소개 가능 | public이며 browse 노출 조건 충족 |
+| 공개 러브트리 | tree visibility가 public |
+| 둘러보기 준비 중 | public이지만 `publicMomentCount < 3` |
+| 둘러보기 소개 가능 | public이고 `publicMomentCount >= 3` |
 | 비공개 보관 | Plus private 또는 grandfathered private |
 
-### 5.4. 공개/비공개 전환 버튼 위치
-
-공개/비공개 전환은 기본 작업 흐름을 방해하지 않는 위치에 둡니다.
-
-권장 위치:
-
-- Editor sidebar의 접힌 설정 패널
-- My Trees card overflow menu
-
-기본 Editor 작업 화면에 visibility 설명을 과도하게 노출하지 않습니다.
-
-### 5.5. Settings
-
-Settings에서 기본 공개 범위 설정을 즉시 부활시키는 것은 보류합니다.
-
-권장 방향:
-
-- Settings는 정책 설명과 private storage 안내 중심으로 유지합니다.
-- `기본 공개 범위` 라디오는 Plus entitlement와 backend enforcement가 준비된 뒤 재검토합니다.
-- 사용자가 바꿀 수 없는 정책값을 설정처럼 노출하지 않습니다.
+기본 Editor 작업 화면에는 visibility 설명을 과도하게 노출하지 않습니다. 공개/비공개 전환은 설정 패널, My Trees card menu 등 기본 감정 흐름을 방해하지 않는 위치에 둡니다.
 
 ---
 
-## 6. API/backend 정합성 원칙
+## 8. Engineering handoff policy
 
-### 6.1. create tree
-
-목표 정책:
-
-- 신규 tree는 public-first 방향으로 전환합니다.
-- 단, frontend payload만 단독 변경하지 않습니다.
-- Netlify와 Modal create 정책을 동시에 동기화합니다.
-
-현재 구현:
-
-- Netlify create tree는 public 생성 요청을 차단합니다.
-- Modal create tree도 public 생성 요청을 차단합니다.
-
-전환 조건:
-
-- API 계약 문서 개정
-- backend create guard 개정
-- Modal create guard 개정
-- frontend 생성 UX 개정
-- entitlement 미확정 상태에서 private 선택지를 어떻게 처리할지 결정
-
-### 6.2. toggle visibility
-
-목표 정책:
-
-- public → private 전환은 Plus private 기능으로 잠급니다.
-- private → public 전환은 grandfathered private 해제 또는 publish 흐름으로 취급합니다.
-- Plus entitlement source가 확정되기 전에는 backend enforcement를 구현하지 않습니다.
-
-현재 구현:
-
-- private → public 전환은 공개 memory 3개 이상 조건을 요구합니다.
-- public → private 전환에는 Plus 권한 검증이 없습니다.
-
-전환 시 재정의 필요:
-
-- public-first 이후에도 private → public 전환에 공개 memory 3개 조건을 둘지
-- 또는 visibility 전환과 browse 소개 조건을 완전히 분리할지
-
-권장 방향:
-
-- visibility 전환과 browse 노출 조건은 분리합니다.
-- public 전환 자체는 접근성/공개 상태입니다.
-- browse 노출은 public memory 3개 이상 display filter로 관리합니다.
-
----
-
-## 7. Plus entitlement decision-needed
-
-아래 항목은 아직 미확정입니다.
-
-- Plus entitlement source of truth
-- plan 정보를 저장할 DB 위치
-- free/plus 판정 API
-- frontend에서 Plus 상태를 읽는 방식
-- backend에서 private 생성/전환을 차단할 때 사용할 HTTP status/code
-- 기존 grandfathered private tree를 Plus 없이 계속 private 유지할 기간
-- 결제 UX 도입 시점
-
-권장 API error code 후보:
+개발자-facing canonical 문구:
 
 ```text
-PLUS_REQUIRED_PRIVATE_STORAGE
+Policy: New trees default to public.
+
+Newly created trees should use `visibility: public` as the default product policy. This must be implemented through coordinated frontend and backend changes, not by changing frontend payloads alone.
 ```
 
-권장 사용자 문구 후보:
+```text
+Policy: Private storage requires Plus entitlement.
 
-> 비공개 보관은 Plus에서 사용할 수 있어요.
+Creating a private tree, switching a public tree to private, or using private storage for new private content requires `users/{uid}.privateStorageEnabled === true`.
+```
+
+```text
+Policy: Omitted memory visibility inherits parent tree visibility.
+
+When memory visibility is omitted in a create/update payload, the effective memory visibility inherits the parent tree visibility.
+```
+
+```text
+Policy: Explicit memory visibility may override inheritance when backend policy allows it.
+
+Explicit memory visibility may override inherited visibility only within backend-approved policy boundaries.
+```
+
+```text
+Policy: Public visibility and Browse/Search eligibility are separate.
+
+`visibility: public` means the tree or memory is publicly accessible according to read policy. It does not automatically mean the tree is eligible for Browse/Search introduction.
+```
+
+```text
+Policy: Browse/Search introduction requires publicMomentCount >= 3.
+
+A public tree becomes eligible for Browse/Search introduction only when `publicMomentCount >= 3`. Trees below this threshold may remain public and directly accessible, but should not be introduced in Browse/Search surfaces.
+```
+
+```text
+Policy: Parent tree visibility remains a browse/search guard.
+
+A public memory under a private tree does not make the parent tree Browse/Search eligible. Browse/Search introduction must check parent tree visibility and browse guard together.
+```
 
 ---
 
-## 8. 금지 사항
+## 9. Prohibited implementation shortcuts
 
 - createTree payload만 단독으로 `public`으로 바꾸지 않습니다.
-- Netlify만 바꾸고 Modal을 방치하지 않습니다.
-- Modal만 바꾸고 Netlify를 방치하지 않습니다.
+- frontend-only lock으로 Plus private enforcement 완료를 선언하지 않습니다.
+- backend guard 없이 private storage를 UI에서만 제한하지 않습니다.
+- `publicMomentCount >= 3`을 visibility publication guard로 재사용하지 않습니다.
+- public memory가 존재한다는 이유만으로 private parent tree를 Browse/Search에 노출하지 않습니다.
 - 기존 private tree를 자동 public 전환하지 않습니다.
-- Plus entitlement 없이 frontend-only lock으로 정책 완료를 선언하지 않습니다.
-- 결제/권한 로직 확정 전 Plus private을 확정 기능처럼 과도하게 홍보하지 않습니다.
+- 결제/권한 로직 확정 전 Plus private을 과도하게 홍보하지 않습니다.
 
 ---
 
-## 9. 이후 구현 분리
+## 10. Implementation split
 
-### Frontend 작업
+### Frontend
 
-- My Trees 생성 모달 public-first copy/IA
+- My Trees 생성 UX public-first copy/IA
 - private 선택 Plus 안내
-- Editor badge 상태 분리
-- Editor/My Trees visibility action 재배치
+- memory visibility omitted/inherited copy 정리
+- Editor badge: visibility와 Browse/Search eligibility 분리
 - Settings private storage 안내 조정
 - i18n key 정리
 
-### Backend 작업
+### Backend / runtime
 
-- Netlify create tree policy 전환
-- Netlify toggle visibility entitlement guard
-- Modal create tree policy 전환
-- Modal private endpoint entitlement guard
-- API error contract 고정
-- grandfathered private 처리 정책 반영
+- create tree default visibility policy 반영
+- private storage entitlement guard
+- memory visibility inheritance 처리
+- explicit memory visibility override policy guard
+- Browse/Search eligibility query에서 `publicMomentCount >= 3` 반영
+- parent tree visibility + browse guard 동시 적용
 
-### Docs 작업
+### Docs
 
 - API contract update
-- backend.md update
-- Modal runtime update
-- browse filter/public visibility 용어 정리
+- backend docs update
+- Modal runtime docs update
+- Browse/Search eligibility 용어 정리
 
 ---
 
-## 10. 현재 문서의 적용 상태
+## 11. Application status
 
-이 문서는 정책 전환 기준 문서입니다.
+이 문서는 canonical policy를 고정합니다.
 
-현재 main 코드가 이미 public-first로 바뀌었다는 의미가 아닙니다. 코드 반영 전에는 다음 현재 구현 사실을 유지합니다.
+현재 main 코드가 이미 다음을 모두 구현했다는 뜻은 아닙니다.
 
-- createTree payload는 private-first입니다.
-- backend create guard는 public 생성 요청을 차단합니다.
-- Modal create guard도 public 생성 요청을 차단합니다.
-- Plus entitlement enforcement는 없습니다.
+- 신규 tree public default
+- Plus private storage guard
+- memory visibility inheritance
+- explicit memory visibility override guard
+- Browse/Search `publicMomentCount >= 3` eligibility
+- private parent tree + public child memory browse guard
 
-CTO 승인 후 별도 frontend/backend 작업에서 public-first 전환을 구현합니다.
+실제 구현은 별도 PR에서 진행합니다.

--- a/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
+++ b/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
@@ -1,8 +1,8 @@
 # Publication and Privacy UX Policy
 
-이 문서는 LoveBud / LoveTree의 공개, 비공개, memory visibility, Browse/Search 소개 UX 정책을 정리합니다.
+이 문서는 LoveBud / LoveTree의 공개, 비공개, memory visibility, anonymous public exposure, Browse/Search 소개 UX 정책을 정리합니다.
 
-현재 CTO 확정 정책은 **public-first visibility + Plus private storage + separate browse eligibility**입니다. 이 문서는 제품/UX 정책의 canonical source이며, 코드 구현은 별도 frontend/backend 작업으로 분리합니다.
+현재 CTO 확정 정책은 **public-first visibility + Plus private storage + separate browse eligibility + parent visibility public-read guard**입니다. 이 문서는 제품/UX 정책의 canonical source이며, 코드 구현은 별도 frontend/backend 작업으로 분리합니다.
 
 중요: 이 문서는 현재 main 코드가 이미 public-first로 동작한다는 의미가 아닙니다. 코드 변경 전에는 현재 구현 상태를 별도로 확인해야 합니다.
 
@@ -23,19 +23,29 @@
 
 4. **Explicit memory visibility may override inheritance when backend policy allows it.**
    - 명시적 memory visibility는 backend policy가 허용하는 범위에서만 상속값을 override할 수 있습니다.
-   - override가 허용되더라도 parent tree 접근 권한과 private storage guard를 우회할 수 없습니다.
+   - backend policy가 허용하면 private tree 아래에도 explicit public memory가 저장될 수 있습니다.
+   - override가 허용되더라도 parent tree 접근 권한, anonymous public exposure guard, private storage guard를 우회할 수 없습니다.
 
-5. **Public visibility and Browse/Search eligibility are separate.**
+5. **Stored memory visibility and anonymous public exposure are separate.**
+   - memory가 `visibility: public`으로 저장될 수 있다는 것과 anonymous public read path에서 공개 노출될 수 있다는 것은 별개입니다.
+   - anonymous public read는 `memory.visibility = public`만으로 충분하지 않습니다.
+   - anonymous public read path는 `memory.visibility = public`과 `parent tree.visibility = public`을 모두 요구해야 합니다.
+
+6. **Public visibility and Browse/Search eligibility are separate.**
    - `visibility: public`은 공개 접근 가능 상태입니다.
    - Browse/Search 소개 가능 여부는 별도 eligibility 조건입니다.
 
-6. **Browse/Search introduction requires `publicMomentCount >= 3`.**
+7. **Browse/Search introduction requires `publicMomentCount >= 3`.**
    - public tree라도 공개 순간 수가 3개 미만이면 Browse/Search 소개 대상이 아닙니다.
    - 직접 링크/공개 접근 가능성과 Browse/Search 소개는 같은 뜻이 아닙니다.
 
-7. **Child memory visibility does not by itself make a private tree browseable.**
-   - private tree 아래에 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 봅니다.
-   - parent tree가 private이면 child public memory만으로 Browse/Search 소개 대상이 될 수 없습니다.
+8. **Parent tree visibility is required for anonymous public exposure.**
+   - parent tree가 private이면 child memory가 public으로 저장되어 있더라도 anonymous public exposure/read는 허용하지 않습니다.
+   - parent tree visibility guard는 Browse/Search introduction, community memories list, public memory detail read 경로에 모두 필요합니다.
+
+9. **Owner/private read remains allowed according to private access policy.**
+   - owner/private read path는 기존대로 private tree 아래 public/private memory를 조회할 수 있습니다.
+   - 이 권한은 anonymous public read와 분리합니다.
 
 ---
 
@@ -57,12 +67,14 @@
 - Modal backend visibility policy
 - entitlement check
 - memory visibility inheritance
+- stored memory visibility vs anonymous public exposure 분리
+- parent tree visibility guard for public read paths
 - existing private tree grandfathering
 - Browse/Search eligibility filter
 
 ---
 
-## 3. Visibility model
+## 3. Visibility and exposure model
 
 ### 3.1. Tree visibility
 
@@ -81,32 +93,68 @@ Memory visibility는 다음 순서로 결정합니다.
 
 1. payload에 explicit visibility가 있고 backend policy가 허용하면 그 값을 사용합니다.
 2. payload visibility가 생략되면 parent tree visibility를 상속합니다.
-3. parent tree access policy와 private storage policy를 우회하는 explicit override는 허용하지 않습니다.
+3. parent tree access policy, anonymous public exposure policy, private storage policy를 우회하는 explicit override는 허용하지 않습니다.
 
 예시:
 
 ```text
 parent tree visibility = public
 memory visibility omitted
-=> effective memory visibility = public
+=> stored/effective memory visibility = public
 ```
 
 ```text
 parent tree visibility = private
 memory visibility omitted
-=> effective memory visibility = private
+=> stored/effective memory visibility = private
 ```
 
 ```text
 parent tree visibility = private
 memory visibility = public
-=> backend policy가 허용한 경우에만 public memory가 될 수 있음
-=> 그래도 parent tree가 private이면 Browse/Search 소개 대상은 아님
+=> backend policy가 허용한 경우 public memory로 저장될 수 있음
+=> anonymous public read는 불가
+=> Browse/Search 소개 대상도 아님
+=> owner/private read는 private access policy에 따라 가능
 ```
+
+### 3.3. Stored visibility vs anonymous public exposure
+
+Canonical 문구:
+
+```text
+Stored memory visibility and anonymous public exposure are separate. A memory may be stored as public under a private tree when backend policy allows it, but anonymous public read paths must require both memory.visibility = public and parent tree.visibility = public.
+```
+
+정책 해석:
+
+- `memory.visibility = public`은 memory 자체의 저장 visibility입니다.
+- anonymous public exposure/read는 public read path에서 외부 사용자에게 노출 가능한지 여부입니다.
+- anonymous public read는 `memory.visibility = public` alone으로 허용하지 않습니다.
+- anonymous public read는 `memory.visibility = public` AND `parent tree.visibility = public`을 모두 만족해야 합니다.
+- owner/private read는 이 anonymous exposure 조건과 별개로 private access policy를 따릅니다.
 
 ---
 
-## 4. Browse/Search eligibility
+## 4. Public read path guards
+
+parent tree visibility guard는 아래 public/anonymous 경로에 모두 필요합니다.
+
+| 경로 | 요구 조건 |
+|------|----------|
+| Browse/Search introduction | `parent tree.visibility = public` AND `publicMomentCount >= 3` AND browse guard pass |
+| community memories list | `memory.visibility = public` AND `parent tree.visibility = public` |
+| public memory detail read | `memory.visibility = public` AND `parent tree.visibility = public` |
+
+중요:
+
+- private tree 아래 explicit public memory가 저장되어 있더라도 community memories list에 anonymous로 노출하지 않습니다.
+- private tree 아래 explicit public memory가 저장되어 있더라도 public memory detail read를 anonymous에게 허용하지 않습니다.
+- parent tree가 private이면 Browse/Search introduction도 허용하지 않습니다.
+
+---
+
+## 5. Browse/Search eligibility
 
 Browse/Search eligibility는 공개 접근 가능 여부가 아니라 **소개 가능 여부**입니다.
 
@@ -120,7 +168,8 @@ Browse/Search introduction 조건:
 
 | 상태 | 의미 |
 |------|------|
-| public visibility | direct/public read policy상 공개 접근 가능한 상태 |
+| public visibility | stored visibility 또는 access policy상 public 상태 |
+| anonymous public exposure | anonymous public read path에서 실제 노출 가능한 상태 |
 | browse/search eligible | Browse/Search 화면에서 소개될 수 있는 상태 |
 | publicMomentCount | Browse/Search 소개 기준으로 계산된 공개 순간 수 |
 
@@ -133,7 +182,7 @@ Browse/Search introduction 조건:
 
 ---
 
-## 5. Existing private tree grandfathering
+## 6. Existing private tree grandfathering
 
 기존 private tree는 자동으로 public 전환하지 않습니다.
 
@@ -153,7 +202,7 @@ Browse/Search introduction 조건:
 
 ---
 
-## 6. UX copy guidance
+## 7. UX copy guidance
 
 사용자-facing 문구는 공개 접근과 Browse/Search 소개를 혼동시키지 않아야 합니다.
 
@@ -169,6 +218,8 @@ Browse/Search introduction 조건:
 
 > 순간의 공개 범위를 따로 고르지 않으면, 러브트리의 공개 상태를 따라가요.
 
+> 순간이 공개로 저장되어도, 비공개 러브트리 안에 있으면 공개 감상 공간에는 보이지 않아요.
+
 > 공개는 링크로 볼 수 있는 상태이고, 둘러보기 소개는 충분히 자란 러브트리를 조용히 보여주는 기준이에요.
 
 짧은 UI label 후보:
@@ -177,10 +228,11 @@ Browse/Search introduction 조건:
 - 둘러보기 소개 준비 중
 - 공개 순간 3개부터 소개 가능
 - 비공개 보관은 Plus 기능
+- 비공개 트리 안의 순간은 공개 감상에 노출되지 않음
 
 ---
 
-## 7. Editor / My Trees state labels
+## 8. Editor / My Trees state labels
 
 Visibility badge와 Browse/Search eligibility badge는 분리합니다.
 
@@ -195,7 +247,7 @@ Visibility badge와 Browse/Search eligibility badge는 분리합니다.
 
 ---
 
-## 8. Engineering handoff policy
+## 9. Engineering handoff policy
 
 개발자-facing canonical 문구:
 
@@ -220,7 +272,13 @@ When memory visibility is omitted in a create/update payload, the effective memo
 ```text
 Policy: Explicit memory visibility may override inheritance when backend policy allows it.
 
-Explicit memory visibility may override inherited visibility only within backend-approved policy boundaries.
+Explicit memory visibility may override inherited visibility only within backend-approved policy boundaries. A private tree may contain an explicitly public memory when backend policy allows storage, but this does not grant anonymous public exposure.
+```
+
+```text
+Policy: Stored memory visibility and anonymous public exposure are separate.
+
+A memory may be stored as public under a private tree when backend policy allows it, but anonymous public read paths must require both `memory.visibility = public` and `parent tree.visibility = public`.
 ```
 
 ```text
@@ -236,32 +294,34 @@ A public tree becomes eligible for Browse/Search introduction only when `publicM
 ```
 
 ```text
-Policy: Parent tree visibility remains a browse/search guard.
+Policy: Parent tree visibility remains an anonymous public read guard.
 
-A public memory under a private tree does not make the parent tree Browse/Search eligible. Browse/Search introduction must check parent tree visibility and browse guard together.
+`memory.visibility = public` alone is not sufficient for anonymous public read. Browse/Search introduction, community memories list, and public memory detail read must require parent tree visibility to be public. Owner/private read paths may continue to read public/private memories under private trees according to private access policy.
 ```
 
 ---
 
-## 9. Prohibited implementation shortcuts
+## 10. Prohibited implementation shortcuts
 
 - createTree payload만 단독으로 `public`으로 바꾸지 않습니다.
 - frontend-only lock으로 Plus private enforcement 완료를 선언하지 않습니다.
 - backend guard 없이 private storage를 UI에서만 제한하지 않습니다.
 - `publicMomentCount >= 3`을 visibility publication guard로 재사용하지 않습니다.
-- public memory가 존재한다는 이유만으로 private parent tree를 Browse/Search에 노출하지 않습니다.
+- `memory.visibility = public`만으로 anonymous public read를 허용하지 않습니다.
+- public memory가 존재한다는 이유만으로 private parent tree를 Browse/Search, community memories list, public memory detail에 노출하지 않습니다.
 - 기존 private tree를 자동 public 전환하지 않습니다.
 - 결제/권한 로직 확정 전 Plus private을 과도하게 홍보하지 않습니다.
 
 ---
 
-## 10. Implementation split
+## 11. Implementation split
 
 ### Frontend
 
 - My Trees 생성 UX public-first copy/IA
 - private 선택 Plus 안내
 - memory visibility omitted/inherited copy 정리
+- stored visibility와 anonymous public exposure의 UX 문구 분리
 - Editor badge: visibility와 Browse/Search eligibility 분리
 - Settings private storage 안내 조정
 - i18n key 정리
@@ -272,6 +332,9 @@ A public memory under a private tree does not make the parent tree Browse/Search
 - private storage entitlement guard
 - memory visibility inheritance 처리
 - explicit memory visibility override policy guard
+- anonymous public read path에서 parent tree visibility guard 적용
+- community memories list에서 parent tree visibility guard 적용
+- public memory detail read에서 parent tree visibility guard 적용
 - Browse/Search eligibility query에서 `publicMomentCount >= 3` 반영
 - parent tree visibility + browse guard 동시 적용
 
@@ -281,10 +344,11 @@ A public memory under a private tree does not make the parent tree Browse/Search
 - backend docs update
 - Modal runtime docs update
 - Browse/Search eligibility 용어 정리
+- anonymous public exposure guard 용어 정리
 
 ---
 
-## 11. Application status
+## 12. Application status
 
 이 문서는 canonical policy를 고정합니다.
 
@@ -294,6 +358,9 @@ A public memory under a private tree does not make the parent tree Browse/Search
 - Plus private storage guard
 - memory visibility inheritance
 - explicit memory visibility override guard
+- stored memory visibility vs anonymous public exposure 분리
+- community memories list parent visibility guard
+- public memory detail read parent visibility guard
 - Browse/Search `publicMomentCount >= 3` eligibility
 - private parent tree + public child memory browse guard
 

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -8,15 +8,15 @@
 - 브랜드 정체성 및 디자인 원칙
 - 팬페이지 기반 감성 UX / 페이지 경험 기준 정리
 - 전역 UI 카피 운영 기준 정리
-- 공개/비공개/둘러보기 소개 UX 정책 정리
+- public-first visibility / Plus private storage / Browse/Search eligibility 정책 정리
 
 ## 파일 목록
 
 | 파일명 | 설명 |
 |--------|------|
-| [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 가치 |
+| [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 public-first 감상 공간 원칙 |
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
-| [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | 공개/비공개/둘러보기 소개 UX 정책 |
+| [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, Browse/Search eligibility 정책 |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
@@ -24,6 +24,18 @@
 | [DATA_NAMING_RULE.md](DATA_NAMING_RULE.md) | 데이터 명명 규칙 |
 | [READONLY_SHARE_SCOPE.md](READONLY_SHARE_SCOPE.md) | 읽기 전용 공유 범위 |
 | [VISIBILITY_AND_PRIVATE_STORAGE_POLICY_REVIEW.md](VISIBILITY_AND_PRIVATE_STORAGE_POLICY_REVIEW.md) | visibility/private storage 정책 검토 |
+
+## Canonical policy highlights
+
+현재 제품 visibility / Browse/Search 소개 정책의 핵심은 다음과 같습니다.
+
+- 신규 tree는 정책상 `public`으로 시작합니다.
+- private storage는 Plus entitlement가 필요합니다.
+- memory visibility가 생략되면 parent tree visibility를 상속합니다.
+- explicit memory visibility는 backend policy가 허용하는 범위에서만 inheritance를 override할 수 있습니다.
+- public visibility와 Browse/Search eligibility는 별개입니다.
+- Browse/Search introduction은 `publicMomentCount >= 3`이 필요합니다.
+- private tree 아래 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 봅니다.
 
 ## 원천 자료 (Identity Source)
 
@@ -40,7 +52,7 @@
 
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
-3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — 공개/비공개/둘러보기 소개 UX 정책
+3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / Browse/Search eligibility 정책
 4. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
 5. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
 6. **USER_FLOW.md** — 사용자 여정과 핵심 플로우

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -8,7 +8,7 @@
 - 브랜드 정체성 및 디자인 원칙
 - 팬페이지 기반 감성 UX / 페이지 경험 기준 정리
 - 전역 UI 카피 운영 기준 정리
-- public-first visibility / Plus private storage / Browse/Search eligibility 정책 정리
+- public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책 정리
 
 ## 파일 목록
 
@@ -16,7 +16,7 @@
 |--------|------|
 | [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 public-first 감상 공간 원칙 |
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
-| [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, Browse/Search eligibility 정책 |
+| [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
@@ -27,15 +27,19 @@
 
 ## Canonical policy highlights
 
-현재 제품 visibility / Browse/Search 소개 정책의 핵심은 다음과 같습니다.
+현재 제품 visibility / anonymous public exposure / Browse/Search 소개 정책의 핵심은 다음과 같습니다.
 
 - 신규 tree는 정책상 `public`으로 시작합니다.
 - private storage는 Plus entitlement가 필요합니다.
 - memory visibility가 생략되면 parent tree visibility를 상속합니다.
 - explicit memory visibility는 backend policy가 허용하는 범위에서만 inheritance를 override할 수 있습니다.
+- private tree 아래 explicit public memory는 저장될 수 있습니다.
+- stored memory visibility와 anonymous public exposure는 별개입니다.
+- anonymous public read는 `memory.visibility = public`과 `parent tree.visibility = public`을 모두 요구합니다.
 - public visibility와 Browse/Search eligibility는 별개입니다.
 - Browse/Search introduction은 `publicMomentCount >= 3`이 필요합니다.
-- private tree 아래 public memory가 가능하더라도 Browse/Search 노출은 parent tree visibility와 browse guard를 함께 봅니다.
+- private tree 아래 public memory가 가능하더라도 Browse/Search, community memories list, public memory detail read 노출은 parent tree visibility guard를 함께 봅니다.
+- owner/private read는 private access policy에 따라 private tree 아래 public/private memory를 조회할 수 있습니다.
 
 ## 원천 자료 (Identity Source)
 
@@ -52,7 +56,7 @@
 
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
-3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / Browse/Search eligibility 정책
+3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
 4. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
 5. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
 6. **USER_FLOW.md** — 사용자 여정과 핵심 플로우


### PR DESCRIPTION
## Summary

- Define public-first visibility policy
- Clarify Plus private storage
- Separate stored visibility from anonymous public exposure
- Separate public visibility from Browse/Search eligibility
- Define `publicMomentCount >= 3` as Browse/Search introduction eligibility

## Key policy

- New trees default to public
- Private storage requires Plus entitlement
- Memory visibility omitted inherits parent tree visibility
- Explicit memory visibility may control stored visibility when backend policy allows it
- `memory.visibility = public` alone is not sufficient for anonymous public read
- Anonymous public read requires both `memory.visibility = public` and `parent tree.visibility = public`
- Browse/Search introduction requires `publicMomentCount >= 3`

## Runtime dependency

This docs PR aligns with PR #46:

- `fix(modal): require public parent tree for public memory reads`

Do not merge this docs PR before PR #46 is merged.

## Changed files

- `docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
- `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
- `docs/product/PRODUCT_IDENTITY.md`
- `docs/product/product_index.md`
- `docs/doc_index.md`

## Not changed

- No pages changes
- No CSS changes
- No JS changes
- No modal_compute changes
- No functions changes
- No runtime behavior changes
