### PR TITLE
cleanup(detail): remove redundant moment card image rule from global css

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -507,11 +507,6 @@ h1, h2, h3, h4, .headline {
     .moment-card {
         padding: 16px;
     }
-
-    .moment-card img {
-        width: 60px !important;
-        height: 60px !important;
-    }
 }
 
 /* Mobile optimizations */


### PR DESCRIPTION
1. Summary
   - Remove redundant `.moment-card img` rule from `css/global.css`
   - Equivalent rule already exists in `css/detail.css`

2. Changed files
   - `css/global.css`

3. Removed
   - `.moment-card img` 768px rule only

4. Kept
   - `#memoryTitle`
   - `.moment-card`
   - `.video-main`
   - `.diary-container`
   - `.connected-section`
   - Mobile optimizations
   - Search residual cleanup state

5. Non-changes
   - No `css/detail.css` changes
   - No scripts/netlify/package/workflows changes
   - No pages/js changes
   - No behavior change intended

6. Verification
   - `git diff --check`: Pass
   - `npm run lint`: Pass
   - `npm run build`: Pass