### PR TITLE
ui(layout): align landing browse rails

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -35,6 +35,16 @@
     /* Page width rhythm */
     --page-brand-max: 1280px;
     --page-work-max: 1440px;
+
+    /* Layout Spacing Tokens (PR1) */
+    --page-shell-max: 1280px;
+    --page-pad-desktop: 24px;
+    --page-pad-tablet: 24px;
+    --page-pad-mobile: 16px;
+    --hero-gap: 34px;
+    --section-gap: 56px;
+    --section-gap-compact: 40px;
+    --divider-margin: 48px;
     
     /* Typography Constants */
     --font-heading: 'Outfit', sans-serif;

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         .home-v3-main {
             position: relative;
             z-index: 1;
-            width: min(var(--page-brand-max), calc(100% - 48px));
+            width: min(var(--page-shell-max), calc(100% - (var(--page-pad-desktop) * 2)));
             margin: 0 auto;
             padding: 28px 0 110px;
         }
@@ -56,7 +56,7 @@
             position: relative;
             display: grid;
             grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr);
-            gap: 34px;
+            gap: var(--hero-gap);
             align-items: center;
             min-height: min(860px, calc(100vh - 104px));
             padding: 24px 0 20px;

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -18,10 +18,10 @@
     .intro-hero {
       display: grid;
       grid-template-columns: minmax(0, 1.05fr) 300px;
-      gap: 40px;
+      gap: var(--hero-gap);
       align-items: center;
-      padding: 84px 40px 56px;
-      max-width: var(--page-brand-max);
+      padding: 84px var(--page-pad-desktop) 56px;
+      max-width: var(--page-shell-max);
       margin: 0 auto;
       width: 100%;
     }
@@ -286,15 +286,15 @@
     }
 
     .intro-section {
-      padding: 44px 40px;
-      max-width: var(--page-brand-max);
+      padding: 44px var(--page-pad-desktop);
+      max-width: var(--page-shell-max);
       margin: 0 auto;
       width: 100%;
       border-top: 1px solid var(--outline-variant);
     }
 
     .intro-section.intro-section-wide {
-      max-width: var(--page-brand-max);
+      max-width: var(--page-shell-max);
     }
 
     .intro-section h2 {
@@ -994,7 +994,7 @@
       }
 
       .intro-hero, .intro-section, .cta-section {
-        padding: 64px 22px 36px;
+        padding: 64px var(--page-pad-mobile) 36px;
       }
 
       .intro-hero h1 {

--- a/pages/search.html
+++ b/pages/search.html
@@ -10,12 +10,12 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
     <style>
         .search-container {
-            max-width: var(--page-work-max);
+            max-width: var(--page-shell-max);
             margin: 0 auto;
-            padding: 28px 40px 58px;
+            padding: 28px var(--page-pad-desktop) 58px;
             display: grid;
             grid-template-columns: minmax(0, 1.62fr) 420px;
-            gap: 34px;
+            gap: var(--hero-gap);
         }
 
         .search-container .material-symbols-outlined {
@@ -612,7 +612,7 @@
             .search-container {
                 grid-template-columns: 1fr;
                 gap: 26px;
-                padding: 24px 24px 48px;
+                padding: 24px var(--page-pad-tablet) 48px;
             }
 
             .browse-utility-row {
@@ -639,7 +639,7 @@
 
         @media (max-width: 768px) {
             .search-container {
-                padding: 20px 16px 36px;
+                padding: 20px var(--page-pad-mobile) 36px;
                 gap: 22px;
             }
 


### PR DESCRIPTION
## Summary

Aligns Intro and Browse page rails to the Home landing benchmark.

The Home page remains the visual baseline. This PR keeps Home's rail and spacing feel intact while bringing Intro and Browse closer to it.

## Changes

- Adds shared layout spacing tokens in css/global.css.
- Tokenizes Home rail and hero gap without visual change.
- Aligns Intro hero and section side padding to the Home rail.
- Aligns Browse container width and side padding to the Home rail.
- Confirms Browse remains usable at 1280px with the 3-column layout.

## Safety

- No JavaScript changes.
- No Editor changes.
- No Modal, runtime, or API changes.
- No Search logic changes.
- No typography changes.
- No button, chip, tag, or card design changes.
- No hero visual resizing.
- No prototype or reference folder changes.

## Validation

- Home 1440 / 1024 / 375: PASS.
- Intro 1440 / 1024 / 375: PASS.
- Browse 1440 / 1024 / 375: PASS.
- Horizontal overflow: none.
- Browse sticky sidebar: unaffected.
- Browse 3-column layout: maintained.
- 1320px exception: not needed.