### PR TITLE
chore: Remove Netlify tests/scripts dependencies (Retry)

### DIFF
--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -5,9 +5,7 @@ const path = require("path");
 
 const ROOT = process.cwd();
 const REQUIRED_PATHS = [
-  "index.html",
-  "netlify.toml",
-  "netlify/functions"
+  "index.html"
 ];
 
 function assertExists(relPath) {

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -219,7 +219,7 @@ function verifyRoutesAndFunctions() {
 
   const tomlPath = path.join(ROOT, 'netlify.toml');
   if (!fs.existsSync(tomlPath)) {
-    check('netlify.toml 존재', false, '파일 없음');
+    check('netlify.toml 존재', true, '파일 없음 (스킵)');
     return;
   }
   check('netlify.toml 존재', true);
@@ -299,7 +299,6 @@ function verifyRequiredFiles() {
     'js/shared-header.js',
     'js/firebase-config.js',
     'css/global.css',
-    'netlify.toml',
     'package.json',
   ];
 

--- a/scripts/test-memories-api.js
+++ b/scripts/test-memories-api.js
@@ -1,7 +1,12 @@
-const { queryMemories, getMemory } = require('../netlify/functions/_lib/doc-store');
 const fs = require('fs');
 const path = require('path');
 
+const libPath = path.resolve(__dirname, '../netlify/functions/_lib/doc-store.js');
+if (!fs.existsSync(libPath)) {
+  console.log('Skipping API tests: netlify/functions missing');
+  process.exit(0);
+}
+const { queryMemories, getMemory } = require('../netlify/functions/_lib/doc-store');
 const envPath = path.resolve(__dirname, '.env');
 try {
   const content = fs.readFileSync(envPath, 'utf-8');

--- a/scripts/test-trees-api.js
+++ b/scripts/test-trees-api.js
@@ -1,7 +1,12 @@
-const { queryTrees } = require('../netlify/functions/_lib/doc-store');
 const fs = require('fs');
 const path = require('path');
 
+const libPath = path.resolve(__dirname, '../netlify/functions/_lib/doc-store.js');
+if (!fs.existsSync(libPath)) {
+  console.log('Skipping API tests: netlify/functions missing');
+  process.exit(0);
+}
+const { queryTrees } = require('../netlify/functions/_lib/doc-store');
 // .env 수동 로드
 const envPath = path.resolve(__dirname, '.env');
 try {

--- a/scripts/verify-api.js
+++ b/scripts/verify-api.js
@@ -1,7 +1,12 @@
-const { queryTrees, queryMemories, getTree } = require('../netlify/functions/_lib/doc-store');
 const fs = require('fs');
 const path = require('path');
 
+const libPath = path.resolve(__dirname, '../netlify/functions/_lib/doc-store.js');
+if (!fs.existsSync(libPath)) {
+  console.log('Skipping API verification: netlify/functions missing');
+  process.exit(0);
+}
+const { queryTrees, queryMemories, getTree } = require('../netlify/functions/_lib/doc-store');
 // .env 로드
 const envPath = path.resolve(__dirname, '.env');
 try {

--- a/scripts/verify-env.js
+++ b/scripts/verify-env.js
@@ -147,9 +147,15 @@ async function verifyFunctionSyntax() {
   ];
 
   const path = require('path');
+  const fs = require('fs');
   for (const fn of functions) {
+    const fullPath = path.resolve(process.cwd(), fn);
+    if (!fs.existsSync(fullPath)) {
+      check(fn, true, '스킵 (파일 없음)');
+      continue;
+    }
     try {
-      require(path.resolve(process.cwd(), fn));
+      require(fullPath);
       check(fn, true);
     } catch (e) {
       check(fn, false, e.message.split('\n')[0]);

--- a/tests/routes/detail-alias-consistency.test.js
+++ b/tests/routes/detail-alias-consistency.test.js
@@ -9,7 +9,12 @@ function read(file) {
   return fs.readFileSync(path.join(ROOT, file), 'utf8');
 }
 
-test('detail route alias exists in netlify.toml', () => {
+test('detail route alias exists in netlify.toml', (t) => {
+  const tomlPath = path.join(ROOT, 'netlify.toml');
+  if (!fs.existsSync(tomlPath)) {
+    t.skip('netlify.toml not found');
+    return;
+  }
   const toml = read('netlify.toml');
   assert.match(toml, /from\s*=\s*"\/detail\.html"/);
   assert.match(toml, /to\s*=\s*"\/pages\/detail\.html"/);

--- a/tests/routes/static-page-aliases.test.js
+++ b/tests/routes/static-page-aliases.test.js
@@ -23,7 +23,11 @@ function hasRedirect(toml, from, to) {
   return false;
 }
 
-test('netlify static page aliases map root pages to /pages/*.html', () => {
+test('netlify static page aliases map root pages to /pages/*.html', (t) => {
+  if (!fs.existsSync(NETLIFY_TOML)) {
+    t.skip('netlify.toml not found');
+    return;
+  }
   const toml = readToml();
 
   const requiredAliases = [

--- a/tests/smoke/routes.test.js
+++ b/tests/smoke/routes.test.js
@@ -9,7 +9,12 @@ function read(relPath) {
   return fs.readFileSync(path.join(ROOT, relPath), "utf8");
 }
 
-test("netlify.toml keeps API redirects and does not use global SPA fallback", () => {
+test("netlify.toml keeps API redirects and does not use global SPA fallback", (t) => {
+  const tomlPath = path.join(ROOT, "netlify.toml");
+  if (!fs.existsSync(tomlPath)) {
+    t.skip("netlify.toml not found, skipping");
+    return;
+  }
   const netlifyToml = read("netlify.toml");
 
   assert.notEqual(


### PR DESCRIPTION
Removes direct dependencies on \
etlify.toml\ and \
etlify/functions/**\ from active tests and scripts to unblock Netlify artifacts deletion.