### PR TITLE
chore(auth): bump protected page auth asset versions

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -296,7 +296,7 @@
     <script src="../js/auth/auth-cache.js?v=20260417-31"></script>
     <script src="../js/auth/auth-ui.js?v=20260421-2"></script>
     <script src="../js/auth/auth-session.js?v=20260417-31"></script>
-    <script src="../js/auth/auth-firebase.js?v=20260420-1"></script>
+    <script src="../js/auth/auth-firebase.js?v=20260427-3"></script>
     <script src="../js/auth.js?v=20260417-31"></script>
     <script>renderSharedHeader();</script>
 </body>

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -119,7 +119,7 @@
   <script src="../js/auth/auth-cache.js?v=20260417-31"></script>
   <script src="../js/auth/auth-ui.js?v=20260421-2"></script>
   <script src="../js/auth/auth-session.js?v=20260417-31"></script>
-  <script src="../js/auth/auth-firebase.js?v=20260420-1"></script>
+  <script src="../js/auth/auth-firebase.js?v=20260427-3"></script>
   <script src="../js/auth/auth-login-page.js?v=20260420-1"></script>
   <script src="../js/auth.js?v=20260417-31"></script>
   <script>renderSharedHeader();</script>

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -65,9 +65,9 @@
      <script src="../js/auth/auth-cache.js?v=20260417-31"></script>
      <script src="../js/auth/auth-ui.js?v=20260421-2"></script>
      <script src="../js/auth/auth-session.js?v=20260417-31"></script>
-     <script src="../js/auth/auth-firebase.js?v=20260420-1"></script>
+     <script src="../js/auth/auth-firebase.js?v=20260427-3"></script>
      <script src="../js/auth.js?v=20260417-31"></script>
-    <script src="../js/settings.js?v=20260425-1"></script>
+    <script src="../js/settings.js?v=20260427-3"></script>
   <script>
     renderSharedHeader();
     initSettings();


### PR DESCRIPTION
## Summary
- Bumps protected page auth script cache-bust versions so test slots load the latest auth gate code.
- Bumps Settings page script version so the Settings auth gate from PR #140 is loaded.
- Does not change auth logic.

## Why
Browser QA on test5 showed protected pages loading stale JS:
- \uth-firebase.js?v=20260420-1\ did not contain \isProtectedRoute\ or \clearCommunityCaches\.
- Settings did not load the script containing \handleSettingsAuthUser\.
The protected route failures were therefore classified as \stale JS asset suspected\.

## Changed files
- \pages/my-trees.html\ 
- \pages/settings.html\ 
- \pages/editor.html\ 

## Non-changes
- No JS logic changes
- No CSS changes
- No API/runtime changes
- No Firebase config/security rules changes
- No PR #7/prototype/reference/demo changes

## Verification
- \git diff --check\: PASS
- \
pm run lint\: PASS
- \
pm run build\: NOT RUN
- \
pm run verify\: NOT RUN
- Browser verification: pending test5 redeploy

Refs #133