### PR TITLE
docs: mark Netlify references as historical-only before artifact deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@
 - Modal은 browse summary, compute, read-heavy 처리의 최우선 계층입니다.
 - Cloudflare Pages는 실서비스 프론트 및 same-origin `/api` 진입점입니다.
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
-- Netlify는 주경로가 아니라 fallback 또는 단계적 제거 대상입니다.
+- Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
 
 ### 브라우저 API 원칙
 - 사용자 브라우저는 가능하면 **same-origin `/api`**만 사용합니다.

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -8,7 +8,7 @@
 - 브라우저는 가능하면 **same-origin `/api`** 만 사용합니다.
 - 공식 사용자-facing 주소는 `pages.dev` 기준으로 설명합니다.
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
-- Netlify는 주경로가 아니라 fallback 또는 단계적 제거 대상입니다.
+- Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 제품/브랜드/UI 판단의 source of truth 입니다.
 - prototype/reference 폴더는 repo hygiene에서 자동 삭제/이동/ignore 대상으로 분류하지 않습니다.
 - `pages/gpt-v2/`, `assets/gpt-v2/`, `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.

--- a/docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md
+++ b/docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md
@@ -38,20 +38,13 @@ netlify/functions/community-memories.js
 netlify/functions/_lib/**
 ```
 
-Netlify-targeting tests도 남아 있습니다.
-
-```text
-tests/functions/**
-tests/contracts/** where they import or assert netlify/functions behavior
-```
-
 ## 3. Why they remain
 
-Netlify files remain for three reasons.
+Netlify files remain for historical reference and pending artifact deletion.
 
-1. Some tests still import or assert legacy `netlify/functions/**` behavior.
-2. Some docs still describe historical route behavior and need transition context.
-3. Removal must not happen before Cloudflare/Modal route parity and CI independence are confirmed.
+1. Tests transition completed (PR #161, #162, #163) - no tests now import or assert `netlify/functions/**` behavior.
+2. Docs transition in progress (this PR) - marking Netlify as historical-only / removal-ready.
+3. Removal must not happen before docs transition is complete and CTO approval for artifact deletion.
 
 Their presence does not mean Netlify is the active production runtime.
 


### PR DESCRIPTION
- AGENTS.md: Changed Netlify description from "fallback or staged removal target" to "legacy artifact / removal candidate. Not active production fallback"
- docs/doc_index.md: Changed Netlify description from "fallback or staged removal target" to "legacy artifact / removal candidate. Not active production fallback"
- docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md: Updated to reflect tests transition completed (PR #161, #162, #163)
- README.md, API_CONTRACT.md, OPERATIONS.md, RUNBOOK.md: Already marked as historical-only, no changes
- No Netlify artifact deletion
- No runtime code changes
- No tests changes
