### PR TITLE
docs(design): preserve prototype reference folders

### DIFF
--- a/docs/design/PROTOTYPE_REFERENCE_POLICY.md
+++ b/docs/design/PROTOTYPE_REFERENCE_POLICY.md
@@ -1,0 +1,103 @@
+# Prototype Reference Preservation Policy
+
+이 문서는 LoveBud 저장소의 prototype / reference 폴더를 repo cleanup 과정에서 자동 삭제하거나 이동하지 않기 위한 보존 정책입니다.
+
+## 1. Policy summary
+
+Prototype / reference 폴더는 현재 production flow에 직접 연결되어 있지 않더라도 삭제 후보로 단정하지 않습니다.
+
+아래 성격의 파일과 폴더는 LoveBud 디자인 탐색, 둘러보기 경험, 트리 시각화, 랜딩 스타일 비교를 위한 reference asset으로 보존합니다.
+
+- landing / browse / editor visual experiment
+- tree visualization prototype
+- scrapbook / hotspot / demo interaction reference
+- AI-generated or GPT-generated UI prototype
+- hidden experiment page
+- PR discussion에 남은 design exploration artifact
+
+## 2. Protected prototype/reference paths
+
+다음 경로는 repo hygiene, cleanup, unused-file 정리 과정에서 자동 삭제/이동/ignore 대상이 아닙니다.
+
+```text
+pages/gpt-v2/
+assets/gpt-v2/
+pages/gpt-svg-tree/
+```
+
+또한 아래 패턴의 demo/reference 폴더도 파일명만 보고 삭제 후보로 단정하지 않습니다.
+
+```text
+hotspot-prototype*
+scrapbook-demo*
+prototype*
+reference*
+demo*
+```
+
+중요:
+
+- `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.
+- PR #7을 close하거나 branch를 삭제하지 않습니다.
+- production artifact 우려가 있더라도 현재 정책은 보존 우선입니다.
+- 실제 이동/삭제/ignore 처리가 필요하면 CTO 별도 승인이 필요합니다.
+
+## 3. Repo hygiene rule
+
+Repo hygiene 작업자는 다음을 금지합니다.
+
+- prototype/reference 폴더 자동 삭제
+- prototype/reference 폴더 자동 이동
+- prototype/reference 폴더 `.gitignore` 추가
+- PR #7 관련 파일 삭제
+- `pages/gpt-svg-tree/` 삭제 또는 branch cleanup
+- 파일명만 보고 unused artifact로 단정
+
+정리가 필요해 보이는 경우에는 먼저 아래 정보를 보고해야 합니다.
+
+1. 대상 경로
+2. 현재 production navigation/API와 연결 여부
+3. 디자인 reference로 남길 가치
+4. production artifact 우려
+5. 삭제/이동/보존 중 권장 판단
+6. CTO 승인 필요 여부
+
+## 4. Production artifact concern
+
+Prototype/reference 폴더가 `pages/` 또는 `assets/` 아래에 있으면 정적 배포 산출물에 포함될 수 있습니다.
+
+그러나 현재 정책은 다음 순서로 판단합니다.
+
+1. 먼저 보존한다.
+2. production 노출 우려를 문서화한다.
+3. 숨김 경로, 라우팅 차단, archive 이동, 삭제 중 어떤 처리가 필요한지 별도 검토한다.
+4. CTO 승인 전에는 이동/삭제하지 않는다.
+
+즉, production artifact 우려는 삭제의 자동 근거가 아닙니다.
+
+## 5. Specific PR #7 rule
+
+PR #7 `experiment: SVG tree prototype`은 오래된 open/draft PR이지만, tree visualization reference로 보존합니다.
+
+정책:
+
+- PR #7 close 금지
+- PR #7 branch 삭제 금지
+- PR #7 관련 `pages/gpt-svg-tree/` 파일 삭제 금지
+- PR #7을 main에 merge할지, archive할지, close할지는 CTO가 별도 판단합니다.
+
+## 6. Review checklist
+
+Prototype/reference 관련 변경 PR을 검토할 때 아래를 확인합니다.
+
+- 변경 파일에 `pages/gpt-v2/`, `assets/gpt-v2/`, `pages/gpt-svg-tree/`가 포함되어 있는가
+- `hotspot-prototype*`, `scrapbook-demo*`, `prototype*`, `reference*`, `demo*` 패턴의 폴더가 포함되어 있는가
+- 삭제/이동/ignore가 포함되어 있는가
+- CTO 별도 승인이 명시되어 있는가
+- production artifact 우려와 design reference 가치가 함께 기록되어 있는가
+
+## 7. One-line rule
+
+```text
+Prototype/reference folders are preserved design assets, not automatic cleanup targets.
+```

--- a/docs/design/design_index.md
+++ b/docs/design/design_index.md
@@ -1,11 +1,12 @@
 # 디자인 문서 인덱스
 
-이 폴더에는 LoveBud의 **UI/UX 디자인 시스템, 시각 기준, 이미지 생성 프롬프트**가 저장됩니다.
+이 폴더에는 LoveBud의 **UI/UX 디자인 시스템, 시각 기준, 이미지 생성 프롬프트, prototype/reference 보존 정책**이 저장됩니다.
 
 ## 용도
 - 디자인 시스템 및 구현 규칙
 - 비주얼 에셋 생성 프롬프트
 - 색상, 타이포그래피, 레이아웃 기준
+- prototype/reference 폴더 보존 기준
 
 ## 폴더 구조
 
@@ -17,12 +18,32 @@ design/
 
 ## 파일 목록
 
+| 파일명 | 설명 |
+|--------|------|
+| [UI_DESIGN_SYSTEM.md](UI_DESIGN_SYSTEM.md) | LoveBud UI/UX 디자인 시스템과 화면 기준 |
+| [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md) | pages/assets 하위 prototype/reference 폴더 보존 정책 |
+
 ### 프롬프트 (Prompts)
 
 | 파일명 | 설명 |
 |--------|------|
 | [prompts/image-generation-prompts.md](prompts/image-generation-prompts.md) | Lovetree 이미지 생성 프롬프트 모음 (12개 화면) |
 | [prompts/home-hero-slide-prompts.txt](prompts/home-hero-slide-prompts.txt) | 홈 히어로 슬라이드 이미지 생성 프롬프트 (5장) |
+
+## Prototype / reference 보존 원칙
+
+아래 경로와 패턴은 repo cleanup 과정에서 자동 삭제/이동/ignore 대상으로 분류하지 않습니다.
+
+- `pages/gpt-v2/`
+- `assets/gpt-v2/`
+- `pages/gpt-svg-tree/`
+- `hotspot-prototype*`
+- `scrapbook-demo*`
+- `prototype*`
+- `reference*`
+- `demo*`
+
+삭제, 이동, ignore 처리가 필요하면 CTO 별도 승인이 필요합니다.
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -10,6 +10,8 @@
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
 - Netlify는 주경로가 아니라 fallback 또는 단계적 제거 대상입니다.
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 제품/브랜드/UI 판단의 source of truth 입니다.
+- prototype/reference 폴더는 repo hygiene에서 자동 삭제/이동/ignore 대상으로 분류하지 않습니다.
+- `pages/gpt-v2/`, `assets/gpt-v2/`, `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.
 - 신규 tree의 정책상 기본 visibility는 `public`입니다.
 - private storage는 Plus entitlement가 필요합니다.
 - memory visibility가 생략되면 parent tree visibility를 상속합니다.
@@ -39,6 +41,10 @@ Visibility, private storage, anonymous public exposure, Browse/Search eligibilit
 
 - `./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
 - `./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
+
+Prototype/reference 폴더 정리, 보존, repo hygiene 판단이 필요하면 아래를 추가로 읽습니다.
+
+- `./design/PROTOTYPE_REFERENCE_POLICY.md`
 
 운영/배포 판단이 필요하면 아래를 추가로 읽습니다.
 
@@ -70,6 +76,7 @@ Visibility, private storage, anonymous public exposure, Browse/Search eligibilit
 
 - **index**: [design_index.md](./design/design_index.md)
 - [UI_DESIGN_SYSTEM.md](./design/UI_DESIGN_SYSTEM.md) - UI 구조 / 감정 위계 / 컴포넌트 규칙 source of truth
+- [PROTOTYPE_REFERENCE_POLICY.md](./design/PROTOTYPE_REFERENCE_POLICY.md) - prototype/reference 폴더 보존 정책
 - [prompts/image-generation-prompts.md](./design/prompts/image-generation-prompts.md) - 이미지 생성 프롬프트 모음
 - [prompts/home-hero-slide-prompts.txt](./design/prompts/home-hero-slide-prompts.txt) - 홈 히어로 슬라이드 프롬프트
 


### PR DESCRIPTION
## Summary

- Add a canonical prototype/reference preservation policy
- Mark `pages/gpt-v2/`, `assets/gpt-v2/`, and `pages/gpt-svg-tree/` as protected reference paths
- Clarify that PR #7 related prototype assets are preserved and must not be closed/deleted as cleanup
- Clarify that `hotspot-prototype*`, `scrapbook-demo*`, `prototype*`, `reference*`, and `demo*` folders must not be treated as automatic cleanup targets
- Link the policy from the design index and top-level doc index

## Policy

Prototype/reference folders are preserved design assets, not automatic cleanup targets.

Repo hygiene must not automatically delete, move, or ignore prototype/reference folders. Any deletion, movement, ignore rule, or PR #7 branch cleanup requires separate CTO approval.

## Changed files

- `docs/design/PROTOTYPE_REFERENCE_POLICY.md`
- `docs/design/design_index.md`
- `docs/doc_index.md`

## Not changed

- No production code changes
- No UI/CSS/JS changes
- No prototype files modified
- No prototype files deleted or moved
- No PR #7 changes
- No branch deletion
- No runtime behavior changes

## Merge note

Do not merge without CTO approval.
