### PR TITLE
chore(detail): remove extra growth label line height

### DIFF
--- a/css/detail.css
+++ b/css/detail.css
@@ -309,7 +309,6 @@
     color: var(--primary);
     font-size: 11px;
     font-weight: 800;
-    line-height: 1.4;
     text-transform: uppercase;
     letter-spacing: 0.08em;
 }


### PR DESCRIPTION
## Summary

- Removes one extra line-height declaration from .growth-label
- Aligns css/detail.css with the original inline style moved in PR #97

## Scope

Changed files:
- css/detail.css

## Verification

- git diff --check passed
- Confirmed only css/detail.css changed
- Confirmed only .growth-label lost the extra line-height: 1.4