### PR TITLE
chore(auth): clear community caches on sign out

### DIFF
--- a/js/auth/auth-firebase.js
+++ b/js/auth/auth-firebase.js
@@ -216,6 +216,10 @@
       window.clearPrivateCaches();
     }
 
+    if (window.apiClient && typeof window.apiClient.clearCommunityCaches === 'function') {
+      window.apiClient.clearCommunityCaches();
+    }
+
     if (typeof clearConfirmedAuthCache === 'function') {
       clearConfirmedAuthCache();
     }


### PR DESCRIPTION
## Summary
- Calls `window.apiClient.clearCommunityCaches()` during sign out when available.
- Keeps existing private cache and confirmed auth cache clearing order intact.

## Why
PR #147 exposed a narrow reset helper for public community memory preview caches. This PR wires that helper into logout so public preview caches do not persist across sign-out within the same browser session.

## Changed files
- `js/auth/auth-firebase.js`

## Non-changes
- No `postgres-client.js` changes
- No private cache policy changes
- No Firebase config/security rules changes
- No API endpoint changes
- No CSS/HTML changes
- No PR #7/prototype/reference/demo changes

## Verification
- GitHub diff scope reviewed: `js/auth/auth-firebase.js` only
- Browser verification not performed

Refs public community cache cleanup audit