### PR TITLE
fix(auth): remove inline logout handler

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -729,7 +729,7 @@ function buildUserDropdown(user) {
     '<a href="' + myTreesHref + '" class="user-dropdown-item"><span class="material-symbols-outlined">account_tree</span>내 러브트리</a>',
     '<button class="user-dropdown-item" disabled style="cursor:default;opacity:0.6;"><span class="material-symbols-outlined">settings</span>설정</button>',
     '<div class="dropdown-divider"></div>',
-    '<button class="user-dropdown-item" onclick="signOut()"><span class="material-symbols-outlined">logout</span>로그아웃</button>',
+    '<button type="button" class="user-dropdown-item" data-auth-action="logout"><span class="material-symbols-outlined">logout</span>로그아웃</button>',
     '</div>',
     '</div>'
   ].join('');
@@ -827,6 +827,18 @@ function attachDropdownListener() {
         if (m !== menu) m.classList.remove('show');
       });
       menu.classList.toggle('show');
+      return;
+    }
+    var logoutButton = e.target.closest('[data-auth-action="logout"]');
+    if (logoutButton) {
+      e.preventDefault();
+      e.stopPropagation();
+      document.querySelectorAll('.user-dropdown-menu.show').forEach(function (m) {
+        m.classList.remove('show');
+      });
+      if (typeof signOut === 'function') {
+        signOut();
+      }
       return;
     }
     if (!e.target.closest('.user-dropdown')) {

--- a/js/auth/auth-ui.js
+++ b/js/auth/auth-ui.js
@@ -141,7 +141,7 @@
       '<div class="dropdown-divider"></div>',
       buildLangInlineOptions(currentLang),
       '<div class="dropdown-divider"></div>',
-      '<button class="user-dropdown-item" onclick="signOut()"><span class="material-symbols-outlined">logout</span>' + tText('logout_btn', '로그아웃') + '</button>',
+      '<button type="button" class="user-dropdown-item" data-auth-action="logout"><span class="material-symbols-outlined">logout</span>' + tText('logout_btn', '로그아웃') + '</button>',
       "</div>",
       "</div>",
     ].join("");
@@ -239,6 +239,19 @@
         document.querySelectorAll('.lang-dropdown.show').forEach(function (m) {
           m.classList.remove('show');
         });
+        return;
+      }
+
+      var logoutButton = e.target.closest('[data-auth-action="logout"]');
+      if (logoutButton) {
+        e.preventDefault();
+        e.stopPropagation();
+        document.querySelectorAll(".user-dropdown-menu.show").forEach(function (m) {
+          m.classList.remove("show");
+        });
+        if (typeof signOut === "function") {
+          signOut();
+        }
         return;
       }
 


### PR DESCRIPTION
﻿- Summary
  - Remove inline onclick="signOut()" from active and fallback auth dropdowns.
  - Add type="button" and data-auth-action="logout" to logout buttons.
  - Handle logout through existing dropdown click delegation.
- Changed files
  - js/auth.js
  - js/auth/auth-ui.js
- Verification
  - grep onclick signOut: PASS
  - grep data-auth-action logout: PASS
  - grep logoutButton: PASS
  - node --check: PASS
  - git diff --check: PASS
  - npm test: PASS
  - npm run lint: PASS
  - npm run build: PASS
- Scope
  - Auth dropdown only.
  - No shared-header change.
  - No Search/Detail/API/CSS/Modal/Netlify changes.
  - No PR #7/prototype/reference/demo changes.
