### PR TITLE
refactor(detail): move inline styles to css

### DIFF
--- a/css/detail.css
+++ b/css/detail.css
@@ -282,6 +282,38 @@
     box-shadow: 0 0 0 8px rgba(144, 73, 81, 0.08);
 }
 
+/* Inline styles moved to classes */
+.detail-diary-quote {
+    margin-bottom: 24px;
+    color: var(--on-surface);
+    font-size: 1.18rem;
+    font-weight: 500;
+    font-style: italic;
+    line-height: 1.55;
+}
+
+.detail-diary-content {
+    color: var(--on-surface-variant);
+    font-size: 1rem;
+    line-height: 1.9;
+}
+
+.connected-fragments-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+}
+
+.growth-label {
+    margin-top: 14px;
+    color: var(--primary);
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
 @media (max-width: 1180px) {
     .detail-page-shell { padding: 22px 24px 40px; }
     .detail-layout { grid-template-columns: 1fr; gap: 28px; }

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -59,8 +59,8 @@
                     </div>
 
                     <div class="diary-container">
-                        <p id="diaryQuote" style="font-size: 1.18rem; color: var(--on-surface); font-weight: 500; font-style: italic; line-height: 1.55; margin-bottom: 24px;">&nbsp;</p>
-                        <div id="diaryContent" style="line-height: 1.9; color: var(--on-surface-variant); font-size: 1rem;">&nbsp;</div>
+                        <p id="diaryQuote" class="detail-diary-quote">&nbsp;</p>
+                        <div id="diaryContent" class="detail-diary-content">&nbsp;</div>
                     </div>
                 </section>
             </section>
@@ -72,13 +72,13 @@
                         <h3 id="connectedTitle" class="headline">이어진 순간들</h3>
                         <p id="connectedSummary" class="connected-summary">&nbsp;</p>
                     </div>
-                    <div id="connectedFragments" style="display: grid; grid-template-columns: 1fr; gap: 16px;"></div>
+                    <div id="connectedFragments" class="connected-fragments-grid"></div>
                 </div>
 
                 <div class="growth-visualization">
                     <div class="growth-line"></div>
                     <div class="growth-dot"></div>
-                    <p id="growthLabel" style="margin-top: 14px; font-weight: 800; color: var(--primary); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;">감정이 자라는 중</p>
+                    <p id="growthLabel" class="growth-label">감정이 자라는 중</p>
                 </div>
             </aside>
         </main>


### PR DESCRIPTION
## Summary

- Moves remaining Detail page inline styles into css/detail.css 
- Replaces four style attributes in pages/detail.html with page-specific classes
- Preserves all existing element IDs used by Detail JS

## Scope

Changed files:
- pages/detail.html 
- css/detail.css 

## Non-changes

- No css/global.css changes
- No css/index.css changes
- No css/intro.css changes
- No JS changes
- No HTML structure changes
- No copy/content changes

## Verification

- git diff --check passed
- Confirmed only pages/detail.html and css/detail.css changed
- Confirmed Detail element IDs are preserved
- Confirmed remaining Detail inline styles were moved to classes