### PR TITLE
docs(project): update backlog after PR63

### DIFF
--- a/docs/design/UI_POLISH_ROADMAP.md
+++ b/docs/design/UI_POLISH_ROADMAP.md
@@ -1,129 +1,258 @@
-# UI Polish Roadmap after PR51
+# UI Polish Roadmap after PR63
 
 ## 목적
 
-이 문서는 PR #49, PR #51 이후 남은 public UI polish 작업을 PR3 / PR4 / PR5 단위로 분리하기 위한 디자인 실행 로드맵입니다.
+이 문서는 PR #49, PR #51, PR #62, PR #63 이후 남은 public UI polish와 후속 기능 개선 작업을 분리하기 위한 디자인 실행 로드맵입니다.
 
-이 문서는 구현 지시서가 아니라 **범위 분리 기준**입니다. 실제 CSS/HTML/JS 변경은 각 UI PR에서 별도 승인 후 진행합니다.
+이 문서는 구현 지시서가 아니라 **범위 분리 기준**입니다. 실제 CSS/HTML/JS/API 변경은 각 PR에서 별도 승인 후 진행합니다.
 
 ## 완료된 UI 단계
 
 | 단계 | 상태 | 범위 | 메모 |
 |------|------|------|------|
-| PR #49 `ui(layout): align landing browse rails` | 완료 | layout rail / container / spacing unification | Home, Intro, Browse의 큰 레이아웃 폭, rail, spacing 기준을 통일 |
-| PR #51 `ui(style): align typography accent hierarchy` | 진행 중 | typography / accent hierarchy unification | test1 배포 트리거 완료. Gemini Local Verifier test1 검증 대기. merge 전 test1 visual verification 필요 |
+| PR #49 `ui(layout): align landing browse rails` | 완료 | layout rail / container / spacing unification | Home, Intro, Browse의 큰 레이아웃 폭, rail, spacing 기준을 통일. production verification PASS |
+| PR #51 `ui(style): align typography accent hierarchy` | 완료 | typography / accent hierarchy unification | Home 기준 typography / accent hierarchy 통일. production verification PASS |
+| PR #62 `ui(style): align button badge chip tone` | 완료 | button / badge / chip tone unification | Home / Intro / Browse 버튼, 배지, 칩 tone 통일. production verification PASS |
+| PR #63 `ui(intro): balance hero visual whitespace` | 완료 | Intro hero visual / whitespace balance | Intro hero visual column, scene height, tablet breakpoint, warm scrapbook tone 개선. production verification PASS |
 
-## 다음 UI 순서
+## 다음 UI / 기능 순서
 
-1. **PR3: button / badge / chip tone unification**
-2. **PR4: intro hero visual / whitespace balance**
-3. **PR5: browse card / hub panel surface unification**
+1. **PR5 Audit: Browse card / hub panel surface audit**
+2. **PR5 Implementation: Browse card / hub panel surface unification**
+3. **Search URL state: query / category / sort / limit URL sync**
+4. **Selected tree deep link: `?tree=` preview selection**
+5. **YouTube thumbnail fallback hardening**
+6. **CI/E2E Playwright dependency stabilization**
+7. **Runtime legacy clarification: Netlify legacy vs Cloudflare/Modal active runtime**
+8. **Search CSS extraction / inline style reduction**
 
-이 순서는 의도적으로 작은 시각 단위에서 큰 surface 단위로 진행합니다. PR3에서 공통 interactive tone을 먼저 맞춘 뒤, PR4에서 Intro hero의 밀도를 조정하고, PR5에서 Browse card/hub surface를 정리합니다.
+이 순서는 의도적으로 visual surface 정리 → 공유 가능한 Browse UX → known warning / CI 안정화 → 구조 정리 순서로 진행합니다.
 
 ---
 
-## PR3: button / badge / chip tone unification
+## PR5 Audit: Browse card / hub panel surface audit
 
 ### 목표
 
-공개 화면의 버튼, badge, pill, chip, CTA가 같은 제품군으로 보이도록 tone을 통일합니다.
+Browse 화면의 result card, right hub panel, growing section이 Home / Intro와 같은 surface hierarchy 안에 보이는지 실도메인 기준으로 확인합니다.
 
 ### 포함 범위
 
-- button shape / radius / shadow / border tone
-- badge, pill, chip style
-- primary / secondary / quiet CTA visual consistency
-- Home, Intro, Browse에서 반복되는 interactive surface tone 정리
-- hover / focus-visible의 시각 강도 통일
+- Browse result card tone 감사
+- Browse right hub panel tone 감사
+- `growing-trees-section` surface 감사
+- card / hub hierarchy 관찰
+- 1440 / 1024 / 375 viewport 관찰
+- console / network warning vs blocker 확인
+- Browse data load 확인
 
 ### 제외 범위
 
-- layout 변경 금지
-- grid / container / spacing 재조정 금지
+- 코드 수정 금지
+- CSS 수정 금지
 - JS 변경 금지
 - API / runtime 변경 금지
-- Search rendering logic 변경 금지
-- card/hub panel hierarchy 변경은 PR5로 분리
-- Intro hero visual density 조정은 PR4로 분리
-
-### 검증 포인트
-
-- Home / Intro / Browse 1440 / 1024 / 375 확인
-- primary CTA와 secondary button의 위계가 명확한지 확인
-- badge/pill/chip이 과하게 튀지 않고 Home tone과 맞는지 확인
-- focus-visible이 잘림 없이 표시되는지 확인
-
----
-
-## PR4: intro hero visual / whitespace balance
-
-### 목표
-
-Intro hero가 Home hero와 같은 브랜드 밀도 안에서 보이도록 visual size와 whitespace를 조정합니다.
-
-### 포함 범위
-
-- Intro hero visual balance
-- Intro hero visual size 조정
-- Intro hero whitespace 조정
-- Home과 Intro의 hero density 비교 조정
-- Intro hero heading / visual / supporting copy 간 체감 밀도 정리
-
-### 제외 범위
-
-- Browse 제외
-- Search / Browse card 변경 금지
-- button / badge / chip 전역 tone 변경 금지
-- JS 변경 금지
-- API / runtime 변경 금지
-- DOM 구조 변경은 별도 승인 없이는 금지
-
-### 검증 포인트
-
-- Home hero와 Intro hero의 첫인상 밀도 비교
-- Intro 1440 / 1024 / 375에서 visual이 과도하게 크거나 작지 않은지 확인
-- mobile에서 hero visual이 copy를 밀어내지 않는지 확인
-- horizontal overflow 없음 확인
-
----
-
-## PR5: browse card / hub panel surface unification
-
-### 목표
-
-Browse 화면의 result card와 right hub panel이 같은 surface hierarchy 안에 보이도록 정리합니다.
-
-### 포함 범위
-
-- Browse result card tone
-- Browse right hub panel tone
-- card / hub hierarchy
-- card border / shadow / background / radius 정리
-- empty / loading / populated state의 surface consistency 확인
-
-### 제외 범위
-
-- Search JS 변경 금지
-- Search API 변경 금지
-- rendering logic 변경 금지
-- thumbnail fetch / 404 handling 변경 금지
-- filtering / sorting / query behavior 변경 금지
-- Home / Intro hero 변경 금지
+- Search thumbnail 404 수정 금지
+- rendering / filtering / sorting behavior 변경 금지
 
 ### 검증 포인트
 
 - Browse/Search는 로컬 서버 단독 검증 금지
-- test/preview URL에서 실제 data load 확인
+- production 또는 test/preview URL에서 실제 data load 확인
 - result card와 right hub panel의 위계가 명확한지 확인
 - 1440 / 1024 / 375에서 card density와 panel spacing 확인
 - console/network 신규 오류 없음 확인
 
 ---
 
+## PR5 Implementation: Browse card / hub panel surface unification
+
+### 목표
+
+Audit 결과를 바탕으로 Browse 화면의 card / hub surface를 정리합니다.
+
+### 포함 범위
+
+- Browse result card border / shadow / background / radius 정리
+- Browse right hub panel border / shadow / background / radius 정리
+- `growing-trees-section` 표면감 조정
+- loading / empty / populated state의 surface consistency 확인
+- Home / Intro와 연결되는 warm scrapbook tone 유지
+
+### 제외 범위
+
+- Search JS 변경 금지
+- Search API 변경 금지
+- renderer / adapter logic 변경 금지
+- thumbnail fetch / 404 handling 변경 금지
+- filtering / sorting / query behavior 변경 금지
+- Home / Intro hero 변경 금지
+- package / lockfile / workflow 수정 금지
+- prototype/reference/demo 폴더 수정 금지
+
+### 허용 후보 파일
+
+- `pages/search.html` 우선
+- CSS-only 또는 page-local style 변경으로 끝낼 수 있는지 먼저 판단
+
+### 검증 포인트
+
+- Cloudflare PR Preview 또는 지정 test/preview URL 필수
+- Home / Intro / Browse 1440 / 1024 / 375 확인
+- Browse data load 정상 확인
+- horizontal overflow 없음 확인
+- console/network 신규 blocker 없음 확인
+- 기존 `ytimg.com` thumbnail 404는 unrelated warning으로만 기록
+
+---
+
+## Search URL state
+
+### 목표
+
+Browse 검색 상태를 URL query와 동기화하여 새로고침, 공유, 뒤로가기/앞으로가기 UX를 개선합니다.
+
+### 포함 범위
+
+- 검색어 `q`
+- 카테고리 `category`
+- 정렬 `sort`
+- limit `limit`
+- 초기 진입 시 URL query를 읽어 Browse 상태 복원
+- 상태 변경 시 URL query 갱신
+
+### 제외 범위
+
+- card / hub panel visual 변경 금지
+- API response shape 변경 금지
+- thumbnail fallback 변경 금지
+- runtime/backend 변경 금지
+
+### 검증 포인트
+
+- `/pages/search.html?q=...&category=...&sort=...&limit=...` 직접 진입 확인
+- 검색/필터/정렬/더보기 후 URL 갱신 확인
+- 뒤로가기/앞으로가기 동작 확인
+- Browse data load 정상 확인
+
+---
+
+## Selected tree deep link
+
+### 목표
+
+공개 Browse에서 특정 트리 preview를 직접 열 수 있게 합니다.
+
+### 포함 범위
+
+- `?tree=<treeId>` 또는 동등한 query parameter 지원
+- 직접 진입 시 해당 카드 활성화
+- desktop에서 right hub panel preview hydrate
+- mobile에서 preview panel open 처리
+- tree가 없거나 비공개/삭제된 경우 안전한 fallback 처리
+
+### 제외 범위
+
+- 공개/비공개 정책 변경 금지
+- private tree 노출 금지
+- API 권한 정책 변경 금지
+- visual surface 변경 금지
+
+### 검증 포인트
+
+- 존재하는 공개 tree id 직접 진입
+- 존재하지 않는 tree id 직접 진입
+- mobile 375에서 preview open/close 확인
+- console/network 신규 blocker 없음 확인
+
+---
+
+## YouTube thumbnail fallback hardening
+
+### 목표
+
+반복 관찰되는 `ytimg.com` thumbnail 404 warning을 정식 bugfix로 분리합니다.
+
+### 포함 범위
+
+- YouTube thumbnail canonicalization 점검
+- broken thumbnail fallback 점검
+- card / preview thumbnail fallback 일관성 확인
+- warning 감소 또는 사용자-visible fallback 안정화
+
+### 제외 범위
+
+- Browse surface polish와 혼합 금지
+- API/runtime 변경 금지
+- card layout 변경 금지
+- unrelated renderer refactor 금지
+
+---
+
+## CI/E2E Playwright dependency stabilization
+
+### 목표
+
+반복 `Cannot find module 'playwright'` blocker를 CI/dependency/setup 차원에서 정리합니다.
+
+### 포함 범위
+
+- `package.json` / lockfile / workflow 변경 필요성 검토
+- E2E smoke scripts와 CI 실행 조건 정리
+- known blocker 문서와 실제 CI 상태 간 차이 축소
+
+### 제외 범위
+
+- UI polish PR과 혼합 금지
+- runtime/API 기능 수정과 혼합 금지
+- Preview 검증 기준 완화 금지
+
+---
+
+## Runtime legacy clarification
+
+### 목표
+
+Netlify legacy artifact와 active Cloudflare/Modal runtime을 계속 분리하여, 향후 backend 작업자가 잘못된 파일을 수정하지 않도록 합니다.
+
+### 포함 범위
+
+- active runtime truth 문서화
+- Netlify legacy deprecation 문서화
+- PR #36 / #38 계열 backend 방향 재정렬
+
+### 제외 범위
+
+- 즉시 Netlify archive/delete 금지
+- runtime code 이동/삭제 금지
+- Modal deploy 변경 금지
+
+---
+
+## Search CSS extraction / inline style reduction
+
+### 목표
+
+PR5 surface 정리 이후, `pages/search.html` 내부 style과 일부 inline style을 단계적으로 줄여 유지보수성을 개선합니다.
+
+### 포함 범위
+
+- search page CSS 분리 가능성 검토
+- inline style을 class로 이동
+- Browse controls markup/style 책임 분리 검토
+
+### 제외 범위
+
+- 기능 변경 금지
+- API/runtime 변경 금지
+- thumbnail fallback과 혼합 금지
+- surface polish와 같은 PR에 섞지 않기
+
+---
+
 ## 금지 / 보류 항목
 
-아래 항목은 UI polish PR3 / PR4 / PR5에 포함하지 않습니다.
+아래 항목은 위 작업들에 임의 포함하지 않습니다.
 
 - PR #7 prototype close 금지
 - PR #7 branch 삭제 금지
@@ -131,16 +260,15 @@ Browse 화면의 result card와 right hub panel이 같은 surface hierarchy 안�
 - `assets/gpt-v2/` 보존
 - `pages/gpt-svg-tree/` 보존
 - 실제 prototype/reference 파일 수정 금지
-- runtime / API 수정 금지
-- Modal / functions 수정 금지
-- Search thumbnail 404 수정은 별도 기능/bugfix 이슈로 분리
-- package / lockfile 수정 금지
+- runtime / API 수정 금지 unless 해당 PR의 명시 범위
+- Modal / functions 수정 금지 unless 해당 PR의 명시 범위
+- package / lockfile 수정 금지 unless CI/E2E stabilization PR의 명시 범위
 
 ## Prototype / reference 보존 기준
 
 Prototype/reference 폴더는 cleanup 대상이 아니라 보존 대상입니다. 관련 판단은 [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md)를 우선합니다.
 
-특히 아래 경로는 PR3 / PR4 / PR5의 작업 범위가 아닙니다.
+특히 아래 경로는 UI polish 작업 범위가 아닙니다.
 
 - `pages/gpt-v2/`
 - `assets/gpt-v2/`
@@ -148,15 +276,17 @@ Prototype/reference 폴더는 cleanup 대상이 아니라 보존 대상입니다
 
 ## 검증 원칙
 
-- 각 PR은 병합 전 Cloudflare PR Preview 또는 지정 test/preview URL에서 검증합니다.
+- 각 UI PR은 병합 전 Cloudflare PR Preview 또는 지정 test/preview URL에서 검증합니다.
 - Browse/Search는 로컬 서버 단독 검증으로 승인하지 않습니다.
 - production은 merge 후 확인합니다.
 - 1440 / 1024 / 375 viewport를 기본 확인 범위로 둡니다.
 - console error, network error, horizontal overflow를 함께 확인합니다.
 - UI polish PR에서는 runtime/API/JS logic 변화가 없어야 합니다.
+- 기능 PR에서는 visual polish를 섞지 않습니다.
 
 ## 운영 메모
 
-- PR3 / PR4 / PR5는 서로 다른 목적의 UI polish입니다.
-- 한 PR에서 button tone, hero density, Browse card hierarchy를 동시에 처리하지 않습니다.
-- PR #51 검증이 끝나기 전에는 PR3 구현 착수를 별도 승인 없이 진행하지 않습니다.
+- 문서/백로그는 전체를 잡아두되, 실제 PR은 한 번에 하나씩 엽니다.
+- PR은 할 일 목록이 아니라 실제 diff 검수 단위입니다.
+- 여러 구현 PR을 미리 열어두지 않습니다.
+- 현재 열린 PR #7은 보존 prototype PR이며 main 병합 대상이 아닙니다.

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,7 +23,7 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `7e221b8829500c26a7542481bea1585d916fb14a`
+- 기준 main 커밋: `7e287bb6e77e91d9a1c33681e7308f2e54f7022d`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
@@ -31,15 +31,16 @@
 | Runtime routing truth | 진행 중 | production/test slot route matrix | `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal 경로로 실측. Netlify Functions 호출 흔적 없음. Netlify legacy deprecation 문서 정리 진행 중 |
 | Public layout UI | 완료 | PR #49 `ui(layout): align landing browse rails` | layout rail / container / spacing 통일 완료. production verification PASS. Merge SHA: `dfb158a843932edeaaf7c859d0fa3e2d06c9be08` |
 | Typography / accent hierarchy | 완료 | PR #51 `ui(style): align typography accent hierarchy` | typography / accent hierarchy 통일 완료. production verification PASS. Merge SHA: `99af8a69fbe1cf61ac23017b938027164a213b3a` |
+| PR3 button / badge / chip tone | 완료 | PR #62 `ui(style): align button badge chip tone` | Home / Intro / Browse button, badge, chip tone 통일 완료. production verification PASS. Merge SHA: `ae5ac03a2e9582c6c5cef6a965d6600ec6fa8e44` |
+| PR4 intro hero visual / whitespace | 완료 | PR #63 `ui(intro): balance hero visual whitespace` | Intro hero visual column, tree scene height, tablet breakpoint, warm scrapbook tone 개선 완료. production verification PASS. Merge SHA: `7e287bb6e77e91d9a1c33681e7308f2e54f7022d` |
 | UI verification rules | 완료 | PR #50 `docs(project): clarify UI verification environment rules` | UI verification environment rules 문서화 완료 |
 | Test preview slot rules | 완료 | PR #52 `docs(ops): test preview slot branch rules` | test preview slot branch rules 문서화 완료. Merge SHA: `bbc988041e248d171a8560419dc739394ba4e23f` |
 | Local generated artifact ignore | 완료 | PR #53 `chore: ignore local generated artifacts` | local generated artifacts `.gitignore` 정리 완료. Merge SHA: `5f8d185cde4b1d46df75a8c4382fd71a4a671ca8`. prototype/reference 보존 대상 침범 없음 |
-| Task status tracking | 완료 | PR #54 `docs(project): update task status after PR49 and PR50` | TASK_STATUS 이전 최신화 완료. Merge SHA: `0a5386eea7e6c7921164c956e8946f06ca25fe37` |
+| Task status tracking | 진행 중 | PR #64 후보 `docs(project): update backlog after PR63` | PR #62 / PR #63 완료 상태와 다음 백로그 순서 반영 중 |
 | Prototype reference preservation | 완료 | PR #55 `docs(design): preserve prototype reference folders` | prototype/reference preservation policy 문서화 완료. PR #7 보존 정책 문서화 완료. Merge SHA: `1f1c0758d9307e8e090386d21b21a265e5fe257b` |
 | Known CI/E2E blockers | 완료 | PR #56 `docs(ops): document known CI and E2E blockers` | known CI/E2E blockers 문서화 완료. Merge SHA: `c67956a23f61ea26dfb47e64813d340d960985ba` |
-| UI polish roadmap | 완료 | PR #57 `docs(project): add UI polish roadmap after PR51` | UI polish roadmap after PR51 문서화 완료. Merge SHA: `aaf31fe72298ddc510db29728ca8c35b2a808a5e` |
+| UI polish roadmap | 완료 | PR #57, PR #64 후보 | PR #49 / #51 / #62 / #63 이후 남은 public UI polish와 후속 backlog 순서 정리 중 |
 | Verification warning catalog | 완료 | PR #58 `docs(project): add verification warning catalog` | verification warning catalog 문서화 완료. Merge SHA: `7e221b8829500c26a7542481bea1585d916fb14a` |
-| PR3 button / badge / chip tone | 진행 중 | 예정 브랜치 `ui/button-badge-chip-tone-unification` | PR3 준비 중. Home 기준 유지. button / badge / chip tone unification만 대상으로 함. merge 전 test/preview 검증 필요. layout width/spacing, JS/API, card/hub panel, intro hero visual 수정 금지 |
 | 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. SVG tree prototype. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
 
@@ -54,24 +55,32 @@
 
 ---
 
-## 다음 예정 작업
+## 다음 예정 작업 / Backlog
 
-| 작업 | 상태 | 메모 |
-|------|------|------|
-| PR3 button/badge/chip tone unification | 진행 중 | 예정 브랜치 `ui/button-badge-chip-tone-unification`. Home 기준 유지. merge 전 test/preview 검증 필요. layout width/spacing, JS/API, card/hub panel, intro hero visual 수정 금지 |
-| PR4 intro hero visual/whitespace | 대기 | PR3 이후 별도 UI PR로 진행 |
-| PR5 browse card/hub panel | 대기 | PR4 이후 별도 UI PR로 진행 |
-| Netlify Functions legacy deprecation 문서 PR | 진행 중 | active runtime truth 고정. 코드 이동/삭제 없음 |
-| Active Cloudflare/Modal public-first backend 설계 | 대기 | Netlify legacy deprecation 정리 후 별도 브랜치 필요 |
-| PR #36 / #38 계열 backend 방향 재정렬 | 대기 | 신규 backend policy는 `netlify/functions/*`가 아닌 active Cloudflare/Modal runtime 대상으로 재설계 필요 |
-| Search에 “새로 자라는 러브트리” 보조 섹션 설계 | 대기 | 설계 승인 후 별도 브랜치에서 진행 |
-| PR #7 재동기화 가능성 확인 | 대기 | prototype/reference 보존 상태 유지. main 병합 대상 아님. close/branch 삭제 금지 |
-| Search 보조 섹션 UI 구현 | 대기 | 설계 승인 이후 UI 구현 브랜치 분리 |
+| 우선순위 | 작업 | 상태 | 메모 |
+|------|------|------|------|
+| 0 | TASK_STATUS / UI_POLISH_ROADMAP 최신화 | 진행 중 | PR #62 / #63 완료와 후속 backlog를 문서에 반영. docs-only |
+| 1 | PR5 Browse card / hub panel surface audit | 대기 | 구현 전 실도메인 기준 Browse card, preview/sidebar, growing section surface를 감사. 코드 수정 없음 |
+| 2 | PR5 Browse card / hub panel surface implementation | 대기 | audit 이후 별도 UI PR. Search JS/API/renderer/filtering/thumbnail 처리 변경 금지 |
+| 3 | Search URL state | 대기 | 검색어, 카테고리, 정렬, limit 상태를 URL query와 동기화. 별도 기능 PR |
+| 4 | Selected tree deep link | 대기 | `/pages/search.html?tree=...` 진입 시 해당 공개 트리 preview 선택 지원. Search URL state 이후 검토 |
+| 5 | YouTube thumbnail fallback hardening | 대기 | 기존 `ytimg.com` 404 warning 정식 정리. UI polish와 분리된 bugfix PR |
+| 6 | CI/E2E Playwright dependency stabilization | 대기 | 반복 `Cannot find module 'playwright'` blocker를 dependency/setup 차원에서 정리. package/workflow 영향 별도 검토 |
+| 7 | Netlify legacy / Cloudflare-Modal runtime clarification | 진행 중 | active runtime truth 고정. 코드 이동/삭제 없이 문서 우선 |
+| 8 | Search CSS extraction / inline style reduction | 대기 | PR5 이후 검토. `pages/search.html` 내부 style과 inline style을 단계적으로 분리 |
+| 9 | Active Cloudflare/Modal public-first backend 설계 | 대기 | Netlify legacy deprecation 정리 후 별도 브랜치 필요 |
+| 10 | PR #36 / #38 계열 backend 방향 재정렬 | 대기 | 신규 backend policy는 `netlify/functions/*`가 아닌 active Cloudflare/Modal runtime 대상으로 재설계 필요 |
+| 11 | PR #7 재동기화 가능성 확인 | 대기 | prototype/reference 보존 상태 유지. main 병합 대상 아님. close/branch 삭제 금지 |
 
 ---
 
 ## 작업 이력 (Task History)
 
+- 2026-04-26: PR #63 `ui(intro): balance hero visual whitespace` merged / closed. production verification PASS. Merge SHA `7e287bb6e77e91d9a1c33681e7308f2e54f7022d`
+- 2026-04-26: PR #62 `ui(style): align button badge chip tone` merged / closed. production verification PASS. Merge SHA `ae5ac03a2e9582c6c5cef6a965d6600ec6fa8e44`
+- 2026-04-26: PR #61 `docs(ops): add branch cleanup plan after PR58` merged / closed. Branch cleanup plan 문서화 완료
+- 2026-04-26: PR #60 `docs(design): add button badge chip baseline` merged / closed. Button / badge / chip baseline 문서화 완료
+- 2026-04-26: PR #59 `docs(project): update task status after PR58` merged / closed. TASK_STATUS 이전 최신화 완료
 - 2026-04-26: PR #58 `docs(project): add verification warning catalog` merged / closed. Verification warning catalog 문서화 완료. Merge SHA `7e221b8829500c26a7542481bea1585d916fb14a`
 - 2026-04-26: PR #57 `docs(project): add UI polish roadmap after PR51` merged / closed. UI polish roadmap after PR51 문서화 완료. Merge SHA `aaf31fe72298ddc510db29728ca8c35b2a808a5e`
 - 2026-04-26: PR #56 `docs(ops): document known CI and E2E blockers` merged / closed. Known CI/E2E blockers 문서화 완료. Merge SHA `c67956a23f61ea26dfb47e64813d340d960985ba`
@@ -82,7 +91,6 @@
 - 2026-04-26: PR #51 `ui(style): align typography accent hierarchy` merged / closed. typography / accent hierarchy 통일 완료. production verification PASS. Merge SHA `99af8a69fbe1cf61ac23017b938027164a213b3a`
 - 2026-04-26: PR #50 `docs(project): clarify UI verification environment rules` main 병합 완료. UI verification environment rules 문서화 완료
 - 2026-04-26: PR #49 `ui(layout): align landing browse rails` main 병합 및 production verification PASS. Merge SHA `dfb158a843932edeaaf7c859d0fa3e2d06c9be08`
-- 2026-04-26: PR3 button / badge / chip tone unification 준비 중. 예정 브랜치 `ui/button-badge-chip-tone-unification`. merge 전 test/preview 검증 필요
 - 2026-04-26: PR #7 `experiment: SVG tree prototype` open/draft 상태 보존. close 금지, branch 삭제 금지, navigation 연결 금지
 - 2026-04-25: production/test1/test2/test3 route matrix 기준 `/api/trees`, `/api/memories` active upstream이 Modal임을 확인. Netlify Functions는 legacy artifact로 정리 필요
 - 2026-04-25: PR #32 public-first + Plus private policy direction 문서 반영 완료


### PR DESCRIPTION
## Summary
- Update `docs/project/TASK_STATUS.md` after PR #62 and PR #63 completion
- Update `docs/design/UI_POLISH_ROADMAP.md` so PR #49, #51, #62, and #63 are recorded as complete
- Add the next backlog sequence: PR5 Browse surface audit/implementation, Search URL state, selected tree deep link, YouTube thumbnail fallback, CI/E2E stabilization, runtime legacy clarification, and Search CSS extraction

## Scope
Changed files only:
- `docs/project/TASK_STATUS.md`
- `docs/design/UI_POLISH_ROADMAP.md`

## Not changed
- No code changes
- No CSS changes
- No HTML changes
- No JS changes
- No runtime/API changes
- No package or lockfile changes
- No workflow changes
- No prototype/reference/demo files changed
- No PR #7 modification or close

## Validation basis
- Branch created from main SHA `7e287bb6e77e91d9a1c33681e7308f2e54f7022d`
- Compare result: branch is 2 commits ahead, 0 behind
- Changed files are limited to the two docs files above

Do not merge without CTO approval.