### PR TITLE
CSP 하드닝: 인증 드롭다운 및 공유 헤더에서 inline event handler 제거

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -729,7 +729,7 @@ function buildUserDropdown(user) {
     '<a href="' + myTreesHref + '" class="user-dropdown-item"><span class="material-symbols-outlined">account_tree</span>내 러브트리</a>',
     '<button class="user-dropdown-item" disabled style="cursor:default;opacity:0.6;"><span class="material-symbols-outlined">settings</span>설정</button>',
     '<div class="dropdown-divider"></div>',
-    '<button class="user-dropdown-item" onclick="signOut()"><span class="material-symbols-outlined">logout</span>로그아웃</button>',
+    '<button type="button" class="user-dropdown-item" data-auth-action="logout"><span class="material-symbols-outlined">logout</span>로그아웃</button>',
     '</div>',
     '</div>'
   ].join('');

--- a/js/auth/auth-ui.js
+++ b/js/auth/auth-ui.js
@@ -141,7 +141,7 @@
       '<div class="dropdown-divider"></div>',
       buildLangInlineOptions(currentLang),
       '<div class="dropdown-divider"></div>',
-      '<button class="user-dropdown-item" onclick="signOut()"><span class="material-symbols-outlined">logout</span>' + tText('logout_btn', '로그아웃') + '</button>',
+      '<button type="button" class="user-dropdown-item" data-auth-action="logout"><span class="material-symbols-outlined">logout</span>' + tText('logout_btn', '로그아웃') + '</button>',
       "</div>",
       "</div>",
     ].join("");

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -250,7 +250,7 @@
 
         return [
             '<header class="nav-bar">',
-                '<div class="headline" style="font-size: 1.5rem; font-weight: 900; color: var(--on-surface); letter-spacing: -0.04em; cursor: pointer;" onclick="location.href=\'' + logoHref + '\'">LoveTree</div>',
+                '<a href="' + logoHref + '" class="headline" style="font-size: 1.5rem; font-weight: 900; color: var(--on-surface); letter-spacing: -0.04em; text-decoration: none; cursor: pointer;" aria-label="LoveTree 홈으로 이동">LoveTree</a>',
                 '<button class="mobile-nav-toggle" id="mobileNavToggle" type="button" aria-label="메뉴 열기" aria-expanded="false">',
                     '<span class="material-symbols-outlined">menu</span>',
                 '</button>',


### PR DESCRIPTION
## 변경 사항

- js/auth/auth-ui.js: 로그아웃 버튼 onclick 제거, type='button' 및 data-auth-action='logout' 추가
- js/auth.js: fallback 로그아웃 버튼 onclick 제거, type='button' 및 data-auth-action='logout' 추가  
- js/shared-header.js: 로고 div onclick 제거, 시맨틱 <a> 태그로 교체 및 aria-label 추가

## 검증

- node --check 통과
- npm test 통과 (60/60)
- npm run lint 통과
- npm run build 통과
- 로컬 브라우저 smoke 테스트 통과

## 목적

CSP(Content Security Policy) 하드닝 및 접근성 개선을 위해 inline event handler를 제거하고 시맨틱 HTML을 사용합니다.