### PR TITLE
fix(modal): allow PUT and DELETE CORS methods

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -923,7 +923,7 @@ web_app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins(),
     allow_credentials=False,
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Summary
Updated Modal backend CORS configuration to include `PUT` and `DELETE` methods in the `allow_methods` list. This is necessary for the newly added private update and delete routes to be accessible from the browser.

## Changed files
- `modal_compute/app.py`

## Verification
- Local syntax check: `python -m py_compile modal_compute/app.py` passed.
- Whitespace check: `git diff --check origin/main...HEAD` passed.
- Manual verification of code change in `modal_compute/app.py`.

## Runtime verification
- **Not run**: No CTO-assigned fixed test slot provided for Modal deployment.

## Separate follow-up needed
- Memory update/delete atomic owner guard hardening (investigation report provided to CTO).