### PR TITLE
fix(modal): add SQL-level owner guards for memory writes

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -843,6 +843,12 @@ def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) 
         UPDATE memories
         SET {', '.join(updates)}, updated_at = NOW()
         WHERE id = %s
+          AND EXISTS (
+              SELECT 1
+              FROM trees t
+              WHERE t.id = memories.tree_id
+                AND t.owner_id = %s
+          )
         RETURNING id, tree_id, parent_id, title, memo, artist, source, source_url,
                   source_type, thumbnail, emotion_tags, timestamp, visibility,
                   created_at, updated_at;
@@ -850,7 +856,7 @@ def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) 
 
     with get_db_connection() as conn:
         with conn.cursor() as cur:
-            cur.execute(query, tuple(params + [safe_memory_id]))
+            cur.execute(query, tuple(params + [safe_memory_id, owner_id]))
             row = cur.fetchone()
         conn.commit()
 
@@ -870,7 +876,20 @@ def delete_owner_memory(owner_id: str, memory_id: str) -> dict[str, Any]:
                 "UPDATE memories SET parent_id = NULL WHERE tree_id = %s AND parent_id = %s;",
                 (tree_id, safe_memory_id),
             )
-            cur.execute("DELETE FROM memories WHERE id = %s RETURNING id;", (safe_memory_id,))
+            cur.execute(
+                """
+                DELETE FROM memories
+                WHERE id = %s
+                  AND EXISTS (
+                      SELECT 1
+                      FROM trees t
+                      WHERE t.id = memories.tree_id
+                        AND t.owner_id = %s
+                  )
+                RETURNING id;
+                """,
+                (safe_memory_id, owner_id),
+            )
             row = cur.fetchone()
         conn.commit()
 

--- a/tests/contracts/modal-private-ownership-policy.test.js
+++ b/tests/contracts/modal-private-ownership-policy.test.js
@@ -20,6 +20,34 @@ function getFunctionBody(source, functionName) {
   return match[0];
 }
 
+function assertMemoryWriteOwnerGuard(body, label) {
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /exists\(\s*select1fromtreest/i,
+    `${label} must guard the write with a trees EXISTS subquery`
+  );
+
+  assert.match(
+    normalized,
+    /t\.id=memories\.tree_id/i,
+    `${label} owner guard must join trees to the target memory tree_id`
+  );
+
+  assert.match(
+    normalized,
+    /t\.owner_id=%s/i,
+    `${label} owner guard must constrain trees.owner_id`
+  );
+
+  assert.match(
+    normalized,
+    /safe_memory_id,owner_id/i,
+    `${label} write query parameters must include owner_id`
+  );
+}
+
 test('create_owner_memory calls fetch_owner_tree with tree_id and owner_id', () => {
   const source = readModalApp();
   const body = getFunctionBody(source, 'create_owner_memory');
@@ -176,6 +204,20 @@ test('update_owner_memory calls require_memory_owner', () => {
   );
 });
 
+test('update_owner_memory SQL write includes tree owner guard', () => {
+  const source = readModalApp();
+  const body = getFunctionBody(source, 'update_owner_memory');
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /updatememoriesset/i,
+    'update_owner_memory must update memories table'
+  );
+
+  assertMemoryWriteOwnerGuard(body, 'update_owner_memory');
+});
+
 test('delete_owner_memory calls require_memory_owner', () => {
   const source = readModalApp();
   const body = getFunctionBody(source, 'delete_owner_memory');
@@ -186,4 +228,18 @@ test('delete_owner_memory calls require_memory_owner', () => {
     /require_memory_owner\(/,
     'delete_owner_memory must call require_memory_owner'
   );
+});
+
+test('delete_owner_memory SQL write includes tree owner guard', () => {
+  const source = readModalApp();
+  const body = getFunctionBody(source, 'delete_owner_memory');
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /deletefrommemorieswhere/i,
+    'delete_owner_memory must delete from memories table'
+  );
+
+  assertMemoryWriteOwnerGuard(body, 'delete_owner_memory');
 });


### PR DESCRIPTION
## summary
- `update_owner_memory()` 실제 `UPDATE memories` SQL에 tree owner `EXISTS` guard를 추가했습니다.
- `delete_owner_memory()` 실제 `DELETE FROM memories` SQL에 tree owner `EXISTS` guard를 추가했습니다.
- 기존 `require_memory_owner()` 사전 검증과 응답 shape는 유지했습니다.
- ownership contract test에 memory write SQL-level owner guard 검사를 추가했습니다.

## changed files
- `modal_compute/app.py`
- `tests/contracts/modal-private-ownership-policy.test.js`

## validation results
- `python -m py_compile modal_compute/app.py`: PASS
- `node --test tests/contracts/modal-private-ownership-policy.test.js`: PASS, 12/12
- `npm test`: PASS, 63/63
- `git diff --check`: PASS

## explicit non-goals
- Cloudflare gateway route 변경 없음
- Firebase/Admin auth verification 변경 없음
- public fetch retry/visibility policy 변경 없음
- SQL schema/migration 실행 없음
- Modal/Cloudflare/Firebase 설정 변경 없음
- app.py extraction/refactor 없음
- ORDER BY/delete tree cleanup 없음
- browser/UI 검증 대상 아님

## risk notes
- SQL guard가 TOCTOU/future regression 방어를 추가합니다.
- 사전 owner check 이후 SQL write 단계에서 tree owner가 맞지 않으면 row가 반환되지 않아 기존 404 fallback 경로를 탑니다.
- `delete_owner_memory()`의 child `parent_id` 정리 로직은 기존 쿼리를 유지했습니다.

## browser verification
- 필요 없음. Backend SQL-level owner guard contract 변경이며 UI/runtime 변경 없음.