### PR TITLE
fix(auth): clear dependent caches on null auth

### DIFF
--- a/js/auth/auth-firebase.js
+++ b/js/auth/auth-firebase.js
@@ -192,6 +192,42 @@
     }
   }
 
+  function clearAuthDependentCaches(options) {
+    var clearFirebaseState = !!(options && options.clearFirebaseState);
+    var clearStaleFirebaseAuthState = options && options.clearStaleFirebaseAuthState;
+    var clearConfirmedAuthCache = options && options.clearConfirmedAuthCache;
+
+    if (clearFirebaseState) {
+      try {
+        if (typeof clearStaleFirebaseAuthState === 'function') {
+          clearStaleFirebaseAuthState();
+        }
+      } catch (e) {}
+    }
+
+    try {
+      localStorage.removeItem('isLoggedIn');
+    } catch (e) {}
+
+    try {
+      if (window.clearPrivateCaches) {
+        window.clearPrivateCaches();
+      }
+    } catch (e) {}
+
+    try {
+      if (window.apiClient && typeof window.apiClient.clearCommunityCaches === 'function') {
+        window.apiClient.clearCommunityCaches();
+      }
+    } catch (e) {}
+
+    try {
+      if (typeof clearConfirmedAuthCache === 'function') {
+        clearConfirmedAuthCache();
+      }
+    } catch (e) {}
+  }
+
   async function signOut(options) {
     var clearStaleFirebaseAuthState = options && options.clearStaleFirebaseAuthState;
     var clearConfirmedAuthCache = options && options.clearConfirmedAuthCache;
@@ -204,25 +240,11 @@
       console.error('Logout failed:', error);
     }
 
-    if (typeof clearStaleFirebaseAuthState === 'function') {
-      clearStaleFirebaseAuthState();
-    }
-
-    try {
-      localStorage.removeItem('isLoggedIn');
-    } catch (e) {}
-
-    if (window.clearPrivateCaches) {
-      window.clearPrivateCaches();
-    }
-
-    if (window.apiClient && typeof window.apiClient.clearCommunityCaches === 'function') {
-      window.apiClient.clearCommunityCaches();
-    }
-
-    if (typeof clearConfirmedAuthCache === 'function') {
-      clearConfirmedAuthCache();
-    }
+    clearAuthDependentCaches({
+      clearFirebaseState: true,
+      clearStaleFirebaseAuthState: clearStaleFirebaseAuthState,
+      clearConfirmedAuthCache: clearConfirmedAuthCache
+    });
 
     window.location.reload();
   }
@@ -321,18 +343,21 @@
           if (typeof isInvalidAuthSessionError === 'function' && isInvalidAuthSessionError(error)) {
             console.warn('Invalid Firebase session detected. Signing out.');
             await firebase.auth().signOut().catch(function() {});
-            if (typeof clearStaleFirebaseAuthState === 'function') {
-              clearStaleFirebaseAuthState();
-            }
-            if (typeof clearConfirmedAuthCache === 'function') {
-              clearConfirmedAuthCache();
-            }
+            clearAuthDependentCaches({
+              clearFirebaseState: true,
+              clearStaleFirebaseAuthState: clearStaleFirebaseAuthState,
+              clearConfirmedAuthCache: clearConfirmedAuthCache
+            });
             if (typeof resolveAuthBootstrap === 'function') {
               resolveAuthBootstrap(null);
             }
             return;
           }
         }
+      } else {
+        clearAuthDependentCaches({
+          clearConfirmedAuthCache: clearConfirmedAuthCache
+        });
       }
 
       if (typeof persistConfirmedAuthSession === 'function') {


### PR DESCRIPTION
## Summary
- Add a small auth-dependent cache cleanup helper in `js/auth/auth-firebase.js`.
- Reuse the helper for explicit sign out and invalid Firebase session handling.
- Clear dependent private/community cache hooks when Firebase resolves `user === null`.
- Keep protected-route offline fallback behavior unchanged.

## Scope
- `js/auth/auth-firebase.js` only.
- No page HTML changes.
- No asset version bump.
- No backend/API changes.
- No Firebase Console or Security Rules changes.
- No expired token residue handling.
- No `clearPrivateCaches` implementation added.
- No prototype/reference/demo/variant changes.

## Behavior
- Explicit sign out:
  - keeps Firebase signOut attempt
  - clears Firebase stale auth state
  - clears confirmed auth cache
  - invokes existing private/community cache hooks if available
  - keeps existing reload

- Invalid session:
  - keeps Firebase signOut attempt
  - clears Firebase stale auth state
  - clears confirmed auth cache
  - invokes existing private/community cache hooks if available
  - keeps existing `resolveAuthBootstrap(null)` and return flow

- Auth null:
  - clears confirmed auth cache and existing private/community cache hooks
  - does not clear Firebase stale auth state
  - does not add reload or redirect
  - keeps existing `persistConfirmedAuthSession(null)`, UI update, bootstrap, and callback flow

## Validation
- GitHub compare scope: PASS
- Changed files limited to:
  - `js/auth/auth-firebase.js`
- Local `git diff --check`: not run in this environment
- `npm run lint`: not run in this environment
- `npm run build`: not run in this environment
- CI required before merge