### PR TITLE
docs(ops): clarify preview slot verification rules

### DIFF
--- a/docs/ops/DEPLOY_CHECKLIST.md
+++ b/docs/ops/DEPLOY_CHECKLIST.md
@@ -85,12 +85,19 @@ Firebase Console > Authentication > Settings > Authorized Domains
 - UI/layout PR은 Cloudflare PR Preview 또는 지정 test slot URL에서 확인합니다.
 - post-merge 확인은 Cloudflare Pages production URL에서 진행합니다.
 
-### Test slot verification note
+### Test slot verification pointer
 
+세부 판정 기준은 [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)를 따릅니다.
+
+요약:
+- public 화면은 Cloudflare PR Preview를 우선 사용합니다.
 - 로그인 필요 화면(`editor`, `my-trees`, `settings`)은 PR Preview에서 auth/domain 문제가 있으면 fixed test slot을 사용합니다.
 - test1은 기본적으로 UI PR 검증용이며 `origin/test1` 기준으로 운영합니다.
-- test slot URL 접근 불가 또는 DNS 실패는 code failure로 단정하지 말고 slot infra blocker로 분리합니다.
-- Browser / Web / Local 역할 구분, PARTIAL/BLOCKED 판정, release/restore 절차는 [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)를 따릅니다.
+- Browser verifier는 실제 화면/console/network를 확인합니다.
+- Web verifier는 GitHub metadata를 확인하며, browser-only 검증을 수행한 것처럼 보고하지 않습니다.
+- Local/Ops slot executor만 slot branch reset/push를 수행합니다.
+- test slot URL 접근 불가, DNS 실패, target SHA 불명확, login gate까지만 확인된 경우는 PASS가 아니라 BLOCKED 또는 PARTIAL로 분리합니다.
+- screenshot, console, network evidence에는 token/password/cookie/private content 원문을 남기지 않습니다.
 
 ## 5. fallback / legacy 점검
 
@@ -130,6 +137,7 @@ Firebase Console > Authentication > Settings > Authorized Domains
 
 6. **Auth Domain Error**
    - Firebase Console 승인 도메인 확인
+   - PR Preview에서만 재현되면 fixed test slot으로 전환하고 `PARTIAL` 또는 `BLOCKED`로 분리 보고
 
 ## 7. 오래된 설명 제거 기준
 

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -42,6 +42,7 @@
   - `https://lovebud.pages.dev/`
   - Cloudflare PR Preview URL
   - Cloudflare branch preview URL
+  - fixed test slot URL when auth/runtime verification requires stable domain
 
 ### Modal
 - 코드 위치: `modal_compute/app.py`
@@ -108,7 +109,9 @@
 2. slot URL 접근 실패, Cloudflare deploy failure, Firebase/Auth/domain failure, actual page runtime failure를 분리해 보고합니다.
 3. fixed slot이 열리지만 target SHA 반영이 불명확하면 PARTIAL로 보고합니다.
 4. Browser verifier가 실제 화면에 접근하지 못한 경우 Web/GitHub metadata 확인만으로 UI PASS를 선언하지 않습니다.
-5. 세부 역할, 판정, release/restore 기준은 [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)를 따릅니다.
+5. slot branch update/push는 Local/Ops executor만 수행합니다.
+6. evidence에는 screenshot, console, network log의 token/password/cookie/private content 원문을 남기지 않습니다.
+7. 세부 역할, PR Preview vs fixed slot decision rules, PARTIAL/BLOCKED 판정, evidence hygiene, release/restore 기준은 [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)를 따릅니다.
 
 ## 5. 운영 환경 변수 체크리스트
 
@@ -150,3 +153,4 @@
 - Cloudflare Pages가 same-origin `/api/*` entry
 - Vercel은 deprecated transitional fallback / upstream under audit
 - Netlify는 legacy / fallback / artifact이며 `netlify/functions/*`는 현재 active production backend가 아님
+- fixed test slot 검증의 역할/판정/evidence 기준은 `docs/ops/TEST_PREVIEW_SLOTS.md`가 canonical입니다

--- a/docs/ops/TEST_PREVIEW_SLOTS.md
+++ b/docs/ops/TEST_PREVIEW_SLOTS.md
@@ -3,19 +3,21 @@
 **Status:** Active  
 **Owner:** CTO / Ops Lead  
 **Last Updated:** 2026-04-26  
-**Branch:** docs/test-preview-slot-branch-rules
+**Branch:** docs/preview-slot-verification-rules
 
 ---
 
-## 1. 목적
+## 1. Purpose
 
-PR별 Cloudflare Preview URL은 Firebase Auth domain, login redirect, runtime/API 검증 과정에서 반복적인 제한이 발생할 수 있습니다. Fixed Test Preview Slots는 검증이 필요한 브랜치에 대해 고정된 도메인을 미리 할당하여, 아래 검증을 안정적으로 수행하기 위한 운영 체계입니다.
+Fixed Test Preview Slots provide stable Cloudflare Pages domains for verification when a PR Preview is insufficient. They are used to separate product/code failures from preview infrastructure, Firebase Auth domain, login redirect, or test data availability issues.
 
-- 로그인이 필요한 화면 검증: `editor/`, `my-trees/`, `settings/` 등 인증이 필요한 페이지
-- API/backend/runtime 경로 확인: `/api/*`, `/runtime/*` 경로의 smoke test
-- DB read 검증: 데이터 조회 동작 검증
-- UI production-like preview: 실제 프로덕션과 유사한 환경에서의 UI/UX 검증
-- PR별 Preview URL 대체: Auth/domain 문제로 PR Preview가 정상 동작하지 않을 때의 대체 검증 수단
+Use this document as the source of truth for:
+
+- Browser / Web / Local role boundaries
+- PR Preview vs fixed slot decision rules
+- slot access failure and partial verification reporting
+- evidence hygiene for screenshots, console logs, and network logs
+- slot release / restore procedure
 
 ---
 
@@ -23,67 +25,161 @@ PR별 Cloudflare Preview URL은 Firebase Auth domain, login redirect, runtime/AP
 
 | Slot | Domain | Default use |
 |------|--------|-------------|
-| test1 | https://test1.lovebud.pages.dev | UI PR 검증 |
-| test2 | https://test2.lovebud.pages.dev | runtime/backend route 검증 |
-| test3 | https://test3.lovebud.pages.dev | policy/visibility 검증 |
-| test4 | https://test4.lovebud.pages.dev | QA CRUD disposable data 검증 |
-| test5 | https://test5.lovebud.pages.dev | 예비/대체 슬롯 |
-| test6 | https://test6.lovebud.pages.dev | 임시/예외 검증 슬롯 |
+| test1 | https://test1.lovebud.pages.dev | UI PR verification |
+| test2 | https://test2.lovebud.pages.dev | runtime/backend route verification |
+| test3 | https://test3.lovebud.pages.dev | policy/visibility verification |
+| test4 | https://test4.lovebud.pages.dev | QA CRUD disposable data verification |
+| test5 | https://test5.lovebud.pages.dev | spare / fallback slot |
+| test6 | https://test6.lovebud.pages.dev | temporary / exceptional verification slot |
 
-각 slot domain은 Cloudflare Pages에 연결된 고정 도메인입니다. 실제 배정은 CTO 또는 담당 Lead가 작업 지시에 명시합니다.
+Each slot domain is a fixed Cloudflare Pages domain. Actual assignment must be stated by the CTO or responsible Lead.
 
 ---
 
-## 3. test1 branch source of truth
+## 3. Branch source of truth
 
-### 3.1 test1 기본 운영 branch
+### 3.1 test1 default branch
 
-`https://test1.lovebud.pages.dev`는 기본적으로 GitHub remote branch `origin/test1`을 기준으로 운영합니다.
-
-PR preview/test 검증에서 test1 slot을 갱신해야 할 때의 기본 업데이트 대상은 아래입니다.
+`https://test1.lovebud.pages.dev` is operated from the GitHub remote branch below unless CTO explicitly says otherwise.
 
 ```text
 origin/test1
 ```
 
-### 3.2 `origin/slot/test1` 사용 금지 원칙
+### 3.2 `origin/slot/test1` is not the default
 
-`origin/slot/test1`은 혼선을 줄이기 위해 기본 업데이트 대상이 아닙니다.
+`origin/slot/test1` is not the default update target. Do not update it unless CTO explicitly names it.
 
-특별한 CTO 지시 없이 아래 branch를 갱신하지 않습니다.
+### 3.3 Required identifiers
 
-```text
-origin/slot/test1
-```
+Every fixed slot verification report must record:
 
-PR 검증 보고서나 실행 지시에서 `test1`이 언급되면, 별도 지시가 없는 한 `origin/test1`을 의미합니다.
+- PR number or task name
+- PR head branch
+- PR head SHA
+- target slot
+- slot branch before update
+- slot branch after update
+- Cloudflare deploy status
+- URL actually verified
 
-### 3.3 혼선 방지 규칙
-
-- `test1.lovebud.pages.dev` 검증 지시에는 반드시 대상 branch를 적습니다.
-- 기본값은 `origin/test1`입니다.
-- `origin/slot/test1`을 사용해야 하는 예외 상황은 CTO가 명시해야 합니다.
-- PR #49 검증 때 발생한 `origin/test1` / `origin/slot/test1` 혼용을 반복하지 않습니다.
+Do not infer the target SHA from a local branch name.
 
 ---
 
-## 4. PR preview/test slot 검증 절차
+## 4. Role split: Browser / Web / Local
 
-test1 slot을 PR branch 검증에 사용할 때는 아래 순서를 따릅니다.
+### 4.1 Browser verifier
 
-1. PR 번호와 PR head branch를 확인합니다.
-2. PR head SHA를 확인하고 보고에 기록합니다.
-3. `origin/test1`을 PR head SHA로 업데이트합니다.
-4. Cloudflare Pages deploy 완료를 기다립니다.
-5. `https://test1.lovebud.pages.dev`에서 deploy token/source 또는 화면 반영을 확인합니다.
-6. 필요한 viewport를 확인합니다. 기본 UI 검증은 1440px / 1024px / 375px을 우선합니다.
-7. Network/Console을 확인합니다.
-8. 검증 결과와 미검증 항목을 분리해 보고합니다.
-9. production 검증이 필요한 경우, PR이 `main`에 merge되고 production deploy가 끝난 뒤 별도로 수행합니다.
+The Browser verifier uses a real browser, DevTools, MCP, Playwright, or equivalent browser automation to observe the rendered product.
 
-### 4.1 권장 실행 흐름
+Allowed:
 
-아래 흐름은 Local Slot Ops 또는 지정된 실행자가 수행합니다.
+- open PR Preview, branch preview, fixed slot, or production URL
+- verify login gate and actual page access
+- check 1440 / 1024 / 375 viewports unless the task narrows scope
+- inspect console and network
+- capture screenshots or short observation notes
+- classify horizontal overflow, runtime warnings, and blockers
+
+Forbidden:
+
+- code edits
+- PR merge / close / branch deletion
+- Issue updates
+- branch reset / push / force push
+- production data mutation
+- memory/tree create, edit, delete, title change, or visibility change unless explicitly approved
+- recording raw token, password, cookie, Authorization header, Firebase credential, or private content
+
+### 4.2 Web verifier / GitHub executor
+
+The Web verifier checks GitHub metadata and repository state. If no real browser verification is performed, the report must say so.
+
+Allowed:
+
+- PR state, draft status, head SHA, changed files, mergeability checks
+- PR body issue hygiene checks
+- Issue open/closed checks
+- docs-only scope checks
+- Cloudflare bot comment / preview URL existence checks
+
+Forbidden:
+
+- claiming UI PASS from GitHub metadata alone
+- modifying code/docs/issues/PRs without explicit instruction
+- branch reset / force push
+- treating PR Preview URL existence as rendered-page verification
+
+### 4.3 Local / Ops slot executor
+
+The Local/Ops executor updates slot branches from a clean clone or clean worktree.
+
+Allowed:
+
+- `git fetch origin`
+- verify `origin/main`, PR head SHA, and current slot branch SHA
+- update the approved slot branch to the approved target SHA
+- use `git push --force-with-lease origin <slot-branch>`
+- check Cloudflare deploy status
+
+Forbidden:
+
+- modifying PR head branch
+- direct push or force push to `main`
+- using plain `--force`
+- guessing target SHA
+- resetting a slot to another PR or to `main` without approval
+- sharing a contaminated local worktree across unrelated implementation tasks
+
+---
+
+## 5. PR Preview vs fixed slot decision rules
+
+### 5.1 Use PR Preview first when all are true
+
+- The page is public or does not require Firebase login.
+- The change is mostly static UI/docs and does not require an account-specific state.
+- Cloudflare PR Preview URL is created for the target head SHA.
+- Browser verifier can reach the actual page and inspect console/network.
+
+Examples:
+
+- public landing page UI
+- public Browse page visual-only change
+- docs-only preview check, if a rendered page is not required
+
+### 5.2 Use fixed slot when any are true
+
+- The screen requires login: `editor`, `my-trees`, `settings`, or account-bound flows.
+- Firebase Authorized Domain, OAuth redirect, popup, or redirect-loop risk is expected.
+- PR Preview opens but cannot reach the actual authenticated page.
+- API/runtime route verification needs a stable domain.
+- CTO explicitly assigns `test1` through `test6`.
+
+### 5.3 Decision matrix
+
+| Work type | Preferred target | Notes |
+|-----------|------------------|-------|
+| Public static UI | PR Preview | fixed slot optional if preview is unavailable |
+| Browse/Search with API/data load | PR Preview or assigned slot | local static server alone is not PASS |
+| Login-required UI | fixed slot | PR Preview may be metadata-only if auth domain blocks access |
+| Runtime/API route smoke | fixed slot or production-equivalent preview | record endpoint, status, and response class |
+| Production regression after merge | production URL | only after merge + deploy complete |
+| Docs-only | GitHub metadata may be enough | rendered site verification not required unless docs are served |
+
+### 5.4 Fallback rules
+
+- If PR Preview fails due to auth/domain issues, switch to fixed slot.
+- If fixed slot also fails, classify the failure instead of blaming code by default.
+- If PR Preview and fixed slot disagree, report both URL, target SHA, deploy status, and observed behavior.
+- If target SHA reflection is unclear, mark PARTIAL.
+
+---
+
+## 6. Slot update procedure
+
+The default flow is Local/Ops only.
 
 ```bash
 git fetch origin
@@ -91,436 +187,186 @@ git rev-parse origin/main
 git rev-parse origin/<pr-head-branch>
 git rev-parse origin/test1
 
-# CTO가 승인한 PR head SHA로 test1을 맞춘다.
 git checkout test1
-git reset --hard <pr-head-sha>
+git reset --hard <approved-pr-head-sha>
 git push --force-with-lease origin test1
 ```
 
-`<pr-head-sha>`는 반드시 PR metadata에서 확인한 값이어야 합니다. 추정하거나 로컬 branch 이름만 믿지 않습니다.
+Rules:
+
+- `<approved-pr-head-sha>` must come from PR metadata or CTO instruction.
+- Use the assigned slot branch only.
+- Use `--force-with-lease`, never plain `--force`.
+- Do not modify the PR branch.
+- Do not modify `main`.
 
 ---
 
-## Role split: Browser / Web / Local
+## 7. Slot access failure and partial verification
 
-Fixed slot 검증은 역할별 권한과 금지선을 분리합니다.
+Verification judgments must separate what was observed from what was not observed.
 
-### Browser verifier
+| Situation | Judgment | Required report |
+|-----------|----------|-----------------|
+| Slot URL cannot be reached or DNS fails | BLOCKED | classify as slot infra/DNS blocker, not product code failure |
+| Cloudflare deploy failed | BLOCKED | deploy id/status/log link if available |
+| URL opens but target SHA is unclear | PARTIAL | URL, observed asset/source/network evidence, unknown SHA state |
+| Login gate reached but actual page not verified | PARTIAL | auth gate confirmed; page interior not verified |
+| Actual page opens but no valid test data is available | PARTIAL | no mutation; identify missing test data |
+| Browser verified viewport + console + network | PASS candidate | still separate warnings from blockers |
+| New console exception or API 5xx tied to PR change | BLOCKED or revision needed | include endpoint/status/viewport/screenshot reference |
 
-Browser verifier는 실제 브라우저, DevTools, MCP, Playwright 등으로 화면과 런타임 상태를 확인합니다.
+Terminology:
 
-허용 범위:
-- slot URL 접근 확인
-- login gate / actual page 내부 접근 여부 확인
-- viewport 확인: 기본 1440px / 1024px / 375px
-- console / network 확인
-- screenshot 또는 짧은 관찰 로그 작성
-- UI 상태, horizontal overflow, runtime warning/blocker 분류
+- `PASS`: required observations completed, no blocking regression found.
+- `PARTIAL`: some required observations completed, but one or more material checks were not possible.
+- `BLOCKED`: verification could not proceed because of infra/auth/deploy/data access or a blocking runtime failure.
+- `FAIL`: observed product behavior does not meet the expected result.
 
-금지 범위:
-- 코드 수정 금지
-- PR 수정 / merge / close 금지
-- Issue 수정 금지
-- branch update / reset / push 금지
-- 운영 데이터 create / edit / delete 금지
-- memory 생성/수정/삭제 금지
-- tree title / visibility 변경 금지
-- token/password/cookie 원문 기록 금지
-
-### Web verifier / GitHub executor
-
-Web verifier는 GitHub PR, Issue, docs metadata를 확인합니다. 브라우저 실측을 수행하지 않는 경우 그 한계를 보고에 명시합니다.
-
-허용 범위:
-- PR 상태, draft 여부, head SHA, changed files 확인
-- PR body의 issue hygiene 확인
-- Issue open/closed 상태 확인
-- docs-only 또는 scope guard 검증
-- Cloudflare/Preview URL 존재 여부 확인
-
-금지 범위:
-- 별도 지시 없는 코드/문서 수정 금지
-- 별도 지시 없는 PR close / merge 금지
-- 별도 지시 없는 Issue update 금지
-- branch reset / force push 금지
-- browser-only 검증을 수행한 것처럼 보고 금지
-
-### Local / Ops slot executor
-
-Local/Ops는 clean clone 또는 clean worktree에서 slot branch를 target SHA로 맞춥니다.
-
-허용 범위:
-- `origin/test1` 현재 SHA 확인
-- PR head SHA 확인
-- CTO가 지정한 target SHA로 `origin/test1` 업데이트
-- `git push --force-with-lease origin test1` 사용
-- Cloudflare deploy 상태 확인
-
-금지 범위:
-- PR branch 수정 금지
-- main 수정 / push / force push 금지
-- `--force` 단독 사용 금지
-- target SHA 추정 금지
-- slot branch를 임의로 main 또는 다른 PR로 reset 금지
+Do not turn PARTIAL into PASS without the missing observation.
 
 ---
 
-## PR Preview vs fixed slot decision rules
+## 8. Evidence hygiene
 
-### PR Preview를 우선 사용할 수 있는 경우
+Evidence must be useful, minimal, and safe to share.
 
-- public page 변경이며 로그인 또는 Firebase Auth domain 영향을 받지 않는 경우
-- 정적 UI 변경이 대부분이고 actual account state가 필요 없는 경우
-- Cloudflare PR Preview URL이 정상 생성되고 target SHA 반영이 확인되는 경우
+### 8.1 Screenshots
 
-### fixed slot을 우선 사용하거나 CTO 지정 slot을 따르는 경우
+- Capture only the relevant viewport and state.
+- Redact email, account name, tokens, private notes, private tree titles, or user content when visible.
+- Label screenshots with URL, viewport, and state if they are not obvious.
+- Do not include unrelated browser tabs or password managers.
 
-- `editor`, `my-trees`, `settings`처럼 로그인 필요 화면을 검증하는 경우
-- Firebase Auth domain, login redirect, popup/redirect origin 이슈가 예상되는 경우
-- PR Preview가 auth domain mismatch 또는 redirect loop로 actual page 내부 검증에 실패하는 경우
-- CTO가 test1/test2/test3 등 고정 slot을 명시한 경우
+### 8.2 Console logs
 
-### fallback 판정
+- Include the error/warning message, source file, line number, and timestamp when useful.
+- Remove raw token, cookie, Firebase credential, Authorization header, and full private payloads.
+- Separate known warnings from new blockers.
+- Do not report extension noise as app failure without isolation.
 
-- PR Preview가 auth/domain 문제로 실패하면 fixed slot으로 전환합니다.
-- fixed slot도 실패하면 code failure로 단정하지 않고 infra/DNS/Auth blocker로 분리합니다.
-- fixed slot이 접근 가능하지만 target SHA 반영이 불명확하면 PARTIAL로 보고합니다.
-- PR Preview와 fixed slot 결과가 다르면 URL, target SHA, deploy status를 함께 기록합니다.
+### 8.3 Network logs
 
----
+- Record method, endpoint path, status, and high-level response class.
+- Redact `Authorization`, `Cookie`, session token, API key, and full private response body.
+- HAR export is not required unless CTO asks for it.
+- If mutation did not occur, state `NO MUTATIONS`.
+- If mutation is required, use test4 + disposable data + explicit approval.
 
-## Slot access failure and partial verification
-
-검증 판정은 확인 가능한 증거 기준으로만 작성합니다.
-
-| 상황 | 판정 | 보고 기준 |
-|------|------|-----------|
-| test slot URL 접근 불가 / DNS 실패 | BLOCKED | code/UI 결과가 아니라 slot infra/DNS blocker로 분리 |
-| slot URL은 접근되지만 target SHA 반영 불명확 | PARTIAL | URL, 확인한 asset/source/network 근거, 미확인 항목 기록 |
-| login gate까지만 확인되고 actual page 내부 미확인 | PARTIAL | auth gate 확인과 actual UI 미검증을 분리 |
-| actual page 내부 접근 가능하나 test account/test tree 여부 불명확 | PARTIAL + no mutation | 데이터 변경 없이 시각 상태만 기록 |
-| viewport / console / network 모두 확인 | PASS 후보 | blocker/warning 구분 후 merge 가능 여부 별도 판단 |
-| 신규 console exception 또는 API 5xx가 PR 변경과 관련됨 | 수정 요청 또는 BLOCKED | endpoint/status/screenshot/viewport 근거 포함 |
-
-주의:
-- `BLOCKED`는 PR 코드가 틀렸다는 뜻이 아닐 수 있습니다.
-- `PARTIAL`은 확인된 항목과 미확인 항목을 모두 적어야 합니다.
-- Browser verifier가 slot에 접근할 수 없으면 Web verifier의 GitHub metadata 확인만으로 UI PASS를 선언하지 않습니다.
-
----
-
-## Slot release / restore procedure
-
-검증 후 slot branch 처리도 별도 운영 대상입니다.
-
-1. 검증 보고서에 slot URL, target branch, target SHA, slot branch SHA, Cloudflare deploy status를 기록합니다.
-2. 검증이 끝난 뒤 slot을 main으로 돌릴지, 현재 PR SHA로 유지할지 CTO에게 확인합니다.
-3. 다음 사용자에게 넘기기 전 아래를 기록합니다.
-   - 현재 slot URL
-   - 현재 slot branch
-   - 현재 slot branch SHA
-   - Cloudflare deploy status
-   - 점유 중인 PR/작업명
-4. 검증 실패 시 원인을 분리합니다.
-   - code/UI failure
-   - slot infra/DNS failure
-   - Cloudflare deploy failure
-   - Firebase/Auth/domain failure
-   - test account/data availability failure
-5. 임의로 slot branch를 reset하지 않습니다.
-6. slot branch restore도 `--force-with-lease` 조건을 만족할 때만 수행합니다.
-
----
-
-## Evidence hygiene: screenshots, console, network logs
-
-검증 증거는 필요한 최소 정보만 기록합니다.
-
-- token/password/cookie 원문 기록 금지
-- screenshot에 계정명, email, token, private content, 운영 데이터가 보이면 redaction 후 공유
-- console log 공유 시 auth token, Firebase credential, cookie 값 제거
-- network/HAR 공유 시 request/response headers의 `Authorization`, `Cookie`, session token, API key 원문 제거
-- test account 식별자는 필요한 최소 수준으로만 기록
-- 운영 데이터의 tree title, private note, memory content는 원문을 장문 인용하지 않음
-- mutation이 없었으면 `NO MUTATIONS`를 명시
-- mutation이 필요한 검증은 test4 + disposable data + 별도 승인 기준을 사용
-
----
-
-## 5. force-with-lease 사용 조건
-
-test slot branch는 검증 대상 PR branch를 고정 도메인에 임시 배포하기 위해 강제로 이동할 수 있습니다. 다만 force update는 아래 조건을 모두 만족할 때만 허용합니다.
-
-- CTO 또는 담당 Lead가 해당 slot 사용을 승인했습니다.
-- 대상 slot이 명시되었습니다.
-- 대상 remote branch가 명시되었습니다. test1 기본값은 `origin/test1`입니다.
-- PR head SHA를 확인했습니다.
-- 현재 slot 점유자가 없거나, 점유 해제가 확인되었습니다.
-- `git push --force-with-lease`를 사용합니다.
-- `--force` 단독 사용은 금지합니다.
-
-예외 없이 `main`에는 force push하지 않습니다.
-
----
-
-## 6. 브랜치 운영 금지선
-
-### 6.1 main 직접 push 금지
-
-`main`은 PR merge 경로로만 변경합니다.
-
-- main 직접 commit 금지
-- main 직접 push 금지
-- main force push 금지
-- screenshot-only 변경도 main 직접 push 금지
-
-### 6.2 PR branch 수정 금지
-
-test slot 검증을 위해 PR branch 자체를 수정하지 않습니다.
-
-- PR head branch에 추가 commit 금지
-- PR head branch force push 금지
-- PR branch rebase 금지
-- PR branch를 test slot 정리 목적으로 변경 금지
-
-검증 slot은 PR branch를 바꾸는 도구가 아닙니다. PR branch의 특정 head SHA를 `origin/test1` 같은 slot branch에 반영하는 도구입니다.
-
-### 6.3 production 검증 분리
-
-Test slot 검증은 PR merge 전 검증입니다. Production 검증은 PR이 `main`에 merge되고 `https://lovebud.pages.dev/`에 배포된 뒤 별도로 수행합니다.
-
-PR merge 전에는 production 도메인을 해당 PR branch의 source of truth로 사용하지 않습니다.
-
----
-
-## 7. 사용 범위
-
-다음 검증 작업에 Fixed Test Preview Slots를 사용합니다.
-
-### 7.1 로그인 필요 화면
-
-- `editor/` 편집기 페이지 인증 흐름
-- `my-trees/` 내 트리 페이지
-- `settings/` 설정 페이지
-
-### 7.2 API/backend/runtime
-
-- `/api/*` 엔드포인트 smoke test
-- `/runtime/*` 경로 동작 확인
-- Cloudflare Pages Functions → Modal 연동 간접 검증
-
-### 7.3 DB read 검증
-
-- 트리 목록 조회
-- 트리 상세 조회
-- 공개 범위에 따른 표시 필터링
-
-### 7.4 UI 반응형 검증
-
-- Desktop / Tablet / Mobile breakpoint
-- Browser DevTools 기반 viewport/network 확인
-
-### 7.5 대체 검증
-
-- PR별 Cloudflare Preview URL이 Firebase Auth domain 문제로 정상 동작하지 않을 때
-- login redirect loop 또는 domain mismatch 오류가 발생할 때
-
----
-
-## 8. 사용 금지 / 제한
-
-### 8.1 절대 금지
-
-- production write 동작: save/edit/delete/PUT/PATCH/DELETE는 별도 승인 전 금지
-- 기존 사용자 데이터 수정/삭제 금지
-- token/password/cookie 원문 기록 금지
-- main 직접 수정 금지
-- main 직접 push 금지
-- `--force` 단독 push 금지
-- 임의 slot branch 생성/push 금지
-- PR branch 수정 금지
-
-### 8.2 제한적 허용
-
-- write 테스트: test4 슬롯에서 QA disposable data로만 수행
-- api write 테스트: 테스트 계획에 명시된 경우에만 수행
-- cache invalidation: Cloudflare Pages 캐시 무효화는 CTO 승인 후 수행
-- force-with-lease: Section 5 조건을 모두 만족할 때만 slot branch에 한정해 수행
-
----
-
-## 9. 슬롯 배정 규칙
-
-| Slot | 기본 용도 | 예시 |
-|------|-----------|------|
-| test1 | UI PR 검증 | PR UI 변경 사항 프리뷰 |
-| test2 | runtime/backend route 검증 | `/api/health`, route winner smoke |
-| test3 | policy/visibility 검증 | 공개/비공개 표시 필터 검증 |
-| test4 | QA CRUD disposable data 검증 | 테스트 데이터 create/read/update/delete |
-| test5 | 예비/대체 슬롯 | 긴급 대체 또는 추가 검증 |
-| test6 | 임시/예외 검증 슬롯 | CTO가 지정한 단기 검증 |
-
-실제 배정은 CTO 또는 담당 Lead가 보고서에 명시합니다. 한 slot은 한 PR 또는 한 검증 목적에만 배정합니다.
-
----
-
-## 10. Firebase/Auth 체크리스트
-
-슬롯 사용 전 필요한 범위에서 확인합니다.
-
-### 10.1 Firebase Authorized Domains
-
-- [ ] `test1.lovebud.pages.dev` 등록 확인
-- [ ] `test2.lovebud.pages.dev` 등록 확인
-- [ ] `test3.lovebud.pages.dev` 등록 확인
-- [ ] `test4.lovebud.pages.dev` 등록 확인
-- [ ] `test5.lovebud.pages.dev` 등록 확인
-- [ ] `test6.lovebud.pages.dev` 등록 확인
-
-### 10.2 Google Login Redirect
-
-- [ ] Google OAuth consent screen의 Authorized redirect URIs에 대상 test slot URL 포함
-- [ ] Firebase Auth popup/redirect 방식 정상 동작
-
-### 10.3 로그인 세션 유지
-
-- [ ] 로그인 후 redirect target이 현재 슬롯 도메인으로 유지되는지 확인
-- [ ] logout → login 반복 시 cookie/session 충돌 없음
-- [ ] 여러 브라우저 탭에서 동시 로그인/로그아웃 문제 없음
-
----
-
-## 11. Cloudflare 체크리스트
-
-### 11.1 도메인 연결 상태
-
-- [ ] Cloudflare Pages 프로젝트에 대상 test slot custom domain 연결 완료
-- [ ] DNS 설정이 Pages 프로젝트를 가리키는지 확인
-- [ ] SSL/TLS 인증서 발급 완료
-
-### 11.2 브랜치 바라보는 상태
-
-- [ ] 대상 slot이 현재 어떤 git branch를 배포 중인지 확인
-- [ ] test1은 기본적으로 `origin/test1`을 확인
-- [ ] `origin/slot/test1`은 기본 업데이트 대상이 아님을 확인
-- [ ] 배포된 commit SHA 기록
-
-### 11.3 배포 상태
-
-- [ ] Cloudflare Pages 배포 상태: Success/Failed
-- [ ] 최신 deploy 시간 확인
-- [ ] 배포 로그 확인
-- [ ] test URL에서 token/source 또는 화면 반영 확인
-
-### 11.4 캐시 무효화
-
-- [ ] Cloudflare Pages 캐시 무효화 필요 여부 판단
-- [ ] 무효화 실행은 CTO 승인 후 수행
-- [ ] 무효화 후 재배포 대기
-
----
-
-## 12. 검증 보고 템플릿
+### 8.4 Evidence summary template
 
 ```text
-[Slot Verification Report]
-- Slot:
-- Slot URL:
-- Target branch:
-- Target SHA:
-- Slot branch updated:
-- Slot branch SHA after update:
-- Cloudflare deploy status:
-- Token/source reflected:
-- Viewports checked:
-- Network result:
-- Console result:
-- Firebase Auth result:
-- API result:
-- UI result:
-- Data mutation performed: yes/no
-- Cleanup required: yes/no
-- Production verification required after merge: yes/no
-- Final judgment:
+[Evidence]
+- URL:
+- Viewport:
+- Target SHA reflected: yes/no/unclear
+- Screenshot: attached/not captured/redacted
+- Console: clean / known warnings / new blocker
+- Network: clean / known warnings / new blocker
+- Auth state: not required / login gate only / actual page verified
+- Data mutation: NO MUTATIONS / approved disposable mutation
 ```
 
 ---
 
-## 13. 위험 관리
+## 9. Slot release / restore procedure
 
-### 13.1 데이터 위험
+After verification, do not leave ownership ambiguous.
 
-- test slot은 production-like 환경이므로 실제 운영 데이터 변경 가능성이 있습니다.
-- write/delete 작업은 test4에서 disposable data로만 수행합니다.
-- 테스트 데이터는 사후 삭제 또는 격리 상태를 유지합니다.
-
-### 13.2 보안 위험
-
-- 슬롯 도메인에서의 인증 token/cookie는 로그 기록 금지
-- 테스트 계정 사용
-- 외부 공유 금지
-
-### 13.3 운영 위험
-
-- slot 사용 후 반드시 배정 해제 또는 main 기준으로 복구 계획을 보고합니다.
-- 슬롯 점유 시간 최소화
-- 여러 작업자 간 충돌 방지: slot 사용 여부 공유
-
-### 13.4 모니터링
-
-- Cloudflare Pages 배포 실패 알림
-- Firebase Auth error rate 모니터링
-- slot 사용 로그 기록
+1. Report slot URL, slot branch, target SHA, deploy status, and occupying PR/task.
+2. Ask CTO whether to restore the slot to `main`, leave it on the PR SHA, or hand it to the next task.
+3. If restoring, use the same `--force-with-lease` rules.
+4. Record the final slot branch SHA.
+5. Do not reset a slot branch silently.
 
 ---
 
-## 14. 승인 및 보고 절차
+## 10. Firebase/Auth checklist
 
-### 14.1 slot 사용 요청
+Use this only when the task requires login or auth-domain validation.
 
-1. 검증 필요 PR, branch, 목적을 기재하여 CTO 또는 Ops Lead에게 요청
-2. slot 할당 받기
-3. 대상 remote branch와 target SHA를 확인
-4. slot branch 갱신 권한을 확인
+- [ ] target slot domain is in Firebase Authorized Domains
+- [ ] OAuth redirect domain is compatible with target slot
+- [ ] login returns to the same slot domain
+- [ ] logout/login repeat does not create redirect loops
+- [ ] actual page interior is reached after login, not just the login page
 
-### 14.2 검증 수행
+Slot domains to check as needed:
 
-1. Firebase/Auth, Cloudflare 체크리스트 실행
-2. 검증 보고서 작성
-3. 문제 발견 시 즉시 중단 및 보고
-
-### 14.3 사용 후 처리
-
-1. slot branch를 main 기준으로 되돌릴지 유지할지 CTO 확인
-2. 검증 보고서 완료본 제출
-3. slot 해제 및 다음 사용자에게 양도
+- `test1.lovebud.pages.dev`
+- `test2.lovebud.pages.dev`
+- `test3.lovebud.pages.dev`
+- `test4.lovebud.pages.dev`
+- `test5.lovebud.pages.dev`
+- `test6.lovebud.pages.dev`
 
 ---
 
-## 15. 금지선 요약
+## 11. Cloudflare checklist
 
-- 실제 Cloudflare/Firebase 설정 변경 금지. 단, CTO가 별도 승인한 경우 제외
-- API/backend 코드 수정 금지
-- main branch 직접 수정/push 금지
-- `--force` 단독 push 금지
-- PR branch 수정 금지
-- 임의 slot branch 생성/push 금지
-- production 데이터 write/delete 금지
-- token/password/cookie 원문 기록 금지
-- 슬롯 점유 시간 초과 금지
+- [ ] target custom domain is connected to the Cloudflare Pages project
+- [ ] DNS resolves to the Pages project
+- [ ] SSL/TLS certificate is valid
+- [ ] deployed branch is the expected slot branch
+- [ ] deployed commit SHA is recorded or asset/source reflection is documented
+- [ ] deploy status is Success/Failed/In progress
+- [ ] cache issue is considered only after deploy status and SHA are checked
 
----
-
-## 16. 참고 문서
-
-- [OPERATIONS.md](OPERATIONS.md) - 일반 운영 원칙
-- [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 검증 체크리스트
-- [RUNBOOK.md](RUNBOOK.md) - 장애 대응 실행서
-- [PR_CHECKLIST.md](PR_CHECKLIST.md) - PR 점검 기준
-- [../engineering/API_CONTRACT.md](../engineering/API_CONTRACT.md) - API 계약
-- [../product/PRODUCT_IDENTITY.md](../product/PRODUCT_IDENTITY.md) - 제품 정체성
+Cache invalidation requires CTO approval.
 
 ---
 
-문서 버전: 1.2  
-다음 리뷰: CTO 승인 후
+## 12. Verification report template
+
+```text
+[Slot Verification Report]
+- Role: Browser / Web / Local
+- Slot:
+- Slot URL:
+- PR / task:
+- Target branch:
+- Target SHA:
+- Slot branch before:
+- Slot branch after:
+- Cloudflare deploy status:
+- Target SHA reflected: yes/no/unclear
+- Viewports checked:
+- Auth result:
+- API/network result:
+- Console result:
+- UI result:
+- Data mutation performed: NO MUTATIONS / approved disposable mutation
+- Evidence:
+- Missing checks:
+- Final judgment: PASS / PARTIAL / BLOCKED / FAIL
+- Production verification required after merge: yes/no
+- Slot release / restore decision:
+```
+
+---
+
+## 13. Guardrails
+
+- main direct commit/push/force-push is prohibited.
+- PR branch modification is prohibited during slot verification.
+- plain `--force` is prohibited.
+- production data write/delete is prohibited unless separately approved.
+- token/password/cookie/raw credential logging is prohibited.
+- PR #7 prototype and prototype/reference/demo folders are not slot cleanup targets.
+- API/backend code changes are not part of slot verification.
+- Browser-only verification must not be replaced by GitHub metadata when the task requires rendered UI proof.
+
+---
+
+## 14. Reference docs
+
+- [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - deployment verification checklist
+- [RUNBOOK.md](RUNBOOK.md) - operations runbook
+- [PR_CHECKLIST.md](PR_CHECKLIST.md) - PR review checklist
+- [../engineering/API_CONTRACT.md](../engineering/API_CONTRACT.md) - API contract
+- [../product/PRODUCT_IDENTITY.md](../product/PRODUCT_IDENTITY.md) - product identity
+
+---
+
+Document version: 1.3  
+Next review: CTO approval after next fixed-slot verification cycle


### PR DESCRIPTION
## Summary
- Clarify Browser / Web / Local verification role boundaries in `TEST_PREVIEW_SLOTS.md`.
- Document PR Preview vs fixed slot decision rules, slot access failure, PARTIAL/BLOCKED handling, slot release/restore, and evidence hygiene.
- Keep `DEPLOY_CHECKLIST.md` and `RUNBOOK.md` as short pointers to the canonical fixed slot rules.

Refs #65

## Scope guard
- Docs-only change under `docs/ops/`.
- No code, JS, HTML, runtime, workflow, package, or lockfile changes.
- PR #74 and PR #7 untouched.
- Issue #65 and Issue #72 remain open.

## Verification
- Changed files checked via GitHub compare: only `docs/ops/TEST_PREVIEW_SLOTS.md`, `docs/ops/DEPLOY_CHECKLIST.md`, `docs/ops/RUNBOOK.md`.
- Static command verification not run in this environment.
- Verification pending.