### PR TITLE
feat(api): proxy private write routes to Modal

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -30,6 +30,7 @@ function buildModalUrl(request, env) {
   if (!modalBaseUrl) return null;
 
   const sourceUrl = new URL(request.url);
+  const method = request.method.toUpperCase();
   const path = sourceUrl.pathname.replace(/\/+$/, '');
   const target = new URL(modalBaseUrl);
 
@@ -60,17 +61,21 @@ function buildModalUrl(request, env) {
 
   if (path === '/api/trees') {
     target.pathname = '/modal/private/trees';
-    const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 100) || 100, 1), 200);
-    target.searchParams.set('limit', String(limit));
+    if (method === 'GET') {
+      const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 100) || 100, 1), 200);
+      target.searchParams.set('limit', String(limit));
+    }
     return target;
   }
 
   if (path === '/api/memories') {
     target.pathname = '/modal/private/memories';
-    const treeId = sourceUrl.searchParams.get('treeId');
-    const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 100) || 100, 1), 200);
-    if (treeId) target.searchParams.set('treeId', treeId);
-    target.searchParams.set('limit', String(limit));
+    if (method === 'GET') {
+      const treeId = sourceUrl.searchParams.get('treeId');
+      const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 100) || 100, 1), 200);
+      if (treeId) target.searchParams.set('treeId', treeId);
+      target.searchParams.set('limit', String(limit));
+    }
     return target;
   }
 
@@ -108,6 +113,15 @@ function isModalOwnedGetRoute(request, env) {
   return modalUrl !== null;
 }
 
+function isModalOwnedWriteRoute(request, env) {
+  if (request.method.toUpperCase() !== 'POST') return false;
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/+$/, '');
+  if (!['/api/trees', '/api/memories'].includes(path)) return false;
+  const modalUrl = buildModalUrl(request, env || {});
+  return modalUrl !== null;
+}
+
 function buildNotFoundResponse() {
   return new Response(
     JSON.stringify({ error: 'Route not found' }),
@@ -122,7 +136,7 @@ function buildNotFoundResponse() {
   );
 }
 
-function buildMethodNotAllowedResponse() {
+function buildMethodNotAllowedResponse(allow = 'GET') {
   return new Response(
     JSON.stringify({ error: 'Method not allowed' }),
     {
@@ -131,7 +145,7 @@ function buildMethodNotAllowedResponse() {
         'content-type': 'application/json; charset=utf-8',
         'x-lovebud-upstream': 'cloudflare',
         'x-lovebud-route-status': 'method-not-allowed',
-        'allow': 'GET'
+        'allow': allow
       }
     }
   );
@@ -183,9 +197,44 @@ async function tryModalRead(request, env) {
   return withUpstreamHeader(response, 'modal');
 }
 
+async function tryModalWrite(request, env) {
+  if (request.method.toUpperCase() !== 'POST') return null;
+  if (!isModalOwnedWriteRoute(request, env || {})) return null;
+
+  const modalUrl = buildModalUrl(request, env || {});
+  if (!modalUrl) return null;
+
+  const headers = {
+    accept: 'application/json',
+    'content-type': request.headers.get('content-type') || 'application/json',
+    ...(request.headers.get('authorization')
+      ? { authorization: request.headers.get('authorization') }
+      : {})
+  };
+
+  const response = await fetch(modalUrl.toString(), {
+    method: 'POST',
+    headers,
+    body: request.body
+  });
+
+  return withUpstreamHeader(response, 'modal');
+}
+
 export async function onRequest(context) {
   const { request, env } = context;
   const isModalOwned = isModalOwnedGetRoute(request, env || {});
+  const isModalOwnedWrite = isModalOwnedWriteRoute(request, env || {});
+
+  if (isModalOwnedWrite) {
+    try {
+      const modalResponse = await tryModalWrite(request, env || {});
+      if (modalResponse) return modalResponse;
+    } catch (error) {
+      console.warn('[LoveBudCloudflareProxy] Modal write failed, returning 503', error);
+      return buildModalUnavailableResponse();
+    }
+  }
 
   if (isBrowseSummaryRequest(request)) {
     const cache = caches.default;
@@ -224,7 +273,10 @@ export async function onRequest(context) {
 
   const modalUrl = buildModalUrl(request, env || {});
   if (modalUrl) {
-    return buildMethodNotAllowedResponse();
+    const url = new URL(request.url);
+    const path = url.pathname.replace(/\/+$/, '');
+    const allow = ['/api/trees', '/api/memories'].includes(path) ? 'GET, POST' : 'GET';
+    return buildMethodNotAllowedResponse(allow);
   }
 
   return buildNotFoundResponse();


### PR DESCRIPTION
## Summary

- Allows Cloudflare Pages `/api/*` catch-all to proxy private write routes to Modal
- Adds POST proxy support for:
  - `POST /api/trees` -> `/modal/private/trees`
  - `POST /api/memories` -> `/modal/private/memories`
- Keeps existing GET read routing and browse cache behavior intact

## Scope

Changed files:

- `functions/api/[[path]].js`

## Explicit non-changes

- No Copy/Fork UI implementation
- No Search Preview UI changes
- No API client changes
- No Modal app changes
- No database/schema changes
- No new endpoint contract beyond forwarding existing private write routes
- No PR #7/prototype/reference/demo changes

## Why

The browser API client already calls same-origin private write routes such as `POST /api/trees` and `POST /api/memories`. The active Cloudflare catch-all previously recognized those Modal-owned routes but returned 405 for non-GET methods. This PR unlocks the existing Modal private write routes so later Copy/Fork implementation can create copied trees and memories through the same-origin `/api/*` contract.

## Verification needed

- Confirm changed files remain limited to `functions/api/[[path]].js`
- Confirm GET browse/private read behavior is unchanged
- Confirm unauthenticated POST still fails through Modal auth with 401 rather than Cloudflare 405
- Confirm authenticated `POST /api/trees` reaches Modal private tree creation
- Confirm authenticated `POST /api/memories` reaches Modal private memory creation

## Review notes

This is the backend routing unlock only. It does not implement public tree copy/fork UI or copy orchestration.