### PR TITLE
docs(runtime): clarify active and legacy runtime paths

### DIFF
--- a/docs/ops/DEPLOY_CHECKLIST.md
+++ b/docs/ops/DEPLOY_CHECKLIST.md
@@ -1,11 +1,13 @@
 # LoveBud 배포 체크리스트
 
-이 문서는 현재 운영 기준인 **Modal > Cloudflare Pages > Vercel > Netlify** 구조에서 배포 전후 확인 항목을 정리합니다.
+이 문서는 현재 운영 기준인 **Cloudflare Pages Entry + Modal Active Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact** 구조에서 배포 전후 확인 항목을 정리합니다.
 
 - 공식 서비스 주소: `https://lovebud.pages.dev/`
-- 브라우저 API 기준: same-origin `/api/...`
-- Vercel 역할: upstream / secondary entry
-- Netlify 역할: fallback / legacy
+- 브라우저 API 기준: Cloudflare Pages same-origin `/api/...`
+- Cloudflare Pages 역할: 공식 사용자-facing production / preview entry
+- Modal 역할: active compute/runtime 우선 경로
+- Vercel 역할: deprecated transitional fallback / upstream under audit
+- Netlify 역할: legacy / fallback / artifact. `netlify/functions/*`는 현재 active production backend가 아님
 
 ## 0. 빠른 엔드포인트 검증 (1분)
 
@@ -30,7 +32,9 @@ curl -s "https://<MODAL_BASE_URL>/modal/browse/latest?limit=3"
 - browse summary는 Modal 우선 read path입니다.
 - preview hydrate도 Modal 우선 시도를 가집니다.
 - Cloudflare Pages가 공식 사용자-facing entry입니다.
-- Vercel / Netlify는 보조 계층입니다.
+- Cloudflare PR Preview / branch preview가 UI/API 의존 화면의 preview 검증 기준입니다.
+- Vercel / Netlify는 보조 또는 legacy 계층입니다.
+- Netlify 관련 파일은 삭제 대상이라고 단정하지 않지만, active production runtime처럼 설명하지 않습니다.
 - browse display filter와 publication guard를 혼동하지 않습니다.
 
 ## 1. Firebase Authorized Domains 점검
@@ -76,11 +80,21 @@ Firebase Console > Authentication > Settings > Authorized Domains
 | 로그인 | `https://lovebud.pages.dev/login.html` | Firebase 도메인 오류 없음 |
 | 에디터 | `https://lovebud.pages.dev/editor.html` | 기본 진입 정상 |
 
-## 5. fallback 점검
+검증 원칙:
+- Browse/Search/API 의존 화면은 로컬 정적 서버 단독 PASS 금지입니다.
+- UI/layout PR은 Cloudflare PR Preview 또는 지정 test slot URL에서 확인합니다.
+- post-merge 확인은 Cloudflare Pages production URL에서 진행합니다.
+
+## 5. fallback / legacy 점검
 
 - [ ] Modal 차단 시 browse summary가 Vercel upstream fallback으로 계속 응답하는지 확인
 - [ ] catch-all `/api/*`가 `LOVEBUD_UPSTREAM_ORIGIN` 기준으로 정상 proxy 되는지 확인
-- [ ] Netlify legacy 계층이 필요한 경로에서만 보조적으로 관여하는지 확인
+- [ ] Netlify legacy 계층이 필요한 경로 또는 CI/local harness에서만 보조적으로 관여하는지 확인
+
+주의:
+- CI/E2E smoke workflow에서 `netlify dev`가 쓰일 수 있습니다.
+- 이 경로는 local test harness이며, production active runtime이 Netlify라는 뜻이 아닙니다.
+- Netlify dev의 env 누락 failure는 production Cloudflare/Modal runtime failure와 분리해서 봅니다.
 
 ## 6. 장애 대응 우선순위
 
@@ -102,7 +116,12 @@ Firebase Console > Authentication > Settings > Authorized Domains
    - Pages 로그 확인
    - fallback 계층이므로 일부 경로에 영향 가능
 
-5. **Auth Domain Error**
+5. **Netlify dev / legacy function failure**
+   - CI/local harness인지 확인
+   - `NETLIFY_DATABASE_URL` / `DATABASE_URL` 누락인지 확인
+   - production Cloudflare Pages URL에서 재현되는지 분리 확인
+
+6. **Auth Domain Error**
    - Firebase Console 승인 도메인 확인
 
 ## 7. 오래된 설명 제거 기준
@@ -112,11 +131,13 @@ Firebase Console > Authentication > Settings > Authorized Domains
 - `lovebud.vercel.app`를 공식 사용자-facing 주소처럼 설명하는 문장
 - `lovebud.netlify.app`를 주서비스처럼 설명하는 문장
 - Netlify를 primary runtime으로 설명하는 문장
+- `netlify/functions/*`를 active Cloudflare/Modal backend 구현 위치처럼 설명하는 문장
 - Cloudflare Pages를 무시하고 Vercel을 공식 진입점으로 단정하는 문장
+- CI/E2E의 `netlify dev` 사용을 production runtime truth로 해석하는 문장
 
 현재 기준 문장:
 - **공식 주소는 Cloudflare Pages (`pages.dev`)**
-- **browse summary의 1순위는 Modal**
+- **browse summary와 active compute의 1순위는 Modal**
 - **Cloudflare Pages가 same-origin API entry**
-- **Vercel은 upstream / secondary entry**
-- **Netlify는 fallback / legacy**
+- **Vercel은 deprecated transitional fallback / upstream under audit**
+- **Netlify는 legacy / fallback / artifact**

--- a/docs/ops/ENV_DEPENDENCY.md
+++ b/docs/ops/ENV_DEPENDENCY.md
@@ -1,21 +1,25 @@
 # LoveBud 환경변수 의존성 맵
 
-> 목적: 현재 운영 구조(Modal > Cloudflare Pages > Vercel > Netlify)에서 어떤 환경변수가 어느 계층에 필요한지 빠르게 추적하기 위한 문서
+> 목적: 현재 운영 구조에서 어떤 환경변수가 어느 계층에 필요한지 빠르게 추적하기 위한 문서
 
 ## 0. 현재 운영 기준
 
 - 공식 서비스 주소: `https://lovebud.pages.dev/`
-- 운영 우선순위: `Modal > Cloudflare Pages > Vercel > Netlify`
-- browse summary는 Modal을 먼저 보고, 실패 시 Vercel fallback으로 내려갑니다.
-- preview hydrate(`api/community/memories`)도 Modal을 먼저 시도하고, 필요 시 Vercel fallback으로 내려갑니다.
-- Vercel은 upstream / secondary entry 계층입니다.
-- Netlify는 아직 남아 있지만 주서비스 런타임으로 설명하지 않습니다.
+- 운영 기준: `Cloudflare Pages Entry + Modal Active Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact`
+- Cloudflare Pages는 공식 사용자-facing production / preview entry입니다.
+- Cloudflare Pages same-origin `/api/*`가 브라우저 API entry입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- browse summary는 Modal을 먼저 보고, 실패 시 Vercel fallback으로 내려갈 수 있습니다.
+- preview hydrate(`api/community/memories`)도 Modal을 먼저 시도하고, 필요 시 Vercel fallback으로 내려갈 수 있습니다.
+- Vercel은 deprecated transitional fallback / upstream under audit입니다.
+- Netlify는 legacy / fallback / artifact 성격으로 남아 있으며 주서비스 런타임으로 설명하지 않습니다.
+- `netlify/functions/*`는 삭제 대상이라고 단정하지 않지만, 현재 active production backend처럼 취급하지 않습니다.
 
 ---
 
 ## 1. Cloudflare Pages 환경 변수
 
-Cloudflare Pages는 정적 프런트 + same-origin `/api/*` entry 역할을 합니다.
+Cloudflare Pages는 공식 사용자-facing entry, 정적 프런트, same-origin `/api/*` entry 역할을 합니다.
 
 ### MODAL_BASE_URL
 
@@ -28,7 +32,7 @@ Cloudflare Pages는 정적 프런트 + same-origin `/api/*` entry 역할을 합�
 
 **누락 시 증상**
 - Modal 우선 경로를 사용하지 못함
-- 주요 read 경로가 Vercel fallback 중심으로만 동작
+- 주요 read 경로가 Vercel fallback 중심으로만 동작할 수 있음
 - 기능이 완전히 멈추기보다 성능/요약 품질이 낮아질 수 있음
 
 ### LOVEBUD_UPSTREAM_ORIGIN
@@ -44,13 +48,13 @@ Cloudflare Pages는 정적 프런트 + same-origin `/api/*` entry 역할을 합�
 
 **누락 시 증상**
 - 기본값으로 동작 가능
-- 다만 운영자가 upstream을 명시적으로 제어하지 못함
+- 다만 운영자가 fallback upstream을 명시적으로 제어하지 못함
 
 ---
 
 ## 2. Modal 환경 변수 / secret
 
-Modal은 browse summary와 read-heavy aggregation의 1순위 계층입니다.
+Modal은 browse summary와 read-heavy aggregation의 active compute/runtime 우선 계층입니다.
 
 ### DATABASE_URL
 
@@ -65,7 +69,7 @@ Modal은 browse summary와 read-heavy aggregation의 1순위 계층입니다.
 **누락 시 증상**
 - Modal browse/latest 실패
 - private/community read 일부 실패
-- Cloudflare Pages 경로는 Vercel fallback 중심으로 내려감
+- Cloudflare Pages 경로는 Vercel fallback 중심으로 내려갈 수 있음
 
 **운영 원칙**
 - Modal secret `lovebud-db`에서 주입
@@ -91,15 +95,19 @@ Modal은 browse summary와 read-heavy aggregation의 1순위 계층입니다.
 
 ### Vercel
 
-Vercel은 현재 upstream / secondary entry 계층입니다.
+Vercel은 deprecated transitional fallback / upstream under audit입니다.
 
 운영자가 확인할 수 있는 대표 항목:
 - fallback 대상 라우팅 상태
 - secondary entry 헬스 체크
 
+주의:
+- Vercel은 공식 사용자-facing production entry로 설명하지 않습니다.
+- production 검증 기준은 Cloudflare Pages production / preview입니다.
+
 ### Netlify
 
-Netlify는 현재 fallback / legacy 계층입니다.
+Netlify는 legacy / fallback / artifact 성격으로 남아 있습니다.
 
 ### DATABASE_URL / NETLIFY_DATABASE_URL / POSTGRES_URL
 
@@ -109,11 +117,16 @@ Netlify는 현재 fallback / legacy 계층입니다.
 
 **용도**
 - legacy CRUD
-- 일부 legacy fallback read
+- 일부 legacy fallback read 또는 CI/local harness 경로
 
 **누락 시 증상**
-- Netlify fallback 전체 실패
-- 여전히 남아 있는 legacy 경로 실패 가능
+- Netlify dev 또는 legacy function 경로 실패 가능
+- CI/E2E smoke에서 `netlify dev`가 이 변수 없이 실행되면 `/community/trees` 503 같은 local runtime failure가 발생할 수 있음
+
+**운영 해석**
+- CI/E2E에서 Netlify dev가 쓰인다는 사실은 production active runtime이 Netlify라는 뜻이 아닙니다.
+- `netlify/functions/*`는 현재 Cloudflare Pages production backend가 아닙니다.
+- Netlify 관련 환경변수 누락은 production Cloudflare/Modal runtime truth와 분리해 원인 분석합니다.
 
 ### FIREBASE_SERVICE_ACCOUNT_JSON
 
@@ -124,7 +137,7 @@ Netlify는 현재 fallback / legacy 계층입니다.
 - 레거시 쓰기/권한 확인 경로
 
 **누락 시 증상**
-- 인증 필요한 legacy API 실패
+- 인증 필요한 legacy API 실패 가능
 
 ---
 
@@ -149,18 +162,20 @@ Netlify는 현재 fallback / legacy 계층입니다.
 
 ### browse summary만 느리다
 우선 확인:
-1. `MODAL_BASE_URL`
-2. Modal `/modal/health`
-3. Modal `/modal/browse/latest?limit=3`
-4. Pages 로그
-5. Vercel fallback 동작 여부
+1. Cloudflare Pages production / preview URL에서 재현되는지 확인
+2. `MODAL_BASE_URL`
+3. Modal `/modal/health`
+4. Modal `/modal/browse/latest?limit=3`
+5. Pages 로그
+6. Vercel fallback 동작 여부
 
 ### `/api/community/memories`만 실패한다
 우선 확인:
-1. `MODAL_BASE_URL`
-2. Modal community/memories 상태
-3. Vercel fallback 상태
-4. Pages 로그
+1. Cloudflare Pages production / preview URL에서 재현되는지 확인
+2. `MODAL_BASE_URL`
+3. Modal community/memories 상태
+4. Vercel fallback 상태
+5. Pages 로그
 
 ### catch-all `/api/*`만 실패한다
 우선 확인:
@@ -168,11 +183,18 @@ Netlify는 현재 fallback / legacy 계층입니다.
 2. Vercel upstream 상태
 3. Pages 로그
 
+### CI/E2E local Netlify dev만 실패한다
+우선 확인:
+1. 해당 failure가 GitHub Actions local harness인지 확인
+2. `NETLIFY_DATABASE_URL` / `DATABASE_URL` 누락 여부 확인
+3. production Cloudflare Pages URL에서 같은 failure가 재현되는지 분리 확인
+4. PR 변경 범위가 package/workflow/test/runtime인지 확인
+
 ---
 
 ## 6. 운영 원칙 한 줄 정리
 
-- **Modal**: browse summary / private read / community read 1순위
-- **Cloudflare Pages**: 공식 진입점 + same-origin API entry
-- **Vercel**: upstream / secondary entry
-- **Netlify**: fallback / legacy
+- **Cloudflare Pages**: 공식 사용자-facing production / preview entry + same-origin API entry
+- **Modal**: active compute/runtime 우선 경로
+- **Vercel**: deprecated transitional fallback / upstream under audit
+- **Netlify**: legacy / fallback / artifact. `netlify/functions/*`는 현재 active production backend가 아님

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -3,27 +3,33 @@
 ## 1. 프로젝트 주요 정보
 
 - 공식 서비스 URL: `https://lovebud.pages.dev/`
-- 운영 우선순위: `Modal > Cloudflare Pages > Vercel > Netlify`
-- Modal 앱: `lovebud-browse-snapshot`
-- Vercel 역할: upstream / secondary entry
-- Netlify 역할: legacy write / fallback
+- 운영 기준: `Cloudflare Pages Entry + Modal Active Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact`
+- Cloudflare Pages 역할: 공식 사용자-facing production / preview entry, 정적 프런트, same-origin `/api/*` entry
+- Modal 역할: active compute/runtime 우선 경로, browse summary 및 private/community read/write target
+- Vercel 역할: deprecated transitional fallback / upstream under audit
+- Netlify 역할: legacy / fallback / artifact. `netlify/functions/*`는 현재 `lovebud.pages.dev` production backend가 아님
 
 ## 2. 현재 운영 구조
 
 ### Entry
 - 브라우저 진입점은 Cloudflare Pages입니다.
 - 정적 자산과 `/api/*` 상대 경로는 `lovebud.pages.dev` 기준으로 동작합니다.
+- PR Preview / branch preview 검증도 Cloudflare Pages preview URL을 기준으로 봅니다.
+- Browse/Search/API 의존 화면은 로컬 정적 서버 단독 결과로 PASS 처리하지 않습니다.
 
-### Primary Read
+### Active Runtime
+- Cloudflare Pages Functions가 same-origin `/api/*` entry를 담당합니다.
 - browse summary는 Cloudflare Pages `functions/api/[[path]].js`가 `MODAL_BASE_URL` 기준 Modal을 먼저 호출합니다.
 - Modal live endpoint:
   - `GET /modal/health`
   - `GET /modal/browse/latest?limit=3`
+- Modal은 현재 active compute/runtime 우선 경로입니다.
 
 ### Fallback / Legacy
-- Modal read 실패 시 Cloudflare Pages가 Vercel upstream으로 fallback 합니다.
-- catch-all `/api/*`의 기본 upstream origin은 현재 Vercel입니다.
-- Netlify는 여전히 legacy / fallback 계층으로 남아 있습니다.
+- Modal read 실패 시 Cloudflare Pages가 Vercel upstream으로 fallback 할 수 있습니다.
+- catch-all `/api/*`의 기본 fallback upstream origin은 현재 Vercel입니다.
+- Netlify 관련 파일과 `netlify/functions/*`는 legacy / fallback / artifact 성격으로 남아 있습니다.
+- Netlify 코드는 삭제 대상이라고 단정하지 않습니다. 별도 승인 없이 이동, archive, 삭제하지 않습니다.
 
 ## 3. 배포 절차
 
@@ -32,6 +38,10 @@
 - 주요 파일:
   - `functions/api/[[path]].js`
   - `pages/*.html`
+- production / preview 검증 기준:
+  - `https://lovebud.pages.dev/`
+  - Cloudflare PR Preview URL
+  - Cloudflare branch preview URL
 
 ### Modal
 - 코드 위치: `modal_compute/app.py`
@@ -41,24 +51,28 @@
   - `modal app logs lovebud-browse-snapshot`
   - `/modal/health`
   - `/modal/browse/latest?limit=3`
+- 이번 문서 기준 정리는 Modal 코드나 배포를 변경하지 않습니다.
 
 ### Vercel
-- 역할: upstream / secondary entry 유지
+- 역할: deprecated transitional fallback / upstream under audit
 - 공식 사용자-facing 주소가 아니라 보조 계층으로 취급
 
 ### Netlify
-- 역할: legacy backend / fallback 유지
-- 주서비스 주소가 아니라 보조 계층으로 취급
+- 역할: legacy / fallback / artifact
+- 주서비스 주소가 아니라 보조 계층 또는 과거 산출물로 취급
+- `netlify/functions/*`는 현재 active runtime 구현 위치로 보지 않습니다.
+- Netlify runtime 재활성화, 코드 이동, 삭제, archive는 별도 CTO 승인 전 수행하지 않습니다.
 
 ## 4. 장애 대응
 
 ### browse summary가 느리거나 비어 보일 때
 확인 순서:
-1. `MODAL_BASE_URL`가 Cloudflare Pages에 설정되어 있는지 확인
-2. Modal `/modal/health` 200 확인
-3. Modal `/modal/browse/latest?limit=3` 응답 shape 확인
-4. Modal 실패 시 Vercel fallback 응답 확인
-5. Pages function logs 확인
+1. Cloudflare Pages preview / production URL에서 재현되는지 확인
+2. `MODAL_BASE_URL`가 Cloudflare Pages에 설정되어 있는지 확인
+3. Modal `/modal/health` 200 확인
+4. Modal `/modal/browse/latest?limit=3` 응답 shape 확인
+5. Modal 실패 시 Vercel fallback 응답 확인
+6. Pages function logs 확인
 
 ### `/api/community/trees?view=summary` 실패
 확인 순서:
@@ -80,6 +94,13 @@
 1. `LOVEBUD_UPSTREAM_ORIGIN` 설정 확인
 2. 설정이 없으면 기본값 `https://lovebud.vercel.app` 기준으로 동작하는지 확인
 3. Vercel upstream 상태 확인
+
+### CI/E2E에서 Netlify dev가 실패할 때
+해석 기준:
+1. CI/E2E smoke workflow가 `netlify dev`를 사용할 수 있습니다.
+2. 이 경로는 CI 로컬 실행 harness이며, production active runtime이 Netlify라는 뜻이 아닙니다.
+3. Netlify dev의 `DATABASE_URL` / `NETLIFY_DATABASE_URL` 누락으로 발생하는 503은 production Cloudflare/Modal runtime truth와 분리해서 봅니다.
+4. CI/E2E blocker를 이유로 `netlify/functions/*`를 active runtime처럼 수정하지 않습니다.
 
 ## 5. 운영 환경 변수 체크리스트
 
@@ -116,8 +137,8 @@
 
 ## 7. 운영 원칙 한 줄 요약
 
-- 공식 주소는 Cloudflare Pages (`pages.dev`)
-- browse summary의 1순위는 Modal
-- Cloudflare Pages가 same-origin entry
-- Vercel은 upstream / secondary entry
-- Netlify는 fallback / legacy
+- 공식 주소와 사용자-facing 검증 기준은 Cloudflare Pages (`pages.dev`)
+- browse summary와 API compute의 1순위는 Modal
+- Cloudflare Pages가 same-origin `/api/*` entry
+- Vercel은 deprecated transitional fallback / upstream under audit
+- Netlify는 legacy / fallback / artifact이며 `netlify/functions/*`는 현재 active production backend가 아님


### PR DESCRIPTION
## Summary
- Clarify Cloudflare Pages as the official user-facing production and preview entry.
- Clarify Modal as the active compute/runtime priority for Browse/Search/API paths.
- Clarify Netlify as legacy/fallback/artifact, not the active production backend.
- Document that CI/E2E `netlify dev` usage is a local harness and must not be confused with production runtime truth.

Refs #65

## Scope guard
- Docs-only changes.
- Changed only `docs/ops/DEPLOY_CHECKLIST.md`, `docs/ops/ENV_DEPENDENCY.md`, and `docs/ops/RUNBOOK.md`.
- No code, runtime, API, package, lockfile, workflow, prototype/reference/demo, or PR #7 changes.
- No Netlify Functions deletion, archive, movement, or reactivation.

## Validation
- Confirmed changed files are limited to docs/ops.
- Confirmed official production URL is documented as `https://lovebud.pages.dev/`.
- Confirmed Netlify language avoids implying immediate deletion or active production runtime status.
- Issue #65 remains the backlog tracker and is referenced only with `Refs #65`.