### PR TITLE
fix(auth): block cached offline user on protected routes

### DIFF
--- a/js/auth/auth-firebase.js
+++ b/js/auth/auth-firebase.js
@@ -96,6 +96,11 @@
     return false;
   }
 
+  function isProtectedRoute() {
+    var path = window.location.pathname || '';
+    return /\/pages\/(my-trees|editor|settings)(?:\.html)?$/.test(path);
+  }
+
   function initOfflineAuth(options) {
     var markAuthReady = options && options.markAuthReady;
     var updateNavUI = options && options.updateNavUI;
@@ -104,7 +109,7 @@
     var resolveAuthBootstrap = options && options.resolveAuthBootstrap;
 
     var cachedUser = typeof getCachedAuthUser === 'function' ? getCachedAuthUser() : null;
-    var user = cachedUser && cachedUser.uid ? cachedUser : null;
+    var user = !isProtectedRoute() && cachedUser && cachedUser.uid ? cachedUser : null;
 
     if (typeof markAuthReady === 'function') {
       markAuthReady();


### PR DESCRIPTION
## Summary

- Adds a minimal protected-route detector for `/pages/my-trees.html`, `/pages/editor.html`, and `/pages/settings.html`.
- Changes offline auth fallback so protected routes resolve auth bootstrap as `null` instead of treating a stale confirmed cache as an authenticated user.
- Leaves non-protected page cached-auth behavior intact for nav/UI continuity.

## Scope

Changed file:

- `js/auth/auth-firebase.js`

No CSS, HTML, Search/Browse, Firebase config, rules, functions, Modal, Netlify, docs, prototype/reference/demo changes.

## Verification

- Compared branch against `main`: 1 commit ahead, 0 behind.
- Diff scope verified: `js/auth/auth-firebase.js` only, +6 / -1.
- Static reasoning check: on protected routes, `initOfflineAuth()` now computes `user` as `null` even when `getCachedAuthUser()` returns a cached uid; non-protected routes preserve cached-user offline behavior.
- CI: success.

Production/browser validation not run in this executor session.

Refs #133