### PR TITLE
refactor(intro): move inline styles to css classes

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -10,6 +10,25 @@
   flex-direction: column;
 }
 
+/* Inline styles moved to classes */
+.intro-what-desc-secondary {
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.intro-section-desc {
+  margin-top: 1rem;
+}
+
+.intro-single-column {
+  grid-template-columns: 1fr;
+}
+
+.intro-icon-small {
+  font-size: 18px;
+}
+
 .intro-hero {
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.72fr);

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -54,7 +54,7 @@
             <p class="intro-what-lead" data-i18n="intro.whatIsDesc1">
               좋아하게 된 첫 장면과 이어진 마음을 하나의 트리로 남기는 공간입니다.
             </p>
-            <p data-i18n="intro.whatIsDesc2" style="margin-top: 1rem; font-size: 0.95rem; opacity: 0.85;">
+            <p data-i18n="intro.whatIsDesc2" class="intro-what-desc-secondary">
               단순한 아카이빙을 넘어, 나의 감정이 어디서 시작되어 어떻게 깊어졌는지 한눈에 확인할 수 있는 디지털 감정 정원입니다.
             </p>
           </div>
@@ -91,12 +91,12 @@
         <div class="intro-grid-layout">
           <div class="intro-section-text">
             <h2 data-i18n="intro.howToTitle">처음은 이렇게 남겨요</h2>
-            <p data-i18n="intro.howToDesc" style="margin-top: 1rem;">
+            <p data-i18n="intro.howToDesc" class="intro-section-desc">
               복잡한 과정 없이, 당신의 소중한 순간들을 세 단계를 통해 하나의 트리로 피워낼 수 있습니다.
             </p>
           </div>
           <div class="intro-section-visual">
-            <div class="how-to-grid" style="grid-template-columns: 1fr;">
+            <div class="how-to-grid intro-single-column">
           <div class="how-to-card">
             <div class="how-to-visual">
               <div class="how-to-badge">01</div>
@@ -159,17 +159,17 @@
         <div class="intro-grid-layout">
           <div class="intro-section-text">
             <h2 data-i18n="intro.valueTitle">이런 순간이 남아요</h2>
-            <p data-i18n="intro.valueDesc" style="margin-top: 1rem;">
+            <p data-i18n="intro.valueDesc" class="intro-section-desc">
               러브트리는 단순히 보관하는 기능을 넘어, 당신의 사랑이 어떤 의미를 갖는지 보여주는 거울이 됩니다.
             </p>
           </div>
           <div class="intro-section-visual">
-            <div class="value-grid" style="grid-template-columns: 1fr;">
+            <div class="value-grid intro-single-column">
               <div class="value-item value-item-featured">
                 <div class="value-item-visual" aria-hidden="true">
                   <div class="value-mini-chip">첫 장면</div>
                   <div class="value-mini-card first-moment">
-                    <div class="value-mini-play"><span class="material-symbols-outlined" style="font-size:18px;">play_arrow</span></div>
+                    <div class="value-mini-play"><span class="material-symbols-outlined intro-icon-small">play_arrow</span></div>
                     <div class="value-mini-line"></div>
                     <div class="value-mini-line short"></div>
                   </div>


### PR DESCRIPTION
## Summary

- Moves remaining safe Intro inline styles into page-specific CSS classes
- Keeps Intro HTML under the 500-line target

## Scope

Changed files:
- pages/intro.html 
- css/intro.css 

## Non-changes

- No css/global.css changes
- No JS changes
- No inline script changes
- No HTML structure changes
- No copy/content changes
- No Search/Public Tree Copy changes
- No runtime/API/Auth changes
- No PR #7 prototype/reference/demo changes

## Line Counts After Change

- pages/intro.html: 290 lines
- css/intro.css: 1099 lines (base + inline style classes added)