### PR TITLE
chore(editor): document css entrypoint import order

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -1,3 +1,13 @@
+/*
+ * Editor CSS entrypoint.
+ *
+ * This file intentionally preserves the existing single stylesheet link from
+ * pages/editor.html while the editor styles are split into role-based files.
+ *
+ * Import order is cascade-sensitive. Do not reorder these imports or replace
+ * them with multiple page-level stylesheet links without editor browser
+ * verification across desktop, tablet, and mobile viewports.
+ */
 @import url("./editor/base.css");
 @import url("./editor/layout.css");
 @import url("./editor/sidebar.css");


### PR DESCRIPTION
## Summary
- Adds an explanatory comment to `css/editor.css` after PR #132 split the editor styles into role-based files.
- Documents that `css/editor.css` is the intentional single stylesheet entrypoint for `pages/editor.html`.
- Marks the import order as cascade-sensitive and requires editor browser verification before reordering or replacing the entrypoint with multiple page-level stylesheet links.

## Changed files
- `css/editor.css`

## Non-changes
- No selector/property/value changes
- No import order changes
- No `pages/editor.html` changes
- No JS changes
- No runtime/API changes
- No PR #7/prototype/reference/demo changes

## Verification
- GitHub compare confirms only `css/editor.css` changed
- Comment-only CSS change; no browser verification required before review