### PR TITLE
docs(runtime): clarify Netlify legacy removal guardrails

### DIFF
--- a/docs/engineering/REVIEW_GUARDRAILS.md
+++ b/docs/engineering/REVIEW_GUARDRAILS.md
@@ -28,7 +28,23 @@
 
 ## 반복 false positive 금지 항목
 
-### 1. `vercel.json`
+### 1. Firebase Web `apiKey`
+
+- `js/firebase-config.js`의 Firebase Web config는 브라우저 초기화용 설정입니다.
+- 값이 코드에 보인다는 사실만으로 **즉시 blocker**로 분류하지 않습니다.
+- 이 항목은 보통 **운영 점검 항목**으로 분리합니다.
+
+점검 방향:
+- Firebase authorized domains
+- Auth provider 설정
+- Security Rules
+- abuse 방지 설정
+
+금지:
+- "apiKey가 보이므로 즉시 배포 불가" 식의 단정
+- 서버 secret과 동일한 성격으로 취급
+
+### 2. `vercel.json`
 
 - 현재 `vercel.json`은 deprecated transitional fallback / audit 대상입니다.
 - 공식 사용자-facing entry는 Cloudflare Pages `https://lovebud.pages.dev/` 기준입니다.
@@ -38,7 +54,7 @@
 - “Netlify가 있으니 Vercel 설정은 불필요” 식의 추정
 - Vercel을 현재 공식 프론트 엔트리로 단정
 
-### 2. Netlify route gap
+### 3. Netlify route gap
 
 - Netlify route gaps are not automatic blockers for Cloudflare production.
 - Netlify is Legacy Artifact Only / Removal Candidate, not an active fallback implementation target.
@@ -75,7 +91,7 @@
 - 실제 현재 증상과 연결 없이 “파일이 크니 심각” 판정
 - generic 프론트엔드 교과서식 리뷰를 최우선 이슈로 분류
 
-### 6. 이름만 보고 위험 단정
+### 7. 이름만 보고 위험 단정
 
 - 파일명만 보고 runtime 구조를 단정하지 않습니다.
 - 반드시 현재 파일 내용과 실제 호출 구조를 확인합니다.
@@ -111,6 +127,7 @@
 - “vercel.json은 혼란스럽다 → 삭제”
 - “Netlify route gap이 있다 → active fallback parity 구현 필요”
 - “번들러가 없으니 지금 당장 도입 필요”
+- “Firebase apiKey가 보인다 → 즉시 blocker”
 
 ---
 

--- a/docs/engineering/REVIEW_GUARDRAILS.md
+++ b/docs/engineering/REVIEW_GUARDRAILS.md
@@ -65,7 +65,7 @@
 - 신규 backend policy를 `netlify/functions/*`에 구현
 - Cloudflare production route gap과 Netlify legacy route gap을 같은 문제로 취급
 
-### 3. browse vs search
+### 4. browse vs search
 
 - `pages/search.html`은 구현 경로명입니다.
 - `browse`, `둘러보기`, `감상 허브`는 제품 경험 표현입니다.
@@ -74,7 +74,7 @@
 - search와 browse를 같은 층위 개념으로 혼동
 - 경로명만 보고 제품 카피가 틀렸다고 단정
 
-### 4. browse display filter vs publication guard
+### 5. browse display filter vs publication guard
 
 - browse display filter: read/display 정책
 - publication guard: write/state transition 정책
@@ -82,7 +82,7 @@
 금지:
 - 둘을 같은 기능 또는 같은 버그 범주로 취급
 
-### 5. 파일 크기 / 번들러 / 컴포넌트화
+### 6. 파일 크기 / 번들러 / 컴포넌트화
 
 - 파일이 크다는 사실만으로 현재 blocker라고 단정하지 않습니다.
 - 번들러 도입, 전면 컴포넌트화, monolith 제거는 장기 과제일 수 있습니다.

--- a/docs/engineering/REVIEW_GUARDRAILS.md
+++ b/docs/engineering/REVIEW_GUARDRAILS.md
@@ -8,8 +8,10 @@
 
 ## 먼저 확인할 전제
 
-- 실서비스 프론트 주소: `https://lovebud.vercel.app/`
-- 인프라 우선순위: **Modal > Vercel > Netlify**
+- 공식 사용자-facing 주소: `https://lovebud.pages.dev/`
+- active runtime: **Cloudflare Pages + Modal**
+- Vercel: deprecated transitional fallback / audit 중
+- Netlify: Legacy Artifact Only / Removal Candidate / Issue #119 runtime routing audit 대상
 - 브라우저는 가능하면 **same-origin `/api`** 만 사용
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 source of truth
 - browse display filter 와 publication guard 는 다른 문제
@@ -26,30 +28,26 @@
 
 ## 반복 false positive 금지 항목
 
-### 1. Firebase Web `apiKey`
+### 1. `vercel.json`
 
-- `js/firebase-config.js`의 Firebase Web config는 브라우저 초기화용 설정입니다.
-- 값이 코드에 보인다는 사실만으로 **즉시 blocker**로 분류하지 않습니다.
-- 이 항목은 보통 **운영 점검 항목**으로 분리합니다.
-
-점검 방향:
-- Firebase authorized domains
-- Auth provider 설정
-- Security Rules
-- abuse 방지 설정
-
-금지:
-- “apiKey가 보이므로 즉시 배포 불가” 식의 단정
-- 서버 secret과 동일한 성격으로 취급
-
-### 2. `vercel.json`
-
-- 현재 `vercel.json`은 공식 엔트리 계약과 rewrite 규칙의 일부입니다.
-- Vercel은 현재 문서 기준 공식 프론트 엔트리 계층입니다.
+- 현재 `vercel.json`은 deprecated transitional fallback / audit 대상입니다.
+- 공식 사용자-facing entry는 Cloudflare Pages `https://lovebud.pages.dev/` 기준입니다.
 
 금지:
 - `vercel.json`을 자동으로 삭제/정리 후보로 분류
 - “Netlify가 있으니 Vercel 설정은 불필요” 식의 추정
+- Vercel을 현재 공식 프론트 엔트리로 단정
+
+### 2. Netlify route gap
+
+- Netlify route gaps are not automatic blockers for Cloudflare production.
+- Netlify is Legacy Artifact Only / Removal Candidate, not an active fallback implementation target.
+- Route gaps in `netlify.toml` or `netlify/functions/*` should be routed to Issue #119 runtime routing audit unless CTO explicitly reactivates Netlify runtime.
+
+금지:
+- CTO 승인 없이 Netlify route parity를 맞추기 위해 신규 API route 추가
+- 신규 backend policy를 `netlify/functions/*`에 구현
+- Cloudflare production route gap과 Netlify legacy route gap을 같은 문제로 취급
 
 ### 3. browse vs search
 
@@ -77,9 +75,9 @@
 - 실제 현재 증상과 연결 없이 “파일이 크니 심각” 판정
 - generic 프론트엔드 교과서식 리뷰를 최우선 이슈로 분류
 
-### 6. 이름만 보고 보안 위험 단정
+### 6. 이름만 보고 위험 단정
 
-- 파일명만 보고 DB direct access, secret leakage, inactive config를 단정하지 않습니다.
+- 파일명만 보고 runtime 구조를 단정하지 않습니다.
 - 반드시 현재 파일 내용과 실제 호출 구조를 확인합니다.
 
 금지:
@@ -103,15 +101,15 @@
 
 ## 좋은 리뷰 예시
 
-- my-trees 첫 진입 지연을 `700ms fallback`, auth polling, boot 중복과 연결해서 설명
-- browse 느림을 summary read path, 캐시 miss, fallback query 구조와 연결해서 설명
+- my-trees 첫 진입 지연을 auth polling, boot 중복과 연결해서 설명
+- browse 느림을 summary read path, 캐시 miss, degraded response 구조와 연결해서 설명
 - editor/my-trees write path가 same-origin `/api` 계약을 지키는지 점검
 
 ## 나쁜 리뷰 예시
 
 - “파일이 크다 → 심각”
-- “Firebase apiKey가 보인다 → 즉시 blocker”
 - “vercel.json은 혼란스럽다 → 삭제”
+- “Netlify route gap이 있다 → active fallback parity 구현 필요”
 - “번들러가 없으니 지금 당장 도입 필요”
 
 ---

--- a/docs/ops/OPERATIONS.md
+++ b/docs/ops/OPERATIONS.md
@@ -11,13 +11,14 @@ LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 | **Cloudflare Pages** | **Primary Entry / API Router** | 실서비스 진입점, 정적 프런트 서빙, same-origin `/api/*` 라우팅, `functions/api/*` 실행 | 1순위 |
 | **Modal** | **Active API / Backend Target** | `/api/trees`, `/api/memories`, browse/community/private read/write target, 대표 카드 계산 | 1순위 |
 | **Vercel** | **Deprecated Transitional Fallback** | 일부 fallback / 전이기 보조 계층 | audit 중 |
-| **Netlify** | **Legacy Artifact Only** | `netlify/functions/*`, `netlify.toml` legacy reference. 현재 `lovebud.pages.dev` production/test slot active backend 아님 | 신규 구현 금지 |
+| **Netlify** | **Legacy Artifact Only / Removal Candidate** | `netlify/functions/*`, `netlify.toml` historical/reference purpose. 현재 `lovebud.pages.dev` production/test slot active backend 또는 active fallback 아님 | 신규 구현 금지 |
 
 핵심 원칙:
 - 실서비스 주소는 **반드시 `https://lovebud.pages.dev/`** 기준으로 본다.
 - browser-facing API entry는 **Cloudflare Pages same-origin `/api/*`** 기준으로 본다.
 - active backend target은 **Cloudflare Pages Functions → Modal** 경로 기준으로 본다.
 - `netlify/functions/*`는 현재 active production backend가 아니며, Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend 정책 구현 대상이 아니다.
+- Netlify route gap은 즉시 blocker가 아니며, Issue #119 runtime routing audit에서 제거/보존 여부를 판단한다.
 
 ---
 
@@ -27,12 +28,12 @@ LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 - **Cloudflare Pages 프로젝트(운영 기준)**: `lovebud.pages.dev`
 - **Modal 앱**: `lovebud-browse-snapshot`
 - **Vercel 주소(Deprecated transitional fallback)**: `https://lovebud.vercel.app/`
-- **Netlify 주소 / Functions(Legacy artifact only)**: `https://lovebud.netlify.app/`, `netlify/functions/*`
+- **Netlify 주소 / Functions(Legacy artifact only / Removal Candidate)**: `https://lovebud.netlify.app/`, `netlify/functions/*`
 
 주의:
 - Vercel과 Netlify 주소는 현재 공식 사용자-facing 대표 주소가 아닙니다.
 - 운영 문서에서 `lovebud.vercel.app`, `lovebud.netlify.app`를 주서비스처럼 설명하지 않습니다.
-- Netlify Functions를 현재 `lovebud.pages.dev` production/test slot backend처럼 설명하지 않습니다.
+- Netlify Functions를 현재 `lovebud.pages.dev` production/test slot backend나 active fallback처럼 설명하지 않습니다.
 
 ---
 
@@ -111,18 +112,21 @@ Modal runtime 핵심 변수:
 ### 4.3 Vercel / Netlify
 
 Vercel은 deprecated transitional fallback입니다.
-Netlify Functions는 legacy artifact입니다.
+Netlify Functions는 Legacy Artifact Only / Removal Candidate입니다.
 
 운영 설명에서는 두 계층 모두 **주경로**로 표현하지 않습니다.
+Netlify는 active fallback 구현 대상이 아니며, removal audit 완료 전까지 historical/reference purpose로만 남습니다.
 
 ---
 
-## 5. fallback 운영 원칙
+## 5. Degraded response / transitional fallback 운영 원칙
 
 - Modal browse summary가 실패해도 browse 전체가 멈추면 안 된다.
-- fallback은 유지하되, 성능 및 요약 품질 기준은 Modal이 우선이다.
-- 점진적 제거 대상은 “Vercel/Netlify 주경로 설명”이지, 모든 fallback 문구의 즉시 삭제가 아니다.
-- Netlify Functions는 현재 active fallback으로 확인되지 않았으므로 legacy artifact로만 표기한다.
+- fallback이라는 표현은 Vercel deprecated transitional fallback 또는 Modal 실패 시 degraded response에 한정한다.
+- Netlify Functions는 active fallback이 아니다.
+- Netlify artifacts는 removal audit 완료 전까지 historical/reference purpose로만 남는다.
+- CTO가 Netlify runtime 재활성화를 명시 승인하지 않는 한, `netlify.toml` 또는 `netlify/functions/*`에 신규 route parity, backend policy, feature parity를 추가하지 않는다.
+- Netlify route gap은 고쳐서 유지할 문제가 아니라 Issue #119 runtime routing audit에서 제거/보존 여부를 판단한다.
 
 ---
 
@@ -136,8 +140,8 @@ Netlify Functions는 legacy artifact입니다.
 3. `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal로 고정
 4. browse summary는 Modal 우선으로 고정
 5. Vercel은 deprecated transitional fallback으로 축소
-6. Netlify Functions는 legacy artifact로 축소
-7. tests/docs reference transition 완료 후 Netlify archive 여부를 별도 승인한다
+6. Netlify Functions는 Legacy Artifact Only / Removal Candidate로 축소
+7. tests/docs reference transition 완료 후 Issue #119 audit에서 Netlify archive 여부를 별도 승인한다
 
 ---
 
@@ -148,7 +152,7 @@ PR #38은 active runtime이 아닌 `netlify/functions/*`에 backend 정책을 �
 해당 판단은 다음 기준을 따른다.
 
 - active production/test slot runtime: Cloudflare Pages Functions → Modal
-- legacy artifact: `netlify/functions/*`
+- legacy artifact / removal candidate: `netlify/functions/*`
 - archive: 이번 문서 정리 PR에서 수행하지 않음
 - Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend policy를 `netlify/functions/*`에 구현하지 않음
 
@@ -163,7 +167,8 @@ PR #38은 active runtime이 아닌 `netlify/functions/*`에 backend 정책을 �
 - 응답 server가 Cloudflare인지 확인했는가
 - Cloudflare Pages env에 `MODAL_BASE_URL`이 설정되어 있는가
 - Modal `/modal/health`가 정상 응답하는가
-- `netlify/functions/*`를 새 backend 구현 대상으로 오해하지 않았는가
+- `netlify/functions/*`를 새 backend 구현 대상이나 active fallback 구현 대상으로 오해하지 않았는가
+- Netlify route gap을 Issue #119 audit 대상으로 분리했는가
 
 ---
 


### PR DESCRIPTION
## Summary

- Clarifies that Netlify is Legacy Artifact Only / Removal Candidate, not an active fallback implementation target
- Updates runtime guardrails to use Cloudflare Pages + Modal as the active production truth
- Adds guidance that Netlify route gaps are not immediate blockers and should be handled through Issue #119 runtime routing audit
- Narrows fallback terminology to Vercel transitional fallback or Modal failure degradation only

## Changed files

- docs/ops/OPERATIONS.md
- docs/engineering/REVIEW_GUARDRAILS.md

## Scope note

- This PR intentionally limits the runtime guardrail update to the two runtime/review policy documents above.
- Broader status/CI/screenshot documentation refresh will be handled separately after this PR.
- No runtime routing implementation or Netlify archive action is included.

## Non-changes

- No runtime code changes
- No netlify.toml changes
- No netlify/functions/* changes
- No package.json changes
- No tests changes
- No pages/settings.html changes
- No css/settings.css changes
- No PR #7 prototype changes
- No prototype/reference/demo changes
- No TASK_STATUS / CI blocker / verification evidence changes

## Policy notes

- Official user-facing address: https://lovebud.pages.dev/
- Active runtime: Cloudflare Pages + Modal
- Vercel: deprecated transitional fallback / audit
- Netlify: Legacy Artifact Only / Removal Candidate
- Netlify runtime reactivation requires explicit CTO approval
- Netlify route gaps should be evaluated under Issue #119, not fixed as active fallback parity work

## Verification

- Confirmed changed files through GitHub diff
- Confirmed changed files are documentation files only
- Confirmed no netlify.toml, netlify/functions/*, package.json, tests, PR #7, or PR #122 files changed
- Confirmed Netlify language in changed files no longer describes it as active fallback implementation target