### PR TITLE
feat(search): add preview view link copy action

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -175,6 +175,18 @@
       ko: '대표 순간이 열려요.',
       en: 'The featured moment opens here.'
     },
+    'search.previewShareLink': {
+      ko: '감상 링크 복사',
+      en: 'Copy view link'
+    },
+    'search.previewShareLinkCopied': {
+      ko: '링크가 복사됐어요',
+      en: 'Link copied'
+    },
+    'search.previewShareLinkFailed': {
+      ko: '복사하지 못했어요',
+      en: 'Copy failed'
+    },
 
     // 검색 입력
     'search.placeholder': {

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -106,6 +106,21 @@
         `;
     }
 
+    function renderShareButton(tree) {
+        if (!tree?.id) return '';
+        const label = getSearchCopy(
+            'search.previewShareLink',
+            '감상 링크 복사',
+            'Copy view link'
+        );
+        return `
+            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
+                <span class="material-symbols-outlined" style="font-size:16px;">link</span>
+                ${escapeHtml(label)}
+            </button>
+        `;
+    }
+
     let _dom = null;
 
     function init(domRefs) {
@@ -463,6 +478,7 @@
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '이제 막 감상이 시작될 공개 러브트리예요.', 'This public LoveTree is just about to begin.'))}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderShareButton(tree)}
                 `;
             } else {
                 const pathStages = memories.slice(0, 3).map((m, i) => {
@@ -488,6 +504,7 @@
                         ${renderInfoCallout('touch_app', getSearchCopy('search.previewJourneyCta', '이곳에서 대표 순간과 이어진 감정을 훑어보고, 마음이 머무는 순간으로 들어가 보세요.', 'Scan the featured moment and connected feelings here, then open the moment that draws you in.'), 'primary')}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderShareButton(tree)}
                 `;
             }
         }

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -116,7 +116,7 @@
         return `
             <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
                 <span class="material-symbols-outlined" style="font-size:16px;">link</span>
-                ${escapeHtml(label)}
+                <span data-share-tree-link-label>${escapeHtml(label)}</span>
             </button>
         `;
     }

--- a/js/search.js
+++ b/js/search.js
@@ -727,7 +727,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const treeId = shareButton.dataset.shareTreeLink;
         if (!treeId) return;
 
-        const originalText = shareButton.textContent;
+        const labelSpan = shareButton.querySelector('[data-share-tree-link-label]');
+        if (!labelSpan) return;
+
+        const originalText = labelSpan.textContent;
         const copiedText = getSearchCopy('search.previewShareLinkCopied', '링크가 복사됐어요', 'Link copied');
         const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
 
@@ -735,15 +738,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             const url = new URL('/pages/search.html', window.location.origin);
             url.searchParams.set('tree', treeId);
             await navigator.clipboard.writeText(url.toString());
-            shareButton.textContent = copiedText;
+            labelSpan.textContent = copiedText;
             setTimeout(() => {
-                shareButton.textContent = originalText;
+                labelSpan.textContent = originalText;
             }, 1500);
         } catch (error) {
             console.warn('[search] clipboard copy failed:', error.message);
-            shareButton.textContent = failedText;
+            labelSpan.textContent = failedText;
             setTimeout(() => {
-                shareButton.textContent = originalText;
+                labelSpan.textContent = originalText;
             }, 1500);
         }
     });

--- a/js/search.js
+++ b/js/search.js
@@ -717,6 +717,37 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
+    // 감상 링크 복사 버튼 event delegation
+    document.addEventListener('click', async (event) => {
+        const shareButton = event.target.closest('[data-share-tree-link]');
+        if (!shareButton) return;
+
+        event.preventDefault();
+
+        const treeId = shareButton.dataset.shareTreeLink;
+        if (!treeId) return;
+
+        const originalText = shareButton.textContent;
+        const copiedText = getSearchCopy('search.previewShareLinkCopied', '링크가 복사됐어요', 'Link copied');
+        const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
+
+        try {
+            const url = new URL('/pages/search.html', window.location.origin);
+            url.searchParams.set('tree', treeId);
+            await navigator.clipboard.writeText(url.toString());
+            shareButton.textContent = copiedText;
+            setTimeout(() => {
+                shareButton.textContent = originalText;
+            }, 1500);
+        } catch (error) {
+            console.warn('[search] clipboard copy failed:', error.message);
+            shareButton.textContent = failedText;
+            setTimeout(() => {
+                shareButton.textContent = originalText;
+            }, 1500);
+        }
+    });
+
     if (mobilePreviewMediaQuery?.addEventListener) {
         mobilePreviewMediaQuery.addEventListener('change', () => {
             syncPreviewVisibility();


### PR DESCRIPTION
## Summary

Refs #65  
Related #84, but this PR does not implement tree copy/fork.

- Adds "감상 링크 복사" / "Copy view link" action to Search Preview
- Copies canonical `/pages/search.html?tree=<treeId>` view link
- Uses selected tree id only
- Does not include `q`, `category`, `sort`, or `limit` in the copied URL
- Does not implement click-to-update `tree` URL state
- Does not implement tree copy/fork/import

## Scope

Changed files:

- `js/i18n/i18n-search.js` 
- `js/search-preview-renderer.js` 
- `js/search.js` 

Explicit non-changes:

- No API/runtime/backend/Auth changes
- No Search file moves
- No CSS extraction
- No tree copy/fork/import behavior
- PR #7 and prototype/reference/demo untouched

## Verification

Local Code Executor reported:

- `git diff --check`: PASS
- `npm run lint`: PASS
- `npm run build`: PASS
- `npm test`: FAIL with known existing/out-of-scope failure
  - `tests/contracts/api-route-mapping.test.js` 
  - `emotion_tags` fixture mismatch in `js/search.js` 
  - unrelated to this PR's clipboard event delegation

## Preview verification needed

After PR creation, verify on Cloudflare Preview:

- `/pages/search.html` 
- Select a public tree
- "감상 링크 복사" button appears in Search Preview
- Clicking the button copies `/pages/search.html?tree=<treeId>` 
- Success state displays "링크가 복사됐어요"
- Pasted link opens the selected tree via the existing PR #83 deep link behavior
- 375px mobile layout remains stable
- No new console/network blockers
