### PR TITLE
refactor(global): remove residual detail responsive overrides

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -460,50 +460,6 @@ h1, h2, h3, h4, .headline {
     margin: 4px 0;
 }
 
-/* Page-specific responsive overrides */
-
-/* Detail page */
-@media (max-width: 1024px) {
-    .detail-layout {
-        grid-template-columns: 1fr;
-        gap: 40px;
-        padding: 40px 24px;
-    }
-
-    .diary-section {
-        margin-top: 0;
-    }
-
-    .connected-section {
-        margin-top: 40px;
-    }
-
-    .diary-container {
-        padding: 40px;
-    }
-}
-
-@media (max-width: 768px) {
-    .detail-layout {
-        padding: 24px 16px;
-        gap: 32px;
-    }
-
-    .video-main {
-        border-radius: 1.5rem;
-        margin-bottom: 24px;
-    }
-
-    .diary-container {
-        padding: 32px 24px;
-        border-radius: 2rem;
-    }
-
-    .moment-card {
-        padding: 16px;
-    }
-}
-
 /* Mobile optimizations */
 @media (max-width: 480px) {
     .thumbnail-wrapper {


### PR DESCRIPTION
## Summary
- Removes residual Detail page responsive overrides from \css/global.css\.
- Keeps Detail page styling owned by \css/detail.css\.
- Leaves shared/global styles untouched.

## Why
Detail page styles have been extracted into \css/detail.css\, but \global.css\ still contained a page-specific responsive override block for \.detail-layout\, \.diary-section\, \.connected-section\, \.diary-container\, \.video-main\, and \.moment-card\.

## Changed files
- \css/global.css\

## Non-changes
- No \css/detail.css\ changes
- No HTML changes
- No JS changes
- No Search/Auth/API/runtime changes
- No PR #7/prototype/reference/demo changes
- No shared appreciation component cleanup in this PR
- No editor save-status cleanup in this PR

## Verification
- \git diff --check\: PASS
- \
pm run lint\: PASS
- \
pm run build\: PASS
- \
pm run verify\: PASS
- Browser verification: NOT PERFORMED (Static CSS removal only)

Refs global CSS cleanup audit