### PR TITLE
fix(auth): canonicalize settings logout and protected aliases

### DIFF
--- a/js/auth/auth-firebase.js
+++ b/js/auth/auth-firebase.js
@@ -98,7 +98,7 @@
 
   function isProtectedRoute() {
     var path = window.location.pathname || '';
-    return /\/pages\/(my-trees|editor|settings)(?:\.html)?$/.test(path);
+    return /^\/(?:pages\/)?(?:my-trees|editor|settings)(?:\.html)?$/.test(path);
   }
 
   function initOfflineAuth(options) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -257,25 +257,44 @@
     redirectToLogin();
   }
 
+  function redirectAfterLogout() {
+    window.location.href = '../index.html';
+  }
+
+  function getCanonicalLogoutOptions() {
+    return {
+      clearStaleFirebaseAuthState: function() {
+        if (window.LoveBudAuthCache && typeof window.LoveBudAuthCache.clearStaleFirebaseAuthState === 'function') {
+          window.LoveBudAuthCache.clearStaleFirebaseAuthState();
+        }
+      },
+      clearConfirmedAuthCache: function() {
+        if (window.LoveBudAuthCache && typeof window.LoveBudAuthCache.clearConfirmedAuthCache === 'function') {
+          window.LoveBudAuthCache.clearConfirmedAuthCache('lovebud_auth_cache', 'lovebud_auth_confirmed', 'lovebud_auth_token');
+        }
+      }
+    };
+  }
+
   // 로그아웃 처리
   function handleLogout() {
-    if (typeof window.signOut === 'function') {
-      window.signOut().then(function() {
-        window.location.href = '../index.html';
-      }).catch(function() {
-        window.location.href = '../index.html';
-      });
-    } else {
-      if (typeof firebase !== 'undefined' && firebase.auth) {
-        firebase.auth().signOut().then(function() {
-          window.location.href = '../index.html';
-        }).catch(function() {
-          window.location.href = '../index.html';
-        });
-      } else {
-        window.location.href = '../index.html';
-      }
+    if (window.LoveBudAuthFirebase && typeof window.LoveBudAuthFirebase.signOut === 'function') {
+      Promise.resolve(window.LoveBudAuthFirebase.signOut(getCanonicalLogoutOptions()))
+        .catch(redirectAfterLogout);
+      return;
     }
+
+    if (typeof window.signOut === 'function') {
+      window.signOut().then(redirectAfterLogout).catch(redirectAfterLogout);
+      return;
+    }
+
+    if (typeof firebase !== 'undefined' && firebase.auth) {
+      firebase.auth().signOut().then(redirectAfterLogout).catch(redirectAfterLogout);
+      return;
+    }
+
+    redirectAfterLogout();
   }
 
   window.initSettings = initSettings;


### PR DESCRIPTION
## Summary
- Route settings logout through `LoveBudAuthFirebase.signOut()` first.
- Keep safe fallback paths when the canonical auth module is unavailable.
- Expand protected-route detection to include `/pages/*`, root `.html` aliases, and extensionless aliases for `my-trees`, `editor`, and `settings`.

## Scope
- Auth hardening only.
- Changed files limited to:
  - `js/settings.js`
  - `js/auth/auth-firebase.js`

## Non-changes
- No Firebase config or Security Rules changes.
- No backend/API changes.
- No Search/Browse changes.
- No CSS/UI changes.
- No Netlify changes.
- No prototype/reference/demo/variant changes.

## Validation
- GitHub compare scope: PASS.
- `_redirects` inspected: root aliases exist for `/editor.html` and `/my-trees.html`; `/settings.html` and extensionless aliases are not listed.
- Production HTTP status check could not be completed from this environment due DNS resolution failure for `lovebud.pages.dev`.
- CI required before merge.