### PR TITLE
fix(backend): add owner-verified private update/delete routes

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -688,6 +688,197 @@ def create_owner_memory(owner_id: str, payload: dict[str, Any]) -> dict[str, Any
     return normalize_memory_row(row)
 
 
+def fetch_tree_for_owner_check(tree_id: str) -> dict[str, Any] | None:
+    query = """
+        SELECT id, owner_id, title, visibility, created_at, updated_at
+        FROM trees
+        WHERE id = %s
+        LIMIT 1;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (tree_id,))
+            return cur.fetchone()
+
+
+def require_tree_owner(tree_id: str, owner_id: str) -> dict[str, Any]:
+    tree = fetch_tree_for_owner_check(tree_id)
+    if not tree:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    if str(tree.get("owner_id") or "") != owner_id:
+        raise HTTPException(status_code=403, detail="Access denied: not your tree")
+    return tree
+
+
+def fetch_memory_for_owner_check(memory_id: str) -> dict[str, Any] | None:
+    query = """
+        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
+               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.created_at, m.updated_at, t.owner_id AS tree_owner_id
+        FROM memories m
+        INNER JOIN trees t
+          ON t.id = m.tree_id
+        WHERE m.id = %s
+        LIMIT 1;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (memory_id,))
+            return cur.fetchone()
+
+
+def require_memory_owner(memory_id: str, owner_id: str) -> dict[str, Any]:
+    memory = fetch_memory_for_owner_check(memory_id)
+    if not memory:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    if str(memory.get("tree_owner_id") or "") != owner_id:
+        raise HTTPException(status_code=403, detail="Access denied: not your memory")
+    return memory
+
+
+def update_owner_tree(owner_id: str, tree_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    safe_tree_id = validate_required_uuid(tree_id, "treeId")
+    require_tree_owner(safe_tree_id, owner_id)
+
+    updates: list[str] = []
+    params: list[Any] = []
+
+    if "title" in payload:
+        updates.append("title = %s")
+        params.append(validate_optional_string(payload.get("title"), 200))
+
+    if "visibility" in payload:
+        visibility = validate_visibility(payload.get("visibility"), "public")
+        require_plus_for_private_storage(owner_id, visibility)
+        updates.append("visibility = %s")
+        params.append(visibility)
+
+    if not updates:
+        tree = fetch_owner_tree(safe_tree_id, owner_id)
+        if not tree:
+            raise HTTPException(status_code=404, detail="Tree not found")
+        return tree
+
+    query = f"""
+        UPDATE trees
+        SET {', '.join(updates)}, updated_at = NOW()
+        WHERE id = %s
+          AND owner_id = %s
+        RETURNING id;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, tuple(params + [safe_tree_id, owner_id]))
+            row = cur.fetchone()
+        conn.commit()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Tree not found")
+
+    tree = fetch_owner_tree(safe_tree_id, owner_id)
+    if not tree:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    return tree
+
+
+def delete_owner_tree(owner_id: str, tree_id: str) -> dict[str, Any]:
+    safe_tree_id = validate_required_uuid(tree_id, "treeId")
+    require_tree_owner(safe_tree_id, owner_id)
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE memories SET parent_id = NULL WHERE tree_id = %s AND parent_id IS NOT NULL;",
+                (safe_tree_id,),
+            )
+            cur.execute("DELETE FROM memories WHERE tree_id = %s;", (safe_tree_id,))
+            cur.execute(
+                "DELETE FROM trees WHERE id = %s AND owner_id = %s RETURNING id;",
+                (safe_tree_id, owner_id),
+            )
+            row = cur.fetchone()
+        conn.commit()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    return {"deleted": True, "id": str(row["id"])}
+
+
+def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+    require_memory_owner(safe_memory_id, owner_id)
+
+    updates: list[str] = []
+    params: list[Any] = []
+
+    if "title" in payload:
+        updates.append("title = %s")
+        params.append(validate_optional_string(payload.get("title"), 200))
+
+    if "memo" in payload:
+        updates.append("memo = %s")
+        params.append(validate_optional_string(payload.get("memo"), 5000))
+
+    if "emotionTags" in payload:
+        emotion_tags = payload.get("emotionTags") if isinstance(payload.get("emotionTags"), list) else []
+        if len(emotion_tags) > 20:
+            raise HTTPException(status_code=400, detail="emotionTags exceeds maximum of 20 items")
+        updates.append("emotion_tags = %s")
+        params.append(json.dumps([str(tag).strip() for tag in emotion_tags if str(tag).strip()]))
+
+    if "visibility" in payload:
+        visibility = validate_visibility(payload.get("visibility"), "public")
+        require_plus_for_private_storage(owner_id, visibility)
+        updates.append("visibility = %s")
+        params.append(visibility)
+
+    if not updates:
+        memory = require_memory_owner(safe_memory_id, owner_id)
+        return normalize_memory_row(memory)
+
+    query = f"""
+        UPDATE memories
+        SET {', '.join(updates)}, updated_at = NOW()
+        WHERE id = %s
+        RETURNING id, tree_id, parent_id, title, memo, artist, source, source_url,
+                  source_type, thumbnail, emotion_tags, timestamp, visibility,
+                  created_at, updated_at;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, tuple(params + [safe_memory_id]))
+            row = cur.fetchone()
+        conn.commit()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return normalize_memory_row(row)
+
+
+def delete_owner_memory(owner_id: str, memory_id: str) -> dict[str, Any]:
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+    memory = require_memory_owner(safe_memory_id, owner_id)
+    tree_id = str(memory["tree_id"])
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE memories SET parent_id = NULL WHERE tree_id = %s AND parent_id = %s;",
+                (tree_id, safe_memory_id),
+            )
+            cur.execute("DELETE FROM memories WHERE id = %s RETURNING id;", (safe_memory_id,))
+            row = cur.fetchone()
+        conn.commit()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"deleted": True, "id": str(row["id"])}
+
+
 # --- Modal App Setup ---
 
 app = modal.App("lovebud-browse-snapshot")
@@ -820,6 +1011,29 @@ def get_private_tree_detail(
     return tree
 
 
+@web_app.put("/modal/private/trees/{tree_id}")
+async def put_private_tree(
+    tree_id: str,
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError as error:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from error
+    return update_owner_tree(user["uid"], tree_id, payload if isinstance(payload, dict) else {})
+
+
+@web_app.delete("/modal/private/trees/{tree_id}")
+def delete_private_tree(
+    tree_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return delete_owner_tree(user["uid"], tree_id)
+
+
 @web_app.get("/modal/private/memories")
 def get_private_memories(
     treeId: str | None = None,
@@ -842,6 +1056,29 @@ async def post_private_memory(
     except json.JSONDecodeError as error:
         raise HTTPException(status_code=400, detail="Invalid JSON body") from error
     return create_owner_memory(user["uid"], payload if isinstance(payload, dict) else {})
+
+
+@web_app.put("/modal/private/memories/{memory_id}")
+async def put_private_memory(
+    memory_id: str,
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError as error:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from error
+    return update_owner_memory(user["uid"], memory_id, payload if isinstance(payload, dict) else {})
+
+
+@web_app.delete("/modal/private/memories/{memory_id}")
+def delete_private_memory(
+    memory_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return delete_owner_memory(user["uid"], memory_id)
 
 
 @app.function(


### PR DESCRIPTION
## Summary
- Add owner-verified Modal private update/delete routes for trees and memories.
- Keep Cloudflare route files unchanged because existing specific routes already forward PUT/DELETE to Modal private routes.
- Preserve existing public create/read behavior.

## Scope
- `modal_compute/app.py` only.
- No UI/CSS/page changes.
- No JS client changes.
- No Cloudflare catch-all changes.
- No Firebase Console/Security Rules changes.
- No prototype/reference/demo/variant changes.

## Implemented routes
- `PUT /modal/private/trees/{tree_id}`
- `DELETE /modal/private/trees/{tree_id}`
- `PUT /modal/private/memories/{memory_id}`
- `DELETE /modal/private/memories/{memory_id}`

## Security / ownership
- All new routes require `Authorization: Bearer <Firebase ID token>`.
- Tree update/delete checks `trees.owner_id == uid`.
- Memory update/delete checks ownership through `memories -> trees.owner_id`.
- Non-owner returns 403.
- Missing target returns 404.

## Policy
- `visibility` uses existing `validate_visibility()`.
- Private visibility uses existing `require_plus_for_private_storage()`.
- Unknown payload fields are ignored by allowlist behavior.

## Validation
- GitHub API diff scope: PASS
- Changed files: `modal_compute/app.py` only
- Local `git diff --check`: not run
- `npm run lint`: not run
- `npm run build`: not run
- CI required before merge

## Rebase note
This branch was created from `af8ac02...` and is currently behind `main` by PR #152 merge commit `24c5083...`.

The branch is intentionally not remote-rebased because this executor cannot perform a local rebase, and remote ref rewriting/update_ref was not approved.

Known file separation:
- PR #152 changed `js/auth/auth-firebase.js`
- This PR changes `modal_compute/app.py` only

Final mergeability and CI must be checked by GitHub after PR creation.

## Known follow-up
- Cloudflare route precedence must be verified on a fixed test slot before final production confidence.
- Contract/integration tests should be added in a separate follow-up.