### PR TITLE
cleanup(editor): move presentation inline styles to editor css

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -277,6 +277,13 @@ body {
     display: none !important;
 }
 
+.editor-flow-lead {
+    margin: -6px 0 0;
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--on-surface-variant);
+}
+
 .memory-node {
     position: absolute;
     z-index: 2;
@@ -659,6 +666,17 @@ body {
     display: flex;
     flex-direction: column;
     gap: 10px;
+}
+
+#memoryStartTimeField {
+    margin-top: 10px;
+}
+
+.editor-form-help {
+    margin: 6px 0 0;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--on-surface-variant);
 }
 
 .editor-form-field-primary {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -24,7 +24,7 @@
             </div>
             <section class="editor-status-section">
                 <h3 id="editorFlowHeading">러브트리</h3>
-                <p id="editorFlowLead" class="editor-flow-lead" style="margin:-6px 0 0;font-size:13px;line-height:1.7;color:var(--on-surface-variant);">...</p>
+                <p id="editorFlowLead" class="editor-flow-lead">...</p>
                 <div class="editor-status-card">
                     <div class="editor-reference-kicker" aria-hidden="true">✿ Our LoveTree</div>
                     <div class="editor-space-between-row">
@@ -107,10 +107,10 @@
                     <label id="memoryUrlLabel" class="editor-form-label">...</label>
                     <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
                 </div>
-                <div class="editor-form-field" id="memoryStartTimeField" style="margin-top: 10px;">
+                <div class="editor-form-field" id="memoryStartTimeField">
                     <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">입덕 순간 시간</label>
                     <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23 또는 83초" class="editor-form-input">
-                    <p id="memoryStartTimeHint" class="editor-form-help" style="margin: 6px 0 0; font-size: 12px; line-height: 1.6; color: var(--on-surface-variant);">유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.</p>
+                    <p id="memoryStartTimeHint" class="editor-form-help">유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.</p>
                 </div>
                 <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
                     <div class="memory-link-preview__thumb-wrap">


### PR DESCRIPTION
## Summary
- Move remaining presentation-only inline styles from `pages/editor.html` into `css/editor.css` 
- Keep JS-controlled `display:none` state unchanged
- Preserve all CSS values

## Changed files
- `pages/editor.html` 
- `css/editor.css` 

## Moved styles
- `#editorFlowLead` 
- `#memoryStartTimeField` 
- `#memoryStartTimeHint` 

## Preserved
- `#addMemoryForm` keeps `style="display:none;"` 
- `onmousedown="event.stopPropagation()"` unchanged
- inline `window.i18nEditor` script unchanged

## Non-changes
- No JS changes
- No HTML structure changes
- No `css/global.css` changes
- No `css/detail.css` changes
- No `css/search.css` changes
- No settings files changes
- No PR #7/prototype/reference/demo changes

## Verification
- `git diff --check` 
- `npm run lint` 
- `npm run build`
