### PR TITLE
chore(api-client): add apiClient merge collision guard

### DIFF
--- a/js/postgres-client.js
+++ b/js/postgres-client.js
@@ -136,17 +136,40 @@
         };
     }
 
+    function mergeApiGroupsWithCollisionWarning(groups) {
+        const merged = {};
+        const owners = {};
+
+        groups.forEach((group) => {
+            const groupName = group.name;
+            const api = group.api || {};
+
+            Object.keys(api).forEach((key) => {
+                if (Object.prototype.hasOwnProperty.call(merged, key) && typeof console !== 'undefined' && console.warn) {
+                    console.warn(
+                        `[apiClient] Duplicate API method "${key}" from ${owners[key]} overwritten by ${groupName}.`
+                    );
+                }
+
+                merged[key] = api[key];
+                owners[key] = groupName;
+            });
+        });
+
+        return merged;
+    }
+
     const treeApi = createTreeApi();
     const memoryApi = createMemoryApi();
     const communityApi = createCommunityApi();
     const browseApi = createBrowseApi(communityApi);
 
-    const apiClient = {
-        ...treeApi,
-        ...memoryApi,
-        ...communityApi,
-        ...browseApi
-    };
+    const apiClient = mergeApiGroupsWithCollisionWarning([
+        { name: 'treeApi', api: treeApi },
+        { name: 'memoryApi', api: memoryApi },
+        { name: 'communityApi', api: communityApi },
+        { name: 'browseApi', api: browseApi }
+    ]);
 
     window.apiClient = apiClient;
 


### PR DESCRIPTION
## Summary

Refs #72

- Adds a small collision warning guard for the flat browser `apiClient` merge
- Preserves the existing flat `window.apiClient` shape
- Preserves current merge order and overwrite behavior if a duplicate method key appears
- Does not rename, move, or regroup API methods

## Scope

- Changed file: `js/postgres-client.js` only
- No Search changes
- No Auth changes
- No runtime/API/backend changes
- No `window.__LoveBudApiClientInternals` changes
- PR #7 and prototype/reference/demo untouched

## Verification

- GitHub compare confirms `js/postgres-client.js` is the only changed file
- Local lint/build/test not run in this Web executor environment; CI should validate after PR creation

## Notes

This is a behavior-preserving guardrail change for Issue #72. It does not implement the broader API client naming/loading audit and does not migrate to nested namespaces such as `apiClient.trees.getTree()`.