### PR TITLE
docs(runtime): sync Modal public-first and Plus private status

### DIFF
--- a/docs/engineering/API_CONTRACT.md
+++ b/docs/engineering/API_CONTRACT.md
@@ -1,8 +1,8 @@
 # LoveBud API 응답 계약
 
 > **버전:** 1.5  
-> **최종 갱신:** 2026-04-25  
-> **관련 커밋:** `0230475`, `bb9741b`, `bb9e663`
+> **최종 갱신:** 2026-04-27  
+> **관련 커밋:** `0230475`, `bb9741b`, `bb9e663`, `10b3d9d`
 
 ---
 
@@ -167,15 +167,22 @@ Current document baseline:
 - `POST /api/memories` and `GET /api/memories` route through `functions/api/memories.js` to Modal `/modal/private/memories`.
 - `netlify/functions/*` may still contain older private-first code, but it is not authoritative for `lovebud.pages.dev` production/test slots.
 
+Current main runtime state:
+
+- My Trees create payload explicitly sends `visibility: 'public'`.
+- Modal create tree path defaults omitted visibility to `public`.
+- Modal private tree/memory create and private visibility update paths call the private storage entitlement guard.
+- Public read paths retain parent tree visibility guards.
+- Public visibility remains separate from Browse/Search eligibility.
+
 ### 3.2 목표 정책 계약
 
 CTO 결정 기준 목표 정책은 **public-first + Plus private**입니다.
 
-- 신규 tree는 public-first 방향으로 전환합니다.
+- 신규 tree는 public-first 정책입니다.
 - 기존 private tree는 자동 public 전환하지 않고 grandfathered private으로 유지합니다.
-- private 생성/전환은 Plus entitlement source 확정 후 backend에서 검증합니다.
+- private 생성/전환은 Plus entitlement guard 대상입니다.
 - `public visibility`와 `browse 노출 조건`은 분리합니다.
-- createTree payload만 단독으로 public 변경하는 것은 금지합니다.
 - Cloudflare Pages Functions와 Modal create/toggle 정책은 반드시 동기화합니다.
 - `netlify/functions/*`에는 신규 backend 정책을 구현하지 않습니다. Netlify runtime 재활성화가 명시 승인된 경우만 예외입니다.
 
@@ -201,7 +208,7 @@ interface VisibilityPolicyState {
 
 따라서 public tree라도 public memory가 3개 미만이면 public 접근은 가능하지만 browse summary에는 노출되지 않을 수 있습니다.
 
-### 3.4 create tree 전환 계약
+### 3.4 create tree runtime 계약
 
 현재 active path:
 
@@ -211,7 +218,7 @@ interface VisibilityPolicyState {
 → Modal /modal/private/trees
 ```
 
-목표:
+Request target:
 
 ```typescript
 interface CreateTreeRequestTarget {
@@ -220,13 +227,14 @@ interface CreateTreeRequestTarget {
 }
 ```
 
-목표 정책:
+현재 main runtime 상태:
 
 - visibility 생략 시 신규 tree는 `public`으로 생성합니다.
-- `visibility: 'private'` 생성은 Plus entitlement 필요 대상입니다.
-- entitlement source 확정 전에는 private 생성 허용/차단을 구현하지 않습니다.
-- frontend만 먼저 public payload로 바꾸지 않습니다.
-- Cloudflare/Modal path가 함께 준비되어야 합니다.
+- My Trees 생성 payload는 `visibility: 'public'`을 명시합니다.
+- `visibility: 'private'` 생성은 Plus entitlement guard 대상입니다.
+- 현재 Modal 구현은 private visibility 요청에 대해 Firestore user profile 기반 entitlement guard를 호출합니다.
+- canonical entitlement field는 `users/{uid}.privateStorageEnabled`입니다.
+- 현재 구현은 compatibility 목적으로 `plan`, `plus`, `entitlements.privateStorage`도 확인하지만, 장기 API 계약으로 고정할지는 별도 결정이 필요합니다.
 
 ### 3.5 toggle visibility 전환 계약
 
@@ -245,11 +253,11 @@ interface UpdateTreeVisibilityRequest {
 - `private -> public` 시 browse 노출 조건은 별도 판단
 - public 전환 자체와 browse summary 노출을 같은 guard로 묶지 않습니다.
 
-### 3.6 decision-needed: entitlement error contract
+### 3.6 implemented guard / contract-needed: entitlement error contract
 
-아직 미확정입니다.
+Modal main에는 private storage entitlement guard가 구현되어 있습니다.
 
-후보:
+Contract-needed 후보:
 
 ```typescript
 interface PlusRequiredError {
@@ -264,11 +272,12 @@ HTTP status 후보:
 - `403`: 현재 auth/permission 계열과 일관됨
 - `402`: 의미상 결제 필요에 가깝지만 운영 관행이 불균일함
 
-결정 필요:
+아직 고정하지 말 것:
 
-- Plus entitlement source of truth
-- status code
-- error body shape
+- 최종 status code
+- 최종 error body shape
+- frontend toast/i18n mapping
+- compatibility entitlement fields의 장기 지원 여부
 - grandfathered private 예외 처리
 
 ---
@@ -306,7 +315,7 @@ type BrowseTreeSummaryList = BrowseTreeSummary[];
 
 **현재 구현 의미**
 - summary는 tree 목록 자체가 아니라, public tree와 public memory를 합쳐 만든 browse 카드 요약 모델입니다.
-- public-first 전환 후에도 browse summary는 `browseEligible` 조건을 통과한 public tree만 반환해야 합니다.
+- public-first create 이후에도 browse summary는 `browseEligible` 조건을 통과한 public tree만 반환해야 합니다.
 - visibility가 public이어도 memory/quality 조건이 부족하면 summary에서 제외될 수 있습니다.
 
 ### 4.2 Preview Hydration Contract
@@ -394,9 +403,9 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 ### 6.3 visibility 정책 관련 금지
 
-- frontend만 createTree payload를 public으로 변경하지 않습니다.
 - frontend-only Plus lock으로 정책 완료를 선언하지 않습니다.
 - public visibility를 browse 노출과 같은 의미로 표시하지 않습니다.
+- Plus-required HTTP status/body shape를 확정 전제하고 UI 처리를 고정하지 않습니다.
 
 ---
 
@@ -409,7 +418,9 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 ### 7.2 visibility guard 원칙
 
 - create tree 정책은 Cloudflare Pages Functions와 Modal에서 동기화해야 합니다.
-- private 생성/전환 guard는 entitlement source 확정 후 active backend에서 강제해야 합니다.
+- private 생성/전환 guard는 active backend에서 강제해야 합니다.
+- canonical entitlement field는 `users/{uid}.privateStorageEnabled`입니다.
+- compatibility entitlement fields의 장기 지원 여부는 별도 contract-needed 항목입니다.
 - 기존 private tree grandfathering을 고려해야 합니다.
 - browse display filter는 public visibility와 별도로 유지합니다.
 - `netlify/functions/*`에 신규 visibility/private-storage 정책을 구현하지 않습니다.
@@ -425,6 +436,7 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 | `functions/api/trees/[id].js` | active tree detail Cloudflare handler where applicable |
 | `functions/api/[[path]].js` | active Cloudflare catch-all handler for recognized read/community routes |
 | `modal_compute/app.py` | active Modal API/backend target |
+| `js/my-trees/my-trees-actions.js` | My Trees create payload source |
 | `js/utils/normalize.js` | 프론트 정규화 유틸 |
 | `js/api/public-tree-adapter.js` | browse summary/hydrate adapter |
 | `netlify/functions/*` | legacy artifact only, not current production backend |
@@ -433,17 +445,17 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 
 ## 9. 장기 TODO
 
-### 9.1 public-first backend 전환
+### 9.1 public-first runtime drift watch
 
-- Cloudflare/Modal create tree public-first 전환
-- create payload 단독 변경 금지 원칙 유지
+- Cloudflare/Modal create tree public-first 상태 유지
 - API 계약 테스트 추가
+- existing private tree 자동 public 전환 금지 유지
 
 ### 9.2 Plus private entitlement
 
-- entitlement source of truth 확정
-- plan 저장 위치 확정
-- active backend guard 추가
+- final entitlement source of truth 확정
+- compatibility entitlement fields 장기 지원 여부 결정
+- Plus-required status/body contract 확정
 - frontend 안내와 API error 처리 동기화
 
 ### 9.3 browse 노출 조건 고정
@@ -466,11 +478,11 @@ const normalized = window.LoveBudNormalize.normalizeMemory(apiResponse);
 |-----------|------|
 | 새 코드에 `{id, data}` 접근 | PR reject |
 | active API 응답에 flat camelCase 계약 미준수 | PR reject |
-| createTree payload만 public으로 단독 변경 | PR reject |
 | Cloudflare와 Modal visibility 정책 불일치 | PR reject |
 | Plus private을 frontend-only로 잠금 | PR reject |
 | 기존 private tree 자동 public 전환 | PR reject |
 | public visibility를 browse 노출로 설명 | 정책 위반으로 수정 |
+| Plus-required HTTP status/body shape를 독단 확정 | contract-needed로 되돌림 |
 | 신규 backend policy를 `netlify/functions/*`에 구현 | PR reject unless Netlify runtime is explicitly reactivated |
 
 ---

--- a/docs/ops/MODAL_BROWSE_RUNTIME.md
+++ b/docs/ops/MODAL_BROWSE_RUNTIME.md
@@ -39,8 +39,12 @@ LoveBud browse/public summary 경로에서 Modal을 1순위 읽기/계산 계층
 - `GET /modal/private/trees`
 - `POST /modal/private/trees`
 - `GET /modal/private/trees/{tree_id}`
+- `PUT /modal/private/trees/{tree_id}`
+- `DELETE /modal/private/trees/{tree_id}`
 - `GET /modal/private/memories`
 - `POST /modal/private/memories`
+- `PUT /modal/private/memories/{memory_id}`
+- `DELETE /modal/private/memories/{memory_id}`
 
 Modal browse summary는 아래 key를 flat camelCase로 반환합니다.
 
@@ -63,48 +67,46 @@ Modal browse summary는 아래 key를 flat camelCase로 반환합니다.
 
 ### 3.1 현재 Modal 구현
 
-현재 Modal private owner write path는 private-first입니다.
+현재 main 기준 Modal owner write path는 **public-first create + Plus private guard** 상태입니다.
 
-- `/modal/private/trees` POST는 tree visibility 기본값을 `private`으로 처리합니다.
-- `/modal/private/trees` POST에 `visibility: public`이 들어오면 현재 구현은 409를 반환합니다.
-- `/modal/private/memories` POST는 memory visibility 기본값을 `private`으로 처리합니다.
-- Plus entitlement 검증은 아직 없습니다.
+- `/modal/private/trees` POST는 tree visibility 기본값을 `public`으로 처리합니다.
+- My Trees 생성 payload도 `visibility: public`을 명시합니다.
+- `/modal/private/trees` POST에 `visibility: private`이 들어오면 Modal은 private storage entitlement를 확인합니다.
+- `/modal/private/memories` POST에서 memory visibility가 생략되면 parent tree visibility를 상속합니다.
+- tree 또는 memory visibility를 `private`으로 생성하거나 전환하는 path는 private storage entitlement guard를 탑니다.
+- 기존 private tree를 자동 public 전환하지 않습니다.
 
-### 3.2 목표 정책
+### 3.2 현재 정책 상태
 
-CTO 결정 기준 목표 정책은 **public-first + Plus private**입니다.
+CTO 기준 정책인 **public-first + Plus private**은 현재 main의 Modal/My Trees create path에 부분 반영되어 있습니다.
 
-- 신규 tree는 public-first 방향으로 전환합니다.
-- 기존 private tree는 자동 public 전환하지 않고 grandfathered private으로 유지합니다.
-- private 생성/전환은 Plus entitlement source 확정 후 backend에서 검증합니다.
-- public visibility와 browse 노출 조건은 분리합니다.
-- createTree payload만 단독으로 public 변경하는 것은 금지합니다.
-- Netlify와 Modal 정책은 반드시 동기화합니다.
+현재 반영됨:
 
-### 3.3 Modal 전환 원칙
+- 신규 tree create 기본값은 `public`
+- My Trees 생성 payload는 `visibility: public` 명시
+- private tree/memory 생성 또는 private 전환 시 Plus entitlement guard 호출
+- 기존 private tree 자동 public 전환 금지
+- public visibility와 Browse/Search eligibility 분리
+- anonymous public read path에서 parent tree visibility guard 유지
 
-Modal은 Netlify/API 정책과 동시에 바뀌어야 합니다.
+계속 분리해서 봐야 할 항목:
 
-금지:
+- public tree가 곧바로 Browse/Search에 소개되는 것은 아님
+- Browse/Search summary는 public memory count / quality filter를 통과한 tree만 반환
+- grandfathered private tree의 기존 사용자 경험은 별도 정책으로 유지
 
-- Netlify는 public-first인데 Modal은 private-first로 남기는 상태
-- Modal은 public-first인데 Netlify는 private-first로 남기는 상태
-- Cloudflare route가 Modal/Netlify 차이를 숨기도록 방치하는 상태
-- Plus entitlement 없이 Modal private write만 frontend에서 숨기는 상태
+### 3.3 Modal runtime contract-needed 항목
 
-전환 시 필요한 항목:
+현재 Modal은 active runtime 기준으로 public-first create와 private entitlement guard를 수행합니다. 다만 다음 항목은 아직 정책/계약으로 독단 확정하지 않습니다.
 
-- `/modal/private/trees` POST default visibility 변경 여부
-- private 생성 시 entitlement check
-- public → private toggle endpoint가 Modal에 추가될 경우 동일 entitlement check
-- grandfathered private owner read 유지
-- public browse filters 유지
+Contract-needed:
 
-Decision-needed:
-
-- Modal이 user plan을 직접 조회할지, upstream/API layer에서 검증할지
-- Modal secret/env로 entitlement source에 접근할지
-- Modal private endpoint의 Plus-required error contract
+- `users/{uid}.privateStorageEnabled` 외 compatibility entitlement fields를 장기 계약으로 유지할지 여부
+- Plus-required HTTP status와 error body shape를 API contract로 고정할지 여부
+- grandfathered private owner의 신규 private storage 제한/허용 UX
+- private 전환 실패 시 frontend toast/i18n 문구
+- Settings/결제 UX와 private storage 안내 문구
+- Browse/Search threshold의 장기 정책화 여부
 
 ---
 
@@ -121,10 +123,10 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 
 - 이 조건은 **browse summary display filter / quality filter**입니다.
 - `visibility: public` 자체와 같은 의미가 아닙니다.
-- public-first 전환 후에도 public tree가 곧바로 browse에 노출되는 것은 아닙니다.
+- public-first create 상태에서도 public tree가 곧바로 browse에 노출되는 것은 아닙니다.
 - publication/visibility 전환 guard와 browse display filter를 혼동하지 않습니다.
 
-전환 후 권장 해석:
+현재 해석:
 
 | 개념 | 의미 | Modal browse 영향 |
 |------|------|-------------------|
@@ -161,6 +163,10 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 
 - `DATABASE_URL`
   - Modal secret `lovebud-db`에서 주입
+- `FIREBASE_SERVICE_ACCOUNT_JSON`
+  - private storage entitlement lookup에 필요한 Firebase Admin service account JSON
+- `FIREBASE_PROJECT_ID`
+  - Firebase ID token verification 및 Admin project 검증에 사용
 
 ### Optional
 
@@ -168,12 +174,12 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
   - 콤마 구분 문자열
   - 기본값이 있더라도 운영에서는 명시 설정 권장
 
-### Decision-needed for Plus private
+### Contract-needed for Plus private
 
-- Plus entitlement source env/secret
-- plan lookup endpoint or DB table
+- canonical 외 compatibility entitlement fields의 장기 지원 여부
 - entitlement cache policy
 - Plus-required error code/status
+- Plus-required response body shape
 
 ---
 
@@ -185,9 +191,10 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 4. `/modal/browse/latest?limit=3`가 배열을 반환하는지 확인
 5. 각 item에 browse 카드가 기대하는 key가 모두 있는지 확인
 6. Modal 장애 시 Cloudflare Pages route가 Vercel fallback으로 계속 browse를 살리는지 확인
-7. public-first 전환 시 Netlify와 Modal create policy가 같은지 확인
-8. Plus private 적용 시 Modal private write path가 entitlement를 검증하는지 확인
-9. grandfathered private tree가 browse에 노출되지 않는지 확인
+7. tree create에서 visibility 생략 시 `public`으로 생성되는지 확인
+8. My Trees create payload가 `visibility: public`을 명시하는지 확인
+9. private tree/memory create 또는 private 전환 시 Modal private write path가 entitlement를 검증하는지 확인
+10. grandfathered private tree가 browse에 노출되지 않는지 확인
 
 ---
 
@@ -207,23 +214,25 @@ Modal summary SQL은 browse summary 품질을 위해 아래 조건을 직접 강
 
 ## 9. 역할 분리
 
-- Modal: browse summary 읽기/집계 1순위 계층
+- Modal: browse summary 읽기/집계 1순위 계층 + active private owner write target
 - Cloudflare Pages: same-origin entry + API 라우터
 - Vercel: upstream / secondary entry 유지
 - Netlify: fallback / legacy 유지
 
-Visibility 정책 전환 후에도 프런트가 직접 Modal URL이나 Vercel/Netlify URL에 강결합되지 않도록 현재 구조를 기본값으로 둡니다.
+Visibility 정책 이후에도 프런트가 직접 Modal URL이나 Vercel/Netlify URL에 강결합되지 않도록 현재 구조를 기본값으로 둡니다.
 
 ---
 
-## 10. public-first 전환 전 금지 사항
+## 10. 구현 상태와 금지 사항
 
-- createTree payload만 public으로 변경
-- Modal만 public-first로 변경
-- Netlify만 public-first로 변경
+현재 main은 public-first create와 Plus private guard를 일부 반영했습니다. 다음 shortcut은 여전히 금지합니다.
+
 - 기존 private tree 자동 public 전환
-- Plus entitlement 없이 private write를 정책상 완료로 선언
+- public visibility를 Browse/Search 자동 노출로 설명
+- Plus entitlement guard를 frontend-only로 간주
+- Plus-required HTTP status/body shape를 문서에서 독단 확정
 - browse latest filter에서 public memory threshold를 암묵적으로 제거
+- Netlify legacy artifact에 신규 backend 정책을 구현
 
 ---
 
@@ -231,11 +240,10 @@ Visibility 정책 전환 후에도 프런트가 직접 Modal URL이나 Vercel/Ne
 
 ### Modal/backend 작업
 
-- public-first create policy 반영
-- private create entitlement guard
-- public/private visibility transition 정책 반영
-- grandfathered private 유지
-- browse summary filter 유지
+- Plus-required error status/body contract 고정
+- compatibility entitlement fields의 장기 지원 여부 결정
+- grandfathered private 세부 UX와 backend 예외 처리 정리
+- browse summary filter 유지 여부의 장기 정책화
 
 ### Cloudflare/API routing 작업
 
@@ -244,8 +252,8 @@ Visibility 정책 전환 후에도 프런트가 직접 Modal URL이나 Vercel/Ne
 
 ### Frontend 작업
 
-- public-first UX copy
-- Plus private 안내
+- Plus-required 실패 toast/i18n 문구
+- Settings/결제 UX와 private storage 안내
 - browse 노출 조건 설명
 
-이 문서는 코드 변경 지시가 아니라 운영/정책 정합성 기준입니다.
+이 문서는 코드 변경 지시가 아니라 현재 main runtime 상태와 남은 계약 필요 항목을 동기화한 운영 문서입니다.

--- a/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
+++ b/docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md
@@ -4,7 +4,7 @@
 
 현재 CTO 확정 정책은 **public-first visibility + Plus private storage + separate browse eligibility + parent visibility public-read guard**입니다. 이 문서는 제품/UX 정책의 canonical source이며, 코드 구현은 별도 frontend/backend 작업으로 분리합니다.
 
-중요: 이 문서는 현재 main 코드가 이미 public-first로 동작한다는 의미가 아닙니다. 코드 변경 전에는 현재 구현 상태를 별도로 확인해야 합니다.
+중요: 이 문서는 현재 main 코드가 canonical policy의 모든 세부 항목을 구현했다는 의미가 아닙니다. 코드 변경 또는 정책 판단 전에는 현재 구현 상태를 별도로 확인해야 합니다.
 
 ---
 
@@ -51,14 +51,26 @@
 
 ## 2. Current implementation note
 
-현재 main 구현은 정책 전환 중간 상태일 수 있습니다. 문서의 canonical policy와 실제 코드 동작이 다를 수 있으므로 구현 작업 전에는 관련 frontend/backend/runtime 파일을 다시 확인해야 합니다.
+현재 main 구현은 canonical policy의 일부를 이미 반영했지만, 모든 UX/contract 세부사항이 확정된 것은 아닙니다. 문서의 canonical policy와 실제 코드 동작이 다를 수 있으므로 구현 작업 전에는 관련 frontend/backend/runtime 파일을 다시 확인해야 합니다.
 
-기존 확인 기준:
+현재 main 확인 기준:
 
-- My Trees 생성 모달은 과거 private-first payload를 사용했습니다.
-- backend create tree guard는 과거 public 생성 요청을 제한했습니다.
-- Editor visibility toggle은 public/private 전환 UI를 제공하되 Plus entitlement guard가 완전히 연결되지 않았을 수 있습니다.
+- My Trees 생성 모달은 `visibility: public` payload를 명시합니다.
+- Modal create tree path는 visibility 생략 시 `public`을 기본값으로 사용합니다.
+- Modal private tree/memory create 및 private visibility update path는 private storage entitlement guard를 호출합니다.
+- public read path는 parent tree visibility guard를 유지합니다.
+- Editor visibility toggle은 public/private 전환 UI를 제공하지만, Plus-required 실패 UX와 i18n 문구는 별도 점검이 필요합니다.
 - Settings의 private storage 문구는 정책/결제 구현 상태에 따라 별도 조정이 필요합니다.
+
+정책/계약으로 아직 독단 확정하지 않을 항목:
+
+- Plus-required HTTP status: `403` vs `402`
+- final error body shape
+- frontend toast/i18n mapping
+- compatibility entitlement fields의 장기 지원 여부
+- grandfathered private 세부 UX
+- Settings/결제 UX
+- Browse/Search threshold의 장기 정책화 여부
 
 정책 전환은 다음을 함께 맞춘 뒤 진행합니다.
 
@@ -303,13 +315,13 @@ Policy: Parent tree visibility remains an anonymous public read guard.
 
 ## 10. Prohibited implementation shortcuts
 
-- createTree payload만 단독으로 `public`으로 바꾸지 않습니다.
 - frontend-only lock으로 Plus private enforcement 완료를 선언하지 않습니다.
 - backend guard 없이 private storage를 UI에서만 제한하지 않습니다.
 - `publicMomentCount >= 3`을 visibility publication guard로 재사용하지 않습니다.
 - `memory.visibility = public`만으로 anonymous public read를 허용하지 않습니다.
 - public memory가 존재한다는 이유만으로 private parent tree를 Browse/Search, community memories list, public memory detail에 노출하지 않습니다.
 - 기존 private tree를 자동 public 전환하지 않습니다.
+- Plus-required HTTP status/body shape를 독단 확정하지 않습니다.
 - 결제/권한 로직 확정 전 Plus private을 과도하게 홍보하지 않습니다.
 
 ---
@@ -328,8 +340,9 @@ Policy: Parent tree visibility remains an anonymous public read guard.
 
 ### Backend / runtime
 
-- create tree default visibility policy 반영
-- private storage entitlement guard
+- Plus-required error status/body contract 고정
+- compatibility entitlement fields의 장기 지원 여부 결정
+- grandfathered private 세부 UX와 backend 예외 처리 정리
 - memory visibility inheritance 처리
 - explicit memory visibility override policy guard
 - anonymous public read path에서 parent tree visibility guard 적용
@@ -352,16 +365,21 @@ Policy: Parent tree visibility remains an anonymous public read guard.
 
 이 문서는 canonical policy를 고정합니다.
 
-현재 main 코드가 이미 다음을 모두 구현했다는 뜻은 아닙니다.
+현재 main 코드는 다음 runtime 상태를 반영합니다.
 
-- 신규 tree public default
-- Plus private storage guard
-- memory visibility inheritance
-- explicit memory visibility override guard
-- stored memory visibility vs anonymous public exposure 분리
-- community memories list parent visibility guard
-- public memory detail read parent visibility guard
-- Browse/Search `publicMomentCount >= 3` eligibility
-- private parent tree + public child memory browse guard
+- My Trees 생성 payload는 `visibility: public`을 명시함
+- Modal create tree path는 visibility 생략 시 `public`을 기본값으로 사용함
+- Modal private tree/memory create 및 private visibility update path는 private storage entitlement guard를 호출함
+- public read path는 parent tree visibility guard를 유지함
+- public visibility와 Browse/Search 자동 노출은 별개임
 
-실제 구현은 별도 PR에서 진행합니다.
+현재 main 코드가 이미 다음을 모두 최종 계약으로 확정했다는 뜻은 아닙니다.
+
+- Plus-required HTTP status/body shape
+- frontend toast/i18n mapping
+- compatibility entitlement fields의 장기 지원 여부
+- grandfathered private 세부 UX
+- Settings/결제 UX
+- Browse/Search threshold의 장기 정책화 여부
+
+실제 구현 및 contract 확정은 별도 PR에서 진행합니다.


### PR DESCRIPTION
## Summary

Docs-only drift sync for the current Modal runtime state.

This PR updates runtime/product/API docs to reflect the current main behavior:

- My Trees create payload explicitly sends `visibility: public`.
- Modal create tree defaults omitted visibility to `public`.
- Modal private tree/memory create and private visibility update paths call the private storage entitlement guard.
- Public visibility remains separate from Browse/Search eligibility.
- Public read paths retain parent tree visibility guards.

## Changed docs

- `docs/ops/MODAL_BROWSE_RUNTIME.md`
  - Replaces stale private-first / public 409 / no Plus entitlement language.
  - Describes current Modal as public-first create + Plus private guard.
  - Keeps Browse/Search eligibility separate from public visibility.
  - Narrows remaining items to contract-needed decisions.

- `docs/engineering/API_CONTRACT.md`
  - Updates create tree runtime contract to match current Modal behavior.
  - Keeps canonical entitlement field as `users/{uid}.privateStorageEnabled`.
  - Documents compatibility fields as current implementation detail only.
  - Leaves Plus-required HTTP status/body shape as contract-needed.

- `docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
  - Keeps canonical policy unchanged.
  - Updates Current implementation note and Application status only.
  - Lists unresolved UX/contract decisions explicitly.

## Current runtime state reflected

- `visibility: public` is sent by My Trees create flow.
- Modal create tree default is public when visibility is omitted.
- Private tree/memory create and private visibility update paths call entitlement guard.
- Public visibility does not mean automatic Browse/Search introduction.
- Parent tree visibility remains a public read guard.

## Explicit non-goals

- No code changes.
- No Modal, Cloudflare Functions, JS, CSS, pages, Netlify, DB schema, or runtime changes.
- No PR #7 / prototype / reference / demo / variant changes.
- Does not finalize Plus-required HTTP status (`403` vs `402`).
- Does not finalize Plus-required error body shape.
- Does not finalize frontend toast/i18n mapping.
- Does not finalize compatibility entitlement fields as long-term contract.
- Does not finalize grandfathered private UX.
- Does not finalize Settings/payment UX.
- Does not make Browse/Search threshold a long-term product contract.

## Validation

- Confirmed branch is based on latest main SHA `85dfa41521603abc833a37a51692a036acffb41f`.
- Confirmed diff is docs-only and limited to the allowed three files.
- Confirmed branch is ahead of main by 3 commits and behind by 0.
- Confirmed stale current-state phrasing was replaced in target docs.
- Markdown lint was not run because no repository-local shell execution was available in this web/API executor environment.
- `git diff --check` was not run locally for the same reason; changes were made through GitHub file updates only.