### PR TITLE
docs(project): update task status after PR70

### DIFF
--- a/docs/design/UI_POLISH_ROADMAP.md
+++ b/docs/design/UI_POLISH_ROADMAP.md
@@ -1,146 +1,163 @@
-# UI Polish Roadmap after PR51
+# UI Polish Roadmap after PR70
 
 ## 목적
 
-이 문서는 PR #49, PR #51 이후 남은 public UI polish 작업을 PR3 / PR4 / PR5 단위로 분리하기 위한 디자인 실행 로드맵입니다.
+이 문서는 PR #49, #51, #62, #63, #66, #67, #69, #70 이후 남은 public UI polish와 Search 후속 작업을 분리하기 위한 디자인 실행 로드맵입니다.
 
-이 문서는 구현 지시서가 아니라 **범위 분리 기준**입니다. 실제 CSS/HTML/JS 변경은 각 UI PR에서 별도 승인 후 진행합니다.
+이 문서는 구현 지시서가 아니라 **범위 분리 기준**입니다. 실제 CSS/HTML/JS/API 변경은 각 PR에서 별도 승인 후 진행합니다.
 
-## 완료된 UI 단계
+## 완료된 UI / Search 단계
 
 | 단계 | 상태 | 범위 | 메모 |
 |------|------|------|------|
-| PR #49 `ui(layout): align landing browse rails` | 완료 | layout rail / container / spacing unification | Home, Intro, Browse의 큰 레이아웃 폭, rail, spacing 기준을 통일 |
-| PR #51 `ui(style): align typography accent hierarchy` | 진행 중 | typography / accent hierarchy unification | test1 배포 트리거 완료. Gemini Local Verifier test1 검증 대기. merge 전 test1 visual verification 필요 |
+| PR #49 `ui(layout): align landing browse rails` | 완료 | layout rail / container / spacing unification | Home, Intro, Browse의 큰 레이아웃 폭, rail, spacing 기준을 통일. production verification PASS |
+| PR #51 `ui(style): align typography accent hierarchy` | 완료 | typography / accent hierarchy unification | Home 기준 typography / accent hierarchy 통일. production verification PASS |
+| PR #62 `ui(style): align button badge chip tone` | 완료 | button / badge / chip tone unification | Home / Intro / Browse 버튼, 배지, 칩 tone 통일. production verification PASS |
+| PR #63 `ui(intro): balance hero visual whitespace` | 완료 | Intro hero visual / whitespace balance | Intro hero visual column, scene height, tablet breakpoint, warm scrapbook tone 개선. production verification PASS |
+| PR #66 `ui(search): unify browse card and hub surfaces` | 완료 | Browse card / hub panel surface unification | Browse result card, preview sidebar, growing trees section, placeholder tone 정리 완료 |
+| PR #67 상당 변경 | 완료 | Search URL state | `q`, `category`, `sort`, `limit` query sync main 반영 완료. PR #67은 중복 merge 방지를 위해 closed / unmerged 처리됨 |
+| PR #69 `fix(search): harden YouTube thumbnail fallback` | 완료 | thumbnail fallback hardening | broken thumbnail image를 숨기고 fallback surface를 노출. preview fallback overlay obstruction 제거 완료 |
+| PR #70 `docs(runtime): clarify active and legacy runtime paths` | 완료 | runtime truth clarification | Cloudflare Pages / Modal / Netlify 역할 분리 문서화 완료 |
 
-## 다음 UI 순서
+## 현재 남은 Issue #65 Backlog
 
-1. **PR3: button / badge / chip tone unification**
-2. **PR4: intro hero visual / whitespace balance**
-3. **PR5: browse card / hub panel surface unification**
+Issue #65는 open backlog tracker입니다. 현재 미완료 항목은 아래 3개뿐입니다.
 
-이 순서는 의도적으로 작은 시각 단위에서 큰 surface 단위로 진행합니다. PR3에서 공통 interactive tone을 먼저 맞춘 뒤, PR4에서 Intro hero의 밀도를 조정하고, PR5에서 Browse card/hub surface를 정리합니다.
-
----
-
-## PR3: button / badge / chip tone unification
-
-### 목표
-
-공개 화면의 버튼, badge, pill, chip, CTA가 같은 제품군으로 보이도록 tone을 통일합니다.
-
-### 포함 범위
-
-- button shape / radius / shadow / border tone
-- badge, pill, chip style
-- primary / secondary / quiet CTA visual consistency
-- Home, Intro, Browse에서 반복되는 interactive surface tone 정리
-- hover / focus-visible의 시각 강도 통일
-
-### 제외 범위
-
-- layout 변경 금지
-- grid / container / spacing 재조정 금지
-- JS 변경 금지
-- API / runtime 변경 금지
-- Search rendering logic 변경 금지
-- card/hub panel hierarchy 변경은 PR5로 분리
-- Intro hero visual density 조정은 PR4로 분리
-
-### 검증 포인트
-
-- Home / Intro / Browse 1440 / 1024 / 375 확인
-- primary CTA와 secondary button의 위계가 명확한지 확인
-- badge/pill/chip이 과하게 튀지 않고 Home tone과 맞는지 확인
-- focus-visible이 잘림 없이 표시되는지 확인
+1. **Selected tree deep link**
+2. **Search JS responsibility split**
+3. **Search CSS extraction / inline style reduction**
 
 ---
 
-## PR4: intro hero visual / whitespace balance
+## Selected tree deep link
 
 ### 목표
 
-Intro hero가 Home hero와 같은 브랜드 밀도 안에서 보이도록 visual size와 whitespace를 조정합니다.
+공개 Browse에서 특정 트리 preview를 직접 열 수 있게 합니다.
 
 ### 포함 범위
 
-- Intro hero visual balance
-- Intro hero visual size 조정
-- Intro hero whitespace 조정
-- Home과 Intro의 hero density 비교 조정
-- Intro hero heading / visual / supporting copy 간 체감 밀도 정리
+- `?tree=<treeId>` 또는 동등한 query parameter 지원
+- 직접 진입 시 해당 공개 tree 카드 선택
+- desktop에서 preview sidebar hydrate
+- mobile에서 preview panel open 처리
+- tree가 없거나 비공개/삭제된 경우 안전한 fallback 처리
 
 ### 제외 범위
 
-- Browse 제외
-- Search / Browse card 변경 금지
-- button / badge / chip 전역 tone 변경 금지
-- JS 변경 금지
-- API / runtime 변경 금지
-- DOM 구조 변경은 별도 승인 없이는 금지
+- 공개/비공개 정책 변경 금지
+- private tree 노출 금지
+- API 권한 정책 변경 금지
+- visual surface 변경 금지
+- thumbnail fallback 변경 금지
+- Search CSS extraction과 혼합 금지
 
 ### 검증 포인트
 
-- Home hero와 Intro hero의 첫인상 밀도 비교
-- Intro 1440 / 1024 / 375에서 visual이 과도하게 크거나 작지 않은지 확인
-- mobile에서 hero visual이 copy를 밀어내지 않는지 확인
+- 존재하는 공개 tree id 직접 진입
+- 존재하지 않는 tree id 직접 진입
+- desktop preview hydrate 확인
+- mobile 375에서 preview open/close 확인
+- Browse data load 정상 확인
+- console/network 신규 blocker 없음 확인
+
+---
+
+## Search JS responsibility split
+
+### 목표
+
+`js/search.js`의 URL state, controls, browse data loading, preview control 책임을 단계적으로 분리해 유지보수성을 개선합니다.
+
+### 포함 범위
+
+- URL state / controls module 분리 검토
+- browse data loading module 분리 검토
+- preview controller module 분리 검토
+- 기존 behavior parity 유지
+- 작은 단계별 refactor 우선
+
+### 제외 범위
+
+- 사용자-visible 기능 변경 금지
+- API response shape 변경 금지
+- runtime/backend 변경 금지
+- visual surface 변경 금지
+- thumbnail fallback 변경 금지
+- CSS extraction과 혼합 금지
+
+### 검증 포인트
+
+- Search URL state regression 확인
+- Browse data load 정상 확인
+- latest / popular / load more 동작 확인
+- selected preview 동작 확인
+- desktop / mobile 기본 흐름 확인
+- console/network 신규 blocker 없음 확인
+
+---
+
+## Search CSS extraction / inline style reduction
+
+### 목표
+
+PR #66 이후 남은 `pages/search.html` 내부 style과 JS-rendered inline style을 단계적으로 줄여 유지보수성을 개선합니다.
+
+### 포함 범위
+
+- search page CSS 분리 가능성 검토
+- page-local `<style>`의 class 기반 정리
+- JS-rendered inline style을 class로 이동할 수 있는지 검토
+- Browse controls markup/style 책임 분리 검토
+- behavior parity 유지
+
+### 제외 범위
+
+- 기능 변경 금지
+- API/runtime 변경 금지
+- thumbnail fallback 변경 금지
+- Search URL state 변경 금지
+- selected tree deep link 구현과 혼합 금지
+- broad design retheme 금지
+
+### 검증 포인트
+
+- Cloudflare PR Preview 또는 지정 test/preview URL 확인
+- Browse/Search data load 확인
+- 1440 / 1024 / 375 viewport 확인
 - horizontal overflow 없음 확인
-
----
-
-## PR5: browse card / hub panel surface unification
-
-### 목표
-
-Browse 화면의 result card와 right hub panel이 같은 surface hierarchy 안에 보이도록 정리합니다.
-
-### 포함 범위
-
-- Browse result card tone
-- Browse right hub panel tone
-- card / hub hierarchy
-- card border / shadow / background / radius 정리
-- empty / loading / populated state의 surface consistency 확인
-
-### 제외 범위
-
-- Search JS 변경 금지
-- Search API 변경 금지
-- rendering logic 변경 금지
-- thumbnail fetch / 404 handling 변경 금지
-- filtering / sorting / query behavior 변경 금지
-- Home / Intro hero 변경 금지
-
-### 검증 포인트
-
-- Browse/Search는 로컬 서버 단독 검증 금지
-- test/preview URL에서 실제 data load 확인
-- result card와 right hub panel의 위계가 명확한지 확인
-- 1440 / 1024 / 375에서 card density와 panel spacing 확인
-- console/network 신규 오류 없음 확인
+- console/network 신규 blocker 없음 확인
+- 기존 known warning은 warning catalog 기준으로 분리 보고
 
 ---
 
 ## 금지 / 보류 항목
 
-아래 항목은 UI polish PR3 / PR4 / PR5에 포함하지 않습니다.
+아래 항목은 위 작업들에 임의 포함하지 않습니다.
 
 - PR #7 prototype close 금지
 - PR #7 branch 삭제 금지
 - `pages/gpt-v2/` 보존
 - `assets/gpt-v2/` 보존
 - `pages/gpt-svg-tree/` 보존
-- 실제 prototype/reference 파일 수정 금지
-- runtime / API 수정 금지
-- Modal / functions 수정 금지
-- Search thumbnail 404 수정은 별도 기능/bugfix 이슈로 분리
-- package / lockfile 수정 금지
+- 실제 prototype/reference/demo 파일 수정 금지
+- runtime / API 수정 금지 unless 해당 PR의 명시 범위
+- Modal / functions 수정 금지 unless 해당 PR의 명시 범위
+- package / lockfile 수정 금지 unless CI/E2E stabilization PR의 명시 범위
+- Issue #65 close 금지
+
+## Runtime truth 기준
+
+- 공식 사용자-facing production / preview entry는 Cloudflare Pages입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- Netlify 관련 파일과 `netlify/functions/*`는 legacy / fallback / artifact 성격으로 남아 있으며 현재 active production backend로 설명하지 않습니다.
+- CI/E2E에서 `netlify dev`가 쓰이는 경우에도 이는 local harness이며 production runtime truth가 Netlify라는 뜻이 아닙니다.
 
 ## Prototype / reference 보존 기준
 
 Prototype/reference 폴더는 cleanup 대상이 아니라 보존 대상입니다. 관련 판단은 [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md)를 우선합니다.
 
-특히 아래 경로는 PR3 / PR4 / PR5의 작업 범위가 아닙니다.
+특히 아래 경로는 UI polish / Search follow-up 작업 범위가 아닙니다.
 
 - `pages/gpt-v2/`
 - `assets/gpt-v2/`
@@ -148,15 +165,18 @@ Prototype/reference 폴더는 cleanup 대상이 아니라 보존 대상입니다
 
 ## 검증 원칙
 
-- 각 PR은 병합 전 Cloudflare PR Preview 또는 지정 test/preview URL에서 검증합니다.
+- 각 UI/Search PR은 병합 전 Cloudflare PR Preview 또는 지정 test/preview URL에서 검증합니다.
 - Browse/Search는 로컬 서버 단독 검증으로 승인하지 않습니다.
 - production은 merge 후 확인합니다.
 - 1440 / 1024 / 375 viewport를 기본 확인 범위로 둡니다.
 - console error, network error, horizontal overflow를 함께 확인합니다.
 - UI polish PR에서는 runtime/API/JS logic 변화가 없어야 합니다.
+- 기능 PR에서는 visual polish를 섞지 않습니다.
+- refactor PR에서는 behavior parity를 우선합니다.
 
 ## 운영 메모
 
-- PR3 / PR4 / PR5는 서로 다른 목적의 UI polish입니다.
-- 한 PR에서 button tone, hero density, Browse card hierarchy를 동시에 처리하지 않습니다.
-- PR #51 검증이 끝나기 전에는 PR3 구현 착수를 별도 승인 없이 진행하지 않습니다.
+- 현재 남은 Issue #65 작업은 3개입니다.
+- 한 PR에서 selected tree deep link, JS responsibility split, CSS extraction을 동시에 처리하지 않습니다.
+- PR #64는 stale docs PR로 closed / unmerged 처리되었습니다.
+- 현재 열린 PR #7은 보존 prototype PR이며 main 병합 대상이 아닙니다.

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,23 +23,28 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `7e221b8829500c26a7542481bea1585d916fb14a`
+- 기준 main 커밋: `1833aaf2c779bd593bda2687d5ee0df0e4197bfd`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
-| 문서 TF | 완료 | PR #8, PR #10, PR #32, PR #33, PR #50, PR #52, PR #54, PR #55, PR #56, PR #57, PR #58 | project 운영 문서, 검증 기준, public-first 정책, Tree/Memory/Visibility/Delete QA matrix, UI verification environment rules, test preview slot branch rules, TASK_STATUS, prototype/reference preservation policy, known CI/E2E blockers, UI polish roadmap, verification warning catalog main 반영 완료 |
-| Runtime routing truth | 진행 중 | production/test slot route matrix | `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal 경로로 실측. Netlify Functions 호출 흔적 없음. Netlify legacy deprecation 문서 정리 진행 중 |
+| 문서 TF | 완료 | PR #8, #10, #32, #33, #50, #52, #54~#58, #61, #70 | project/ops/design 문서, 검증 기준, public-first 정책, QA matrix, warning catalog, branch cleanup plan, runtime active/legacy clarification main 반영 완료 |
+| Runtime routing truth | 완료 | PR #70 `docs(runtime): clarify active and legacy runtime paths` | Cloudflare Pages 공식 사용자-facing entry, Modal active compute/runtime 우선 경로, Netlify legacy/fallback/artifact 기준 문서화 완료. Merge SHA: `1833aaf2c779bd593bda2687d5ee0df0e4197bfd` |
 | Public layout UI | 완료 | PR #49 `ui(layout): align landing browse rails` | layout rail / container / spacing 통일 완료. production verification PASS. Merge SHA: `dfb158a843932edeaaf7c859d0fa3e2d06c9be08` |
 | Typography / accent hierarchy | 완료 | PR #51 `ui(style): align typography accent hierarchy` | typography / accent hierarchy 통일 완료. production verification PASS. Merge SHA: `99af8a69fbe1cf61ac23017b938027164a213b3a` |
+| Button / badge / chip tone | 완료 | PR #62 `ui(style): align button badge chip tone` | Home / Intro / Browse button, badge, chip tone 통일 완료. production verification PASS. Merge SHA: `ae5ac03a2e9582c6c5cef6a965d6600ec6fa8e44` |
+| Intro hero visual / whitespace | 완료 | PR #63 `ui(intro): balance hero visual whitespace` | Intro hero visual column, tree scene height, tablet breakpoint, warm scrapbook tone 개선 완료. production verification PASS. Merge SHA: `7e287bb6e77e91d9a1c33681e7308f2e54f7022d` |
+| Browse card / hub panel surface | 완료 | PR #66 `ui(search): unify browse card and hub surfaces` | Browse/Search card, preview sidebar, growing section, placeholder tone 정리 완료. production smoke 기준 main 반영 완료 |
+| Search URL state | 완료 | PR #67 상당 직접 squash commit | `q`, `category`, `sort`, `limit` URL state sync main 반영 완료. Current main history includes `01408fbb87805083b08e77974351c9fa17c0d0f9`; PR #67은 중복 merge 방지를 위해 closed / unmerged 처리됨 |
+| YouTube thumbnail fallback | 완료 | PR #69 `fix(search): harden YouTube thumbnail fallback` | failed card thumbnails hide broken image and show fallback surface; preview fallback overlay obstruction removed. Merge SHA: `5f0708c82c6a909f11dbe4fc31776adfd0504778` |
+| CI/E2E Playwright dependency stabilization | 완료 | PR #68 상당 직접 squash commit | `playwright` dev dependency, lockfile, CI E2E smoke `npm ci` 변경 main 반영 완료. PR #68은 중복 merge 방지를 위해 closed / unmerged 처리됨 |
 | UI verification rules | 완료 | PR #50 `docs(project): clarify UI verification environment rules` | UI verification environment rules 문서화 완료 |
 | Test preview slot rules | 완료 | PR #52 `docs(ops): test preview slot branch rules` | test preview slot branch rules 문서화 완료. Merge SHA: `bbc988041e248d171a8560419dc739394ba4e23f` |
 | Local generated artifact ignore | 완료 | PR #53 `chore: ignore local generated artifacts` | local generated artifacts `.gitignore` 정리 완료. Merge SHA: `5f8d185cde4b1d46df75a8c4382fd71a4a671ca8`. prototype/reference 보존 대상 침범 없음 |
-| Task status tracking | 완료 | PR #54 `docs(project): update task status after PR49 and PR50` | TASK_STATUS 이전 최신화 완료. Merge SHA: `0a5386eea7e6c7921164c956e8946f06ca25fe37` |
+| Task status tracking | 진행 중 | PR #64 closed / this update | PR #64는 PR #63 직후 기준이라 stale close됨. 현재 문서는 PR #69 / #70 이후 상태 기준으로 최신화 중 |
 | Prototype reference preservation | 완료 | PR #55 `docs(design): preserve prototype reference folders` | prototype/reference preservation policy 문서화 완료. PR #7 보존 정책 문서화 완료. Merge SHA: `1f1c0758d9307e8e090386d21b21a265e5fe257b` |
 | Known CI/E2E blockers | 완료 | PR #56 `docs(ops): document known CI and E2E blockers` | known CI/E2E blockers 문서화 완료. Merge SHA: `c67956a23f61ea26dfb47e64813d340d960985ba` |
-| UI polish roadmap | 완료 | PR #57 `docs(project): add UI polish roadmap after PR51` | UI polish roadmap after PR51 문서화 완료. Merge SHA: `aaf31fe72298ddc510db29728ca8c35b2a808a5e` |
+| UI polish roadmap | 진행 중 | `docs/design/UI_POLISH_ROADMAP.md` | PR #69 / PR #70 이후 남은 Issue #65 backlog 3개와 맞추는 최신화 진행 중 |
 | Verification warning catalog | 완료 | PR #58 `docs(project): add verification warning catalog` | verification warning catalog 문서화 완료. Merge SHA: `7e221b8829500c26a7542481bea1585d916fb14a` |
-| PR3 button / badge / chip tone | 진행 중 | 예정 브랜치 `ui/button-badge-chip-tone-unification` | PR3 준비 중. Home 기준 유지. button / badge / chip tone unification만 대상으로 함. merge 전 test/preview 검증 필요. layout width/spacing, JS/API, card/hub panel, intro hero visual 수정 금지 |
 | 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. SVG tree prototype. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
 
@@ -48,30 +53,47 @@
 ## Runtime / Backend 상태 메모
 
 - Current production/test slot runtime: `Cloudflare Pages same-origin /api/* → Cloudflare Pages Functions → Modal`.
-- `netlify/functions/*`는 legacy artifact only이며 현재 `lovebud.pages.dev` production/test slot active backend가 아닙니다.
-- PR #38은 active Cloudflare/Modal runtime이 아니라 legacy `netlify/functions/*`를 대상으로 했기 때문에 close되었습니다.
+- Cloudflare Pages는 공식 사용자-facing production / preview entry입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- `netlify/functions/*`는 legacy / fallback / artifact 성격으로 남아 있으며 현재 `lovebud.pages.dev` production/test slot active backend가 아닙니다.
+- CI/E2E에서 `netlify dev`가 쓰이는 경우에도 이는 local harness이며 production runtime truth가 Netlify라는 뜻이 아닙니다.
 - Netlify archive는 즉시 수행하지 않습니다. tests/docs reference transition 후 별도 승인 필요합니다.
 
 ---
 
-## 다음 예정 작업
+## 다음 예정 작업 / Issue #65 Backlog
+
+Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개입니다.
 
 | 작업 | 상태 | 메모 |
 |------|------|------|
-| PR3 button/badge/chip tone unification | 진행 중 | 예정 브랜치 `ui/button-badge-chip-tone-unification`. Home 기준 유지. merge 전 test/preview 검증 필요. layout width/spacing, JS/API, card/hub panel, intro hero visual 수정 금지 |
-| PR4 intro hero visual/whitespace | 대기 | PR3 이후 별도 UI PR로 진행 |
-| PR5 browse card/hub panel | 대기 | PR4 이후 별도 UI PR로 진행 |
-| Netlify Functions legacy deprecation 문서 PR | 진행 중 | active runtime truth 고정. 코드 이동/삭제 없음 |
-| Active Cloudflare/Modal public-first backend 설계 | 대기 | Netlify legacy deprecation 정리 후 별도 브랜치 필요 |
-| PR #36 / #38 계열 backend 방향 재정렬 | 대기 | 신규 backend policy는 `netlify/functions/*`가 아닌 active Cloudflare/Modal runtime 대상으로 재설계 필요 |
-| Search에 “새로 자라는 러브트리” 보조 섹션 설계 | 대기 | 설계 승인 후 별도 브랜치에서 진행 |
-| PR #7 재동기화 가능성 확인 | 대기 | prototype/reference 보존 상태 유지. main 병합 대상 아님. close/branch 삭제 금지 |
-| Search 보조 섹션 UI 구현 | 대기 | 설계 승인 이후 UI 구현 브랜치 분리 |
+| Selected tree deep link | 대기 | `?tree=<treeId>` 직접 진입 시 공개 tree preview 선택. desktop / mobile preview 동작 확인 필요 |
+| Search JS responsibility split | 대기 | URL state / controls, browse data loading, preview controller 책임 분리. 기능 변경 없이 단계적 refactor 필요 |
+| Search CSS extraction / inline style reduction | 대기 | PR5 이후 `pages/search.html` 내부 style 및 inline style 단계적 정리 |
+
+---
+
+## PR #64 stale close 기록
+
+- PR #64 `docs(project): update backlog after PR63`는 docs-only 범위 자체는 안전했으나 PR #63 직후 기준으로 작성되어 현재 main / Issue #65와 불일치했습니다.
+- PR #69 / PR #70 이후 완료 상태를 반영하지 못하므로 stale 사유로 closed / unmerged 처리되었습니다.
+- PR #64 head branch는 삭제하지 않았습니다.
 
 ---
 
 ## 작업 이력 (Task History)
 
+- 2026-04-26: PR #70 `docs(runtime): clarify active and legacy runtime paths` merged / closed. Cloudflare Pages / Modal / Netlify active/legacy runtime truth 문서화 완료. Merge SHA `1833aaf2c779bd593bda2687d5ee0df0e4197bfd`
+- 2026-04-26: PR #69 `fix(search): harden YouTube thumbnail fallback` merged / closed. YouTube thumbnail fallback hardening 완료. Merge SHA `5f0708c82c6a909f11dbe4fc31776adfd0504778`
+- 2026-04-26: PR #68 `chore(ci): stabilize Playwright E2E dependency` 상당 변경 main 직접 squash 반영 후 PR closed / unmerged. Playwright dependency blocker 정리 완료
+- 2026-04-26: PR #67 `feat(search): sync browse controls with URL state` 상당 변경 main 직접 squash 반영 후 PR closed / unmerged. Search URL state 완료
+- 2026-04-26: PR #66 `ui(search): unify browse card and hub surfaces` merged / closed. Browse/Search surface tone 정리 완료
+- 2026-04-26: PR #64 `docs(project): update backlog after PR63` closed / unmerged. stale docs PR로 정리됨
+- 2026-04-26: PR #63 `ui(intro): balance hero visual whitespace` merged / closed. production verification PASS. Merge SHA `7e287bb6e77e91d9a1c33681e7308f2e54f7022d`
+- 2026-04-26: PR #62 `ui(style): align button badge chip tone` merged / closed. production verification PASS. Merge SHA `ae5ac03a2e9582c6c5cef6a965d6600ec6fa8e44`
+- 2026-04-26: PR #61 `docs(ops): add branch cleanup plan after PR58` merged / closed. Branch cleanup plan 문서화 완료. Merge SHA `7970f7c3997cc4d0f4585e8c1ae4b02895027d6f`
+- 2026-04-26: PR #60 `docs(design): add button badge chip baseline` merged / closed. Button / badge / chip baseline 문서화 완료
+- 2026-04-26: PR #59 `docs(project): update task status after PR58` merged / closed. TASK_STATUS 이전 최신화 완료
 - 2026-04-26: PR #58 `docs(project): add verification warning catalog` merged / closed. Verification warning catalog 문서화 완료. Merge SHA `7e221b8829500c26a7542481bea1585d916fb14a`
 - 2026-04-26: PR #57 `docs(project): add UI polish roadmap after PR51` merged / closed. UI polish roadmap after PR51 문서화 완료. Merge SHA `aaf31fe72298ddc510db29728ca8c35b2a808a5e`
 - 2026-04-26: PR #56 `docs(ops): document known CI and E2E blockers` merged / closed. Known CI/E2E blockers 문서화 완료. Merge SHA `c67956a23f61ea26dfb47e64813d340d960985ba`
@@ -82,11 +104,5 @@
 - 2026-04-26: PR #51 `ui(style): align typography accent hierarchy` merged / closed. typography / accent hierarchy 통일 완료. production verification PASS. Merge SHA `99af8a69fbe1cf61ac23017b938027164a213b3a`
 - 2026-04-26: PR #50 `docs(project): clarify UI verification environment rules` main 병합 완료. UI verification environment rules 문서화 완료
 - 2026-04-26: PR #49 `ui(layout): align landing browse rails` main 병합 및 production verification PASS. Merge SHA `dfb158a843932edeaaf7c859d0fa3e2d06c9be08`
-- 2026-04-26: PR3 button / badge / chip tone unification 준비 중. 예정 브랜치 `ui/button-badge-chip-tone-unification`. merge 전 test/preview 검증 필요
 - 2026-04-26: PR #7 `experiment: SVG tree prototype` open/draft 상태 보존. close 금지, branch 삭제 금지, navigation 연결 금지
-- 2026-04-25: production/test1/test2/test3 route matrix 기준 `/api/trees`, `/api/memories` active upstream이 Modal임을 확인. Netlify Functions는 legacy artifact로 정리 필요
-- 2026-04-25: PR #32 public-first + Plus private policy direction 문서 반영 완료
-- 2026-04-25: PR #33 Tree / Memory / Visibility / Delete QA Matrix 문서 반영 완료
-- 2026-04-24: PR #9 production 검증 완료 및 UI TF 종료
 - 2026-04-24: `feature/search-growing-trees-api` 운영 quick check 통과 및 기능 TF 종료
-- 2026-04-24: project 운영 및 검증 기준 문서 동기화


### PR DESCRIPTION
## Summary
- Update `docs/project/TASK_STATUS.md` to current main HEAD after PR #69 and PR #70.
- Update `docs/design/UI_POLISH_ROADMAP.md` so completed UI/Search/runtime work is no longer listed as pending.
- Record PR #64 as stale closed / unmerged.
- Align the remaining backlog with Issue #65: selected tree deep link, Search JS responsibility split, and Search CSS extraction / inline style reduction.

Refs #65

## Scope guard
- Docs-only changes.
- Changed only `docs/project/TASK_STATUS.md` and `docs/design/UI_POLISH_ROADMAP.md`.
- No code, runtime, API, UI implementation, package, lockfile, workflow, prototype/reference/demo, or PR #7 changes.

## Validation
- Changed files are limited to the two allowed docs files.
- Issue #65 remains open and its remaining backlog matches these docs.
- PR #7 remains open / draft / unmerged and untouched.
- Runtime truth wording follows the PR #70 Cloudflare Pages / Modal / Netlify clarification.