### PR TITLE
cleanup(editor): move recenter mousedown handler to JS

### DIFF
--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -67,6 +67,10 @@ window.LoveBudEditorCanvasViewport = {
     }
 
     if (recenterBtn) {
+      recenterBtn.addEventListener('mousedown', (event) => {
+        event.stopPropagation();
+      });
+
       recenterBtn.addEventListener('click', () => {
         recenterViewport();
       });

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -71,7 +71,7 @@
                     <p class="editor-canvas-caption">좋아하는 순간들이 가지 위에 천천히 붙어가는 작업 공간입니다.</p>
                 </div>
                 <div class="editor-canvas-toolbar">
-                    <button type="button" class="sidebar-btn" id="recenterCanvasBtn" onmousedown="event.stopPropagation()">
+                    <button type="button" class="sidebar-btn" id="recenterCanvasBtn">
                         <span class="btn-icon">⌂</span>
                         <span class="btn-label" id="recenterCanvasBtnLabel">트리 한눈에 보기</span>
                     </button>


### PR DESCRIPTION
## Summary
- Remove the inline `onmousedown="event.stopPropagation()"` handler from `pages/editor.html`.
- Move the same `mousedown` propagation guard into `js/editor/editor-canvas-viewport.js` inside the existing `recenterBtn` binding branch.
- Preserve the existing `click → recenterViewport()` behavior.

## Files
- `pages/editor.html`
- `js/editor/editor-canvas-viewport.js`

## Validation
- Scope check: PASS, changed files are limited to the two expected editor files.
- GitHub compare: PASS, branch is ahead of `main` by two small commits with only the expected files changed.
- Local `git diff --check`: not run in this environment.
- `npm run lint`: not run in this environment.
- `npm run build`: not run in this environment.
- Browser check: not run in this environment.

## Notes
- This PR is a CSP/maintainability cleanup only.
- No CSS, Search, Auth, shared-header, or prototype/reference/demo/variant files are changed.
- `pointerdown` is not added because the existing inline behavior only handled `mousedown`.