### PR TITLE
refactor(home): move inline photo heights to css

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -260,6 +260,14 @@
     backdrop-filter: blur(4px);
 }
 
+.home-v3-photo-side-top {
+    height: 112px;
+}
+
+.home-v3-photo-side-bottom {
+    height: 108px;
+}
+
 .home-v3-card-label {
     margin-top: 13px;
     color: #5a4843;

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 
                     <div class="home-v3-card card-side-top">
                         <div class="home-v3-card-inner">
-                            <div class="home-v3-photo" style="height:112px;"></div>
+                            <div class="home-v3-photo home-v3-photo-side-top"></div>
                             <div class="home-v3-card-label">반짝이던 응원봉의 바다</div>
                             <div class="home-v3-card-meta">빛나는 기억</div>
                         </div>
@@ -127,7 +127,7 @@
 
                     <div class="home-v3-card card-side-bottom">
                         <div class="home-v3-card-inner">
-                            <div class="home-v3-photo" style="height:108px;"></div>
+                            <div class="home-v3-photo home-v3-photo-side-bottom"></div>
                             <div class="home-v3-card-label">다시 보고 싶은 계절</div>
                             <div class="home-v3-card-meta">조용한 여운</div>
                         </div>


### PR DESCRIPTION
## Summary

- Moves two Home photo height inline styles into css/index.css
- Replaces inline style height attributes with page-specific classes
- Leaves Home inline scripts untouched

## Scope

Changed files:
- index.html
- css/index.css

## Non-changes

- No css/global.css changes
- No other page CSS changes
- No JS changes
- No inline script changes
- No page structure changes
- No copy/content changes
- No runtime/API/Auth changes
- No PR #7 prototype/reference/demo changes

## Verification

- git diff check passed
- Confirmed only index.html and css/index.css changed
- Confirmed the two Home photo height inline styles moved to classes
- Confirmed inline scripts were not changed