### PR TITLE
chore(editor): add fallback alt text for detail image

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -173,7 +173,7 @@
                             <button id="deleteMemoryBtn" class="btn-round btn-outline editor-memory-action-btn editor-memory-delete-btn">...</button>
                         </div>
                         <div class="detail-video">
-                            <img id="detailImg" src="" alt="">
+                            <img id="detailImg" src="" alt="선택한 순간 이미지 준비 중">
                             <div class="memory-preview-overlay">
                                 <button type="button" class="play-btn" aria-label="재생">재생</button>
                             </div>


### PR DESCRIPTION
## Summary
- Adds fallback alt text to the editor detail image in the initial HTML.
- Keeps runtime editor detail logic unchanged.

## Why
The editor accessibility audit noted that `detailImg` starts with an empty `alt` value. This small change gives the initial detail image a non-empty fallback description before runtime state takes over.

## Changed files
- `pages/editor.html`

## Non-changes
- No `editor-detail-ui.js` runtime changes
- No Auth/API/runtime changes
- No CSS changes
- No PR #7/prototype/reference/demo changes

## Verification
- GitHub diff scope reviewed: `pages/editor.html` only
- Browser verification not performed

Follow-up
- `editor-detail-ui.js` still resets dynamic empty-state alt to an empty string. Because that file is large and runtime-sensitive, handle it in a local follow-up if screen-reader validation confirms the image is exposed while empty.

Refs editor accessibility audit