### PR TITLE
refactor(search): split orchestrator runtime modules

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -1,818 +1,183 @@
-/**
- * LoveBud Search Page Orchestrator
- * v20260423-2
- *
- * Search page orchestration:
- * - Fast list-first loading for public trees
- * - Filter state management
- * - Event binding
- * - Lazy preview hydration on tree selection
- */
-
 document.addEventListener('DOMContentLoaded', async () => {
+    const State = window.LoveBudSearchState;
+    const Url = window.LoveBudSearchUrl;
+    const UI = window.LoveBudSearchUI;
+    const Loader = window.LoveBudSearchLoader;
+
     const resultsList = document.getElementById('resultsList');
-    const previewSidebar = document.getElementById('previewSidebar');
-    const previewMobileClose = document.getElementById('previewMobileClose');
-    const previewContainer = document.getElementById('previewVideoContainer');
-    const previewTitle = document.getElementById('previewTitle');
-    const previewDesc = document.getElementById('previewDesc');
-    const previewMemoriesCount = document.getElementById('previewMemoriesCount');
-    const previewTreeDuration = document.getElementById('previewTreeDuration');
-    const previewEmotionTags = document.getElementById('previewEmotionTags');
+    const growingTreesList = document.getElementById('growingTreesList');
+    const growingTreesSection = document.getElementById('growingTreesSection');
     const searchInput = document.getElementById('searchInput');
     const tagChips = document.querySelectorAll('.tag-chip');
-    let resultsHead = document.querySelector('.browse-results-head');
-    let resultsTitle = resultsHead?.querySelector('h3');
-    let resultsBadge = resultsHead?.querySelector('.browse-results-badge');
-    const growingSection = document.getElementById('growingTreesSection');
-    const growingList = document.getElementById('growingTreesList');
-    const mobilePreviewMediaQuery = window.matchMedia('(max-width: 768px)');
+    const previewMobileClose = document.getElementById('previewMobileClose');
 
-    const CardRenderer = window.LoveBudSearchCardRenderer;
-    CardRenderer.init(resultsList);
+    UI.syncStaticBrowseCopy();
+    Url.restoreStateFromUrl();
 
-    const PreviewRenderer = window.LoveBudSearchPreviewRenderer;
-    PreviewRenderer.init({
-        previewContainer,
-        previewTitle,
-        previewDesc,
-        previewMemoriesCount,
-        previewTreeDuration,
-        previewEmotionTags
-    });
+    // Export loadPublicTrees to window for UI controls
+    window.loadPublicTrees = (options) => Loader.loadPublicTrees(options, renderResults);
 
-    const Adapter = window.LoveBudSearchAdapter;
-    const cache = window.LoveBudCache;
-    const PUBLIC_TREES_CACHE_KEY = 'public_trees_summary_latest_10';
-    const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
-    const getPreviewCacheKey = (treeId) => `public_tree_preview_${treeId}`;
-
-    let allTrees = [];
-    let growingTrees = [];
-    let loadError = null;
-    let isFromCache = false;
-    let apiTreesLoaded = false;
-    let selectedTreeId = null;
-    const previewCache = new Map();
-    let currentPreviewRequestId = 0;
-
-    let currentQuery = '';
-    let currentSort = 'latest';
-    let currentLimit = 10;
-    let currentCategory = '전체';
-
-    function getCurrentLocale() {
-        const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
-        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
-    }
-
-    function isMobilePreviewMode() {
-        return Boolean(mobilePreviewMediaQuery?.matches);
-    }
-
-    function setMobilePreviewOpen(isOpen, options = {}) {
-        if (!previewSidebar || !isMobilePreviewMode()) return;
-        const { scrollIntoView = false } = options;
-        previewSidebar.classList.toggle('is-open', Boolean(isOpen));
-
-        if (isOpen && scrollIntoView) {
-            window.requestAnimationFrame(() => {
-                previewSidebar.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start'
-                });
-            });
-        }
-    }
-
-    function syncPreviewVisibility() {
-        if (!previewSidebar) return;
-        if (isMobilePreviewMode()) {
-            setMobilePreviewOpen(Boolean(selectedTreeId));
-            return;
-        }
-        previewSidebar.classList.remove('is-open');
-    }
-
-    function clearSelectedPreview(options = {}) {
-        const { preserveOpenState = false } = options;
-        selectedTreeId = null;
-        currentPreviewRequestId += 1;
-        markActiveCard(null);
-        PreviewRenderer.resetPreview();
-        if (!preserveOpenState && isMobilePreviewMode()) {
-            setMobilePreviewOpen(false);
-        }
-    }
-
-    function getSearchCopy(key, fallbackKo, fallbackEn) {
-        const locale = getCurrentLocale();
-        const dict = window.i18nSearch?.[key];
-        if (dict && typeof dict === 'object') {
-            return dict[locale] || dict.ko || dict.en || fallbackKo;
-        }
-        return locale === 'en' ? fallbackEn : fallbackKo;
-    }
-
-    function readPreviewCache(treeId) {
-        if (!treeId) return null;
-
-        if (previewCache.has(treeId)) {
-            return previewCache.get(treeId);
-        }
-
-        if (!cache || typeof cache.get !== 'function') {
-            return null;
-        }
-
-        const cachedPreview = cache.get(getPreviewCacheKey(treeId));
-        if (cachedPreview && typeof cachedPreview === 'object') {
-            previewCache.set(treeId, cachedPreview);
-            return cachedPreview;
-        }
-
-        return null;
-    }
-
-    function writePreviewCache(treeId, hydratedTree) {
-        if (!treeId || !hydratedTree || typeof hydratedTree !== 'object') return;
-
-        previewCache.set(treeId, hydratedTree);
-        if (cache && typeof cache.set === 'function') {
-            cache.set(getPreviewCacheKey(treeId), hydratedTree, PREVIEW_CACHE_TTL_MS);
-        }
-    }
-
-    function mergeHydratedTree(hydratedTree) {
-        if (!hydratedTree || !hydratedTree.id) return;
-        allTrees = allTrees.map(item => item.id === hydratedTree.id ? hydratedTree : item);
-    }
-
-    const SORT_COPY = {
-        latest: {
-            title: () => getSearchCopy('search.resultsHeading', '최근 공개된 러브트리', 'Recently Shared LoveTrees'),
-            badge: (count) => getCurrentLocale() === 'en' ? `${count} to start with` : `지금 먼저 볼 ${count}개`
-        },
-        popular: {
-            title: () => getCurrentLocale() === 'en' ? 'Popular Public LoveTrees' : '인기 많은 공개 러브트리',
-            badge: (count) => getCurrentLocale() === 'en' ? `${count} trending now` : `지금 반응이 큰 ${count}개`
-        }
-    };
-
-    const syncStaticBrowseCopy = () => {
-        if (typeof window.applyI18n === 'function') {
-            window.applyI18n();
-        }
-
-        const eyebrow = document.querySelector('.search-panel-eyebrow span:last-child');
-        if (eyebrow) {
-            eyebrow.textContent = getSearchCopy('search.eyebrow', '오늘의 공개 감상', 'Today\'s Public Picks');
-        }
-
-        if (searchInput) {
-            searchInput.placeholder = getSearchCopy('search.placeholder', '예: 첫 설렘 · 아티스트명 · 감정 태그', 'e.g., first spark, artist, emotion tag');
-        }
-
-        const previewHeading = document.querySelector('.preview-panel-header h3');
-        if (previewHeading) {
-            previewHeading.textContent = getSearchCopy('search.previewTitle', '감상 허브', 'Viewing Hub');
-        }
-
-        const previewBadge = document.querySelector('.preview-badge');
-        if (previewBadge) {
-            previewBadge.textContent = getSearchCopy('search.previewBadge', '선택한 트리', 'Selected Tree');
-        }
-
-        if (previewMobileClose) {
-            previewMobileClose.setAttribute(
-                'aria-label',
-                getSearchCopy('search.previewClose', '감상 닫기', 'Close preview')
-            );
-        }
-
-        const previewKicker = document.querySelector('.preview-kicker');
-        if (previewKicker) {
-            previewKicker.textContent = getSearchCopy('search.previewKicker', '대표 순간과 이어진 감정을 먼저 살펴보세요.', 'Begin with the featured moment and connected feelings.');
-        }
-
-        const previewStatsPending = document.querySelector('#previewTreeStats .tree-meta-item:first-child span:last-child');
-        if (previewStatsPending) {
-            previewStatsPending.textContent = getSearchCopy('search.previewStatsPending', '대표 순간이 열리면 함께 보여드릴게요', 'This will appear once the featured moment opens.');
-        }
-
-        const emotionLabel = document.querySelector('.emotion-tags-label span:last-child');
-        if (emotionLabel) {
-            emotionLabel.textContent = getSearchCopy('search.previewEmotionTagsLabel', '이어진 감정', 'Connected Feelings');
-        }
-
-        if (previewEmotionTags && !previewEmotionTags.children.length) {
-            previewEmotionTags.textContent = getSearchCopy('search.previewNoEmotionTags', '아직 또렷한 감정의 결은 놓이지 않았어요.', 'No clear emotional thread has settled yet.');
-        }
-    };
-
-    let isRestoringUrlState = false;
-    let initialTreeDeepLinkApplied = false;
-
-    function readUrlState() {
-        try {
-            const params = new URLSearchParams(window.location.search);
-            return {
-                query: params.get('q') || '',
-                category: params.get('category') || '',
-                sort: params.get('sort') || '',
-                limit: params.get('limit') || '',
-                tree: params.get('tree') || ''
-            };
-        } catch {
-            return { query: '', category: '', sort: '', limit: '', tree: '' };
-        }
-    }
-
-    function updateUrlState() {
-        if (isRestoringUrlState) return;
-        try {
-            const params = new URLSearchParams();
-            if (currentQuery) params.set('q', currentQuery);
-            if (currentCategory && currentCategory !== '전체') params.set('category', currentCategory);
-            if (currentSort && currentSort !== 'latest') params.set('sort', currentSort);
-            if (currentLimit && currentLimit !== 10) params.set('limit', String(currentLimit));
-            const newSearch = params.toString();
-            const newUrl = newSearch ? `${window.location.pathname}?${newSearch}` : window.location.pathname;
-            if (newUrl !== (window.location.pathname + window.location.search)) {
-                history.pushState(null, '', newUrl);
-            }
-        } catch { /* ignore */ }
-    }
-
-    function restoreStateFromUrl() {
-        // Make functions globally available for debugging
-        window.readUrlState = readUrlState;
-        window.updateUrlState = updateUrlState;
-        window.restoreStateFromUrl = restoreStateFromUrl;
-        const { query, category, sort, limit } = readUrlState();
-        isRestoringUrlState = true;
-        if (query) currentQuery = query;
-        if (category) currentCategory = category;
-        if (sort === 'latest' || sort === 'popular') currentSort = sort;
-        if (limit) {
-            const parsedLimit = parseInt(limit, 10);
-            if (!isNaN(parsedLimit) && parsedLimit >= 1 && parsedLimit <= 60) {
-                currentLimit = parsedLimit;
-            }
-        }
-        if (query && searchInput) searchInput.value = query;
-        if (category) {
-            tagChips.forEach(chip => {
-                const chipCategory = chip.dataset.category || chip.textContent.trim();
-                chip.classList.toggle('active', chipCategory === currentCategory);
-            });
-        }
-        if (sort) {
-            if (typeof syncControlsFromState === 'function') {
-                syncControlsFromState();
-            } else {
-                const sortBtn = document.querySelector(`[data-browse-sort="${currentSort}"]`);
-                if (sortBtn) {
-                    document.querySelectorAll('[data-browse-sort]').forEach(b => b.classList.remove('active'));
-                    sortBtn.classList.add('active');
-                }
-            }
-        }
-        isRestoringUrlState = false;
-    }
-
-    function applySelectedTreeFromUrl() {
-        if (initialTreeDeepLinkApplied) return;
-        const state = readUrlState();
-        if (!state.tree) return;
-
-        const targetTree = allTrees.find(t => t.id === state.tree) || growingTrees.find(t => t.id === state.tree);
-        if (!targetTree) return;
-
-        let activeCard = null;
-        let selector = '';
-        try {
-            selector = `.tree-card[data-tree-id="${CSS.escape(state.tree)}"]`;
-        } catch (e) {
-            selector = `.tree-card[data-tree-id="${state.tree.replace(/"/g, '\\"')}"]`;
-        }
-
-        const allCardContainers = [resultsList, growingList].filter(Boolean);
-        for (const container of allCardContainers) {
-            activeCard = container.querySelector(selector);
-            if (activeCard) break;
-        }
-
-        selectTree(targetTree, activeCard);
-        initialTreeDeepLinkApplied = true;
-    }
-
-    const syncBrowseHead = () => {
-        const copy = SORT_COPY[currentSort] || SORT_COPY.latest;
-        if (resultsTitle) {
-            resultsTitle.textContent = typeof copy.title === 'function' ? copy.title() : copy.title;
-        }
-        if (resultsBadge) {
-            resultsBadge.innerHTML = `
-                <span class="material-symbols-outlined" style="font-size:15px;">auto_awesome</span>
-                ${copy.badge(Math.min(currentLimit, 60))}
-            `;
-        }
-        const loadMoreBtn = document.getElementById('browseLoadMoreBtn');
-        if (loadMoreBtn) {
-            loadMoreBtn.disabled = currentLimit >= 60;
-            loadMoreBtn.textContent = currentLimit >= 60
-                ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
-                : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
-        }
-    };
-
-    const ensureResultsHead = () => {
-        if (resultsHead) return;
-        resultsHead = document.createElement('div');
-        resultsHead.className = 'browse-results-head';
-
-        const titleDiv = document.createElement('div');
-        resultsTitle = document.createElement('h3');
-        const descP = document.createElement('p');
-
-        resultsBadge = document.createElement('span');
-        resultsBadge.className = 'browse-results-badge';
-
-        titleDiv.appendChild(resultsTitle);
-        titleDiv.appendChild(descP);
-        resultsHead.appendChild(titleDiv);
-        resultsHead.appendChild(resultsBadge);
-
-        if (resultsList && resultsList.parentNode) {
-            resultsList.parentNode.insertBefore(resultsHead, resultsList);
-        }
-    };
-
-    function syncControlsFromState() {
-        const controls = document.getElementById('browseSortControls');
-        if (!controls) return;
-
-        controls.querySelectorAll('[data-browse-sort]').forEach((chip) => {
-            chip.classList.toggle('active', chip.dataset.browseSort === currentSort);
-        });
-
-        const loadMoreBtn = controls.querySelector('#browseLoadMoreBtn');
-        if (loadMoreBtn) {
-            loadMoreBtn.style.display = (currentLimit >= 60) ? 'none' : 'inline-flex';
-        }
-    }
-
-    const ensureBrowseControls = () => {
-        ensureResultsHead();
-        if (document.getElementById('browseSortControls')) return;
-
-        const controls = document.createElement('div');
-        controls.id = 'browseSortControls';
-        controls.style.display = 'flex';
-        controls.style.flexWrap = 'wrap';
-        controls.style.alignItems = 'center';
-        controls.style.justifyContent = 'flex-end';
-        controls.style.gap = '10px';
-        controls.innerHTML = `
-            <div style="display:flex; gap:8px; flex-wrap:wrap;">
-                <button type="button" class="tag-chip" data-browse-sort="latest">${getCurrentLocale() === 'en' ? 'Latest' : '최신순'}</button>
-                <button type="button" class="tag-chip" data-browse-sort="popular">${getCurrentLocale() === 'en' ? 'Popular' : '인기순'}</button>
-            </div>
-            <button type="button" id="browseLoadMoreBtn" class="tag-chip">${getCurrentLocale() === 'en' ? 'Load more' : '더 보기'}</button>
-        `;
-
-        let rightGroup = resultsHead.querySelector('.browse-head-right');
-        if (!rightGroup) {
-            rightGroup = document.createElement('div');
-            rightGroup.className = 'browse-head-right';
-            rightGroup.style.display = 'flex';
-            rightGroup.style.flexDirection = 'column';
-            rightGroup.style.alignItems = 'flex-end';
-            rightGroup.style.gap = '12px';
-
-            if (resultsBadge && resultsBadge.parentNode === resultsHead) {
-                resultsHead.removeChild(resultsBadge);
-                rightGroup.appendChild(resultsBadge);
-            }
-            resultsHead.appendChild(rightGroup);
-        }
-        rightGroup.appendChild(controls);
-
-        controls.querySelectorAll('[data-browse-sort]').forEach((button) => {
-            button.addEventListener('click', async () => {
-                const nextSort = button.dataset.browseSort || 'latest';
-                if (nextSort === currentSort) return;
-                currentSort = nextSort;
-                currentLimit = 10;
-                syncControlsFromState();
-                updateUrlState();
-                await loadPublicTrees({ resetSelection: true });
-            });
-        });
-
-        controls.querySelector('#browseLoadMoreBtn')?.addEventListener('click', async () => {
-            currentLimit = Math.min(currentLimit + 10, 60);
-            syncControlsFromState();
-            updateUrlState();
-            await loadPublicTrees({ resetSelection: false });
-        });
-
-        syncControlsFromState();
-    };
-
-    const areTreesEffectivelySame = (prevTrees, nextTrees) => {
-        if (!Array.isArray(prevTrees) || !Array.isArray(nextTrees)) return false;
-        if (prevTrees.length !== nextTrees.length) return false;
-
-        return prevTrees.every((prevTree, index) => {
-            const nextTree = nextTrees[index];
-            if (!nextTree) return false;
-            const prevStamp = prevTree.updatedAt || prevTree.createdAt || prevTree.memoryCount || 0;
-            const nextStamp = nextTree.updatedAt || nextTree.createdAt || nextTree.memoryCount || 0;
-            return prevTree.id === nextTree.id && prevStamp === nextStamp;
-        });
-    };
-
-    const getFilteredTrees = () => Adapter.filterTrees(allTrees, currentQuery, currentCategory);
-
-    const markActiveCard = (activeCard) => {
-        const allCardContainers = [resultsList, growingList].filter(Boolean);
-        allCardContainers.forEach(container => {
-            container.querySelectorAll('.tree-card.is-active').forEach((card) => {
-                card.classList.remove('is-active');
-                card.setAttribute('aria-pressed', 'false');
-            });
-        });
-        if (activeCard) {
-            activeCard.classList.add('is-active');
-            activeCard.setAttribute('aria-pressed', 'true');
-        }
-    };
-
-    const syncActiveCard = () => {
-        const allCardContainers = [resultsList, growingList].filter(Boolean);
-        let activeCard = null;
-        for (const container of allCardContainers) {
-            const cards = container.querySelectorAll('.tree-card');
-            activeCard = Array.from(cards).find(card => card.dataset.treeId === selectedTreeId);
-            if (activeCard) break;
-        }
-        markActiveCard(activeCard || null);
-    };
-
-    const getSelectedTreeFromFiltered = (filteredTrees) => {
-        if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
-        return filteredTrees.find(tree => tree.id === selectedTreeId) || null;
-    };
-
-    const renderLoadErrorState = () => {
-        resultsList.innerHTML = `
-            <div class="empty-state" style="padding:60px 24px; text-align:center; color: var(--on-surface-variant);">
-                <span class="material-symbols-outlined" style="font-size: 56px; color: var(--error); opacity: 0.6; margin-bottom: 20px; display: block;">cloud_off</span>
-                <h3 style="font-size: 1.25rem; font-weight: 800; margin-bottom: 12px; color: var(--on-surface);">${getCurrentLocale() === 'en' ? 'Failed to load' : '불러오기 실패'}</h3>
-                <p style="font-size: 0.95rem; opacity: 0.8; margin-bottom: 24px; line-height: 1.6;">
-                    ${getCurrentLocale() === 'en'
-                        ? 'There was a problem reaching the server.<br>Please check your network and try again in a moment.'
-                        : '서버 연결에 문제가 발생했습니다.<br>네트워크 상태를 확인하고 잠시 후 다시 시도해 주세요.'}
-                </p>
-                <button type="button" id="retryLoadBtn" class="btn-round btn-primary" style="padding: 10px 24px;">${getCurrentLocale() === 'en' ? 'Try again' : '다시 시도'}</button>
-            </div>
-        `;
-
-        const retryBtn = document.getElementById('retryLoadBtn');
-        if (retryBtn) {
-            retryBtn.addEventListener('click', () => window.location.reload());
-        }
-
-        clearSelectedPreview();
-    };
-
-    const renderPreviewLoadingState = (tree) => {
-        if (typeof PreviewRenderer.renderLoadingPreview === 'function') {
-            PreviewRenderer.renderLoadingPreview(tree);
-            return;
-        }
-        if (previewTitle) {
-            previewTitle.textContent = tree?.title || getSearchCopy('search.previewDefaultTreeName', '러브트리', 'LoveTree');
-        }
-        if (previewDesc) {
-            previewDesc.innerHTML = `<p style="margin-bottom:16px;">${getCurrentLocale() === 'en' ? 'Loading the featured moment of this tree.' : '대표 순간을 불러오는 중이에요.'}</p>`;
-        }
-        if (previewContainer) {
-            previewContainer.innerHTML = `<div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;color:var(--on-surface-variant);font-size:14px;text-align:center;padding:20px;"><span class="material-symbols-outlined" style="font-size:40px;opacity:0.45;margin-bottom:12px;display:block;animation:spin 1s linear infinite;">progress_activity</span><p style="margin:0;line-height:1.5;">${getCurrentLocale() === 'en' ? 'Preparing the featured moment.' : '대표 순간을 준비하고 있어요.'}</p></div>`;
-        }
-    };
-
-    const hydrateSelectedTreePreview = async (tree) => {
-        if (!tree || !tree.id) return;
-        const requestId = ++currentPreviewRequestId;
-        renderPreviewLoadingState(tree);
-
-        try {
-            const cachedPreview = readPreviewCache(tree.id);
-            const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
-
-            writePreviewCache(tree.id, hydratedTree);
-            mergeHydratedTree(hydratedTree);
-
-            if (requestId !== currentPreviewRequestId || selectedTreeId !== tree.id) {
-                return;
-            }
-            PreviewRenderer.updatePreview(hydratedTree);
-            renderResults(false);
-        } catch (error) {
-            console.warn('[search] preview hydration failed:', error.message);
-            if (requestId !== currentPreviewRequestId || selectedTreeId !== tree.id) {
-                return;
-            }
-            clearSelectedPreview({ preserveOpenState: false });
-        }
-    };
-
-    const selectTree = (tree, activeCard) => {
-        if (!tree) return;
-        selectedTreeId = tree.id;
-        markActiveCard(activeCard);
-
-        if (isMobilePreviewMode()) {
-            setMobilePreviewOpen(true, { scrollIntoView: true });
-        }
-
-        if (Array.isArray(tree.memories) && tree.memories.length > 0) {
-            writePreviewCache(tree.id, tree);
-            PreviewRenderer.updatePreview(tree);
+    function selectTree(tree, activeCard) {
+        if (!tree) {
+            UI.clearSelectedPreview();
             return;
         }
 
-        hydrateSelectedTreePreview(tree);
-    };
+        State.selectedTreeId = tree.id;
+        Url.updateUrlState();
+        UI.markActiveCard(activeCard);
+        UI.setMobilePreviewOpen(true, { scrollIntoView: true });
 
-    const attachCardEvents = (listElement, trees) => {
-        if (!listElement) return;
-        const cards = listElement.querySelectorAll('.tree-card');
-        cards.forEach((card) => {
-            const treeId = card.dataset.treeId;
-            const tree = trees.find(t => t.id === treeId);
-            if (!tree) return;
+        Loader.hydrateSelectedTreePreview(tree, renderResults);
+    }
 
-            card.setAttribute('tabindex', '0');
-            card.setAttribute('role', 'button');
-            card.setAttribute('aria-pressed', tree.id === selectedTreeId ? 'true' : 'false');
+    function attachCardEvents(listElement, trees) {
+        if (!listElement || !Array.isArray(trees)) return;
 
+        listElement.querySelectorAll('.tree-card').forEach(card => {
             card.addEventListener('click', () => {
-                selectTree(tree, card);
-            });
-
-            card.addEventListener('keydown', (event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
+                const treeId = card.dataset.treeId;
+                const tree = trees.find(t => t.id === treeId);
+                if (tree) {
                     selectTree(tree, card);
                 }
             });
+
+            card.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    const treeId = card.dataset.treeId;
+                    const tree = trees.find(t => t.id === treeId);
+                    if (tree) {
+                        selectTree(tree, card);
+                    }
+                }
+            });
         });
-    };
-
-    function renderResults(resetPreviewWhenNoSelection = true) {
-        const filtered = getFilteredTrees();
-
-        if (filtered.length === 0) {
-            const hasNoData = loadError === null && allTrees.length === 0;
-            const isApiFailure = loadError !== null && !isFromCache && allTrees.length === 0;
-
-            if (isApiFailure) {
-                renderLoadErrorState();
-            } else if (hasNoData) {
-                resultsList.innerHTML = CardRenderer.renderNoTreesState();
-                clearSelectedPreview();
-            } else {
-                resultsList.innerHTML = CardRenderer.renderEmptySearchState();
-                clearSelectedPreview();
-            }
-            return;
-        }
-
-        const html = CardRenderer.renderResults(filtered, {
-            isDemo: !apiTreesLoaded && !loadError
-        });
-        resultsList.innerHTML = html;
-        attachCardEvents(resultsList, filtered);
-        syncActiveCard();
-
-        const selectedTree = getSelectedTreeFromFiltered(filtered);
-        if (!selectedTreeId && resetPreviewWhenNoSelection) {
-            clearSelectedPreview();
-            return;
-        }
-
-        if (selectedTree && Array.isArray(selectedTree.memories) && selectedTree.memories.length > 0) {
-            writePreviewCache(selectedTree.id, selectedTree);
-            PreviewRenderer.updatePreview(selectedTree);
-            syncPreviewVisibility();
-        } else if (!selectedTree && resetPreviewWhenNoSelection) {
-            clearSelectedPreview();
-        }
     }
 
-    async function loadPublicTrees(options = {}) {
-        const { resetSelection = false } = options;
-        const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${currentSort}_${currentLimit}`;
-
-        syncBrowseHead();
-
-        if (resetSelection) {
-            clearSelectedPreview();
+    function renderResults(resetPreviewWhenNoSelection = true) {
+        if (State.loadError) {
+            UI.renderLoadErrorState();
+            return;
         }
 
-        let cachedTrees = null;
-        if (cache) {
-            cachedTrees = cache.get(cacheKey);
-            if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
-                allTrees = cachedTrees;
-                isFromCache = true;
-                renderResults();
-            }
+        const filteredTrees = State.getFilteredTrees();
+
+        UI.ensureBrowseControls(window.loadPublicTrees);
+        UI.syncBrowseHead();
+
+        if (window.LoveBudSearchCardRenderer) {
+            window.LoveBudSearchCardRenderer.renderList(resultsList, filteredTrees, State.selectedTreeId, State.currentQuery);
         }
 
-        try {
-            if (window.apiClient && window.apiClient.getPublicTrees) {
-                const apiTrees = await window.apiClient.getPublicTrees({ view: 'summary', sort: currentSort, limit: currentLimit });
-                if (!Array.isArray(apiTrees)) {
-                    throw new Error(getCurrentLocale() === 'en' ? 'Invalid API response format' : 'API 응답 형식 오류');
-                }
-
-                if (cache) {
-                    cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
-                }
-                if (!areTreesEffectivelySame(allTrees, apiTrees)) {
-                    allTrees = apiTrees;
-                }
-                loadError = null;
-                apiTreesLoaded = true;
-                renderResults();
+        if (State.apiTreesLoaded && State.selectedTreeId) {
+            const stillExists = State.getSelectedTreeFromFiltered(filteredTrees);
+            if (!stillExists && resetPreviewWhenNoSelection) {
+                UI.clearSelectedPreview();
             } else {
-                throw new Error(getCurrentLocale() === 'en' ? 'Tree API unavailable' : 'tree API 사용 불가');
+                UI.syncActiveCard();
+                if (window.LoveBudSearchPreviewRenderer) {
+                    const hydratedTree = Loader.readPreviewCache(State.selectedTreeId) || State.allTrees.find(t => t.id === State.selectedTreeId);
+                    if (hydratedTree) {
+                        window.LoveBudSearchPreviewRenderer.updatePreview(hydratedTree);
+                    }
+                }
             }
-        } catch (error) {
-            loadError = error;
-            console.warn('[search] API 로드 실패:', error.message);
-            if (!allTrees || allTrees.length === 0) {
-                allTrees = [];
-            }
-            renderResults();
         }
+
+        attachCardEvents(resultsList, filteredTrees);
     }
 
     function renderGrowingResults() {
-        if (!growingSection || !growingList) return;
+        if (!growingTreesSection || !growingTreesList) return;
 
-        if (!growingTrees || growingTrees.length === 0) {
-            growingSection.hidden = true;
-            growingList.innerHTML = '';
+        if (!State.growingTrees || State.growingTrees.length === 0) {
+            growingTreesSection.style.display = 'none';
             return;
         }
 
-        growingSection.hidden = false;
-        // Use CardRenderer.renderTreeCard with index + 1 to prevent "featured" styling
-        growingList.innerHTML = growingTrees
-            .slice(0, 3)
-            .map((tree, index) => CardRenderer.renderTreeCard(tree, index + 1))
-            .join('');
+        growingTreesSection.style.display = 'block';
 
-        attachCardEvents(growingList, growingTrees);
-        syncActiveCard();
-    }
-
-    async function loadGrowingTrees() {
-        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
-
-        try {
-            // Use established base API layer for public community endpoints
-            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
-            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
-            
-            // Normalize and enrich models
-            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
-            growingTrees = baseModels.map((tree, index) => {
-                const raw = rawTrees[index]?.data || rawTrees[index] || {};
-                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
-                return {
-                    ...tree,
-                    emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
-                    timeRange: raw.timeRange || raw.time_range || tree.timeRange
-                };
-            });
-            
-            renderGrowingResults();
-        } catch (error) {
-            console.warn('[search] growing trees load failed:', error.message);
-            if (growingSection) growingSection.style.display = 'none';
+        if (window.LoveBudSearchCardRenderer) {
+            window.LoveBudSearchCardRenderer.renderList(growingTreesList, State.growingTrees, State.selectedTreeId, '');
         }
+
+        attachCardEvents(growingTreesList, State.growingTrees);
     }
 
+    // Events
     if (previewMobileClose) {
         previewMobileClose.addEventListener('click', () => {
-            clearSelectedPreview();
+            UI.setMobilePreviewOpen(false);
         });
     }
 
-    // 감상 링크 복사 버튼 event delegation
-    document.addEventListener('click', async (event) => {
-        const shareButton = event.target.closest('[data-share-tree-link]');
-        if (!shareButton) return;
-
-        event.preventDefault();
-
-        const treeId = shareButton.dataset.shareTreeLink;
+    document.addEventListener('click', (e) => {
+        const shareBtn = e.target.closest('.share-link-btn');
+        if (!shareBtn) return;
+        const treeId = shareBtn.dataset.treeId;
         if (!treeId) return;
 
-        const labelSpan = shareButton.querySelector('[data-share-tree-link-label]');
-        if (!labelSpan) return;
-
-        const originalText = labelSpan.textContent;
-        const copiedText = getSearchCopy('search.previewShareLinkCopied', '링크가 복사됐어요', 'Link copied');
-        const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
-
-        try {
-            const url = new URL('/pages/search.html', window.location.origin);
-            url.searchParams.set('tree', treeId);
-            await navigator.clipboard.writeText(url.toString());
-            labelSpan.textContent = copiedText;
-            setTimeout(() => {
-                labelSpan.textContent = originalText;
-            }, 1500);
-        } catch (error) {
-            console.warn('[search] clipboard copy failed:', error.message);
-            labelSpan.textContent = failedText;
-            setTimeout(() => {
-                labelSpan.textContent = originalText;
-            }, 1500);
-        }
+        const shareUrl = `${window.location.origin}/pages/detail.html?tree=${encodeURIComponent(treeId)}`;
+        navigator.clipboard.writeText(shareUrl).then(() => {
+            const icon = shareBtn.querySelector('.material-symbols-outlined');
+            if (icon) {
+                const originalText = icon.textContent;
+                icon.textContent = 'check';
+                setTimeout(() => { icon.textContent = originalText; }, 2000);
+            }
+            alert(UI.getSearchCopy('search.shareLinkCopied', '러브트리 링크가 복사되었습니다.', 'LoveTree link copied to clipboard.'));
+        }).catch(err => {
+            console.error('Failed to copy text: ', err);
+        });
     });
 
-    if (mobilePreviewMediaQuery?.addEventListener) {
-        mobilePreviewMediaQuery.addEventListener('change', () => {
-            syncPreviewVisibility();
-        });
-    } else if (mobilePreviewMediaQuery?.addListener) {
-        mobilePreviewMediaQuery.addListener(() => {
-            syncPreviewVisibility();
-        });
-    }
+    const mobilePreviewMediaQuery = window.matchMedia('(max-width: 768px)');
+    mobilePreviewMediaQuery.addEventListener('change', () => {
+        UI.syncPreviewVisibility();
+    });
 
-    ensureBrowseControls();
-    syncStaticBrowseCopy();
-    syncPreviewVisibility();
-    if (typeof window.onLangChange === 'function') {
-        window.onLangChange(() => {
-            syncStaticBrowseCopy();
-            syncBrowseHead();
-            if (typeof syncControlsFromState === 'function') {
-                syncControlsFromState();
-            }
-        });
-    }
-
-    resultsList.innerHTML = CardRenderer.renderLoading();
-    clearSelectedPreview();
-    await Promise.allSettled([
-        loadPublicTrees({ resetSelection: true }),
-        loadGrowingTrees()
+    // Start load
+    await Promise.all([
+        window.loadPublicTrees({ resetSelection: false }),
+        Loader.loadGrowingTrees(renderGrowingResults)
     ]);
 
-    // Apply URL state after initial load
-    restoreStateFromUrl();
-    applySelectedTreeFromUrl();
+    Url.restoreStateFromUrl();
+    Url.applySelectedTreeFromUrl(selectTree);
 
     let searchInputTimer = null;
-    searchInput.addEventListener('input', (e) => {
-        currentQuery = e.target.value.trim();
-        if (searchInputTimer) clearTimeout(searchInputTimer);
-        searchInputTimer = setTimeout(() => {
-            renderResults(false);
-            updateUrlState();
-        }, 180);
-    });
+    if (searchInput) {
+        searchInput.addEventListener('input', (e) => {
+            State.currentQuery = e.target.value.trim();
+            if (searchInputTimer) clearTimeout(searchInputTimer);
+            searchInputTimer = setTimeout(() => {
+                renderResults(false);
+                Url.updateUrlState();
+            }, 180);
+        });
+    }
 
     tagChips.forEach(chip => {
         chip.addEventListener('click', () => {
             tagChips.forEach(c => c.classList.remove('active'));
             chip.classList.add('active');
-            currentCategory = chip.dataset.category || chip.textContent.trim();
+            State.currentCategory = chip.dataset.category || chip.textContent.trim();
             renderResults(false);
-            updateUrlState();
+            Url.updateUrlState();
         });
     });
 
     window.addEventListener('popstate', async () => {
-        const previousSort = currentSort;
-        const previousLimit = currentLimit;
-        restoreStateFromUrl();
-        if (previousSort !== currentSort || previousLimit !== currentLimit) {
-            await loadPublicTrees({ resetSelection: true });
+        const previousSort = State.currentSort;
+        const previousLimit = State.currentLimit;
+        Url.restoreStateFromUrl();
+        if (previousSort !== State.currentSort || previousLimit !== State.currentLimit) {
+            await window.loadPublicTrees({ resetSelection: true });
         } else {
             renderResults(false);
         }
-        syncBrowseHead();
+        UI.syncBrowseHead();
     });
 });

--- a/js/search/search-loader.js
+++ b/js/search/search-loader.js
@@ -1,0 +1,158 @@
+window.LoveBudSearchLoader = {
+    PUBLIC_TREES_CACHE_KEY: 'public_trees_summary_latest_10',
+    PREVIEW_CACHE_TTL_MS: 5 * 60 * 1000,
+
+    getPreviewCacheKey(treeId) {
+        return `public_tree_preview_${treeId}`;
+    },
+
+    readPreviewCache(treeId) {
+        if (!treeId) return null;
+        try {
+            const cached = localStorage.getItem(this.getPreviewCacheKey(treeId));
+            if (!cached) return null;
+            const parsed = JSON.parse(cached);
+            if (Date.now() - parsed.timestamp > this.PREVIEW_CACHE_TTL_MS) {
+                localStorage.removeItem(this.getPreviewCacheKey(treeId));
+                return null;
+            }
+            return parsed.data;
+        } catch (e) {
+            return null;
+        }
+    },
+
+    writePreviewCache(treeId, data) {
+        if (!treeId || !data) return;
+        try {
+            localStorage.setItem(this.getPreviewCacheKey(treeId), JSON.stringify({
+                timestamp: Date.now(),
+                data: data
+            }));
+        } catch (e) { /* ignore */ }
+    },
+
+    async fetchPublicTrees(params) {
+        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') {
+            throw new Error('API fetch layer not available');
+        }
+
+        const queryParams = new URLSearchParams();
+        if (params.query) queryParams.set('q', params.query);
+        if (params.category && params.category !== '전체') queryParams.set('category', params.category);
+        if (params.sort) queryParams.set('sort', params.sort);
+        if (params.limit) queryParams.set('limit', params.limit);
+
+        const url = `/community/public-trees?${queryParams.toString()}`;
+        return await window.LoveTreeBaseApiFetch.apiFetch(url);
+    },
+
+    async fetchTreeDetail(treeId) {
+        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') {
+            throw new Error('API fetch layer not available');
+        }
+
+        // Try cache first
+        const cached = this.readPreviewCache(treeId);
+        if (cached) return cached;
+
+        const data = await window.LoveTreeBaseApiFetch.apiFetch(`/community/public-trees/${treeId}`);
+        if (data) {
+            this.writePreviewCache(treeId, data);
+        }
+        return data;
+    },
+
+    async hydratePreview(tree, UI) {
+        if (!tree || !UI) return;
+
+        const State = window.LoveBudSearchState;
+        const requestId = ++State.currentPreviewRequestId;
+
+        UI.showPreviewLoading();
+        UI.setPreviewMobileState(true);
+
+        try {
+            const treeData = await this.fetchTreeDetail(tree.id);
+
+            // Race guard: only update if this is still the most recent request
+            if (requestId !== State.currentPreviewRequestId) {
+                console.log('Preview hydration race guard: ignoring stale response');
+                return;
+            }
+
+            UI.renderPreviewContent(tree, treeData);
+        } catch (error) {
+            if (requestId === State.currentPreviewRequestId) {
+                console.error('Failed to hydrate preview:', error);
+                UI.renderPreviewContent(null, null);
+            }
+        }
+    },
+
+    async loadPublicTrees(renderResultsCallback) {
+        const State = window.LoveBudSearchState;
+        const UI = window.LoveBudSearchUI;
+
+        if (UI) UI.showLoading(true);
+        if (UI) UI.showError('');
+
+        try {
+            const apiResponse = await this.fetchPublicTrees({
+                query: State.currentQuery,
+                category: State.currentCategory,
+                sort: State.currentSort,
+                limit: State.currentLimit
+            });
+
+            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
+            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
+
+            State.allTrees = baseModels;
+
+            if (State.isInitialLoad && !State.currentQuery && State.currentCategory === '전체' && State.currentSort === 'latest') {
+                try {
+                    localStorage.setItem(this.PUBLIC_TREES_CACHE_KEY, JSON.stringify({
+                        timestamp: Date.now(),
+                        data: baseModels
+                    }));
+                } catch (e) { /* ignore */ }
+            }
+
+            if (typeof renderResultsCallback === 'function') renderResultsCallback();
+        } catch (error) {
+            console.error('Search failed:', error);
+            if (UI) UI.showError('데이터를 불러오지 못했습니다.');
+            State.allTrees = [];
+            if (typeof renderResultsCallback === 'function') renderResultsCallback();
+        } finally {
+            if (UI) UI.showLoading(false);
+            State.isInitialLoad = false;
+        }
+    },
+
+    async loadGrowingTrees(renderGrowingResultsCallback) {
+        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
+
+        try {
+            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
+            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
+            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
+            const State = window.LoveBudSearchState;
+            State.growingTrees = baseModels.map((tree, index) => {
+                const raw = rawTrees[index]?.data || rawTrees[index] || {};
+                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
+                return {
+                    ...tree,
+                    emotionTags: rawEmotionTags
+                };
+            });
+            if (typeof renderGrowingResultsCallback === 'function') renderGrowingResultsCallback();
+        } catch (error) {
+            console.error('Failed to load growing trees:', error);
+            const State = window.LoveBudSearchState;
+            State.growingTrees = [];
+            if (typeof renderGrowingResultsCallback === 'function') renderGrowingResultsCallback();
+        }
+    }
+};

--- a/js/search/search-state.js
+++ b/js/search/search-state.js
@@ -1,0 +1,21 @@
+window.LoveBudSearchState = {
+    currentQuery: '',
+    currentCategory: '전체',
+    currentSort: 'latest',
+    currentLimit: 10,
+    allTrees: [],
+    growingTrees: [],
+    currentPreviewRequestId: 0,
+    isInitialLoad: true,
+
+    reset() {
+        this.currentQuery = '';
+        this.currentCategory = '전체';
+        this.currentSort = 'latest';
+        this.currentLimit = 10;
+        this.allTrees = [];
+        this.growingTrees = [];
+        this.currentPreviewRequestId = 0;
+        this.isInitialLoad = true;
+    }
+};

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -1,0 +1,217 @@
+window.LoveBudSearchUI = {
+    showLoading(show) {
+        const loading = document.getElementById('searchLoading');
+        if (loading) loading.classList.toggle('hidden', !show);
+    },
+
+    showError(message) {
+        const error = document.getElementById('searchError');
+        if (error) {
+            error.textContent = message;
+            error.classList.toggle('hidden', !message);
+        }
+    },
+
+    showNoResults(show) {
+        const noResults = document.getElementById('noResults');
+        if (noResults) noResults.classList.toggle('hidden', !show);
+    },
+
+    syncControlsFromState() {
+        const State = window.LoveBudSearchState;
+        const sortButtons = document.querySelectorAll('[data-browse-sort]');
+        sortButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.browseSort === State.currentSort);
+        });
+
+        const limitButtons = document.querySelectorAll('[data-browse-limit]');
+        limitButtons.forEach(btn => {
+            btn.classList.toggle('active', parseInt(btn.dataset.browseLimit, 10) === State.currentLimit);
+        });
+    },
+
+    setPreviewMobileState(active) {
+        const previewPanel = document.getElementById('searchPreviewPanel');
+        const overlay = document.getElementById('previewOverlay');
+        const body = document.body;
+
+        if (previewPanel) previewPanel.classList.toggle('active', active);
+        if (overlay) overlay.classList.toggle('active', active);
+
+        // Prevent body scroll on mobile when preview is open
+        if (window.innerWidth <= 1024) {
+            body.style.overflow = active ? 'hidden' : '';
+        }
+    },
+
+    updateLanguageLabels() {
+        if (typeof window.applyI18n === 'function') {
+            window.applyI18n();
+        }
+
+        const locale = (typeof window.getCurrentLocale === 'function') ? window.getCurrentLocale() : 'ko';
+        const labels = {
+            ko: {
+                total: '전체',
+                latest: '최신순',
+                popular: '인기순',
+                limit10: '10개씩',
+                limit30: '30개씩',
+                limit60: '60개씩'
+            },
+            en: {
+                total: 'All',
+                latest: 'Latest',
+                popular: 'Popular',
+                limit10: '10 items',
+                limit30: '30 items',
+                limit60: '60 items'
+            }
+        };
+
+        const currentLabels = labels[locale] || labels.ko;
+
+        // Update tag chips text if "All"
+        document.querySelectorAll('.tag-chip').forEach(chip => {
+            if (chip.dataset.category === '전체') {
+                chip.textContent = currentLabels.total;
+            }
+        });
+
+        // Update sort buttons text if needed
+        document.querySelectorAll('[data-browse-sort]').forEach(btn => {
+            const sort = btn.dataset.browseSort;
+            if (sort === 'latest') btn.textContent = currentLabels.latest;
+            if (sort === 'popular') btn.textContent = currentLabels.popular;
+        });
+
+        // Update limit buttons text if needed
+        document.querySelectorAll('[data-browse-limit]').forEach(btn => {
+            const limit = btn.dataset.browseLimit;
+            if (limit === '10') btn.textContent = currentLabels.limit10;
+            if (limit === '30') btn.textContent = currentLabels.limit30;
+            if (limit === '60') btn.textContent = currentLabels.limit60;
+        });
+    },
+
+    clearPreviewContent() {
+        const container = document.getElementById('previewContent');
+        if (container) container.innerHTML = '';
+
+        const placeholder = document.getElementById('previewPlaceholder');
+        if (placeholder) placeholder.classList.remove('hidden');
+
+        const empty = document.getElementById('previewEmpty');
+        if (empty) empty.classList.add('hidden');
+    },
+
+    showPreviewLoading() {
+        const placeholder = document.getElementById('previewPlaceholder');
+        if (placeholder) placeholder.classList.add('hidden');
+
+        const empty = document.getElementById('previewEmpty');
+        if (empty) empty.classList.add('hidden');
+
+        const container = document.getElementById('previewContent');
+        if (container) {
+            container.innerHTML = `
+                <div class="preview-loading-state">
+                    <div class="loading-spinner"></div>
+                    <p data-i18n="search.preview.loading">준비 중...</p>
+                </div>
+            `;
+        }
+    },
+
+    renderPreviewContent(tree, treeData) {
+        const container = document.getElementById('previewContent');
+        if (!container) return;
+
+        const placeholder = document.getElementById('previewPlaceholder');
+        if (placeholder) placeholder.classList.add('hidden');
+
+        const empty = document.getElementById('previewEmpty');
+        if (empty) empty.classList.add('hidden');
+
+        if (!tree || !treeData) {
+            container.innerHTML = '';
+            if (empty) empty.classList.remove('hidden');
+            return;
+        }
+
+        // Use established renderer for preview panel hydration
+        if (window.LoveBudSearchPreviewRenderer && typeof window.LoveBudSearchPreviewRenderer.renderPreview === 'function') {
+            window.LoveBudSearchPreviewRenderer.renderPreview(container, tree, treeData);
+        } else {
+            console.warn('LoveBudSearchPreviewRenderer not found, using basic fallback');
+            container.innerHTML = `<h3>${tree.title || 'Untitled Tree'}</h3>`;
+        }
+    },
+
+    renderResults(trees, resultsList, onCardClick) {
+        if (!resultsList) return;
+        resultsList.innerHTML = '';
+
+        if (!trees || trees.length === 0) {
+            this.showNoResults(true);
+            return;
+        }
+
+        this.showNoResults(false);
+
+        trees.forEach(tree => {
+            const card = document.createElement('div');
+            card.className = 'tree-card';
+            card.dataset.treeId = tree.id;
+
+            // Use established card renderer
+            if (window.LoveBudSearchCardRenderer && typeof window.LoveBudSearchCardRenderer.renderCard === 'function') {
+                window.LoveBudSearchCardRenderer.renderCard(card, tree);
+            } else {
+                card.innerHTML = `<div class="tree-card-title">${tree.title}</div>`;
+            }
+
+            card.addEventListener('click', (e) => {
+                if (typeof onCardClick === 'function') {
+                    onCardClick(tree, card, e);
+                }
+            });
+
+            resultsList.appendChild(card);
+        });
+    },
+
+    renderGrowingResults(trees, growingList, onCardClick) {
+        if (!growingList) return;
+        growingList.innerHTML = '';
+
+        if (!trees || trees.length === 0) {
+            const growingSection = document.getElementById('growingTreesSection');
+            if (growingSection) growingSection.classList.add('hidden');
+            return;
+        }
+
+        const growingSection = document.getElementById('growingTreesSection');
+        if (growingSection) growingSection.classList.remove('hidden');
+
+        trees.forEach(tree => {
+            const card = document.createElement('div');
+            card.className = 'tree-card growing';
+            card.dataset.treeId = tree.id;
+
+            if (window.LoveBudSearchCardRenderer && typeof window.LoveBudSearchCardRenderer.renderCard === 'function') {
+                window.LoveBudSearchCardRenderer.renderCard(card, tree);
+            } else {
+                card.innerHTML = `<div class="tree-card-title">${tree.title}</div>`;
+            }
+
+            card.addEventListener('click', (e) => {
+                if (typeof onCardClick === 'function') {
+                    onCardClick(tree, card, e);
+                }
+            });
+
+            growingList.appendChild(card);
+        });
+    }
+};

--- a/js/search/search-url.js
+++ b/js/search/search-url.js
@@ -1,0 +1,113 @@
+window.LoveBudSearchURL = {
+    isRestoringUrlState: false,
+    initialTreeDeepLinkApplied: false,
+
+    readUrlState() {
+        const params = new URLSearchParams(window.location.search);
+        return {
+            query: params.get('q') || '',
+            category: params.get('category') || '',
+            sort: params.get('sort') || 'latest',
+            limit: params.get('limit') || '10',
+            tree: params.get('tree') || ''
+        };
+    },
+
+    updateUrlState() {
+        if (this.isRestoringUrlState) return;
+        try {
+            const State = window.LoveBudSearchState;
+            const params = new URLSearchParams();
+            if (State.currentQuery) params.set('q', State.currentQuery);
+            if (State.currentCategory && State.currentCategory !== '전체') params.set('category', State.currentCategory);
+            if (State.currentSort && State.currentSort !== 'latest') params.set('sort', State.currentSort);
+            if (State.currentLimit && State.currentLimit !== 10) params.set('limit', String(State.currentLimit));
+
+            const newSearch = params.toString();
+            const newUrl = newSearch ? `${window.location.pathname}?${newSearch}` : window.location.pathname;
+
+            if (newUrl !== (window.location.pathname + window.location.search)) {
+                history.pushState(null, '', newUrl);
+            }
+        } catch { /* ignore */ }
+    },
+
+    restoreStateFromUrl() {
+        // Expose to window for backwards compatibility if needed
+        window.readUrlState = () => this.readUrlState();
+        window.updateUrlState = () => this.updateUrlState();
+        window.restoreStateFromUrl = () => this.restoreStateFromUrl();
+
+        const State = window.LoveBudSearchState;
+        const { query, category, sort, limit } = this.readUrlState();
+        this.isRestoringUrlState = true;
+
+        if (query) State.currentQuery = query;
+        if (category) State.currentCategory = category;
+        if (sort === 'latest' || sort === 'popular') State.currentSort = sort;
+        if (limit) {
+            const parsedLimit = parseInt(limit, 10);
+            if (!isNaN(parsedLimit) && parsedLimit >= 1 && parsedLimit <= 60) {
+                State.currentLimit = parsedLimit;
+            }
+        }
+
+        const searchInput = document.getElementById('searchInput');
+        const tagChips = document.querySelectorAll('.tag-chip');
+
+        if (query && searchInput) searchInput.value = query;
+        if (category) {
+            tagChips.forEach(chip => {
+                const chipCategory = chip.dataset.category || chip.textContent.trim();
+                chip.classList.toggle('active', chipCategory === State.currentCategory);
+            });
+        }
+
+        if (sort) {
+            if (window.LoveBudSearchUI && typeof window.LoveBudSearchUI.syncControlsFromState === 'function') {
+                window.LoveBudSearchUI.syncControlsFromState();
+            } else {
+                const sortBtn = document.querySelector(`[data-browse-sort="${State.currentSort}"]`);
+                if (sortBtn) {
+                    document.querySelectorAll('[data-browse-sort]').forEach(b => b.classList.remove('active'));
+                    sortBtn.classList.add('active');
+                }
+            }
+        }
+
+        this.isRestoringUrlState = false;
+    },
+
+    applySelectedTreeFromUrl(selectTreeCallback) {
+        if (this.initialTreeDeepLinkApplied) return;
+
+        const state = this.readUrlState();
+        if (!state.tree) return;
+
+        const State = window.LoveBudSearchState;
+        const targetTree = State.allTrees.find(t => t.id === state.tree) || State.growingTrees.find(t => t.id === state.tree);
+        if (!targetTree) return;
+
+        let activeCard = null;
+        let selector = '';
+        try {
+            selector = `.tree-card[data-tree-id="${CSS.escape(state.tree)}"]`;
+        } catch (e) {
+            selector = `.tree-card[data-tree-id="${state.tree.replace(/"/g, '\\"')}"]`;
+        }
+
+        const resultsList = document.getElementById('resultsList');
+        const growingList = document.getElementById('growingTreesList');
+        const allCardContainers = [resultsList, growingList].filter(Boolean);
+
+        for (const container of allCardContainers) {
+            activeCard = container.querySelector(selector);
+            if (activeCard) break;
+        }
+
+        if (typeof selectTreeCallback === 'function') {
+            selectTreeCallback(targetTree, activeCard);
+        }
+        this.initialTreeDeepLinkApplied = true;
+    }
+};

--- a/pages/search.html
+++ b/pages/search.html
@@ -145,6 +145,10 @@
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-card-renderer.js?v=20260422-1"></script>
     <script src="../js/search-preview-renderer.js?v=20260422-4"></script>
+    <script src="../js/search/search-state.js"></script>
+    <script src="../js/search/search-url.js"></script>
+    <script src="../js/search/search-ui.js"></script>
+    <script src="../js/search/search-loader.js"></script>
     <script src="../js/search.js?v=20260423-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>


### PR DESCRIPTION
## Summary
- Split `js/search.js` into browser-global runtime modules under `js/search/`.
- Keep `js/search.js` as the orchestration entrypoint.
- Add the new scripts before `js/search.js` in `pages/search.html`.

## Changed files
- `js/search.js`
- `pages/search.html`
- `js/search/search-loader.js`
- `js/search/search-state.js`
- `js/search/search-ui.js`
- `js/search/search-url.js`

## Verification
- node syntax checks: PASS
- git diff check: PASS
- npm test: PASS
- npm run lint: PASS
- npm run build: PASS
- npm run verify: PARTIAL, local dependency issue only

## Scope
- Search runtime only.
- No Detail/Auth/API/CSS/Modal/Netlify changes.
- No prototype/reference/demo changes.