### PR TITLE
refactor(search): remove residual search overrides from global css

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -514,51 +514,6 @@ h1, h2, h3, h4, .headline {
     }
 }
 
-/* Search page */
-@media (max-width: 1024px) {
-    .search-container {
-        grid-template-columns: 1fr;
-        gap: 40px;
-        padding: 40px 24px;
-    }
-
-    .preview-sidebar {
-        position: static;
-    }
-}
-
-@media (max-width: 768px) {
-    .search-container {
-        padding: 24px 16px;
-        gap: 32px;
-    }
-
-    .search-input {
-        font-size: 1rem;
-        padding: 20px 20px 20px 56px;
-    }
-
-    .result-card {
-        padding: 16px;
-        gap: 16px;
-    }
-
-    .thumbnail-wrapper {
-        width: 120px;
-        height: 90px;
-        flex-shrink: 0;
-    }
-
-    .preview-sidebar {
-        padding: 24px;
-        border-radius: 1.5rem;
-    }
-
-    .video-container {
-        border-radius: 1rem;
-    }
-}
-
 /* Mobile optimizations */
 @media (max-width: 480px) {
     .thumbnail-wrapper {


### PR DESCRIPTION
## Summary
Remove the stale \/* Search page */\ responsive override block from \css/global.css\
Search-specific responsive behavior is already handled by \css/search.css\

## Changed files
- \css/global.css\

## Removed
- \/* Search page */\ block only

## Kept
- \/* Detail page */\
- \/* Mobile optimizations */\
- \UI PR3 Button Badge Chip Tone Unification\

## Non-changes
- No \css/search.css\ changes
- No HTML changes
- No JS/i18n changes
- No Login/Editor/Intro/Detail changes
- No runtime changes

## Verification
- \git diff --check\
- \
pm run lint\
- \
pm run build\
