### PR TITLE
chore(ci): stabilize Playwright E2E dependency

### DIFF
--- a/.github/workflows/ci-e2e-smoke.yml
+++ b/.github/workflows/ci-e2e-smoke.yml
@@ -25,7 +25,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "pg": "^8.12.0"
       },
       "devDependencies": {
-        "dotenv": "^17.4.2"
+        "dotenv": "^17.4.2",
+        "playwright": "^1.59.1"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -876,6 +877,21 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1606,6 +1622,38 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pg": "^8.12.0"
   },
   "devDependencies": {
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
## Summary
- Add `playwright` as a dev dependency so E2E smoke scripts can resolve `require('playwright')`.
- Update `package-lock.json` to pin the dependency tree.
- Use `npm ci` in the CI E2E smoke workflow for lockfile-based installs.

Refs #65

## Validation
- Local `npm ci`: PASS
- Local `node -e "require('playwright'); console.log('playwright ok')"`: PASS
- GitHub Actions reached `Run E2E smoke subset` without `Cannot find module 'playwright'`.

## Remaining known blocker
- `CI E2E Smoke` still fails after dependency resolution because local Netlify dev lacks `NETLIFY_DATABASE_URL` / `DATABASE_URL`, causing `/community/trees` to return 503 and `.tree-card` wait to time out.
- This is a separate E2E runtime/env/data blocker, not the Playwright dependency blocker addressed by this PR.

## Scope guard
- Changed only `package.json`, `package-lock.json`, and `.github/workflows/ci-e2e-smoke.yml`.
- No UI, JS app logic, API/runtime, test script, prototype/reference/demo, or PR #7 changes.