### PR TITLE
docs(project): align document indexes and runtime truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,9 @@ LoveBud / LoveTree는 다음과 같은 서비스가 아닙니다.
 - 따뜻한 디지털 스크랩북
 - 입덕의 첫 순간 우선
 - 감정이 이어진 경로
-- 비공개 우선, 공유는 그 다음
+- public-first visibility와 Plus private storage
+- public visibility와 Browse/Search eligibility 분리
+- Browse/Search 노출은 `publicMomentCount` 등 별도 소개 기준을 따름
 
 카피와 UI는 가능하면 아래 표현을 선호합니다.
 

--- a/docs/design/design_index.md
+++ b/docs/design/design_index.md
@@ -14,8 +14,9 @@
 
 ```
 design/
-├── prompts/   # 이미지 생성용 프롬프트 모음
-└── index.md   # 이 문서
+├── design_index.md   # 이 문서
+├── prompts/          # 이미지 생성용 프롬프트 모음
+└── stitch_image_to_website/  # Stitch/image-to-website reference design notes
 ```
 
 ## 파일 목록
@@ -23,8 +24,8 @@ design/
 | 파일명 | 설명 |
 |--------|------|
 | [UI_DESIGN_SYSTEM.md](UI_DESIGN_SYSTEM.md) | LoveBud UI/UX 디자인 시스템과 화면 기준 |
-| [UI_POLISH_ROADMAP.md](UI_POLISH_ROADMAP.md) | PR #49, PR #51 이후 public UI polish 후속 PR3/PR4/PR5 범위 분리 기준 |
-| [BUTTON_BADGE_CHIP_BASELINE.md](BUTTON_BADGE_CHIP_BASELINE.md) | PR3 button / badge / chip tone 통일 기준 |
+| [UI_POLISH_ROADMAP.md](UI_POLISH_ROADMAP.md) | PR #49, #51, #62, #63, #66, #67, #69, #70 이후 public UI polish와 Search 후속 작업 범위 분리 기준 |
+| [BUTTON_BADGE_CHIP_BASELINE.md](BUTTON_BADGE_CHIP_BASELINE.md) | button / badge / chip tone 통일 기준 |
 | [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md) | pages/assets 하위 prototype/reference 폴더 보존 정책 |
 
 ### 프롬프트 (Prompts)
@@ -33,6 +34,12 @@ design/
 |--------|------|
 | [prompts/image-generation-prompts.md](prompts/image-generation-prompts.md) | Lovetree 이미지 생성 프롬프트 모음 (12개 화면) |
 | [prompts/home-hero-slide-prompts.txt](prompts/home-hero-slide-prompts.txt) | 홈 히어로 슬라이드 이미지 생성 프롬프트 (5장) |
+
+### Reference / candidate design notes
+
+| 파일명 | 설명 |
+|--------|------|
+| [stitch_image_to_website/DESIGN.md](stitch_image_to_website/DESIGN.md) | Stitch image-to-website 관련 reference design note. 현재 active UI polish source of truth는 아니며, 필요 시 reference/archive 후보로 별도 판단합니다. |
 
 ## Prototype / reference 보존 원칙
 

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -90,11 +90,12 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 
 - **index**: [design_index.md](./design/design_index.md)
 - [UI_DESIGN_SYSTEM.md](./design/UI_DESIGN_SYSTEM.md) - UI 구조 / 감정 위계 / 컴포넌트 규칙 source of truth
-- [UI_POLISH_ROADMAP.md](./design/UI_POLISH_ROADMAP.md) - PR #49, PR #51 이후 public UI polish 후속 PR3/PR4/PR5 범위 분리 기준
-- [BUTTON_BADGE_CHIP_BASELINE.md](./design/BUTTON_BADGE_CHIP_BASELINE.md) - PR3 button / badge / chip tone 통일 기준
+- [UI_POLISH_ROADMAP.md](./design/UI_POLISH_ROADMAP.md) - PR #49, #51, #62, #63, #66, #67, #69, #70 이후 public UI polish와 Search 후속 작업 범위 분리 기준
+- [BUTTON_BADGE_CHIP_BASELINE.md](./design/BUTTON_BADGE_CHIP_BASELINE.md) - button / badge / chip tone 통일 기준
 - [PROTOTYPE_REFERENCE_POLICY.md](./design/PROTOTYPE_REFERENCE_POLICY.md) - prototype/reference 폴더 보존 정책
 - [prompts/image-generation-prompts.md](./design/prompts/image-generation-prompts.md) - 이미지 생성 프롬프트 모음
 - [prompts/home-hero-slide-prompts.txt](./design/prompts/home-hero-slide-prompts.txt) - 홈 히어로 슬라이드 프롬프트
+- [stitch_image_to_website/DESIGN.md](./design/stitch_image_to_website/DESIGN.md) - Stitch image-to-website reference design note. 현재 active UI polish source of truth는 아님
 
 ## engineering 문서군
 
@@ -128,6 +129,12 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 프로젝트 운영 문서는 `docs/project/` 아래에 정리됩니다.
 
 - **index**: [project_index.md](./project/project_index.md)
+- [REPORTING_CHAIN.md](./project/REPORTING_CHAIN.md) - 3TF 구조, TF별 Lead, 실행 모델, 보고선
+- [PROJECT_OPERATING_MODEL.md](./project/PROJECT_OPERATING_MODEL.md) - 역할, 책임, 승인권, 세션 시작 프로토콜
+- [BRANCHING_AND_REVIEW.md](./project/BRANCHING_AND_REVIEW.md) - main 우선 확인, 브랜치 작업, 리뷰/검증/완료 보고 원칙
+- [LOCAL_MODEL_WORKFLOW.md](./project/LOCAL_MODEL_WORKFLOW.md) - 로컬 실행 모델 작업 기준
+- [TASK_STATUS.md](./project/TASK_STATUS.md) - 작업 상태 추적 문서
+- [VERIFICATION_AND_EVIDENCE.md](./project/VERIFICATION_AND_EVIDENCE.md) - 검증 및 증빙 기준
 - [VERIFICATION_WARNING_CATALOG.md](./project/VERIFICATION_WARNING_CATALOG.md) - UI/production/test preview 검증 warning과 blocker 분류 기준
 
 ## migration 문서군

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -4,10 +4,14 @@
 
 현재 운영 전제는 아래와 같습니다.
 
-- 실서비스 프론트: `https://lovebud.vercel.app/`
-- 인프라 우선순위: **Modal > Vercel > Netlify**
-- 브라우저는 가능하면 **same-origin `/api`** 만 사용
-- browse display filter 와 publication guard 는 다른 문제로 다룸
+- 실서비스 프론트: `https://lovebud.pages.dev/`
+- 인프라 우선순위: **Modal > Cloudflare Pages > Vercel > Netlify**
+- Cloudflare Pages는 공식 user-facing entry이자 same-origin `/api` router입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- Vercel은 upstream / secondary / transitional fallback 계층입니다.
+- Netlify는 legacy / fallback / artifact 계층입니다.
+- 브라우저는 가능하면 **same-origin `/api`** 만 사용합니다.
+- browse display filter 와 publication guard 는 다른 문제로 다룹니다.
 
 ---
 
@@ -43,6 +47,7 @@
   - `../product/BRAND_EXPERIENCE.md`
   - `../design/UI_DESIGN_SYSTEM.md`
 - 엔지니어링 문서는 현재 계약, 구조, 분리 기준, 전환 원칙을 설명하는 용도로 사용합니다.
+- 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
 
 ---

--- a/docs/ops/LOCAL_SECRETS.md
+++ b/docs/ops/LOCAL_SECRETS.md
@@ -25,11 +25,11 @@
 ## 주요 비밀값 출처 (2026-04-16 기준)
 
 ### DB 연결
-- **DB URL source**: `G:\다른 컴퓨터\내 컴퓨터\133-relovetree\.env`
+- **DB URL source**: `<LOCAL_LEGACY_REPO>/.env`
 - `.env`에서 확인: `NETLIFY_DATABASE_URL` 또는 `DATABASE_URL`
 
 ### 테스트 계정
-- **테스트 계정 source**: `G:\다른 컴퓨터\내 컴퓨터\133-relovetree\scripts\create-test-accounts.js`
+- **테스트 계정 source**: `<LOCAL_LEGACY_REPO>/scripts/create-test-accounts.js`
 - 테스트 계정 기본값은 보통 `.local/test-accounts.json`에서 확인합니다.
 
 ---

--- a/docs/ops/RUNTIME_ROUTING_TRUTH_DRAFT_20260425.md
+++ b/docs/ops/RUNTIME_ROUTING_TRUTH_DRAFT_20260425.md
@@ -1,5 +1,14 @@
 # LoveBud Runtime Routing Truth Draft - 2026-04-25
 
+> **SUPERSEDED**
+>
+> This draft is preserved as investigation history only. Current runtime truth is documented in:
+>
+> - `docs/ops/OPERATIONS.md`
+> - `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
+>
+> Do not use this draft as the current production source of truth without checking those documents first.
+
 This draft records the confirmed route precedence for the production `/api/trees`
 path before updating the canonical deployed-entry documentation.
 

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,7 +23,7 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `c8b96c126d5552aa03fc782abcf4e173420ecc8d`
+- 기준 main 커밋: `90933a4961b240df2caa7f04b737322b22200f26`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
@@ -40,7 +40,7 @@
 | UI verification rules | 완료 | PR #50 `docs(project): clarify UI verification environment rules` | UI verification environment rules 문서화 완료 |
 | Test preview slot rules | 완료 | PR #52 `docs(ops): test preview slot branch rules` | test preview slot branch rules 문서화 완료. Merge SHA: `bbc988041e248d171a8560419dc739394ba4e23f` |
 | Local generated artifact ignore | 완료 | PR #53 `chore: ignore local generated artifacts` | local generated artifacts `.gitignore` 정리 완료. Merge SHA: `5f8d185cde4b1d46df75a8c4382fd71a4a671ca8`. prototype/reference 보존 대상 침범 없음 |
-| Task status tracking | 진행 중 | current docs cleanup branch | PR #64는 stale close됨. 현재 문서는 PR #69 / #70 이후 main 기준과 open PR 현황을 맞추는 중 |
+| Task status tracking | 진행 중 | PR #76 `docs(project): align document indexes and runtime truth` | docs-only 정합성 cleanup 진행 중. 현재 PR은 merge 전 검토 대상이며 완료로 기록하지 않음 |
 | Prototype reference preservation | 완료 | PR #55 `docs(design): preserve prototype reference folders` | prototype/reference preservation policy 문서화 완료. PR #7 보존 정책 문서화 완료. Merge SHA: `1f1c0758d9307e8e090386d21b21a265e5fe257b` |
 | Known CI/E2E blockers | 완료 | PR #56 `docs(ops): document known CI and E2E blockers` | known CI/E2E blockers 문서화 완료. Merge SHA: `c67956a23f61ea26dfb47e64813d340d960985ba` |
 | UI polish roadmap | 완료 | `docs/design/UI_POLISH_ROADMAP.md` | PR #69 / PR #70 이후 남은 Issue #65 backlog 3개와 Search 후속 범위 분리 완료 |
@@ -48,7 +48,7 @@
 | 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. SVG tree prototype. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
 | JS architecture cleanup | 보류 | Issue #72 / PR #73 | Issue #72는 open이며 current status는 paused. PR #73은 closed / unmerged. file-move refactor는 clean worktree와 단일 executor 조건 충족 전 재개 금지 |
-| Editor UI polish | 진행 중 | PR #74 `ui(editor): polish editor surface and empty states` | open / non-draft. `css/editor.css` + `js/i18n/i18n-editor.js` 변경. Cloudflare Preview 배포는 성공했으나 Preview verification pending 및 `git diff --check` trailing whitespace warning 확인 필요. 완료로 기록하지 않음 |
+| Editor UI polish | 완료 | PR #74 `ui(editor): polish editor surface and empty states` | merged / closed. Editor surface polish와 i18n key 보강 main 반영 완료. Merge SHA: `90933a4961b240df2caa7f04b737322b22200f26` |
 
 ---
 
@@ -87,7 +87,8 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 
 ## 작업 이력 (Task History)
 
-- 2026-04-26: PR #74 `ui(editor): polish editor surface and empty states` opened. Editor UI polish 진행 중. 완료 아님. Preview verification pending
+- 2026-04-26: PR #76 `docs(project): align document indexes and runtime truth` opened. docs-only cleanup 진행 중. 완료 아님
+- 2026-04-26: PR #74 `ui(editor): polish editor surface and empty states` merged / closed. Editor surface polish main 반영 완료. Merge SHA `90933a4961b240df2caa7f04b737322b22200f26`
 - 2026-04-26: Issue #72 `JS Architecture Cleanup Tracker` updated. JS architecture cleanup paused. PR #73 closed / unmerged
 - 2026-04-26: PR #70 `docs(runtime): clarify active and legacy runtime paths` merged / closed. Cloudflare Pages / Modal / Netlify active/legacy runtime truth 문서화 완료. Merge SHA `1833aaf2c779bd593bda2687d5ee0df0e4197bfd`
 - 2026-04-26: PR #69 `fix(search): harden YouTube thumbnail fallback` merged / closed. YouTube thumbnail fallback hardening 완료. Merge SHA `5f0708c82c6a909f11dbe4fc31776adfd0504778`

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,7 +23,7 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `1833aaf2c779bd593bda2687d5ee0df0e4197bfd`
+- 기준 main 커밋: `c8b96c126d5552aa03fc782abcf4e173420ecc8d`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
@@ -40,13 +40,15 @@
 | UI verification rules | 완료 | PR #50 `docs(project): clarify UI verification environment rules` | UI verification environment rules 문서화 완료 |
 | Test preview slot rules | 완료 | PR #52 `docs(ops): test preview slot branch rules` | test preview slot branch rules 문서화 완료. Merge SHA: `bbc988041e248d171a8560419dc739394ba4e23f` |
 | Local generated artifact ignore | 완료 | PR #53 `chore: ignore local generated artifacts` | local generated artifacts `.gitignore` 정리 완료. Merge SHA: `5f8d185cde4b1d46df75a8c4382fd71a4a671ca8`. prototype/reference 보존 대상 침범 없음 |
-| Task status tracking | 진행 중 | PR #64 closed / this update | PR #64는 PR #63 직후 기준이라 stale close됨. 현재 문서는 PR #69 / #70 이후 상태 기준으로 최신화 중 |
+| Task status tracking | 진행 중 | current docs cleanup branch | PR #64는 stale close됨. 현재 문서는 PR #69 / #70 이후 main 기준과 open PR 현황을 맞추는 중 |
 | Prototype reference preservation | 완료 | PR #55 `docs(design): preserve prototype reference folders` | prototype/reference preservation policy 문서화 완료. PR #7 보존 정책 문서화 완료. Merge SHA: `1f1c0758d9307e8e090386d21b21a265e5fe257b` |
 | Known CI/E2E blockers | 완료 | PR #56 `docs(ops): document known CI and E2E blockers` | known CI/E2E blockers 문서화 완료. Merge SHA: `c67956a23f61ea26dfb47e64813d340d960985ba` |
-| UI polish roadmap | 진행 중 | `docs/design/UI_POLISH_ROADMAP.md` | PR #69 / PR #70 이후 남은 Issue #65 backlog 3개와 맞추는 최신화 진행 중 |
+| UI polish roadmap | 완료 | `docs/design/UI_POLISH_ROADMAP.md` | PR #69 / PR #70 이후 남은 Issue #65 backlog 3개와 Search 후속 범위 분리 완료 |
 | Verification warning catalog | 완료 | PR #58 `docs(project): add verification warning catalog` | verification warning catalog 문서화 완료. Merge SHA: `7e221b8829500c26a7542481bea1585d916fb14a` |
 | 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. SVG tree prototype. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
+| JS architecture cleanup | 보류 | Issue #72 / PR #73 | Issue #72는 open이며 current status는 paused. PR #73은 closed / unmerged. file-move refactor는 clean worktree와 단일 executor 조건 충족 전 재개 금지 |
+| Editor UI polish | 진행 중 | PR #74 `ui(editor): polish editor surface and empty states` | open / non-draft. `css/editor.css` + `js/i18n/i18n-editor.js` 변경. Cloudflare Preview 배포는 성공했으나 Preview verification pending 및 `git diff --check` trailing whitespace warning 확인 필요. 완료로 기록하지 않음 |
 
 ---
 
@@ -68,21 +70,25 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 | 작업 | 상태 | 메모 |
 |------|------|------|
 | Selected tree deep link | 대기 | `?tree=<treeId>` 직접 진입 시 공개 tree preview 선택. desktop / mobile preview 동작 확인 필요 |
-| Search JS responsibility split | 대기 | URL state / controls, browse data loading, preview controller 책임 분리. 기능 변경 없이 단계적 refactor 필요 |
-| Search CSS extraction / inline style reduction | 대기 | PR5 이후 `pages/search.html` 내부 style 및 inline style 단계적 정리 |
+| Search JS responsibility split | 보류 | JS architecture cleanup paused 상태. Search file-move 재개 전 clean worktree / 단일 executor / Preview 검증 조건 필요 |
+| Search CSS extraction / inline style reduction | 대기 | PR5 이후 `pages/search.html` 내부 style 및 inline style 단계적 정리. Search JS refactor와 혼합 금지 |
 
 ---
 
-## PR #64 stale close 기록
+## PR #64 / PR #73 정리 기록
 
 - PR #64 `docs(project): update backlog after PR63`는 docs-only 범위 자체는 안전했으나 PR #63 직후 기준으로 작성되어 현재 main / Issue #65와 불일치했습니다.
 - PR #69 / PR #70 이후 완료 상태를 반영하지 못하므로 stale 사유로 closed / unmerged 처리되었습니다.
 - PR #64 head branch는 삭제하지 않았습니다.
+- PR #73 `refactor(search): group search page scripts`는 closed / unmerged 처리되었습니다.
+- PR #73은 preview behavior 검증은 있었으나 branch pollution / merge conflict / operational risk 때문에 병합하지 않았고, JS architecture cleanup은 Issue #72 기준 paused 상태입니다.
 
 ---
 
 ## 작업 이력 (Task History)
 
+- 2026-04-26: PR #74 `ui(editor): polish editor surface and empty states` opened. Editor UI polish 진행 중. 완료 아님. Preview verification pending
+- 2026-04-26: Issue #72 `JS Architecture Cleanup Tracker` updated. JS architecture cleanup paused. PR #73 closed / unmerged
 - 2026-04-26: PR #70 `docs(runtime): clarify active and legacy runtime paths` merged / closed. Cloudflare Pages / Modal / Netlify active/legacy runtime truth 문서화 완료. Merge SHA `1833aaf2c779bd593bda2687d5ee0df0e4197bfd`
 - 2026-04-26: PR #69 `fix(search): harden YouTube thumbnail fallback` merged / closed. YouTube thumbnail fallback hardening 완료. Merge SHA `5f0708c82c6a909f11dbe4fc31776adfd0504778`
 - 2026-04-26: PR #68 `chore(ci): stabilize Playwright E2E dependency` 상당 변경 main 직접 squash 반영 후 PR closed / unmerged. Playwright dependency blocker 정리 완료


### PR DESCRIPTION
## Summary
- Align engineering docs with the current Cloudflare Pages + Modal runtime truth.
- Update AGENTS product policy wording to avoid conflict with public-first visibility and Plus private storage.
- Refresh task status with PR #74 merged, PR #73 closed/unmerged, PR #7 draft preservation, and Issue #72 paused state.
- Expand document indexes for project docs and design reference notes.
- Mark the 2026-04-25 runtime routing draft as superseded by current operations/migration docs.
- Replace local absolute secret source paths with placeholders.

Refs #72

## Scope guard
- Docs-only cleanup.
- No code changes.
- No CSS/JS/HTML runtime changes.
- No package/lockfile/workflow changes.
- PR #74 runtime files not modified by this PR.
- PR #7 and prototype/reference/demo folders untouched.
- Issue #65 and Issue #72 remain open.

## Validation
- Changed files are limited to the approved docs list:
  - `AGENTS.md`
  - `docs/doc_index.md`
  - `docs/engineering/engineering_index.md`
  - `docs/design/design_index.md`
  - `docs/project/TASK_STATUS.md`
  - `docs/ops/RUNTIME_ROUTING_TRUTH_DRAFT_20260425.md`
  - `docs/ops/LOCAL_SECRETS.md`
- Confirmed no changes to `css/editor.css`, `js/i18n/i18n-editor.js`, or `pages/editor.html` in this PR.
- Confirmed no runtime/API/backend/workflow/package changes.
- Confirmed PR #74 is recorded as merged / closed, not pending.
- Confirmed PR #7 remains untouched and preserved.