### PR TITLE
chore: ignore local generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,21 @@ temp_*.ps1
 # Local codex notes (duplicate with conversation/)
 docs/*codex*.txt
 
+# Local test artifacts (Playwright, etc.)
+playwright-report/
+test-results/
+*.trace.zip
+*.har
+.playwright-mcp/
+
+# Diff/temp scripts
+diff_output.txt
+staged_diff.txt
+replace_*.js
+
+# Firebase debug logs
+firebase-debug*.log
+
 # SSH backup (private keys - never commit)
 .ssh-backup/
 


### PR DESCRIPTION
## Summary
- `.gitignore` 보강: 로컬 generated artifact가 repo에 섞이지 않도록 패턴 추가
- Playwright/test artifact: `playwright-report/`, `test-results/`, `*.trace.zip`, `*.har`, `.playwright-mcp/`
- Diff/temp scripts: `diff_output.txt`, `staged_diff.txt`, `replace_*.js`
- Firebase debug logs: `firebase-debug*.log`
- Prototype/reference 폴더 보존 (AGENTS.md 요구사항)