### PR TITLE
fix(login): show email auth errors inline

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -354,6 +354,23 @@ input[type="password"]:focus {
     font-size: 1rem;
 }
 
+.login-form-error {
+    margin: -4px 0 14px;
+    padding: 10px 12px;
+    border: 1px solid rgba(144, 73, 81, 0.18);
+    border-radius: 0.9rem;
+    background: rgba(144, 73, 81, 0.07);
+    color: var(--primary);
+    font-size: 0.86rem;
+    font-weight: 700;
+    line-height: 1.45;
+    text-align: left;
+}
+
+.login-form-error[hidden] {
+    display: none;
+}
+
 .login-submit-button {
     width: 100%;
     padding: 14px;

--- a/js/auth.js
+++ b/js/auth.js
@@ -1187,7 +1187,15 @@ form.addEventListener('submit', async function (e) {
         clearStaleFirebaseAuthState();
       }
       var friendlyMessage = getFriendlyErrorMessage(error, false);
-      alert(friendlyMessage || '인증 중 오류가 발생했습니다.');
+      var fallbackMessage = friendlyMessage || '인증 중 오류가 발생했습니다.';
+      if (
+        window.LoveBudLoginPageAuthError &&
+        typeof window.LoveBudLoginPageAuthError.show === 'function'
+      ) {
+        window.LoveBudLoginPageAuthError.show(fallbackMessage);
+      } else {
+        alert(fallbackMessage);
+      }
     } finally {
       submitBtn.disabled = false;
       submitBtn.textContent = originalText;

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -13,6 +13,65 @@
     langBtn.classList.add('active');
   }
 
+  function setupEmailAuthInlineError() {
+    var form = document.getElementById('email-auth-form');
+    var modal = document.getElementById('email-auth-modal');
+    var errorEl = document.getElementById('email-auth-error');
+
+    if (!form || !errorEl || window.__lovebudEmailAuthInlineErrorReady) return;
+    window.__lovebudEmailAuthInlineErrorReady = true;
+
+    var nativeAlert = window.alert;
+    var emailAuthSubmitActive = false;
+    var clearSubmitTimer = null;
+
+    function isEmailAuthModalOpen() {
+      return !!(modal && modal.style.display !== 'none');
+    }
+
+    function shouldShowInline(message) {
+      return emailAuthSubmitActive &&
+        isEmailAuthModalOpen() &&
+        typeof message === 'string' &&
+        !!message.trim();
+    }
+
+    function showInlineError(message) {
+      errorEl.textContent = message;
+      errorEl.hidden = false;
+      errorEl.setAttribute('aria-hidden', 'false');
+    }
+
+    function hideInlineError() {
+      errorEl.textContent = '';
+      errorEl.hidden = true;
+      errorEl.setAttribute('aria-hidden', 'true');
+    }
+
+    function markEmailAuthSubmitActive() {
+      emailAuthSubmitActive = true;
+      if (clearSubmitTimer) window.clearTimeout(clearSubmitTimer);
+      clearSubmitTimer = window.setTimeout(function () {
+        emailAuthSubmitActive = false;
+      }, 15000);
+    }
+
+    form.addEventListener('submit', function () {
+      hideInlineError();
+      markEmailAuthSubmitActive();
+    }, true);
+
+    form.addEventListener('input', hideInlineError);
+
+    window.alert = function (message) {
+      if (shouldShowInline(message)) {
+        showInlineError(String(message).trim());
+        return;
+      }
+      return nativeAlert.apply(window, arguments);
+    };
+  }
+
   function initLoginPage() {
     if (typeof renderSharedHeader === 'function') {
       renderSharedHeader();
@@ -23,6 +82,7 @@
     }
 
     syncLanguageUi();
+    setupEmailAuthInlineError();
 
     if (window.onLangChange) {
       window.onLangChange(function () {

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -15,61 +15,31 @@
 
   function setupEmailAuthInlineError() {
     var form = document.getElementById('email-auth-form');
-    var modal = document.getElementById('email-auth-modal');
     var errorEl = document.getElementById('email-auth-error');
 
-    if (!form || !errorEl || window.__lovebudEmailAuthInlineErrorReady) return;
-    window.__lovebudEmailAuthInlineErrorReady = true;
+    if (!form || !errorEl) return;
 
-    var nativeAlert = window.alert;
-    var emailAuthSubmitActive = false;
-    var clearSubmitTimer = null;
-
-    function isEmailAuthModalOpen() {
-      return !!(modal && modal.style.display !== 'none');
-    }
-
-    function shouldShowInline(message) {
-      return emailAuthSubmitActive &&
-        isEmailAuthModalOpen() &&
-        typeof message === 'string' &&
-        !!message.trim();
-    }
-
-    function showInlineError(message) {
-      errorEl.textContent = message;
+    function show(message) {
+      var text = String(message || '').trim();
+      if (!text) return;
+      errorEl.textContent = text;
       errorEl.hidden = false;
       errorEl.setAttribute('aria-hidden', 'false');
     }
 
-    function hideInlineError() {
+    function hide() {
       errorEl.textContent = '';
       errorEl.hidden = true;
       errorEl.setAttribute('aria-hidden', 'true');
     }
 
-    function markEmailAuthSubmitActive() {
-      emailAuthSubmitActive = true;
-      if (clearSubmitTimer) window.clearTimeout(clearSubmitTimer);
-      clearSubmitTimer = window.setTimeout(function () {
-        emailAuthSubmitActive = false;
-      }, 15000);
-    }
-
-    form.addEventListener('submit', function () {
-      hideInlineError();
-      markEmailAuthSubmitActive();
-    }, true);
-
-    form.addEventListener('input', hideInlineError);
-
-    window.alert = function (message) {
-      if (shouldShowInline(message)) {
-        showInlineError(String(message).trim());
-        return;
-      }
-      return nativeAlert.apply(window, arguments);
+    window.LoveBudLoginPageAuthError = {
+      show: show,
+      hide: hide
     };
+
+    form.addEventListener('submit', hide, true);
+    form.addEventListener('input', hide);
   }
 
   function initLoginPage() {

--- a/pages/login.html
+++ b/pages/login.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/login.css?v=20260419-1">
+    <link rel="stylesheet" href="../css/login.css?v=20260427-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="bokeh-bg">
@@ -188,7 +188,7 @@
      <script src="../js/auth/auth-ui.js?v=20260421-2"></script>
      <script src="../js/auth/auth-session.js?v=20260417-31"></script>
      <script src="../js/auth/auth-firebase.js?v=20260420-2"></script>
-     <script src="../js/auth.js?v=20260417-31"></script>
-    <script src="../js/login-page.js?v=20260419-1"></script>
+     <script src="../js/auth.js?v=20260427-1"></script>
+    <script src="../js/login-page.js?v=20260427-1"></script>
 </body>
 </html>

--- a/pages/login.html
+++ b/pages/login.html
@@ -158,12 +158,13 @@
  </div>
  <div class="login-form-group-large">
      <label for="email-auth-email" class="login-form-label" data-i18n="email_label">이메일</label>
-     <input type="email" id="email-auth-email" required class="login-form-input">
+     <input type="email" id="email-auth-email" required class="login-form-input" aria-describedby="email-auth-error">
  </div>
 <div class="login-form-group-xl">
     <label for="email-auth-password" class="login-form-label" data-i18n="password_label">비밀번호</label>
-    <input type="password" id="email-auth-password" required class="login-form-input">
+    <input type="password" id="email-auth-password" required class="login-form-input" aria-describedby="email-auth-error">
 </div>
+<p id="email-auth-error" class="login-form-error" role="alert" aria-live="polite" aria-hidden="true" hidden></p>
 <button type="submit" id="email-auth-submit" class="login-submit-button login-submit-button-primary" data-i18n="login_btn">로그인</button>
 </form>
 <button id="email-auth-toggle" class="login-email-toggle" data-i18n="switch_to_signup">계정이 없나요? 회원가입으로 전환</button>


### PR DESCRIPTION
## Summary
- Replaced global lert() with LoveBudLoginPageAuthError.show() to support inline error rendering for email authentication.
- Bumped asset query string versions for login.css, uth.js, and login-page.js to 20260427-1.

## Validation
- 
pm run lint and 
pm run build passed.
- Maintained Google login flow and signup catch blocks.
- Checked that there are no global window.alert overrides.