### PR TITLE
fix(search): harden YouTube thumbnail fallback

### DIFF
--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -49,7 +49,7 @@
 
     function showImageFallback(img) {
         if (!img) return;
-        img.hidden = true;
+        img.style.display = 'none';
         const fallback = img.nextElementSibling;
         if (fallback) {
             fallback.hidden = false;
@@ -111,7 +111,7 @@
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
         return `
-            <div class="tree-card-media-fallback" style="flex-direction:column;gap:8px;padding:20px;text-align:center;background:linear-gradient(135deg, rgba(250,242,243,0.96), rgba(255,255,255,0.96));">
+            <div class="tree-card-media-fallback" style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;padding:20px;text-align:center;background:linear-gradient(135deg, rgba(250,242,243,0.96), rgba(255,255,255,0.96));width:100%;height:100%;">
                 <span style="font-size:34px;line-height:1;">${escapeHtml(getTreeIcon(tree.stage))}</span>
                 <div style="font-size:13px;font-weight:800;color:var(--on-surface);">${safeTitle}</div>
             </div>
@@ -123,8 +123,10 @@
             return renderMediaFallback(tree, titleText);
         }
         return `
-            <img src="${src}" alt="${alt}" loading="lazy" onerror="window.LoveBudSearchCardRenderer?.showImageFallback?.(this)" onload="window.LoveBudSearchCardRenderer?.handleImageLoad?.(this)">
-            <div class="tree-card-media-fallback" hidden>${renderMediaFallback(tree, titleText)}</div>
+            <img src="${src}" alt="${alt}" loading="lazy" onerror="window.LoveBudSearchCardRenderer?.showImageFallback?.(this)" onload="window.LoveBudSearchCardRenderer?.handleImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;">
+            <div data-fallback-container hidden style="width:100%;height:100%;position:absolute;inset:0;">
+                ${renderMediaFallback(tree, titleText)}
+            </div>
         `;
     }
 
@@ -152,7 +154,7 @@
          const firstMoment = escapeHtml(firstMem?.title || '대표 순간 준비 중');
 
          return `
-             <div class="tree-card-media" aria-label="${firstMoment}">
+             <div class="tree-card-media" aria-label="${firstMoment}" style="position:relative;overflow:hidden;">
                  ${renderRepresentativeImage(mediaUrl, firstMoment, tree, titleText)}
              </div>
          `;

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -343,8 +343,8 @@
             <div style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                 <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
-                <div style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
-                <div style="position:absolute;left:18px;right:18px;bottom:18px;color:white;">
+                <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
+                <div data-preview-overlay style="position:absolute;left:18px;right:18px;bottom:18px;color:white;">
                     <div style="display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:0 10px;border-radius:999px;background:rgba(255,255,255,0.18);backdrop-filter:blur(10px);font-size:12px;font-weight:800;margin-bottom:10px;">
                         <span class="material-symbols-outlined" style="font-size:14px;">play_circle</span>
                         ${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '대표 순간부터 감상하기', 'Start from the featured moment'))}
@@ -364,6 +364,8 @@
         if (fallback) {
             fallback.hidden = false;
         }
+        const overlays = wrapper.querySelectorAll('[data-preview-overlay]');
+        overlays.forEach(overlay => overlay.style.display = 'none');
     }
 
     function updatePreview(tree) {


### PR DESCRIPTION
## Summary
- Harden Browse/Search thumbnail fallback behavior when YouTube thumbnail requests fail.
- Ensure failed card thumbnails hide the broken image and show the existing fallback surface.
- Ensure preview thumbnail fallback is visible without dark overlay obstruction.
- Keep known `i.ytimg.com` 404 network warnings separate from user-visible fallback behavior.

Refs #65

## Changes
- `js/search-card-renderer.js`
  - Hide failed images with `style.display = 'none'`.
  - Use a positioned fallback container that fills the card media area.
  - Keep fallback icon/title centered and visible.
- `js/search-preview-renderer.js`
  - Mark preview gradient/text overlays with `data-preview-overlay`.
  - Hide preview overlays when image fallback is triggered.

## Validation
- Cloudflare Preview: PASS
- Browse/Search data load: PASS
- 13 public tree cards rendered.
- Failed thumbnail cards showed visible fallback blocks.
- Broken visible image count: 0
- Preview panel fallback remained visible without blank media.
- Search URL state regression: PASS
- No new JS exception or API blocker.
- Remaining `i.ytimg.com` 404s are known network warnings.

## Scope guard
- Changed only `js/search-card-renderer.js` and `js/search-preview-renderer.js`.
- No `js/search.js` changes.
- No API/backend/runtime changes.
- No CSS extraction, Search URL state, selected tree deep link, package, workflow, prototype/reference/demo, or PR #7 changes.