### PR TITLE
refactor(css): split global tokens and base styles

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,114 +1,14 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap');
+/* ─────────────────────────────────────────────────────────────
+   LoveBud Global Import Hub
+   FOUNDATIONAL: tokens -> base
+   COMPONENTS: nav, buttons, cards, etc.
+   ───────────────────────────────────────────────────────────── */
 
-:root {
-    /* Premium Modern Palette - Warm Scrapbook Tone */
-    --primary: #904951;           /* 뮤트 로즈 - 메인 브랜드 */
-    --primary-vibrant: #b85c66;   /* 채도 낮춘 로즈 - hover accent (원색 금지) */
-    --primary-soft: #d4a5a9;      /* 소프트 로즈 - 감정 태그용 */
-    --on-primary: #ffffff;
+@import url('./global/tokens.css');
+@import url('./global/base.css');
 
-    --secondary: #7a8b6e;         /* 웜 그린 - 자연/성장 */
-    --on-secondary: #ffffff;
-    
-    --accent-warm: #c9a87c;       /* 웜 베이지 - 감정적 하이라이트 */
-    --accent-rose: #e8c4c8;       /* 로즈 베이지 - 부드러운 강조 */
-    
-    --background: #fdfbf7;        /* 종이 질감 베이지 (완전 화이트 금지) */
-    --on-background: #3e342f;     /* 다크 브라운 텍스트 (완전 블랙 금지) */
-    --surface: #fdfbf7;
-    --on-surface: #483934;        /* 다크 브라운 - 메인 텍스트 (Premium) */
-    --on-surface-variant: #6c5953; /* 뮤트 브라운 - 보조 텍스트 (Premium) */
-    --on-surface-soft: #7f5d5f;    /* 뮤트 로즈 브라운 - 부드러운 강조 */
-    --on-surface-note: #9c8080;    /* 연한 로즈 그레이 - 각주/노트 */
 
-    --surface-container-low: #f8f5f0;
-    --surface-container: #f2efe9;
-    --surface-container-lowest: #ffffff;
-    
-    --outline-variant: rgba(144, 73, 81, 0.12);
-    --shadow-whisper: 0 12px 40px rgba(75, 64, 57, 0.06);
 
-    --radius-default: 1rem;
-    --radius-lg: 2rem;
-    --radius-full: 9999px;
-
-    /* Page width rhythm */
-    --page-brand-max: 1280px;
-    --page-work-max: 1440px;
-
-    /* Layout Spacing Tokens (PR1) */
-    --page-shell-max: 1280px;
-    --page-pad-desktop: 24px;
-    --page-pad-tablet: 24px;
-    --page-pad-mobile: 16px;
-    --hero-gap: 34px;
-    --section-gap: 56px;
-    --section-gap-compact: 40px;
-    --divider-margin: 48px;
-    
-    /* Typography Constants */
-    --font-heading: 'Outfit', sans-serif;
-    --font-body: 'Noto Sans KR', sans-serif;
-
-    /* Typography / Accent Tokens (PR2) */
-    --hero-title-size: clamp(3.55rem, 6vw, 5.4rem);
-    --hero-title-line-height: 0.98;
-    --hero-title-letter-spacing: -0.055em;
-    --section-title-size: clamp(2.9rem, 4.6vw, 4rem);
-    --hero-accent-color: var(--primary-vibrant);
-    --hero-warm-color: var(--primary);
-    --hero-soft-color: var(--on-surface-variant);
-    --eyebrow-color: var(--primary);
-    --eyebrow-line-color: rgba(144, 73, 81, 0.42);
-    --body-muted-color: var(--on-surface-variant);
-    --body-note-color: var(--on-surface-note);
-}
-
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-body {
-    font-family: var(--font-body);
-    background-color: var(--background);
-    color: var(--on-surface);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
-h1, h2, h3, h4, .headline {
-    font-family: var(--font-heading);
-    letter-spacing: -0.02em;
-    font-weight: 800;
-}
-
-/* Background Effects */
-.noise-overlay {
-    position: fixed;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    pointer-events: none;
-    opacity: 0.04;
-    /* SVG 노이즈 패턴 - 외부 URL 의존성 제거 */
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-    z-index: 9999;
-}
-
-.bokeh-bg {
-    min-height: 100vh;
-    background: 
-        radial-gradient(circle at 12% 12%, rgba(255, 222, 211, 0.72), transparent 22%),
-        radial-gradient(circle at 84% 10%, rgba(239, 206, 215, 0.58), transparent 20%),
-        radial-gradient(circle at 76% 66%, rgba(236, 231, 212, 0.42), transparent 24%),
-        linear-gradient(180deg, #fff9f4 0%, #f9f0ea 42%, #f7efe9 100%);
-    background-attachment: fixed;
-    background-repeat: no-repeat;
-    background-size: cover;
-    color: var(--on-surface);
-}
 
 /* Header Refinement */
 .nav-bar {
@@ -617,10 +517,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
 }
 
 /* Animations */
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
+
 
 /* Auth nav loading state - smooth transition */
 #auth-nav, #auth-nav-container {

--- a/css/global/base.css
+++ b/css/global/base.css
@@ -1,0 +1,50 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-body);
+    background-color: var(--background);
+    color: var(--on-surface);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, .headline {
+    font-family: var(--font-heading);
+    letter-spacing: -0.02em;
+    font-weight: 800;
+}
+
+/* Background Effects */
+.noise-overlay {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    pointer-events: none;
+    opacity: 0.04;
+    /* SVG 노이즈 패턴 - 외부 URL 의존성 제거 */
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+    z-index: 9999;
+}
+
+.bokeh-bg {
+    min-height: 100vh;
+    background: 
+        radial-gradient(circle at 12% 12%, rgba(255, 222, 211, 0.72), transparent 22%),
+        radial-gradient(circle at 84% 10%, rgba(239, 206, 215, 0.58), transparent 20%),
+        radial-gradient(circle at 76% 66%, rgba(236, 231, 212, 0.42), transparent 24%),
+        linear-gradient(180deg, #fff9f4 0%, #f9f0ea 42%, #f7efe9 100%);
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    background-size: cover;
+    color: var(--on-surface);
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/css/global/tokens.css
+++ b/css/global/tokens.css
@@ -1,0 +1,65 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800;900&family=Noto+Sans+KR:wght@300;400;500;700;900&display=swap');
+
+:root {
+    /* Premium Modern Palette - Warm Scrapbook Tone */
+    --primary: #904951;           /* 뮤트 로즈 - 메인 브랜드 */
+    --primary-vibrant: #b85c66;   /* 채도 낮춘 로즈 - hover accent (원색 금지) */
+    --primary-soft: #d4a5a9;      /* 소프트 로즈 - 감정 태그용 */
+    --on-primary: #ffffff;
+
+    --secondary: #7a8b6e;         /* 웜 그린 - 자연/성장 */
+    --on-secondary: #ffffff;
+    
+    --accent-warm: #c9a87c;       /* 웜 베이지 - 감정적 하이라이트 */
+    --accent-rose: #e8c4c8;       /* 로즈 베이지 - 부드러운 강조 */
+    
+    --background: #fdfbf7;        /* 종이 질감 베이지 (완전 화이트 금지) */
+    --on-background: #3e342f;     /* 다크 브라운 텍스트 (완전 블랙 금지) */
+    --surface: #fdfbf7;
+    --on-surface: #483934;        /* 다크 브라운 - 메인 텍스트 (Premium) */
+    --on-surface-variant: #6c5953; /* 뮤트 브라운 - 보조 텍스트 (Premium) */
+    --on-surface-soft: #7f5d5f;    /* 뮤트 로즈 브라운 - 부드러운 강조 */
+    --on-surface-note: #9c8080;    /* 연한 로즈 그레이 - 각주/노트 */
+
+    --surface-container-low: #f8f5f0;
+    --surface-container: #f2efe9;
+    --surface-container-lowest: #ffffff;
+    
+    --outline-variant: rgba(144, 73, 81, 0.12);
+    --shadow-whisper: 0 12px 40px rgba(75, 64, 57, 0.06);
+
+    --radius-default: 1rem;
+    --radius-lg: 2rem;
+    --radius-full: 9999px;
+
+    /* Page width rhythm */
+    --page-brand-max: 1280px;
+    --page-work-max: 1440px;
+
+    /* Layout Spacing Tokens (PR1) */
+    --page-shell-max: 1280px;
+    --page-pad-desktop: 24px;
+    --page-pad-tablet: 24px;
+    --page-pad-mobile: 16px;
+    --hero-gap: 34px;
+    --section-gap: 56px;
+    --section-gap-compact: 40px;
+    --divider-margin: 48px;
+    
+    /* Typography Constants */
+    --font-heading: 'Outfit', sans-serif;
+    --font-body: 'Noto Sans KR', sans-serif;
+
+    /* Typography / Accent Tokens (PR2) */
+    --hero-title-size: clamp(3.55rem, 6vw, 5.4rem);
+    --hero-title-line-height: 0.98;
+    --hero-title-letter-spacing: -0.055em;
+    --section-title-size: clamp(2.9rem, 4.6vw, 4rem);
+    --hero-accent-color: var(--primary-vibrant);
+    --hero-warm-color: var(--primary);
+    --hero-soft-color: var(--on-surface-variant);
+    --eyebrow-color: var(--primary);
+    --eyebrow-line-color: rgba(144, 73, 81, 0.42);
+    --body-muted-color: var(--on-surface-variant);
+    --body-note-color: var(--on-surface-note);
+}


### PR DESCRIPTION
## Summary
- Split foundational global CSS into `css/global/tokens.css` and `css/global/base.css`.
- Keep `css/global.css` as the import hub.
- Move only Google Fonts import, first base `:root` token block, reset/body/headings, background effects, and `@keyframes spin`.
- Preserve header/nav/auth/dropdown/mobile/material-symbols/editor/intro/search/PR3 blocks in `css/global.css`.

## Scope
Changed files:
- `css/global.css`
- `css/global/tokens.css`
- `css/global/base.css`

No changes to:
- HTML
- JS
- Auth/API/Modal/Cloudflare/Firebase
- page-specific CSS
- docs
- prototype/reference/demo/variant

## Validation
- [x] Verified 500+ lines remaining in `global.css` (Phase 1 limits respected).
- [x] Verified `tokens.css` loads before `base.css`.
- [x] Verified Cloudflare standard verification (`npm run verify`).
