### PR TITLE
refactor(my-trees): move safe inline styles to css

### DIFF
--- a/css/my-trees.css
+++ b/css/my-trees.css
@@ -153,6 +153,58 @@ body.my-trees-auth-pending .my-trees-content { visibility: hidden; }
   .create-tree-modal-actions { flex-direction: column-reverse; }
   .create-tree-modal-btn { width: 100%; justify-content: center; }
 }
+
+/* Inline styles moved to classes */
+.my-trees-create-icon {
+  font-size: 20px;
+}
+
+.create-tree-modal-kicker-icon {
+  font-size: 14px;
+}
+
+.create-tree-goal-card {
+  min-height: auto;
+  cursor: default;
+  background: rgba(255, 246, 247, 0.98);
+  border-color: rgba(144, 73, 81, 0.20);
+  box-shadow: 0 10px 24px rgba(144, 73, 81, 0.08);
+}
+
+.create-tree-goal-top {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.create-tree-goal-title-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.create-tree-goal-icon {
+  color: var(--primary);
+  font-size: 18px;
+}
+
+.create-tree-goal-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(144, 73, 81, 0.10);
+  color: var(--primary);
+  font-size: 11px;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.create-tree-goal-desc {
+  font-size: 13px;
+  line-height: 1.65;
+}
+
 @media (max-width: 420px) {
   .tree-card-date { display: none; }
 }

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -39,7 +39,7 @@
         <div id="treesContainer">
           <div id="state-loading" class="trees-loading" style="display: flex;"><div class="spinner"></div><span class="loading-text" data-i18n="myTrees.loading">러브트리 목록을 불러오는 중...</span></div>
           <div id="state-error" class="error-state" style="display: none;"><span class="material-symbols-outlined error-state-icon">error</span><h2 data-i18n="myTrees.error_title">불러오기에 실패했습니다</h2><p data-i18n="myTrees.error_desc">네트워크 연결을 확인하고 다시 시도해주세요.</p><button class="btn-round btn-primary" id="retryLoadBtn" data-i18n="myTrees.retry">다시 시도</button></div>
-          <div id="state-empty" class="empty-state" style="display: none;"><span class="material-symbols-outlined empty-state-icon">account_tree</span><h2 data-i18n="empty_state_title">아직 러브트리가 없어요</h2><p data-i18n="empty_state_desc">첫 러브트리를 만들어 시작해보세요.</p><button class="btn-create-tree" id="createTreeBtn"><span class="material-symbols-outlined" style="font-size:20px;">add_circle</span><span data-i18n="create_tree_btn">새 러브트리 만들기</span></button></div>
+          <div id="state-empty" class="empty-state" style="display: none;"><span class="material-symbols-outlined empty-state-icon">account_tree</span><h2 data-i18n="empty_state_title">아직 러브트리가 없어요</h2><p data-i18n="empty_state_desc">첫 러브트리를 만들어 시작해보세요.</p><button class="btn-create-tree" id="createTreeBtn"><span class="material-symbols-outlined my-trees-create-icon">add_circle</span><span data-i18n="create_tree_btn">새 러브트리 만들기</span></button></div>
           <div id="state-loaded" style="display: none;"></div>
         </div>
       </section>
@@ -49,7 +49,7 @@
     <div class="create-tree-modal" role="dialog" aria-modal="true" aria-labelledby="createTreeModalTitle">
       <div class="create-tree-modal-header">
         <div>
-          <div class="create-tree-modal-kicker"><span class="material-symbols-outlined" style="font-size:14px;">favorite</span><span data-i18n="myTrees.create_modal_kicker">새 러브트리 시작</span></div>
+          <div class="create-tree-modal-kicker"><span class="material-symbols-outlined create-tree-modal-kicker-icon">favorite</span><span data-i18n="myTrees.create_modal_kicker">새 러브트리 시작</span></div>
           <h2 class="create-tree-modal-title" id="createTreeModalTitle" data-i18n="myTrees.create_modal_title">어떤 러브트리를 남길까요?</h2>
           <p class="create-tree-modal-desc" data-i18n="myTrees.create_modal_desc">이름을 정하고 첫 순간을 남겨요.</p>
         </div>
@@ -66,15 +66,15 @@
         </div>
         <div class="create-tree-field" id="createTreeGoalField">
           <div class="create-tree-label" data-i18n="myTrees.create_modal_goal_label">시작 목표</div>
-          <div class="create-tree-visibility-card" style="cursor:default;min-height:auto;background:rgba(255,246,247,0.98);border-color:rgba(144,73,81,0.20);box-shadow:0 10px 24px rgba(144,73,81,0.08);">
-            <div class="create-tree-visibility-top" style="justify-content:space-between;align-items:flex-start;">
-              <span style="display:inline-flex;align-items:center;gap:8px;">
-                <span class="material-symbols-outlined" style="font-size:18px;color:var(--primary);">psychiatry</span>
+          <div class="create-tree-visibility-card create-tree-goal-card">
+            <div class="create-tree-visibility-top create-tree-goal-top">
+              <span class="create-tree-goal-title-wrap">
+                <span class="material-symbols-outlined create-tree-goal-icon">psychiatry</span>
                 <span data-i18n="myTrees.create_modal_goal_title">둘러보기에 소개될 트리로 키우기</span>
               </span>
-              <span style="display:inline-flex;align-items:center;justify-content:center;padding:4px 9px;border-radius:999px;background:rgba(144,73,81,0.10);color:var(--primary);font-size:11px;font-weight:900;white-space:nowrap;" data-i18n="myTrees.create_modal_goal_badge">추천</span>
+              <span class="create-tree-goal-badge" data-i18n="myTrees.create_modal_goal_badge">추천</span>
             </div>
-            <div class="create-tree-visibility-desc" style="font-size:13px;line-height:1.65;" data-i18n="myTrees.create_modal_goal_desc">좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요. 첫 순간부터 차근차근 채워보세요.</div>
+            <div class="create-tree-visibility-desc create-tree-goal-desc" data-i18n="myTrees.create_modal_goal_desc">좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요. 첫 순간부터 차근차근 채워보세요.</div>
           </div>
           <div class="create-tree-help" data-i18n="myTrees.create_modal_goal_help">처음에는 제목만 정하고 시작해도 괜찮아요. 좋아하는 순간을 3개 이상 남기면 둘러보기에 소개될 수 있어요.</div>
         </div>


### PR DESCRIPTION
## Summary

- Moves safe My Trees inline styles into css/my-trees.css
- Replaces modal/icon inline styles in pages/my-trees.html with page-specific classes
- Preserves state display inline styles used for loading/error/empty/loaded UI states

## Scope

Changed files:
- pages/my-trees.html
- css/my-trees.css

## Non-changes

- No css/global.css changes
- No other page CSS changes
- No JS changes
- No HTML structure changes
- No copy/content changes
- No state display inline style removal
- No runtime/API/Auth changes
- No PR #7 prototype/reference/demo changes

## Verification

- git diff --check
- Confirmed only pages/my-trees.html and css/my-trees.css changed
- Confirmed safe inline styles moved to classes
- Confirmed loading/error/empty/loaded display inline styles are preserved
- Confirmed all IDs and data-i18n attributes are preserved