### PR TITLE
docs(runtime): add runtime ownership folder markers

### DIFF
--- a/functions/api/README.md
+++ b/functions/api/README.md
@@ -1,0 +1,38 @@
+# Cloudflare Pages Functions API Entry
+
+## 역할
+
+이 폴더는 Cloudflare Pages의 same-origin `/api/*` 진입점입니다.
+
+## 핵심 구조
+
+- `[[path]].js`: Cloudflare Pages Functions의 catch-all route handler
+  - 사용자 브라우저는 `https://lovebud.pages.dev/api/*`로만 접근
+  - approved routes만 Modal 또는 fallback으로 연결
+  - route 추가 시 contract test 필요
+
+## Approved Routes
+
+현재 Modal로 연결되는 GET routes:
+
+- `/api/community/trees?view=summary` → Modal browse summary
+- `/api/community/growing-trees` → Modal growing trees
+- `/api/community/memories` → Modal community memories
+- `/api/trees` → Modal private trees
+- `/api/memories` → Modal private memories
+- `/api/memories/{id}` → Modal memory detail
+- `/api/trees/{id}` → Modal tree detail (public/private 분기)
+
+## Route 추가 가이드
+
+새 route를 추가할 때:
+
+1. `[[path]].js`에 route mapping 추가
+2. Modal endpoint 존재 확인
+3. `tests/contracts/api-route-mapping.test.js`에 contract test 추가
+4. CTO 승인 후 merge
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/engineering/API_CONTRACT.md`

--- a/modal_compute/README.md
+++ b/modal_compute/README.md
@@ -1,0 +1,36 @@
+# Modal Compute Runtime
+
+## 역할
+
+이 폴더는 LoveBud의 현재 active compute/runtime priority 계층입니다.
+
+## 핵심 구조
+
+- `app.py`: Modal FastAPI application (main entry)
+- `browse_latest.py`: Browse summary cache handler
+- `requirements.txt`: Python dependencies
+
+## Runtime Priority
+
+Browse/community/private read-heavy route는 기본적으로 Modal 우선:
+
+- Browse summary (`/api/community/trees?view=summary`)
+- Growing trees (`/api/community/growing-trees`)
+- Community memories (`/api/community/memories`)
+- Private trees (`/api/trees`)
+- Private memories (`/api/memories`)
+- Memory detail (`/api/memories/{id}`)
+- Tree detail (`/api/trees/{id}`)
+
+## Deploy 가이드
+
+Modal deploy는 별도 승인 필요:
+
+1. CTO 승인 후 deploy
+2. Secrets 출력/커밋 금지
+3. Production deploy 전 staging test
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`

--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -1,0 +1,30 @@
+# Netlify Functions (Legacy)
+
+## 역할
+
+이 폴더는 lovebud.pages.dev의 active production backend가 아닙니다.
+
+## 상태
+
+- **Legacy/fallback/artifact**
+- 현재 Cloudflare Pages + Modal 구조로 migration 완료
+- CTO 승인 없이 삭제/이동/재활성화 금지
+
+## 기존 구조
+
+- `community-memories.js`: Community memories endpoint (legacy)
+- `community-trees.js`: Community trees endpoint (legacy)
+- `memories.js`: Private memories endpoint (legacy)
+- `memory-detail.js`: Memory detail endpoint (legacy)
+- `tree-detail.js`: Tree detail endpoint (legacy)
+- `trees.js`: Private trees endpoint (legacy)
+- `_lib/`: Shared utility functions
+
+## Migration 상태
+
+모든 routes는 현재 Cloudflare Pages Functions → Modal로 연결됩니다.
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`

--- a/netlify/sql/README.md
+++ b/netlify/sql/README.md
@@ -1,0 +1,26 @@
+# Netlify SQL (Legacy Schema)
+
+## 역할
+
+이 폴더는 legacy schema/seed artifact입니다.
+
+## 상태
+
+- **Active migration source of truth가 아님**
+- 현재 Modal PostgreSQL을 사용 중
+- CTO 승인 없이 삭제/이동/재활성화 금지
+
+## 기존 구조
+
+- `001_initial_schema.sql`: Initial database schema (legacy)
+- `002_add_payload_columns.sql`: Payload columns migration (legacy)
+- `002_seed_demo_data.sql`: Demo data seed (legacy)
+
+## Migration 상태
+
+데이터베이스는 현재 Modal PostgreSQL로 migration 완료되었습니다.
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`


### PR DESCRIPTION
## Summary

Refs #79

- Adds folder-level runtime ownership markers for active and legacy runtime areas
- Documents `functions/api/` as the active Cloudflare Pages same-origin `/api/*` entry
- Documents `modal_compute/` as the active compute/runtime priority
- Documents `netlify/functions/` as legacy/fallback/artifact, not the active production backend for `lovebud.pages.dev`
- Documents `netlify/sql/` as a legacy schema/seed artifact, not the active migration source of truth

## Scope

Changed files:

- `functions/api/README.md`
- `modal_compute/README.md`
- `netlify/functions/README.md`
- `netlify/sql/README.md`

## Explicit non-changes

- No code changes
- No runtime behavior changes
- No route mapping changes
- No Modal deploy changes
- No Netlify deletion, move, archive, or reactivation
- No Search/Auth/UI changes
- PR #7 and prototype/reference/demo paths untouched

## Verification

Local executor reported:

- `git diff --check`: PASS
- README-only changes
- `functions/api/[[path]].js` unchanged
- `modal_compute/app.py` unchanged
- Netlify files were not deleted or moved
- Search/Auth/UI/runtime behavior untouched
- main and PR branch verification failures are identical and appear to be existing/out-of-scope i18n/static verification blockers

## Review notes

This PR should not close Issue #79. It covers only PR A from the issue: docs-only runtime ownership markers.