### PR TITLE
harden(api): restrict api client internals exposure to localhost

### DIFF
--- a/js/postgres-client.js
+++ b/js/postgres-client.js
@@ -165,6 +165,12 @@
         return merged;
     }
 
+    function shouldExposeApiClientInternals() {
+        if (typeof window === 'undefined' || !window.location) return false;
+        const hostname = window.location.hostname || '';
+        return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+    }
+
     const treeApi = createTreeApi();
     const memoryApi = createMemoryApi();
     const communityApi = createCommunityApi();
@@ -179,7 +185,7 @@
 
     window.apiClient = apiClient;
 
-    if (typeof window !== 'undefined') {
+    if (shouldExposeApiClientInternals()) {
         window.__LoveBudApiClientInternals = {
             endpointLikelyRequiresAuth: AuthPolicy?.endpointLikelyRequiresAuth,
             getAuthWaitAttempts: AuthPolicy?.getAuthWaitAttempts,


### PR DESCRIPTION
## Summary
- Restrict `window.__LoveBudApiClientInternals` exposure to local development hosts only.
- Keep internals available on:
  - `localhost`
  - `127.0.0.1`
  - `[::1]`
- Avoid `process.env.NODE_ENV` because this project uses static browser JS without a bundler replacement guarantee.

## Scope
- `js/postgres-client.js` only.
- No API route changes.
- No auth behavior changes.
- No production page changes.
- No prototype/reference/demo/variant changes.

## Rationale
`window.__LoveBudApiClientInternals` exposes internal adapter/auth helper references in the browser global scope. This does not by itself grant server authorization, but it is unnecessary in production and increases debug surface area. Localhost exposure is retained for existing contract tests and local debugging.

## Validation
- GitHub compare scope: PASS
- Changed files limited to:
  - `js/postgres-client.js`
- Local `git diff --check`: not run in this environment
- `npm run lint`: not run in this environment
- `npm run build`: not run in this environment
- CI required before merge

## Notes
- Existing contract tests that sandbox `hostname: 'localhost'` should retain access to internals.
- `js/api/public-tree-adapter.js` only extends `window.__LoveBudApiClientInternals` when the object exists; production should no longer create that object by default.