### PR TITLE
fix(editor): add aria-label to sidebarTitleEditBtn

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -33,7 +33,7 @@
                     </div>
                     <span id="sidebarTreeVisibility" class="editor-tree-visibility-pill is-private">비공개</span>
                     <div class="editor-title-settings-panel" aria-label="트리 핵심 설정">
-                        <button type="button" class="editor-mini-setting-btn" id="sidebarTitleEditBtn">
+                        <button type="button" class="editor-mini-setting-btn" id="sidebarTitleEditBtn" aria-label="제목 수정">
                             <span class="material-symbols-outlined" aria-hidden="true">edit</span>
                             <span id="sidebarTitleEditBtnLabel">제목 수정</span>
                         </button>


### PR DESCRIPTION
## 변경 요약

`pages/editor.html`의 `sidebarTitleEditBtn` 아이콘 버튼에 `aria-label="제목 수정"` 을 추가합니다.

## 변경 파일

- `pages/editor.html` — sidebarTitleEditBtn에 aria-label 추가 (1줄)

## 변경 이유

해당 버튼은 아이콘(edit Material Symbol)과 텍스트 span을 함께 가지고 있으나, 스크린 리더 환경에서 버튼 레이블이 명시적으로 선언되지 않아 접근성 개선 대상이었습니다.

## 비변경 확인

- Search Copy/Fork 변경 없음 ✓
- API/client/auth 변경 없음 ✓
- public/private 정책 변경 없음 ✓
- class rename 없음 ✓
- 인라인 i18n 스크립트 변경 없음 (이 PR 범위 외) ✓

## 검증

- lint: pass
- build: pass
- test: 기존 contract 테스트 실패(Test 21, 30, 35, 41) — main 동일, 이 PR과 무관

## 남은 작업 (별도 PR)

- `detail_empty_title` 등 인라인 i18n key를 `i18n-editor.js`로 이동 — 별도 PR