### PR TITLE
fix(shared-header): replace logo inline handler with link

### DIFF
--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -250,7 +250,7 @@
 
         return [
             '<header class="nav-bar">',
-                '<div class="headline" style="font-size: 1.5rem; font-weight: 900; color: var(--on-surface); letter-spacing: -0.04em; cursor: pointer;" onclick="location.href=\'' + logoHref + '\'">LoveTree</div>',
+                '<a href="' + logoHref + '" class="headline" aria-label="LoveTree 홈으로 이동" style="font-size: 1.5rem; font-weight: 900; color: var(--on-surface); letter-spacing: -0.04em; cursor: pointer; text-decoration:none;">LoveTree</a>',
                 '<button class="mobile-nav-toggle" id="mobileNavToggle" type="button" aria-label="메뉴 열기" aria-expanded="false">',
                     '<span class="material-symbols-outlined">menu</span>',
                 '</button>',


### PR DESCRIPTION
## Summary
- Replaced the shared header LoveTree logo clickable `<div>` with a native `<a>` link.
- Removed the inline `onclick="location.href..."` handler from the logo.
- Preserved the existing `logoHref` root/pages path logic and visual styling, adding `text-decoration:none` for link parity.

## Changed files
- `js/shared-header.js`

## Verification
- `node --check js/shared-header.js`: not run in local shell; GitHub connector environment only
- `git diff --check origin/main...HEAD`: not run in local shell; GitHub connector environment only
- `git diff --name-only origin/main...HEAD`: `js/shared-header.js` only, confirmed by GitHub compare
- `grep 'onclick="location.href' js/shared-header.js`: no matching logo handler in branch file inspection
- `grep '<a href=".*class="headline"' js/shared-header.js`: headline anchor present in branch file inspection

## Browser verification
- not run

## Scope guard
- Modified `js/shared-header.js` only.
- Did not modify auth files, pages, css, api, modal, netlify, docs, prototype/reference/demo/variant files.
- Did not use fixed test slot or arbitrary Preview URL.
- No merge performed.