### PR TITLE
docs(project): refresh task status and CI verification notes

### DIFF
--- a/docs/ops/KNOWN_CI_E2E_BLOCKERS.md
+++ b/docs/ops/KNOWN_CI_E2E_BLOCKERS.md
@@ -1,18 +1,32 @@
 # Known CI / E2E Blockers
 
-이 문서는 LoveBud PR 검수 과정에서 반복 관찰된 CI/E2E 실패를 원인 분리하기 위한 운영 문서입니다.
+이 문서는 LoveBud PR 검수 과정에서 과거 반복 관찰된 CI/E2E 실패를 원인 분리하기 위한 운영 문서입니다.
 
-중요: 이 문서는 실패 로그를 무시하자는 문서가 아닙니다. 목적은 **실패 원인이 해당 PR 변경 범위에서 발생한 신규 회귀인지, 이미 알려진 CI/E2E 환경 blocker인지 분리**하는 것입니다.
+중요: 이 문서는 실패 로그를 무시하자는 문서가 아닙니다. 목적은 **실패 원인이 해당 PR 변경 범위에서 발생한 신규 회귀인지, 과거에 반복 관찰된 환경/계약 blocker의 재발인지 분리**하는 것입니다.
 
 ---
 
-## 1. Currently observed recurring blockers
+## 1. Status after PR #111
 
-최근 여러 PR에서 반복 관찰된 blocker는 아래와 같습니다.
+PR #111 이후 stale contract tests와 i18n scan 범위 문제는 정리되었습니다.
 
-### 1.1 CI `verify-static` / `Smoke test` failure
+현재 기준:
 
-반복 관찰 항목:
+- `npm test`: expected green baseline
+- `npm run verify`: expected green baseline
+- `npm run ci`: expected green baseline
+- 과거 `56/61` test baseline은 더 이상 현행 기준으로 사용하지 않습니다.
+- 과거 `Cannot find module 'playwright'`는 Playwright dependency/setup 이슈 재발 여부를 분리하기 위한 historical triage note로만 취급합니다.
+
+따라서 아래 항목들은 **currently expected failures**가 아니라, 재발 시 원인을 분리하기 위한 **historical recurrence triage notes**입니다.
+
+---
+
+## 2. Historical recurrence triage notes
+
+### 2.1 CI `verify-static` / `Smoke test` failure
+
+과거 반복 관찰 항목:
 
 ```text
 CI: failure
@@ -20,15 +34,15 @@ job: verify-static
 step: Smoke test
 ```
 
-현재 판단:
+재발 시 판단:
 
-- Search/static smoke 계열 기존 blocker일 수 있습니다.
 - 모든 PR의 자동 blocker로 단정하지 않습니다.
-- 단, 해당 PR이 Search, browse, static smoke 대상, selector, route mock, test script, package dependency를 변경한 경우에는 별도 원인 분석이 필요합니다.
+- PR이 Search, browse, static smoke 대상, selector, route mock, test script, package dependency를 변경한 경우에는 별도 원인 분석이 필요합니다.
+- PR 변경 파일과 직접 관련이 없고 현재 green baseline에서 갑자기 재발했다면, 먼저 CI 로그와 최근 main 상태를 확인합니다.
 
-### 1.2 CI E2E Smoke / `e2e-smoke` failure
+### 2.2 CI E2E Smoke / `e2e-smoke` failure
 
-반복 관찰 항목:
+과거 반복 관찰 항목:
 
 ```text
 CI E2E Smoke: failure
@@ -36,37 +50,41 @@ job: e2e-smoke
 step: Run E2E smoke subset
 ```
 
-현재 판단:
+재발 시 판단:
 
 - PR 변경 범위와 직접 관련이 있는지 매번 확인합니다.
-- UI/layout/docs-only PR에서 동일한 기존 blocker가 반복된 경우, preview/test URL 실측 결과와 changed files를 함께 봅니다.
+- UI/layout/docs-only PR에서 유사 실패가 재발한 경우에도, preview/test URL 실측 결과와 changed files를 함께 봅니다.
+- 현재 baseline이 green인 상태에서는 같은 이름의 실패라도 자동으로 historical blocker로 면제하지 않습니다.
 
-### 1.3 `Cannot find module 'playwright'`
+### 2.3 Playwright dependency/setup failure
 
-반복 관찰 항목:
+과거 반복 관찰 항목:
 
 ```text
 Cannot find module 'playwright'
 ```
 
-현재 판단:
+재발 시 판단:
 
-- 일반적으로 CI dependency/setup blocker로 분류합니다.
-- docs-only, css-only, layout-only PR에서 `package.json`, lockfile, workflow, E2E script를 변경하지 않았다면 해당 PR의 신규 회귀로 보지 않을 수 있습니다.
-- 단, `package.json`, lockfile, workflow, Playwright 설정, E2E script를 변경한 PR에서는 이 오류도 PR 변경과 직접 관련 있을 수 있으므로 exception 판단을 하지 않습니다.
+- 일반적으로 CI dependency/setup 문제일 수 있습니다.
+- docs-only, css-only, layout-only PR에서 `package.json`, lockfile, workflow, E2E script를 변경하지 않았다면 해당 PR의 신규 회귀인지 먼저 분리합니다.
+- 단, `package.json`, lockfile, workflow, Playwright 설정, E2E script를 변경한 PR에서는 해당 PR이 원인일 수 있으므로 exception 판단을 하지 않습니다.
 
 ---
 
-## 2. These failures are not automatic blockers for every PR
+## 3. These failures are not automatic blockers or automatic exemptions
 
-위 실패가 관찰되었다고 해서 모든 PR을 자동으로 blocker 처리하지 않습니다.
+위 실패가 관찰되었다고 해서 모든 PR을 자동 blocker 처리하지 않습니다.
 
-다만 다음 두 가지를 반드시 구분합니다.
+반대로, 과거 관찰 이력이 있다는 이유만으로 자동 면제하지도 않습니다.
 
-1. **Known blocker recurrence**
-   - 이미 반복 관찰된 동일 실패
+반드시 다음 두 가지를 구분합니다.
+
+1. **Historical blocker recurrence**
+   - 과거와 같은 유형의 실패
    - PR 변경 파일과 직접 관련 없음
    - preview/test URL 또는 관련 수동 검증에서 회귀 없음
+   - 현재 main baseline과 CI 로그를 확인한 뒤 recurrence로 분류
 
 2. **PR-caused failure**
    - PR이 실패 job과 관련된 파일을 직접 변경
@@ -77,11 +95,11 @@ Known blocker라는 판단은 자동 면제가 아니라 원인 분리 결과입
 
 ---
 
-## 3. Required checks before exception merge
+## 4. Required checks before exception merge
 
 CI/E2E failure가 남아 있는 상태에서 docs-only, css-only, UI layout PR의 exception merge를 검토하려면 아래를 모두 확인합니다.
 
-### 3.1 Changed files
+### 4.1 Changed files
 
 확인할 것:
 
@@ -104,7 +122,7 @@ functions/*
 modal_compute/*
 ```
 
-### 3.2 Diff scope
+### 4.2 Diff scope
 
 확인할 것:
 
@@ -114,7 +132,7 @@ modal_compute/*
 - selector/test target과 직접 연결되는 변경인지
 - route/API/runtime 변경이 있는지
 
-### 3.3 CI failure relevance
+### 4.3 CI failure relevance
 
 확인할 것:
 
@@ -122,17 +140,9 @@ modal_compute/*
 - 실패 step 이름
 - 실패 로그의 직접 원인
 - PR diff와 실패 로그 사이의 연결성
+- 현재 main baseline에서 같은 실패가 재현되는지
 
-예시:
-
-```text
-Cannot find module 'playwright'
-```
-
-이 오류는 package/lockfile/workflow/script 변경이 없는 docs-only PR에서는 dependency/setup blocker일 수 있습니다.  
-하지만 package/lockfile/workflow/script를 변경한 PR에서는 해당 PR이 원인일 수 있으므로 별도 판단해야 합니다.
-
-### 3.4 Preview/test URL evidence
+### 4.4 Preview/test URL evidence
 
 UI/layout/css PR은 CI만으로 예외 병합을 판단하지 않습니다.
 
@@ -146,7 +156,7 @@ UI/layout/css PR은 CI만으로 예외 병합을 판단하지 않습니다.
 
 Browse/Search/Editor/Auth/API 의존 화면은 로컬 정적 서버 단독 결과로 최종 PASS/BLOCKER를 판단하지 않습니다.
 
-### 3.5 Runtime/API change 여부
+### 4.5 Runtime/API change 여부
 
 다음 파일 또는 영역이 바뀐 PR은 exception 기준을 높입니다.
 
@@ -163,16 +173,16 @@ runtime/API 변경이 있으면 docs-only/css-only/layout-only exception merge �
 
 ---
 
-## 4. Docs-only PR exception criteria
+## 5. Docs-only PR exception criteria
 
-Docs-only PR에서 known CI/E2E blocker가 반복될 때 exception merge 검토가 가능합니다.
+Docs-only PR에서 historical CI/E2E blocker가 재발할 때 exception merge 검토가 가능합니다.
 
 필수 조건:
 
 - changed files가 문서 파일뿐
 - code/UI/runtime/package/workflow/script 파일 변경 없음
 - diff가 문서 내용 변경으로 제한됨
-- 실패 원인이 기존 CI/Search/E2E setup blocker와 동일
+- 실패 원인이 과거 CI/Search/E2E setup blocker와 동일하거나 관련 없음이 확인됨
 - 문서 링크/상대경로/표현 수위 검토 완료
 - CTO가 명시적으로 docs-only exception merge 승인
 
@@ -182,9 +192,9 @@ Docs-only PR에서 known CI/E2E blocker가 반복될 때 exception merge 검토�
 
 ---
 
-## 5. CSS-only / UI layout PR exception criteria
+## 6. CSS-only / UI layout PR exception criteria
 
-CSS-only 또는 UI layout PR에서 known CI/E2E blocker가 반복될 때 exception merge 검토가 가능합니다.
+CSS-only 또는 UI layout PR에서 historical CI/E2E blocker가 재발할 때 exception merge 검토가 가능합니다.
 
 필수 조건:
 
@@ -204,7 +214,7 @@ CSS-only 또는 UI layout PR에서 known CI/E2E blocker가 반복될 때 excepti
 
 ---
 
-## 6. UI runtime-dependent page rule
+## 7. UI runtime-dependent page rule
 
 아래 화면은 preview/test URL 실측이 특히 중요합니다.
 
@@ -221,7 +231,7 @@ CSS-only 또는 UI layout PR에서 known CI/E2E blocker가 반복될 때 excepti
 
 ---
 
-## 7. Reporting template
+## 8. Reporting template
 
 CI/E2E failure가 있는 PR을 보고할 때는 아래 형식을 사용합니다.
 
@@ -241,6 +251,7 @@ CI/E2E failure가 있는 PR을 보고할 때는 아래 형식을 사용합니다
 - Changed files:
 - Diff scope:
 - Runtime/API/package/workflow/script changes: yes/no
+- Current main baseline: green/failing/not checked
 - Preview/test URL evidence:
 - Failure related to this PR: yes/no/inconclusive
 - Exception merge request possible: yes/no
@@ -248,8 +259,8 @@ CI/E2E failure가 있는 PR을 보고할 때는 아래 형식을 사용합니다
 
 ---
 
-## 8. One-line rule
+## 9. One-line rule
 
 ```text
-Known CI/E2E blocker documentation is for cause separation, not for ignoring failures.
+Known CI/E2E blocker documentation is for recurrence triage and cause separation, not for ignoring failures.
 ```

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -42,7 +42,7 @@
 | Runtime routing transitional layers audit | 진행 중 | Issue #119 | Cloudflare/Vercel/Netlify transitional route ownership audit open. runtime routing 문서 본문 변경은 audit 이후 |
 | SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
 | JS architecture cleanup | 보류 | Issue #72 / PR #73 | Issue #72는 open이며 current status는 paused. PR #73은 closed / unmerged. file-move refactor는 clean worktree와 단일 executor 조건 충족 전 재개 금지 |
-| Issue #65 Search backlog | 진행 중 | Issue #65 | Selected tree deep link, Search JS responsibility split, broader Search CSS extraction은 backlog/open 상태 유지 |
+| Issue #65 Search backlog | 진행 중 | Issue #65 | Search JS responsibility split, broader Search CSS extraction은 backlog/open 상태 유지. Selected tree deep link는 PR #83에서 merged 완료 |
 
 ---
 
@@ -60,11 +60,10 @@
 
 ## 다음 예정 작업 / Issue #65 Backlog
 
-Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개입니다.
+Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 2개입니다.
 
 | 작업 | 상태 | 메모 |
 |------|------|------|
-| Selected tree deep link | 진행 중 | `?tree=<treeId>` 직접 진입 시 공개 tree preview 선택. desktop / mobile preview 동작 확인 필요. 별도 feature branch에서 구현/검증 후 판단 |
 | Search JS responsibility split | 보류 | JS architecture cleanup paused 상태. Search file-move 재개 전 clean worktree / 단일 executor / Preview 검증 조건 필요 |
 | Search CSS extraction / inline style reduction | 진행 중 | PR #80 이후 여러 CSS extraction/cleanup PR이 진행됨. 더 넓은 Search JS refactor와 혼합 금지 |
 
@@ -94,6 +93,7 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 ## 작업 이력 (Task History)
 
 - 2026-04-26: PR #128 `cleanup(editor): move presentation inline styles to editor css` merged / closed. Editor presentation-only inline styles를 `css/editor.css`로 이동. Merge SHA `07efce659ec13b2342d116ac0b43af9181cded3b`
+- 2026-04-26: PR #83 `feat(search): support selected tree deep link` merged / closed. `/pages/search.html?tree=<treeId>` 직접 진입 시 공개 tree preview 선택 지원. Merge SHA `48b1a5ebd62ac8ddabbdc9c0622a4de2a5123bd5`
 - 2026-04-26: PR #127 `docs(runtime): clarify Netlify legacy removal guardrails` merged / closed. OPERATIONS / REVIEW_GUARDRAILS에 Netlify Legacy Artifact Only / Removal Candidate 기준 반영. Merge SHA `d48b9fd6f49724255c85bb423145c6e2a6846008`
 - 2026-04-26: PR #121 `cleanup(search): remove orphan debug comment and duplicate restore call` merged / closed. Search URL state cleanup 완료
 - 2026-04-26: PR #120 `cleanup(detail): move memory title mobile rule to detail css` merged / closed. detail #memoryTitle mobile rule ownership 이동 완료

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,35 +23,26 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `0da436d57c9628e1e72d960d9d814844f4079d98`
+- 기준 main 커밋: `d48b9fd6f49724255c85bb423145c6e2a6846008`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
-| 문서 TF | 완료 | PR #8, #10, #32, #33, #50, #52, #54~#58, #61, #70, #76, #77 | project/ops/design 문서, 검증 기준, public-first 정책, QA matrix, warning catalog, branch cleanup plan, runtime active/legacy clarification, 문서 인덱스/preview slot rules 정리 main 반영 완료 |
-| Runtime routing truth | 완료 | PR #70 `docs(runtime): clarify active and legacy runtime paths` | Cloudflare Pages 공식 사용자-facing entry, Modal active compute/runtime 우선 경로, Netlify legacy/fallback/artifact 기준 문서화 완료. Merge SHA: `1833aaf2c779bd593bda2687d5ee0df0e4197bfd` |
-| Public layout UI | 완료 | PR #49 `ui(layout): align landing browse rails` | layout rail / container / spacing 통일 완료. production verification PASS. Merge SHA: `dfb158a843932edeaaf7c859d0fa3e2d06c9be08` |
-| Typography / accent hierarchy | 완료 | PR #51 `ui(style): align typography accent hierarchy` | typography / accent hierarchy 통일 완료. production verification PASS. Merge SHA: `99af8a69fbe1cf61ac23017b938027164a213b3a` |
-| Button / badge / chip tone | 완료 | PR #62 `ui(style): align button badge chip tone` | Home / Intro / Browse button, badge, chip tone 통일 완료. production verification PASS. Merge SHA: `ae5ac03a2e9582c6c5cef6a965d6600ec6fa8e44` |
-| Intro hero visual / whitespace | 완료 | PR #63 `ui(intro): balance hero visual whitespace` | Intro hero visual column, tree scene height, tablet breakpoint, warm scrapbook tone 개선 완료. production verification PASS. Merge SHA: `7e287bb6e77e91d9a1c33681e7308f2e54f7022d` |
-| Browse card / hub panel surface | 완료 | PR #66 `ui(search): unify browse card and hub surfaces` | Browse/Search card, preview sidebar, growing section, placeholder tone 정리 완료. production smoke 기준 main 반영 완료 |
-| Search URL state | 완료 | PR #67 상당 직접 squash commit | `q`, `category`, `sort`, `limit` URL state sync main 반영 완료. Current main history includes `01408fbb87805083b08e77974351c9fa17c0d0f9`; PR #67은 중복 merge 방지를 위해 closed / unmerged 처리됨 |
-| YouTube thumbnail fallback | 완료 | PR #69 `fix(search): harden YouTube thumbnail fallback` | failed card thumbnails hide broken image and show fallback surface; preview fallback overlay obstruction removed. Merge SHA: `5f0708c82c6a909f11dbe4fc31776adfd0504778` |
-| Search inline style reduction pass 1 | 완료 | PR #80 `ui(search): reduce preview inline styles` | `pages/search.html` only. Cloudflare Preview verification PASS. Production verification pending. Issue #65는 open 유지 |
-| CI/E2E Playwright dependency stabilization | 완료 | PR #68 상당 직접 squash commit | `playwright` dev dependency, lockfile, CI E2E smoke `npm ci` 변경 main 반영 완료. PR #68은 중복 merge 방지를 위해 closed / unmerged 처리됨 |
-| UI verification rules | 완료 | PR #50 `docs(project): clarify UI verification environment rules` | UI verification environment rules 문서화 완료 |
-| Test preview slot rules | 완료 | PR #52, PR #77 | test preview slot branch rules 및 post-merge preview slot verification rules 문서화 완료. PR #52 Merge SHA: `bbc988041e248d171a8560419dc739394ba4e23f`; PR #77 Merge SHA: `6fe90fbef24f7348a1f6b247891e62ba871a5c3b` |
-| Local generated artifact ignore | 완료 | PR #53 `chore: ignore local generated artifacts` | local generated artifacts `.gitignore` 정리 완료. Merge SHA: `5f8d185cde4b1d46df75a8c4382fd71a4a671ca8`. prototype/reference 보존 대상 침범 없음 |
-| Task status tracking | 완료 | PR #76 `docs(project): align document indexes and runtime truth` | docs-only 7 files 정합성 cleanup 완료. Merge SHA: `e447cb903f671afbccb5623a02a71d965a4c58f8` |
-| Prototype reference preservation | 완료 | PR #55 `docs(design): preserve prototype reference folders` | prototype/reference preservation policy 문서화 완료. PR #7 보존 정책 문서화 완료. Merge SHA: `1f1c0758d9307e8e090386d21b21a265e5fe257b` |
-| Known CI/E2E blockers | 완료 | PR #56 `docs(ops): document known CI and E2E blockers` | known CI/E2E blockers 문서화 완료. Merge SHA: `c67956a23f61ea26dfb47e64813d340d960985ba` |
-| UI polish roadmap | 완료 | `docs/design/UI_POLISH_ROADMAP.md` | PR #69 / PR #70 이후 남은 Issue #65 backlog와 Search 후속 범위 분리 완료 |
-| Verification warning catalog | 완료 | PR #58 `docs(project): add verification warning catalog` | verification warning catalog 문서화 완료. Merge SHA: `7e221b8829500c26a7542481bea1585d916fb14a` |
-| 기능 TF | 완료 | `feature/search-growing-trees-api` | main과 동일 상태 (Identical). PR 생성 불필요. `/api/community/growing-trees` 운영 quick check 통과. 기능 TF 종료 |
-| SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. SVG tree prototype. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
+| 문서 TF | 진행 중 | PR #127 이후 status/CI/screenshot refresh | PR #127 runtime guardrail 문서 병합 완료. 본 문서 refresh는 별도 docs-only PR에서 진행 |
+| Runtime routing truth | 진행 중 | PR #70, PR #127, Issue #119 | Cloudflare Pages + Modal active runtime 기준은 문서화됨. Netlify는 Legacy Artifact Only / Removal Candidate로 정리됨. 최종 route 제거/보존 판단은 Issue #119 audit 이후 |
+| CI / contract test baseline | 완료 | PR #111 | stale contract tests와 i18n scan 범위 정리 완료. `npm test`, `npm run verify`, `npm run ci` green baseline 보고됨. 과거 `56/61` 기준은 현행 기준 아님 |
+| Screenshot evidence tooling | 완료 | PR #115 | `test:screenshots:xg`가 cross-platform `--prefix` 방식으로 정리됨 |
+| Accessibility micro-fix | 완료 | PR #110 | Editor title edit button aria-label 추가 완료 |
+| Detail CSS ownership cleanup | 완료 | PR #112, PR #120 | detail page-specific CSS ownership 정리. global 중복/잔여 detail rule 축소 완료 |
+| Login CSS cleanup | 완료 | PR #113 | login inline style refactor 완료. JS-controlled display styles preserved |
+| i18n production key cleanup | 완료 | PR #114 | production verification 중 발견된 editor/detail i18n missing keys 추가 완료 |
+| Search URL state cleanup | 완료 | PR #121 | orphan debug log와 duplicate restore call 제거. URL state behavior 변경 없음 |
+| Dependency classification audit | 완료 | Issue #117 | `dotenv`/`playwright`는 devDependencies 유지, `firebase-admin`/`pg`는 dependencies 유지. package change / PR 불필요 결론 |
+| API client namespace audit | 진행 중 | Issue #116 | `window.apiClient`와 `__LoveBudApiClientInternals` 노출 범위 audit open. 구현/문서 확정은 audit 이후 |
+| Cache lifecycle audit | 완료 | Issue #118 | cache-utils lifecycle / serialization audit completed. 구현 변경 여부는 별도 CTO 판단 필요 |
+| Runtime routing transitional layers audit | 진행 중 | Issue #119 | Cloudflare/Vercel/Netlify transitional route ownership audit open. runtime routing 문서 본문 변경은 audit 이후 |
+| SVG Tree Prototype | 진행 중 | PR #7 `experiment: SVG tree prototype` | open / draft. prototype/reference 보존 대상. merged 아님. 정식 기능 아님. close 금지. branch 삭제 금지. navigation 연결 금지 |
 | JS architecture cleanup | 보류 | Issue #72 / PR #73 | Issue #72는 open이며 current status는 paused. PR #73은 closed / unmerged. file-move refactor는 clean worktree와 단일 executor 조건 충족 전 재개 금지 |
-| Auth architecture/security audit | 진행 중 | Issue #78 | Auth architecture, global exports, token cache cleanup audit open. 구현 승인 아님. 향후 docs-only audit note 또는 token cache security PR 후보 |
-| Runtime ownership guardrails | 진행 중 | Issue #79 | Runtime ownership and legacy folder guardrails open. active/legacy runtime marker docs 후보 |
-| Editor UI polish | 완료 | PR #74 `ui(editor): polish editor surface and empty states` | merged / closed. Editor surface polish와 i18n key 보강 main 반영 완료. Merge SHA: `90933a4961b240df2caa7f04b737322b22200f26` |
+| Issue #65 Search backlog | 진행 중 | Issue #65 | Selected tree deep link, Search JS responsibility split, broader Search CSS extraction은 backlog/open 상태 유지 |
 
 ---
 
@@ -60,9 +51,10 @@
 - Current production/test slot runtime: `Cloudflare Pages same-origin /api/* → Cloudflare Pages Functions → Modal`.
 - Cloudflare Pages는 공식 사용자-facing production / preview entry입니다.
 - Modal은 active compute/runtime 우선 경로입니다.
-- `netlify/functions/*`는 legacy / fallback / artifact 성격으로 남아 있으며 현재 `lovebud.pages.dev` production/test slot active backend가 아닙니다.
-- CI/E2E에서 `netlify dev`가 쓰이는 경우에도 이는 local harness이며 production runtime truth가 Netlify라는 뜻이 아닙니다.
-- Netlify archive는 즉시 수행하지 않습니다. tests/docs reference transition 후 별도 승인 필요합니다.
+- Vercel은 deprecated transitional fallback / audit 대상입니다.
+- `netlify/functions/*`는 Legacy Artifact Only / Removal Candidate이며 현재 `lovebud.pages.dev` production/test slot active backend 또는 active fallback이 아닙니다.
+- Netlify route gap은 즉시 구현 blocker가 아니며 Issue #119 runtime routing audit에서 제거/보존 여부를 판단합니다.
+- Netlify archive는 즉시 수행하지 않습니다. tests/docs reference transition 및 audit 후 별도 승인 필요합니다.
 
 ---
 
@@ -74,7 +66,18 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 |------|------|------|
 | Selected tree deep link | 진행 중 | `?tree=<treeId>` 직접 진입 시 공개 tree preview 선택. desktop / mobile preview 동작 확인 필요. 별도 feature branch에서 구현/검증 후 판단 |
 | Search JS responsibility split | 보류 | JS architecture cleanup paused 상태. Search file-move 재개 전 clean worktree / 단일 executor / Preview 검증 조건 필요 |
-| Search CSS extraction / inline style reduction | 진행 중 | PR #80으로 static inline style reduction pass 1 완료. 더 넓은 CSS extraction은 대기. Search JS refactor와 혼합 금지 |
+| Search CSS extraction / inline style reduction | 진행 중 | PR #80 이후 여러 CSS extraction/cleanup PR이 진행됨. 더 넓은 Search JS refactor와 혼합 금지 |
+
+---
+
+## Audit 상태
+
+| Issue | 상태 | 문서 반영 판단 |
+|------|------|----------------|
+| #116 API client global namespace exposure | 진행 중 | `window.apiClient` / `__LoveBudApiClientInternals` browser namespace contract는 audit 이후 문서화 |
+| #117 dependency classification | 완료 | package 변경 없음. 상태 기록만 유지 |
+| #118 cache-utils lifecycle and serialization behavior | 완료 | audit completed. 후속 구현/문서화는 별도 CTO 판단 필요 |
+| #119 runtime routing transitional layers | 진행 중 | runtime routing 본문 문서는 audit 이후 갱신 |
 
 ---
 
@@ -90,6 +93,19 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 
 ## 작업 이력 (Task History)
 
+- 2026-04-26: PR #127 `docs(runtime): clarify Netlify legacy removal guardrails` merged / closed. OPERATIONS / REVIEW_GUARDRAILS에 Netlify Legacy Artifact Only / Removal Candidate 기준 반영. Merge SHA `d48b9fd6f49724255c85bb423145c6e2a6846008`
+- 2026-04-26: PR #121 `cleanup(search): remove orphan debug comment and duplicate restore call` merged / closed. Search URL state cleanup 완료
+- 2026-04-26: PR #120 `cleanup(detail): move memory title mobile rule to detail css` merged / closed. detail #memoryTitle mobile rule ownership 이동 완료
+- 2026-04-26: Issue #119 `Audit: runtime routing transitional layers` opened. Cloudflare/Vercel/Netlify transitional route ownership audit tracker
+- 2026-04-26: Issue #118 `Audit: cache-utils lifecycle and serialization behavior` completed. cache lifecycle / serialization audit 종료
+- 2026-04-26: Issue #117 `Audit: dependency classification for server and tooling packages` closed. dependency classification 현 상태 유지 결론
+- 2026-04-26: Issue #116 `Audit: API client global namespace exposure` opened. browser API namespace exposure audit tracker
+- 2026-04-26: PR #115 `chore(scripts): make screenshot script cross-platform` merged / closed. `test:screenshots:xg`를 `--prefix xg-test` 방식으로 정리
+- 2026-04-26: PR #114 `fix(i18n): add missing production keys` merged / closed. editor/detail missing production i18n keys 추가
+- 2026-04-26: PR #113 `cleanup(login): refactor inline styles to css classes while preserving encoding` merged / closed. login CSS refactor 완료
+- 2026-04-26: PR #112 `cleanup(detail): remove redundant moment card image rule from global css` merged / closed. detail/global 중복 CSS rule 정리
+- 2026-04-26: PR #111 `fix: resolve CI known failures in contract tests (stale string matches)` merged / closed. contract tests / pre-deploy i18n scan / missing keys 정리. green baseline 보고
+- 2026-04-26: PR #110 `fix(editor): add aria-label to sidebarTitleEditBtn` merged / closed. editor accessibility micro-fix 완료
 - 2026-04-26: PR #80 `ui(search): reduce preview inline styles` squash merged / closed. Search inline style reduction pass 1 main 반영 완료. Merge SHA `0da436d57c9628e1e72d960d9d814844f4079d98`. Cloudflare Preview verification PASS. Production verification pending
 - 2026-04-26: Issue #79 `Audit: Runtime ownership and legacy folder guardrails` opened. active/legacy runtime marker docs 후보로 추적
 - 2026-04-26: Issue #78 `Audit: Auth architecture, global exports, and token cache cleanup` opened. Auth architecture/security audit tracker로 추적

--- a/docs/project/TASK_STATUS.md
+++ b/docs/project/TASK_STATUS.md
@@ -23,7 +23,7 @@
 ## 현재 상태 스냅샷
 
 - 기준일: 2026-04-26
-- 기준 main 커밋: `d48b9fd6f49724255c85bb423145c6e2a6846008`
+- 기준 main 커밋: `07efce659ec13b2342d116ac0b43af9181cded3b`
 
 | 구분 | 상태 | 기준/대상 | 현재 기록 |
 |------|------|-----------|-----------|
@@ -93,6 +93,7 @@ Issue #65는 open backlog tracker이며, 현재 미완료 항목은 아래 3개�
 
 ## 작업 이력 (Task History)
 
+- 2026-04-26: PR #128 `cleanup(editor): move presentation inline styles to editor css` merged / closed. Editor presentation-only inline styles를 `css/editor.css`로 이동. Merge SHA `07efce659ec13b2342d116ac0b43af9181cded3b`
 - 2026-04-26: PR #127 `docs(runtime): clarify Netlify legacy removal guardrails` merged / closed. OPERATIONS / REVIEW_GUARDRAILS에 Netlify Legacy Artifact Only / Removal Candidate 기준 반영. Merge SHA `d48b9fd6f49724255c85bb423145c6e2a6846008`
 - 2026-04-26: PR #121 `cleanup(search): remove orphan debug comment and duplicate restore call` merged / closed. Search URL state cleanup 완료
 - 2026-04-26: PR #120 `cleanup(detail): move memory title mobile rule to detail css` merged / closed. detail #memoryTitle mobile rule ownership 이동 완료

--- a/docs/project/VERIFICATION_AND_EVIDENCE.md
+++ b/docs/project/VERIFICATION_AND_EVIDENCE.md
@@ -312,7 +312,23 @@ docs/verification/YYYY-MM-DD/
 - `2026-04-24_search-page_mobile-375.png`
 - `2026-04-24_detail-cards_11-loaded.png`
 
-### 9.3. screenshot-only Branch 분리 원칙
+### 9.3. screenshot script 사용 예시
+
+로컬 스크린샷 캡처가 필요한 경우 현재 cross-platform script는 prefix 인자를 사용할 수 있습니다.
+
+```bash
+node scripts/capture-screenshots.js --prefix xg-test
+```
+
+동일한 npm script는 아래와 같습니다.
+
+```bash
+npm run test:screenshots:xg
+```
+
+이 명령은 증빙 저장 원칙을 대체하지 않습니다. 산출물은 여전히 날짜별 경로와 파일 naming 표준에 맞춰 PR 증빙으로 정리합니다.
+
+### 9.4. screenshot-only Branch 분리 원칙
 
 스크린샷만 추가하는 브랜치는 다음 규칙을 따릅니다.
 
@@ -320,7 +336,7 @@ docs/verification/YYYY-MM-DD/
 2. **용도**: 스크린샷 또는 캡처 증빙 전용
 3. **main 직접 Push 금지**: 항상 별도 PR로 병합
 
-### 9.4. screenshot-only의 main 직접 Push 금지
+### 9.5. screenshot-only의 main 직접 Push 금지
 
  다음과 같은 경우 main에 직접 Push하지 않습니다.
 


### PR DESCRIPTION
## Summary
- Refreshes project task status after recent PRs and completed audits
- Reframes known CI/E2E blockers as historical recurrence triage notes rather than current expected failures
- Adds screenshot evidence guidance for the cross-platform `--prefix` script

## Changed files
- docs/project/TASK_STATUS.md
- docs/ops/KNOWN_CI_E2E_BLOCKERS.md
- docs/project/VERIFICATION_AND_EVIDENCE.md

## Non-changes
- No code changes
- No package/workflow changes
- No runtime routing changes
- No Netlify/Cloudflare/Modal changes
- No PR #7/prototype/reference/demo changes

## Verification
- Confirmed branch is based on PR #127 merge commit `d48b9fd6f49724255c85bb423145c6e2a6846008`
- Confirmed changed files are limited to the three approved docs
- Confirmed `KNOWN_CI_E2E_BLOCKERS.md` no longer presents the listed failures as currently expected blockers
- Confirmed screenshot guidance uses `node scripts/capture-screenshots.js --prefix xg-test` and `npm run test:screenshots:xg`
- Local git / `git diff --check` not run because local clone failed with DNS resolution error for github.com