### PR TITLE
fix(settings): require auth before initializing settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -195,13 +195,25 @@
     }, true);
   }
 
-  // UI 초기화
-  function initSettings() {
+  var settingsInitialized = false;
+
+  function getSettingsLoginHref() {
+    var redirect = 'settings.html' + (window.location.search || '');
+    return 'login.html?redirect=' + encodeURIComponent(redirect);
+  }
+
+  function redirectToLogin() {
+    window.location.replace(getSettingsLoginHref());
+  }
+
+  function startSettings() {
+    if (settingsInitialized) return;
+    settingsInitialized = true;
+
     var settings = loadSettings();
 
     bindCloseInteractions();
-    
-    // i18n 텍스트 적용 (renderSharedHeader 후 호출되어야 하므로 지연)
+
     setTimeout(function() {
       applyI18nText();
       if (typeof window.applyI18n === 'function') {
@@ -211,6 +223,38 @@
     }, 0);
 
     console.log('[settings] Initialized with browse introduction guidance:', settings);
+  }
+
+  function handleSettingsAuthUser(user) {
+    if (!user || !user.uid) {
+      redirectToLogin();
+      return;
+    }
+    startSettings();
+  }
+
+  // UI 초기화 (auth gate)
+  function initSettings() {
+    if (
+      window.LoveBudAuthBootstrap &&
+      typeof window.LoveBudAuthBootstrap.whenReady === 'function'
+    ) {
+      window.LoveBudAuthBootstrap.whenReady()
+        .then(handleSettingsAuthUser)
+        .catch(function() {
+          redirectToLogin();
+        });
+      return;
+    }
+
+    if (typeof window.registerOnAuthReady === 'function') {
+      window.registerOnAuthReady(function(user) {
+        handleSettingsAuthUser(user || null);
+      });
+      return;
+    }
+
+    redirectToLogin();
   }
 
   // 로그아웃 처리


### PR DESCRIPTION
## Summary
Settings page에서 인증 확인 없이 initSettings()가 바로 실행되는 문제를 수정했습니다. authenticated user일 때만 settings 초기화를 수행하도록 auth gate를 추가했습니다.

## Why
Settings page는 protected page 성격이지만, 기존에는 auth gate가 없어서 인증되지 않은 사용자도 settings 초기화가 실행되었습니다. 이를 막기 위해 LoveBudAuthBootstrap.whenReady() 또는 registerOnAuthReady()를 통해 user를 확인하고, user && user.uid인 경우에만 초기화를 수행하도록 수정했습니다.

## Changed files
- js/settings.js: initSettings()를 auth gate로 변경, startSettings()로 실제 초기화 분리, settingsInitialized flag 추가

## Non-changes
- handleLogout()은 변경하지 않음
- js/auth/auth-firebase.js는 수정하지 않음
- js/auth.js는 수정하지 않음
- pages/settings.html은 수정하지 않음
- CSS/HTML 전체는 수정하지 않음
- Search/Browse 관련 파일은 수정하지 않음
- Firebase config/security rules는 수정하지 않음
- functions/*는 수정하지 않음
- modal_compute/*는 수정하지 않음
- netlify/*는 수정하지 않음
- docs/*는 수정하지 않음
- PR #7/prototype/reference/demo는 수정하지 않음

## Verification
- git diff --check: 통과
- npm run lint: 통과
- npm run build: 통과
- npm test: 실행하지 않음 (settings 관련 단위 테스트 없음)
- 브라우저 검증: 수행하지 않음 (PR review 단계에서 검증 필요)

## Refs #133