### PR TITLE
chore(search): align growing section i18n and icon font loading

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -21,6 +21,18 @@
       ko: '트리를 고르면 열려요.',
       en: 'Choose a tree to open it.'
     },
+    'search.growingTreesTitle': {
+      ko: '새로 자라는 러브트리',
+      en: 'Newly Growing LoveTrees'
+    },
+    'search.growingTreesSubtitle': {
+      ko: '막 자라기 시작한 마음들',
+      en: 'Feelings just beginning to grow'
+    },
+    'search.growingTreesBadge': {
+      ko: '자라는 중',
+      en: 'Growing'
+    },
 
     // 미리보기
     'search.previewTitle': {

--- a/pages/search.html
+++ b/pages/search.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
     <link rel="stylesheet" href="../css/search.css?v=20260426-1">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=block" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="bokeh-bg">
     <div class="noise-overlay"></div>
@@ -65,10 +65,10 @@
             <section id="growingTreesSection" class="growing-trees-section" hidden>
                 <div class="growing-trees-head">
                     <div>
-                        <h3>새로 자라는 러브트리</h3>
-                        <p>막 자라기 시작한 마음들</p>
+                        <h3 data-i18n="search.growingTreesTitle">새로 자라는 러브트리</h3>
+                        <p data-i18n="search.growingTreesSubtitle">막 자라기 시작한 마음들</p>
                     </div>
-                    <span class="growing-trees-badge">자라는 중</span>
+                    <span class="growing-trees-badge" data-i18n="search.growingTreesBadge">자라는 중</span>
                 </div>
                 <div id="growingTreesList">
                     <!-- Populated by JS -->


### PR DESCRIPTION
## Summary
- Adds i18n keys for the hidden `growingTreesSection` static copy.
- Wires the growing trees title, subtitle, and badge to `data-i18n`.
- Aligns Search page Material Symbols loading with the rest of the app by changing `display=block` to `display=swap`.

## Changed files
- `pages/search.html`
- `js/i18n/i18n-search.js`

## Non-changes
- No Search runtime logic changes
- No API/Auth/DB changes
- No CSS changes
- No Browse data behavior changes
- No PR #7/prototype/reference/demo changes

## Verification
- GitHub diff scope reviewed: two files only
- Browser verification not performed

Refs search i18n/font consistency audit