### PR TITLE
fix(modal): align public read DB retry handling

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -450,10 +450,13 @@ def fetch_public_memories(tree_id: str | None = None, limit: int = 100) -> list[
         LIMIT %s;
     """
 
-    with get_db_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, tuple(params))
-            rows = cur.fetchall()
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, tuple(params))
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
 
     return [normalize_memory_row(row) for row in rows]
 
@@ -472,10 +475,13 @@ def fetch_public_memory(memory_id: str) -> dict[str, Any] | None:
         LIMIT 1;
     """
 
-    with get_db_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, (memory_id,))
-            row = cur.fetchone()
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (memory_id,))
+                return cur.fetchone()
+
+    row = run_db_with_retry(operation)
 
     return normalize_memory_row(row) if row else None
 
@@ -494,10 +500,13 @@ def fetch_public_tree(tree_id: str) -> dict[str, Any] | None:
         LIMIT 1;
     """
 
-    with get_db_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, (tree_id,))
-            row = cur.fetchone()
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (tree_id,))
+                return cur.fetchone()
+
+    row = run_db_with_retry(operation)
 
     return normalize_tree_row(row, row.get("memory_count")) if row else None
 

--- a/tests/contracts/modal-public-read-retry-policy.test.js
+++ b/tests/contracts/modal-public-read-retry-policy.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const MODAL_APP = path.join(ROOT, 'modal_compute', 'app.py');
+
+function readModalApp() {
+  return fs.readFileSync(MODAL_APP, 'utf8');
+}
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+function getFunctionBody(source, functionName) {
+  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  assert.ok(match, `missing ${functionName}`);
+  return match[0];
+}
+
+function assertPublicReadUsesRetry(source, functionName, fetchMethod) {
+  const body = getFunctionBody(source, functionName);
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /defoperation\(\):.*withget_db_connection\(\)asconn:/i,
+    `${functionName} must wrap DB access in an operation function`
+  );
+
+  assert.match(
+    normalized,
+    new RegExp(`returncur\\.${fetchMethod}\\(\\)`, 'i'),
+    `${functionName} operation must return cur.${fetchMethod}()`
+  );
+
+  assert.match(
+    normalized,
+    /run_db_with_retry\(operation\)/i,
+    `${functionName} must call run_db_with_retry(operation)`
+  );
+}
+
+test('public memory list fetch uses retry wrapper', () => {
+  const source = readModalApp();
+  assertPublicReadUsesRetry(source, 'fetch_public_memories', 'fetchall');
+});
+
+test('public memory detail fetch uses retry wrapper', () => {
+  const source = readModalApp();
+  assertPublicReadUsesRetry(source, 'fetch_public_memory', 'fetchone');
+});
+
+test('public tree detail fetch uses retry wrapper', () => {
+  const source = readModalApp();
+  assertPublicReadUsesRetry(source, 'fetch_public_tree', 'fetchone');
+});


### PR DESCRIPTION
## summary
- `fetch_public_memories()` public read DB access를 `operation()` + `run_db_with_retry(operation)` 패턴으로 전환했습니다.
- `fetch_public_memory()` public read DB access를 동일 retry wrapper로 전환했습니다.
- `fetch_public_tree()` public read DB access를 동일 retry wrapper로 전환했습니다.
- SQL 조건, query params, 반환 shape, normalization은 변경하지 않았습니다.

## changed files
- `modal_compute/app.py`
- `tests/contracts/modal-public-read-retry-policy.test.js`

## validation results
- `python -m py_compile modal_compute/app.py`: PASS
- `node --test tests/contracts/modal-public-read-retry-policy.test.js`: PASS, 3/3
- `git diff --check`: PASS
- `npm test`: PASS, 68/68
- `npm run build`: PASS

## explicit non-goals
- Cloudflare/Modal/Firebase 설정 변경 없음
- DB migration 실행 없음
- route/path contract 변경 없음
- visibility/public-first policy 변경 없음
- auth/owner guard 변경 없음
- write path 변경 없음
- app.py extraction/refactor 없음
- ORDER BY/delete tree cleanup 없음

## risk notes
- 연결 안정성 일관화만 수행했습니다.
- OperationalError 재시도 동작은 기존 `run_db_with_retry()` 정책을 그대로 따릅니다.
- 브라우저 검증은 필요하지 않습니다. Backend DB retry wrapper consistency 변경입니다.