### PR TITLE
docs(ops): mark Netlify artifacts as legacy removal candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,25 @@ LoveBud / LoveTree는 일반 북마크 정리 앱이나 관리자 도구가 아�
 
 현재 운영 기준 인프라 우선순위는 아래와 같습니다.
 
-1. **Modal** — browse summary, 복합 계산, read-heavy compute 우선
-2. **Cloudflare Pages** — 실서비스 프론트, same-origin `/api`, 공식 배포 진입점
-3. **Vercel** — upstream / secondary entry / proxy fallback 계층
-4. **Netlify** — legacy fallback 또는 단계적 제거 대상 레거시 경로
+1. **Cloudflare Pages** — 실서비스 프론트, same-origin `/api`, 공식 사용자-facing 배포 진입점
+2. **Modal** — active API/backend target, browse summary, private/community read/write compute
+3. **Vercel** — deprecated transitional upstream fallback / audit 중인 보조 계층
+4. **Netlify** — legacy artifact / tests-docs transition 이후 removal candidate
 
 핵심 원칙:
 
 - 사용자 브라우저는 가능하면 **same-origin `/api`**만 사용합니다.
 - 공식 사용자-facing 주소는 **`lovebud.pages.dev`** 기준으로 봅니다.
-- Vercel과 Netlify는 현재 보조 계층 또는 전이기 계층으로 설명합니다.
+- active API path는 **browser → same-origin `/api/*` → Cloudflare Pages Functions → Modal → Neon** 입니다.
+- Vercel은 deprecated transitional fallback / upstream under audit입니다.
+- Netlify는 **active production fallback이 아닙니다.** `netlify.toml`과 `netlify/functions/**`는 legacy artifact이며, tests/docs transition 전까지 삭제하지 않는 removal candidate입니다.
+- 새 backend feature/policy work는 Netlify가 아니라 Cloudflare Pages Functions와 Modal 기준으로만 수행합니다.
 - browse display filter와 publication guard는 **다른 개념**으로 취급합니다.
 
 운영 상세는 아래 문서를 먼저 봅니다.
 
 - `docs/ops/OPERATIONS.md`
+- `docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`
 - `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
 - `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
 
@@ -76,6 +80,7 @@ LoveBud는 저장소 구조와 운영 계약에 프로젝트 고유 전제가 �
 - `vercel.json`을 자동 삭제 후보로 보지 않기
 - browse / search, display filter / publication guard 혼동하지 않기
 - 파일 크기나 번들러 부재만으로 심각 판정하지 않기
+- `netlify/functions/**`를 active backend 구현 위치로 보지 않기
 
 ---
 
@@ -108,10 +113,10 @@ Cloudflare Pages에서는 위 경로가 사용자-facing 주소로 노출됩니�
 
 ### 현재 배포 구조
 
-- **Cloudflare Pages**: 프론트 및 `/api` 엔트리
-- **Modal**: browse / summary 가속 및 compute
-- **Vercel**: upstream / proxy fallback / 전이기 보조 계층
-- **Netlify**: 일부 legacy CRUD fallback
+- **Cloudflare Pages**: 공식 프론트 및 same-origin `/api` 엔트리
+- **Modal**: active backend/API target, browse / summary / private-community compute
+- **Vercel**: deprecated transitional upstream fallback / 전이기 보조 계층
+- **Netlify**: legacy artifact / removal candidate. active production fallback이 아니며 신규 backend 정책 구현 대상이 아님
 
 ---
 
@@ -128,15 +133,16 @@ Cloudflare Pages에서는 위 경로가 사용자-facing 주소로 노출됩니�
 ### 구현 / 운영 판단이 필요할 때
 
 6. `docs/ops/OPERATIONS.md`
-7. `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
-8. `docs/engineering/API_CONTRACT.md`
-9. `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
-10. `docs/engineering/REVIEW_GUARDRAILS.md`
+7. `docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`
+8. `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
+9. `docs/engineering/API_CONTRACT.md`
+10. `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
+11. `docs/engineering/REVIEW_GUARDRAILS.md`
 
 ### 대화 복원이 필요할 때
 
-11. `docs/conversation/summary/summary_index.md`
-12. 최신 summary 문서
+12. `docs/conversation/summary/summary_index.md`
+13. 최신 summary 문서
 
 ---
 

--- a/docs/ops/DEPLOY_CHECKLIST.md
+++ b/docs/ops/DEPLOY_CHECKLIST.md
@@ -7,7 +7,7 @@
 - Cloudflare Pages 역할: 공식 사용자-facing production / preview entry
 - Modal 역할: active compute/runtime 우선 경로
 - Vercel 역할: deprecated transitional fallback / upstream under audit
-- Netlify 역할: legacy / fallback / artifact. `netlify/functions/*`는 현재 active production backend가 아님
+- Netlify 역할: legacy artifact / removal candidate. `netlify/functions/*`는 현재 active production backend 또는 active production fallback이 아님
 
 ## 0. 빠른 엔드포인트 검증 (1분)
 
@@ -33,8 +33,9 @@ curl -s "https://<MODAL_BASE_URL>/modal/browse/latest?limit=3"
 - preview hydrate도 Modal 우선 시도를 가집니다.
 - Cloudflare Pages가 공식 사용자-facing entry입니다.
 - Cloudflare PR Preview / branch preview가 UI/API 의존 화면의 preview 검증 기준입니다.
-- Vercel / Netlify는 보조 또는 legacy 계층입니다.
-- Netlify 관련 파일은 삭제 대상이라고 단정하지 않지만, active production runtime처럼 설명하지 않습니다.
+- Vercel은 deprecated transitional upstream fallback입니다.
+- Netlify는 legacy artifact / removal candidate이며 active production fallback이 아닙니다.
+- Netlify 관련 파일은 tests/docs transition 전까지 삭제하지 않지만, active production runtime처럼 설명하지 않습니다.
 - browse display filter와 publication guard를 혼동하지 않습니다.
 
 ## 1. Firebase Authorized Domains 점검
@@ -99,16 +100,18 @@ Firebase Console > Authentication > Settings > Authorized Domains
 - test slot URL 접근 불가, DNS 실패, target SHA 불명확, login gate까지만 확인된 경우는 PASS가 아니라 BLOCKED 또는 PARTIAL로 분리합니다.
 - screenshot, console, network evidence에는 token/password/cookie/private content 원문을 남기지 않습니다.
 
-## 5. fallback / legacy 점검
+## 5. transitional fallback / legacy 점검
 
 - [ ] Modal 차단 시 browse summary가 Vercel upstream fallback으로 계속 응답하는지 확인
 - [ ] catch-all `/api/*`가 `LOVEBUD_UPSTREAM_ORIGIN` 기준으로 정상 proxy 되는지 확인
-- [ ] Netlify legacy 계층이 필요한 경로 또는 CI/local harness에서만 보조적으로 관여하는지 확인
+- [ ] Netlify legacy artifact가 active production fallback처럼 호출되지 않는지 확인
+- [ ] Netlify-targeting tests/docs가 남아 있더라도 production Cloudflare/Modal runtime truth와 분리해서 해석하는지 확인
 
 주의:
 - CI/E2E smoke workflow에서 `netlify dev`가 쓰일 수 있습니다.
-- 이 경로는 local test harness이며, production active runtime이 Netlify라는 뜻이 아닙니다.
+- 이 경로는 local test harness이며, production active runtime 또는 active production fallback이 Netlify라는 뜻이 아닙니다.
 - Netlify dev의 env 누락 failure는 production Cloudflare/Modal runtime failure와 분리해서 봅니다.
+- Netlify 제거는 [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](NETLIFY_LEGACY_ARTIFACT_AUDIT.md)의 prerequisites 충족 후 별도 승인으로만 진행합니다.
 
 ## 6. 장애 대응 우선순위
 
@@ -134,6 +137,7 @@ Firebase Console > Authentication > Settings > Authorized Domains
    - CI/local harness인지 확인
    - `NETLIFY_DATABASE_URL` / `DATABASE_URL` 누락인지 확인
    - production Cloudflare Pages URL에서 재현되는지 분리 확인
+   - Netlify legacy failure를 이유로 `netlify/functions/**`에 새 backend policy를 구현하지 않음
 
 6. **Auth Domain Error**
    - Firebase Console 승인 도메인 확인
@@ -146,6 +150,7 @@ Firebase Console > Authentication > Settings > Authorized Domains
 - `lovebud.vercel.app`를 공식 사용자-facing 주소처럼 설명하는 문장
 - `lovebud.netlify.app`를 주서비스처럼 설명하는 문장
 - Netlify를 primary runtime으로 설명하는 문장
+- Netlify를 active production fallback으로 설명하는 문장
 - `netlify/functions/*`를 active Cloudflare/Modal backend 구현 위치처럼 설명하는 문장
 - Cloudflare Pages를 무시하고 Vercel을 공식 진입점으로 단정하는 문장
 - CI/E2E의 `netlify dev` 사용을 production runtime truth로 해석하는 문장
@@ -155,4 +160,4 @@ Firebase Console > Authentication > Settings > Authorized Domains
 - **browse summary와 active compute의 1순위는 Modal**
 - **Cloudflare Pages가 same-origin API entry**
 - **Vercel은 deprecated transitional fallback / upstream under audit**
-- **Netlify는 legacy / fallback / artifact**
+- **Netlify는 legacy artifact / removal candidate, not active production fallback**

--- a/docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md
+++ b/docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md
@@ -1,0 +1,118 @@
+# Netlify Legacy Artifact Audit
+
+## 1. Current active runtime
+
+LoveBud의 현재 official user-facing runtime은 Cloudflare Pages입니다.
+
+현재 active API path는 아래 기준으로 판단합니다.
+
+```text
+Browser
+→ same-origin /api/*
+→ Cloudflare Pages Functions
+→ Modal
+→ Neon PostgreSQL
+```
+
+Netlify는 active production fallback이 아닙니다.
+`netlify.toml`과 `netlify/functions/**`는 legacy artifact이며, tests/docs transition 이후 removal candidate로만 취급합니다.
+
+## 2. Netlify files found
+
+현재 저장소에는 아래 Netlify legacy artifact가 남아 있습니다.
+
+```text
+netlify.toml
+netlify/functions/**
+```
+
+대표 파일군:
+
+```text
+netlify/functions/trees.js
+netlify/functions/tree-detail.js
+netlify/functions/memories.js
+netlify/functions/memory-detail.js
+netlify/functions/community-trees.js
+netlify/functions/community-memories.js
+netlify/functions/_lib/**
+```
+
+Netlify-targeting tests도 남아 있습니다.
+
+```text
+tests/functions/**
+tests/contracts/** where they import or assert netlify/functions behavior
+```
+
+## 3. Why they remain
+
+Netlify files remain for three reasons.
+
+1. Some tests still import or assert legacy `netlify/functions/**` behavior.
+2. Some docs still describe historical route behavior and need transition context.
+3. Removal must not happen before Cloudflare/Modal route parity and CI independence are confirmed.
+
+Their presence does not mean Netlify is the active production runtime.
+
+## 4. Why Netlify must not receive new backend policy work
+
+New backend feature or policy work must target the active runtime only.
+
+Allowed active implementation targets:
+
+```text
+functions/api/**
+modal_compute/**
+```
+
+Netlify is not a valid target for new backend policy work unless CTO explicitly reactivates Netlify runtime.
+
+Do not add new behavior to `netlify/functions/**` for:
+
+- public-first tree creation
+- Plus private entitlement
+- private/public visibility policy
+- browse eligibility policy
+- auth/session policy
+- private update/delete route parity
+- new API response contracts
+
+## 5. Removal prerequisites
+
+Netlify artifact removal requires all of the following to be true.
+
+- Cloudflare/Modal route parity confirmed.
+- Netlify-targeting tests migrated or deleted.
+- CI no longer imports `netlify/functions/**`.
+- Production/test slot route matrix confirms Cloudflare → Modal for active API paths.
+- No active Netlify deploy target remains in use.
+- Docs no longer rely on Netlify as an active fallback or active runtime explanation.
+
+## 6. Explicit non-removal decision for this PR
+
+This docs/ops update does not remove Netlify files.
+
+Explicitly not changed:
+
+```text
+netlify.toml
+netlify/functions/**
+tests/**
+functions/**
+modal_compute/**
+```
+
+This PR only marks Netlify as:
+
+```text
+Netlify legacy artifact
+not active production fallback
+removal candidate after tests/docs transition
+```
+
+## 7. Executor rule
+
+When a future task touches backend behavior, the executor must first decide whether the change belongs to the active Cloudflare/Modal runtime.
+
+If a proposed implementation targets `netlify/functions/**`, reject or pause it unless the CTO has explicitly reactivated Netlify runtime.

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -7,7 +7,7 @@
 - Cloudflare Pages 역할: 공식 사용자-facing production / preview entry, 정적 프런트, same-origin `/api/*` entry
 - Modal 역할: active compute/runtime 우선 경로, browse summary 및 private/community read/write target
 - Vercel 역할: deprecated transitional fallback / upstream under audit
-- Netlify 역할: legacy / fallback / artifact. `netlify/functions/*`는 현재 `lovebud.pages.dev` production backend가 아님
+- Netlify 역할: legacy artifact / removal candidate. `netlify/functions/*`는 현재 `lovebud.pages.dev` production backend 또는 active production fallback이 아님
 
 ## 2. 현재 운영 구조
 
@@ -28,8 +28,9 @@
 ### Fallback / Legacy
 - Modal read 실패 시 Cloudflare Pages가 Vercel upstream으로 fallback 할 수 있습니다.
 - catch-all `/api/*`의 기본 fallback upstream origin은 현재 Vercel입니다.
-- Netlify 관련 파일과 `netlify/functions/*`는 legacy / fallback / artifact 성격으로 남아 있습니다.
-- Netlify 코드는 삭제 대상이라고 단정하지 않습니다. 별도 승인 없이 이동, archive, 삭제하지 않습니다.
+- Netlify 관련 파일과 `netlify/functions/*`는 legacy artifact / removal candidate로 남아 있습니다.
+- Netlify는 active production fallback이 아니며, 새 backend feature/policy work의 대상이 아닙니다.
+- Netlify 코드는 tests/docs transition 전까지 삭제 대상이라고 단정하지 않습니다. 별도 승인 없이 이동, archive, 삭제하지 않습니다.
 
 ## 3. 배포 절차
 
@@ -59,10 +60,12 @@
 - 공식 사용자-facing 주소가 아니라 보조 계층으로 취급
 
 ### Netlify
-- 역할: legacy / fallback / artifact
-- 주서비스 주소가 아니라 보조 계층 또는 과거 산출물로 취급
+- 역할: legacy artifact / removal candidate
+- 주서비스 주소, active runtime, active production fallback으로 취급하지 않습니다.
+- `netlify.toml`, `netlify/functions/**`, `tests/functions/**`는 tests/docs transition 전까지 남아 있을 수 있습니다.
 - `netlify/functions/*`는 현재 active runtime 구현 위치로 보지 않습니다.
 - Netlify runtime 재활성화, 코드 이동, 삭제, archive는 별도 CTO 승인 전 수행하지 않습니다.
+- 자세한 기준은 [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](NETLIFY_LEGACY_ARTIFACT_AUDIT.md)를 따릅니다.
 
 ## 4. 장애 대응
 
@@ -99,9 +102,10 @@
 ### CI/E2E에서 Netlify dev가 실패할 때
 해석 기준:
 1. CI/E2E smoke workflow가 `netlify dev`를 사용할 수 있습니다.
-2. 이 경로는 CI 로컬 실행 harness이며, production active runtime이 Netlify라는 뜻이 아닙니다.
+2. 이 경로는 CI 로컬 실행 harness이며, production active runtime 또는 active production fallback이 Netlify라는 뜻이 아닙니다.
 3. Netlify dev의 `DATABASE_URL` / `NETLIFY_DATABASE_URL` 누락으로 발생하는 503은 production Cloudflare/Modal runtime truth와 분리해서 봅니다.
 4. CI/E2E blocker를 이유로 `netlify/functions/*`를 active runtime처럼 수정하지 않습니다.
+5. Netlify-targeting tests는 Cloudflare/Modal parity 확인 후 별도 migration/delete 승인 대상입니다.
 
 ### Fixed test slot access failure
 해석 기준:
@@ -152,5 +156,6 @@
 - browse summary와 API compute의 1순위는 Modal
 - Cloudflare Pages가 same-origin `/api/*` entry
 - Vercel은 deprecated transitional fallback / upstream under audit
-- Netlify는 legacy / fallback / artifact이며 `netlify/functions/*`는 현재 active production backend가 아님
+- Netlify는 legacy artifact / removal candidate이며, active production fallback이 아니고 `netlify/functions/*`는 현재 active production backend가 아님
+- Netlify 제거는 Cloudflare/Modal route parity, Netlify-targeting test migration/deletion, CI import 제거, production/test slot route matrix 확인, active Netlify deploy target 미사용 확인 후 별도 승인으로만 진행합니다.
 - fixed test slot 검증의 역할/판정/evidence 기준은 `docs/ops/TEST_PREVIEW_SLOTS.md`가 canonical입니다


### PR DESCRIPTION
## Summary
- Clarifies Netlify as a legacy artifact / removal candidate.
- States Netlify is not the active production fallback.
- Reaffirms active runtime as Cloudflare Pages same-origin `/api/*` to Cloudflare Pages Functions to Modal to Neon.
- Adds `docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`.
- Documents prerequisites before any future Netlify artifact archive/removal decision.

## Scope
Changed docs:
- `README.md`
- `docs/ops/RUNBOOK.md`
- `docs/ops/DEPLOY_CHECKLIST.md`
- `docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`

No changes to:
- `netlify.toml`
- `netlify/functions/**`
- `tests/**`
- `functions/**`
- `modal_compute/**`
- `js/**`
- `css/**`
- `pages/**`
- prototype/reference/demo/variant paths

## Validation
- Document-only change.
- No runtime files changed.
- No Netlify artifacts changed.
- No tests changed.
- Local `git diff --check`, lint, and build were not run in this GitHub API environment; rely on PR CI after creation.

## Follow-up
- `docs/ops/FILE_BASELINE.md` still needs a separate file-baseline refresh PR.
- Netlify removal itself remains blocked until tests/docs transition is complete.