### PR TITLE
fix(my-trees): default new trees to public visibility

### DIFF
--- a/js/my-trees/my-trees-actions.js
+++ b/js/my-trees/my-trees-actions.js
@@ -192,7 +192,7 @@
       }
 
       setError('');
-      cleanupAndResolve({ title: nextTitle, visibility: 'private' });
+      cleanupAndResolve({ title: nextTitle, visibility: 'public' });
     });
 
     titleInput.addEventListener('input', function() {
@@ -317,9 +317,9 @@
 
   function getDefaultVisibility() {
     if (isTestPublicMode()) {
-      console.log('[my-trees-actions] Test public mode ignored: new trees always start private');
+      console.log('[my-trees-actions] Test public mode ignored: new trees always start public');
     }
-    return 'private';
+    return 'public';
   }
 
   async function createNewTree(options) {
@@ -349,7 +349,7 @@
       modal.setSubmitting(true, i18n);
     }
 
-    console.log('[my-trees-actions] Creating tree with visibility: private');
+    console.log('[my-trees-actions] Creating tree with visibility: public');
 
     try {
       var newTree;
@@ -357,11 +357,11 @@
       if (window.apiClient && window.apiClient.createTree) {
         newTree = await window.apiClient.createTree({
           title: modalResult.title,
-          visibility: 'private'
+          visibility: 'public'
         });
         console.log('[my-trees-actions] Tree created:', newTree);
       } else {
-        newTree = { id: 'tree-' + Date.now(), title: modalResult.title, visibility: 'private' };
+        newTree = { id: 'tree-' + Date.now(), title: modalResult.title, visibility: 'public' };
         options?.showToast?.(safeText(i18n, 'demo_mode', '데모 모드입니다. 실제 트리는 생성되지 않습니다.'), 'error');
       }
 

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -94,7 +94,7 @@
   <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
   <script src="../js/postgres-client.js?v=20260422-1"></script>
   <script src="../js/my-trees/my-trees-ui.js?v=20260422-2"></script>
-  <script src="../js/my-trees/my-trees-actions.js?v=20260425-1"></script>
+  <script src="../js/my-trees/my-trees-actions.js?v=20260427-1"></script>
   <script src="../js/my-trees/my-trees-data.js?v=20260422-4"></script>
   <script src="../js/my-trees/my-trees-state.js?v=20260421-4"></script>
   <script src="../js/my-trees/my-trees-page.js?v=20260420-1"></script>


### PR DESCRIPTION
## Summary
- Changes My Trees UI create payload default visibility from \private\ to \public\.
- Aligns new tree creation with the public-first policy.
- Prevents non-Plus users from hitting \403 Private storage requires Plus\ when creating a new tree.
- Bumps \my-trees-actions.js\ asset version in \pages/my-trees.html\.

## Scope
Changed files:
- \js/my-trees/my-trees-actions.js\
- \pages/my-trees.html\

No changes to:
- Auth/login
- Backend/API/Modal/Cloudflare
- CSS
- Search/Editor/Detail
- Docs
- Prototype/reference/demo/variant paths

## Validation
- \git diff --check\
- \
pm run lint\
- \
pm run build\
- \
pm run verify\
- Production/fixed-slot browser verification still required after merge.