### PR TITLE
chore(api): expose community cache reset helper

### DIFF
--- a/js/postgres-client.js
+++ b/js/postgres-client.js
@@ -100,9 +100,15 @@
             return getCommunityMemories(options);
         }
 
+        function clearCommunityCaches() {
+            publicMemoriesCache = null;
+            publicMemoriesByTreeCache.clear();
+        }
+
         return {
             getCommunityMemories,
-            getCachedCommunityMemories
+            getCachedCommunityMemories,
+            clearCommunityCaches
         };
     }
 


### PR DESCRIPTION
## Summary
- Adds `clearCommunityCaches()` to the community API client.
- Clears both the all-community public memories cache and the per-tree public memories cache.
- Does not wire the helper into logout yet.

## Why
`postgres-client.js` keeps public community memory caches in the `createCommunityApi()` closure for the lifetime of the page. Exposing a reset helper gives later logout/cache cleanup code a narrow API to clear these public preview caches without reaching into implementation details.

## Changed files
- `js/postgres-client.js`

## Non-changes
- No Auth/logout flow changes
- No private cache policy changes
- No API endpoint changes
- No Search/Browse runtime behavior changes unless the helper is explicitly called later
- No CSS/HTML changes
- No PR #7/prototype/reference/demo changes

## Verification
- GitHub diff scope reviewed: `js/postgres-client.js` only
- Browser verification not performed

Follow-up
- Wire `window.apiClient.clearCommunityCaches()` into the future `clearPrivateCaches`/logout cleanup path if stale public preview cache needs to be cleared on sign out.

Refs public community cache cleanup audit