### PR TITLE
cleanup(search): remove orphan debug comment and duplicate restore call

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -245,7 +245,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function restoreStateFromUrl() {
-        console.log('[URL State] Restoring state from URL');
         // Make functions globally available for debugging
         window.readUrlState = readUrlState;
         window.updateUrlState = updateUrlState;
@@ -816,8 +815,4 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         syncBrowseHead();
     });
-
-    // Initial URL state restoration after all scripts are loaded
-    restoreStateFromUrl();
-    applySelectedTreeFromUrl();
 });


### PR DESCRIPTION
## Summary

- Removes an orphan URL state debug log from `js/search.js`
- Removes a duplicate URL state restore call block at the end of `DOMContentLoaded`
- Keeps Search URL state behavior unchanged because the active restore flow remains in place

## Changed files

- `js/search.js`

## Non-changes

- No Search UI layout changes
- No Search API/client changes
- No CSS changes
- No i18n changes
- No pages/search.html changes
- No PR #7/prototype/reference/demo changes

## Verification

- `git diff --check`
- `npm run lint`
- `npm run build`

## Notes

This branch was reset onto current `main` before applying the cleanup so the prior large encoding/noise diff is no longer present.