### PR TITLE
cleanup(detail): move memory title mobile rule to detail css

### DIFF
--- a/css/detail.css
+++ b/css/detail.css
@@ -336,4 +336,8 @@
     .moment-card img { width: 60px !important; height: 60px !important; }
     .growth-visualization { margin-top: 24px; }
     #connectedFragments { grid-template-columns: 1fr !important; gap: 14px !important; min-width: 0; }
+    #memoryTitle {
+        font-size: 2.2rem !important;
+        line-height: 1.2;
+    }
 }

--- a/css/global.css
+++ b/css/global.css
@@ -499,11 +499,6 @@ h1, h2, h3, h4, .headline {
         border-radius: 2rem;
     }
 
-    #memoryTitle {
-        font-size: 2.2rem !important;
-        line-height: 1.2;
-    }
-
     .moment-card {
         padding: 16px;
     }


### PR DESCRIPTION
## Summary

- Moves the mobile #memoryTitle rule from css/global.css to css/detail.css
- Keeps the exact same values (font-size: 2.2rem !important; line-height: 1.2)
- Completes Detail page-specific CSS ownership for this selector

## Changed files

- css/global.css
- css/detail.css