### PR TITLE
feat(search): support selected tree deep link

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -211,6 +211,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     let isRestoringUrlState = false;
+    let initialTreeDeepLinkApplied = false;
 
     function readUrlState() {
         try {
@@ -219,10 +220,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 query: params.get('q') || '',
                 category: params.get('category') || '',
                 sort: params.get('sort') || '',
-                limit: params.get('limit') || ''
+                limit: params.get('limit') || '',
+                tree: params.get('tree') || ''
             };
         } catch {
-            return { query: '', category: '', sort: '', limit: '' };
+            return { query: '', category: '', sort: '', limit: '', tree: '' };
         }
     }
 
@@ -278,6 +280,32 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
         isRestoringUrlState = false;
+    }
+
+    function applySelectedTreeFromUrl() {
+        if (initialTreeDeepLinkApplied) return;
+        const state = readUrlState();
+        if (!state.tree) return;
+
+        const targetTree = allTrees.find(t => t.id === state.tree) || growingTrees.find(t => t.id === state.tree);
+        if (!targetTree) return;
+
+        let activeCard = null;
+        let selector = '';
+        try {
+            selector = `.tree-card[data-tree-id="${CSS.escape(state.tree)}"]`;
+        } catch (e) {
+            selector = `.tree-card[data-tree-id="${state.tree.replace(/"/g, '\\"')}"]`;
+        }
+
+        const allCardContainers = [resultsList, growingList].filter(Boolean);
+        for (const container of allCardContainers) {
+            activeCard = container.querySelector(selector);
+            if (activeCard) break;
+        }
+
+        selectTree(targetTree, activeCard);
+        initialTreeDeepLinkApplied = true;
     }
 
     const syncBrowseHead = () => {
@@ -721,6 +749,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Apply URL state after initial load
     restoreStateFromUrl();
+    applySelectedTreeFromUrl();
 
     let searchInputTimer = null;
     searchInput.addEventListener('input', (e) => {
@@ -756,4 +785,5 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Initial URL state restoration after all scripts are loaded
     restoreStateFromUrl();
+    applySelectedTreeFromUrl();
 });


### PR DESCRIPTION
## Summary
- Supports `/pages/search.html?tree=<treeId>` initial selected tree hydration.
- Reuses existing `selectTree()` preview flow.
- Does not add click-to-update `tree` URL state.
- Preserves existing `q`, `category`, `sort`, `limit` URL behavior.
- Invalid or missing tree id falls back silently.

Refs #65

## Scope
- `js/search.js` only.
- No Search file moves.
- No CSS extraction.
- No API/runtime/backend/Auth changes.
- PR #7 and prototype/reference/demo untouched.

## Verification
- `git diff --name-status`: not run in this environment; GitHub compare shows `js/search.js` only.
- `git diff --check`: not run in this environment.
- `npm run lint`: not run in this environment.
- `npm run build`: not run in this environment.
- `npm test`: not run in this environment.

Verification pending from local executor or CI. No PASS claimed for static commands.