### PR TITLE
docs(ops): document fixed preview slots through test10

### DIFF
--- a/docs/ops/TEST_PREVIEW_SLOTS.md
+++ b/docs/ops/TEST_PREVIEW_SLOTS.md
@@ -31,8 +31,14 @@ Use this document as the source of truth for:
 | test4 | https://test4.lovebud.pages.dev | QA CRUD disposable data verification |
 | test5 | https://test5.lovebud.pages.dev | spare / fallback slot |
 | test6 | https://test6.lovebud.pages.dev | temporary / exceptional verification slot |
+| test7 | https://test7.lovebud.pages.dev | parallel UI/API verification |
+| test8 | https://test8.lovebud.pages.dev | parallel UI/API verification |
+| test9 | https://test9.lovebud.pages.dev | parallel UI/API verification |
+| test10 | https://test10.lovebud.pages.dev | parallel UI/API verification |
 
 Each slot domain is a fixed Cloudflare Pages domain. Actual assignment must be stated by the CTO or responsible Lead.
+
+Fixed slot assignment must be explicit. Available fixed slots are test1 through test10. Executors must not assume test1 when a slot is not explicitly assigned.
 
 ---
 
@@ -155,7 +161,9 @@ Examples:
 - Firebase Authorized Domain, OAuth redirect, popup, or redirect-loop risk is expected.
 - PR Preview opens but cannot reach the actual authenticated page.
 - API/runtime route verification needs a stable domain.
-- CTO explicitly assigns `test1` through `test6`.
+- CTO explicitly assigns `test1` through `test10`.
+
+PR Preview URLs are not sufficient for final PASS on login/auth/API/domain-sensitive UI flows. Browser/UI verification should use a CTO-assigned fixed test preview slot when stable domain behavior matters.
 
 ### 5.3 Decision matrix
 
@@ -299,6 +307,10 @@ Slot domains to check as needed:
 - `test4.lovebud.pages.dev`
 - `test5.lovebud.pages.dev`
 - `test6.lovebud.pages.dev`
+- `test7.lovebud.pages.dev`
+- `test8.lovebud.pages.dev`
+- `test9.lovebud.pages.dev`
+- `test10.lovebud.pages.dev`
 
 ---
 

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -175,6 +175,18 @@
       ko: '대표 순간이 열려요.',
       en: 'The featured moment opens here.'
     },
+    'search.previewShareLink': {
+      ko: '감상 링크 복사',
+      en: 'Copy view link'
+    },
+    'search.previewShareLinkCopied': {
+      ko: '링크가 복사됐어요',
+      en: 'Link copied'
+    },
+    'search.previewShareLinkFailed': {
+      ko: '복사하지 못했어요',
+      en: 'Copy failed'
+    },
 
     // 검색 입력
     'search.placeholder': {

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -106,6 +106,21 @@
         `;
     }
 
+    function renderShareButton(tree) {
+        if (!tree?.id) return '';
+        const label = getSearchCopy(
+            'search.previewShareLink',
+            '감상 링크 복사',
+            'Copy view link'
+        );
+        return `
+            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
+                <span class="material-symbols-outlined" style="font-size:16px;">link</span>
+                ${escapeHtml(label)}
+            </button>
+        `;
+    }
+
     let _dom = null;
 
     function init(domRefs) {
@@ -463,6 +478,7 @@
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '이제 막 감상이 시작될 공개 러브트리예요.', 'This public LoveTree is just about to begin.'))}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderShareButton(tree)}
                 `;
             } else {
                 const pathStages = memories.slice(0, 3).map((m, i) => {
@@ -488,6 +504,7 @@
                         ${renderInfoCallout('touch_app', getSearchCopy('search.previewJourneyCta', '이곳에서 대표 순간과 이어진 감정을 훑어보고, 마음이 머무는 순간으로 들어가 보세요.', 'Scan the featured moment and connected feelings here, then open the moment that draws you in.'), 'primary')}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderShareButton(tree)}
                 `;
             }
         }

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -116,7 +116,7 @@
         return `
             <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
                 <span class="material-symbols-outlined" style="font-size:16px;">link</span>
-                ${escapeHtml(label)}
+                <span data-share-tree-link-label>${escapeHtml(label)}</span>
             </button>
         `;
     }

--- a/js/search.js
+++ b/js/search.js
@@ -727,7 +727,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const treeId = shareButton.dataset.shareTreeLink;
         if (!treeId) return;
 
-        const originalText = shareButton.textContent;
+        const labelSpan = shareButton.querySelector('[data-share-tree-link-label]');
+        if (!labelSpan) return;
+
+        const originalText = labelSpan.textContent;
         const copiedText = getSearchCopy('search.previewShareLinkCopied', '링크가 복사됐어요', 'Link copied');
         const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
 
@@ -735,15 +738,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             const url = new URL('/pages/search.html', window.location.origin);
             url.searchParams.set('tree', treeId);
             await navigator.clipboard.writeText(url.toString());
-            shareButton.textContent = copiedText;
+            labelSpan.textContent = copiedText;
             setTimeout(() => {
-                shareButton.textContent = originalText;
+                labelSpan.textContent = originalText;
             }, 1500);
         } catch (error) {
             console.warn('[search] clipboard copy failed:', error.message);
-            shareButton.textContent = failedText;
+            labelSpan.textContent = failedText;
             setTimeout(() => {
-                shareButton.textContent = originalText;
+                labelSpan.textContent = originalText;
             }, 1500);
         }
     });

--- a/js/search.js
+++ b/js/search.js
@@ -717,6 +717,37 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
+    // 감상 링크 복사 버튼 event delegation
+    document.addEventListener('click', async (event) => {
+        const shareButton = event.target.closest('[data-share-tree-link]');
+        if (!shareButton) return;
+
+        event.preventDefault();
+
+        const treeId = shareButton.dataset.shareTreeLink;
+        if (!treeId) return;
+
+        const originalText = shareButton.textContent;
+        const copiedText = getSearchCopy('search.previewShareLinkCopied', '링크가 복사됐어요', 'Link copied');
+        const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
+
+        try {
+            const url = new URL('/pages/search.html', window.location.origin);
+            url.searchParams.set('tree', treeId);
+            await navigator.clipboard.writeText(url.toString());
+            shareButton.textContent = copiedText;
+            setTimeout(() => {
+                shareButton.textContent = originalText;
+            }, 1500);
+        } catch (error) {
+            console.warn('[search] clipboard copy failed:', error.message);
+            shareButton.textContent = failedText;
+            setTimeout(() => {
+                shareButton.textContent = originalText;
+            }, 1500);
+        }
+    });
+
     if (mobilePreviewMediaQuery?.addEventListener) {
         mobilePreviewMediaQuery.addEventListener('change', () => {
             syncPreviewVisibility();


### PR DESCRIPTION
Fixed slot assignment must be explicit. Available fixed slots are test1 through test10.

PR Preview URLs are not sufficient for final PASS on login/auth/API/domain-sensitive UI flows. Browser/UI verification should use a CTO-assigned fixed test preview slot when stable domain behavior matters. Executors must not assume test1 when a slot is not explicitly assigned.

Changed files:
- docs/ops/TEST_PREVIEW_SLOTS.md

No code/runtime/API/Auth/UI behavior changes.