### PR TITLE
ui(search): unify browse card and hub surfaces

### DIFF
--- a/pages/search.html
+++ b/pages/search.html
@@ -212,7 +212,7 @@
         #growingTreesList {
             display: grid;
             grid-template-columns: repeat(3, minmax(0, 1fr));
-            gap: 18px;
+            gap: 20px;
             align-items: stretch;
             min-width: 0;
         }
@@ -279,10 +279,14 @@
             margin-top: 50px;
             margin-bottom: 44px;
             padding: 28px;
-            background: rgba(255, 255, 255, 0.34);
-            border: 1px solid rgba(144, 73, 81, 0.07);
-            border-radius: 2rem;
-            box-shadow: inset 0 0 32px rgba(255, 255, 255, 0.42);
+            background: 
+                radial-gradient(circle at 20% 20%, rgba(255, 248, 245, 0.62), transparent 48%),
+                rgba(255, 255, 255, 0.38);
+            border: 1px solid rgba(144, 73, 81, 0.08);
+            border-radius: 2.25rem;
+            box-shadow: 
+                inset 0 0 40px rgba(255, 255, 255, 0.52),
+                0 12px 32px rgba(75, 64, 57, 0.03);
         }
 
         .growing-trees-head {
@@ -312,8 +316,9 @@
             display: inline-flex;
             align-items: center;
             padding: 7px 14px;
-            background: rgba(144, 73, 81, 0.08);
-            color: var(--primary);
+            background: rgba(144, 73, 81, 0.06);
+            color: var(--on-surface-variant);
+            border: 1px solid rgba(144, 73, 81, 0.1);
             border-radius: 999px;
             font-size: 11.5px;
             font-weight: 800;
@@ -324,16 +329,20 @@
         .tree-card {
             display: flex;
             flex-direction: column;
-            padding: 12px;
-            background: rgba(255,255,255,0.94);
-            border-radius: 1.7rem;
-            border: 1px solid rgba(144,73,81,0.07);
+            padding: 14px;
+            background: 
+                radial-gradient(circle at 30% 20%, rgba(255, 248, 245, 0.92), transparent 52%),
+                rgba(255, 255, 255, 0.82);
+            border-radius: 1.85rem;
+            border: 1px solid rgba(144, 73, 81, 0.08);
             margin-bottom: 0;
             transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
             cursor: pointer;
             position: relative;
             overflow: hidden;
-            box-shadow: 0 16px 32px rgba(75, 64, 57, 0.045);
+            box-shadow: 
+                0 20px 48px rgba(75, 64, 57, 0.1),
+                0 0 0 1px rgba(255, 255, 255, 0.62) inset;
             min-width: 0;
         }
 
@@ -350,14 +359,18 @@
         }
 
         .tree-card:hover {
-            transform: translateY(-2px);
-            border-color: rgba(144,73,81,0.14);
-            box-shadow: 0 20px 38px rgba(144, 73, 81, 0.07);
+            transform: translateY(-3px);
+            border-color: rgba(144,73,81,0.16);
+            box-shadow: 
+                0 24px 56px rgba(75, 64, 57, 0.14),
+                0 0 0 1px rgba(255, 255, 255, 0.82) inset;
         }
 
         .tree-card.is-active {
-            border-color: rgba(144, 73, 81, 0.18);
-            box-shadow: 0 22px 42px rgba(144, 73, 81, 0.10);
+            border-color: rgba(144, 73, 81, 0.22);
+            box-shadow: 
+                0 26px 60px rgba(144, 73, 81, 0.12),
+                0 0 0 1px rgba(255, 255, 255, 0.42) inset;
         }
 
         .tree-card:hover::before,
@@ -374,10 +387,10 @@
             min-height: 182px;
             margin: 0 0 16px;
             overflow: hidden;
-            border-radius: 1.35rem;
-            background:
+            border-radius: 1.45rem;
+            background: 
                 radial-gradient(circle at 20% 15%, rgba(255, 245, 246, 0.95), rgba(255,255,255,0.18) 46%),
-                linear-gradient(135deg, rgba(144, 73, 81, 0.13), rgba(122, 139, 110, 0.14));
+                linear-gradient(135deg, rgba(144, 73, 81, 0.12), rgba(122, 139, 110, 0.12));
             isolation: isolate;
         }
 
@@ -406,9 +419,9 @@
             color: var(--primary);
             font-size: 34px;
             font-weight: 900;
-            background:
-                radial-gradient(circle at 18% 16%, rgba(255, 245, 246, 0.96), rgba(255,255,255,0.18) 48%),
-                linear-gradient(135deg, rgba(144, 73, 81, 0.11), rgba(122, 139, 110, 0.13));
+            background: 
+                radial-gradient(circle at 18% 16%, rgba(255, 245, 246, 0.92), rgba(255,255,255,0.12) 48%),
+                linear-gradient(135deg, rgba(144, 73, 81, 0.09), rgba(122, 139, 110, 0.11));
         }
 
         .tree-card-media-fallback[hidden] {
@@ -480,11 +493,17 @@
             position: sticky;
             top: 96px;
             height: fit-content;
-            background: rgba(255,255,255,0.88);
-            padding: 26px 22px;
-            border-radius: 2rem;
-            border: 1px solid rgba(144, 73, 81, 0.09);
-            box-shadow: 0 18px 42px rgba(75, 64, 57, 0.06);
+            background: 
+                radial-gradient(circle at 28% 12%, rgba(255, 248, 246, 0.96), transparent 38%),
+                radial-gradient(circle at 80% 22%, rgba(242, 234, 228, 0.72), transparent 28%),
+                linear-gradient(180deg, rgba(255, 249, 245, 0.92), rgba(244, 248, 238, 0.96));
+            padding: 30px 24px;
+            border-radius: 2.25rem;
+            border: 1px solid rgba(144, 73, 81, 0.1);
+            box-shadow: 
+                0 24px 60px rgba(75, 64, 57, 0.12),
+                inset 0 1px 0 rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(14px);
             min-width: 0;
         }
 
@@ -608,30 +627,29 @@
             box-shadow: none;
         }
 
-        @media (max-width: 1180px) {
+        @media (max-width: 1240px) {
             .search-container {
-                grid-template-columns: 1fr;
-                gap: 26px;
+                grid-template-columns: minmax(0, 1fr) 380px;
+                gap: 24px;
                 padding: 24px var(--page-pad-tablet) 48px;
-            }
-
-            .browse-utility-row {
-                flex-direction: column;
-                align-items: stretch;
-            }
-
-            .filter-row {
-                justify-content: flex-start;
             }
 
             #resultsList,
             #growingTreesList {
                 grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 16px;
+            }
+        }
+
+        @media (max-width: 1024px) {
+            .search-container {
+                grid-template-columns: 1fr;
+                gap: 32px;
             }
 
             .preview-sidebar {
                 position: sticky;
-                top: 96px;
+                top: 92px;
                 z-index: 5;
                 align-self: start;
             }
@@ -829,7 +847,7 @@
                 </button>
             </div>
             <div id="previewVideoContainer" class="video-container" style="margin-bottom: 24px;">
-                <div class="preview-empty-state" style="width:100%; height:100%; display:flex; flex-direction: column; align-items:center; justify-content:center; color: var(--on-surface-variant); font-size: 14px; text-align: center; padding: 20px;">
+                <div class="preview-empty-state" style="width:100%; height:100%; display:flex; flex-direction: column; align-items:center; justify-content:center; color: var(--on-surface-variant); font-size: 14px; text-align: center; padding: 20px; background: radial-gradient(circle at 50% 50%, rgba(255, 248, 245, 0.42), transparent 70%);">
                     <p>마음이 닿는 트리를 골라보세요.</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Re-tune Browse/Search card surfaces with warmer scrapbook-style layered backgrounds and softer borders.
- Add deeper warm shadow treatment for result cards and active/hover states.
- Warm up the preview hub/sidebar, growing trees section, and placeholder media area.
- Adjust the 1024px-adjacent layout breakpoint so the sidebar/card grid stays balanced before collapsing.

Refs #65

## Scope guard
- Changed only `pages/search.html`.
- No JS/API/renderer/adapter/filtering/sorting changes.
- Did not touch prototype/reference/demo folders or PR #7.
- Did not change YouTube thumbnail fallback or known `ytimg.com` thumbnail 404 behavior.

## Verification
- Pending Cloudflare PR Preview verification after PR creation.
- Required viewports: 1440 / 1024 / 375.
- Required checks: Browse data load, horizontal overflow, console/network blockers.