### PR TITLE
refactor(modal): extract config env helpers

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -20,6 +20,9 @@ from fastapi.responses import JSONResponse
 from psycopg_pool import ConnectionPool
 from psycopg.rows import dict_row
 
+from modal_compute.config import _allowed_origins as _config_allowed_origins
+from modal_compute.config import get_firebase_project_id
+
 # --- DB Logic (formerly browse_latest.py) ---
 
 _firebase_cert_cache: dict[str, Any] = {"expires_at": 0, "certs": {}}
@@ -142,10 +145,6 @@ def user_has_plus_entitlement(uid: str) -> bool:
 def require_plus_for_private_storage(uid: str, visibility: str) -> None:
     if visibility == "private" and not user_has_plus_entitlement(uid):
         raise PlusRequiredError()
-
-
-def get_firebase_project_id() -> str:
-    return os.getenv("FIREBASE_PROJECT_ID", "relovetree")
 
 
 def get_firebase_certs() -> dict[str, str]:
@@ -907,6 +906,10 @@ def delete_owner_memory(owner_id: str, memory_id: str) -> dict[str, Any]:
     return {"deleted": True, "id": str(row["id"])}
 
 
+def _allowed_origins() -> list[str]:
+    return _config_allowed_origins()
+
+
 # --- Modal App Setup ---
 
 app = modal.App("lovebud-browse-snapshot")
@@ -937,14 +940,6 @@ async def plus_required_exception_handler(request: Request, exc: PlusRequiredErr
             "upgradeRequired": True,
         },
     )
-
-
-def _allowed_origins() -> list[str]:
-    raw = os.getenv(
-        "CORS_ALLOWED_ORIGINS",
-        "https://lovebud.vercel.app,https://lovebud.pages.dev,https://lovebud.netlify.app",
-    )
-    return [value.strip() for value in raw.split(",") if value.strip()]
 
 
 web_app.add_middleware(

--- a/modal_compute/config.py
+++ b/modal_compute/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+
+def get_firebase_project_id() -> str:
+    return os.getenv("FIREBASE_PROJECT_ID", "relovetree")
+
+
+def _allowed_origins() -> list[str]:
+    raw = os.getenv(
+        "CORS_ALLOWED_ORIGINS",
+        "https://lovebud.vercel.app,https://lovebud.pages.dev,https://lovebud.netlify.app",
+    )
+    return [value.strip() for value in raw.split(",") if value.strip()]


### PR DESCRIPTION
## Summary
- Extract Modal config/env helper implementation into `modal_compute/config.py`.
- Keep `modal_compute/app.py` importing the config helpers and using the existing helper names at call sites.
- Preserve env names, defaults, CORS origin parsing, route paths, SQL, auth, entitlement, and response shapes.

## Changed files
- modal_compute/app.py
- modal_compute/config.py

## Functions moved
- `get_firebase_project_id()`
- `_allowed_origins()` env/default parsing implementation

## Behavior-preserving notes
- `FIREBASE_PROJECT_ID` default remains `relovetree`.
- `CORS_ALLOWED_ORIGINS` default remains `https://lovebud.vercel.app,https://lovebud.pages.dev,https://lovebud.netlify.app`.
- Origin splitting/trim/filter behavior is unchanged.
- `_allowed_origins()` remains available in `app.py` as a delegating wrapper so existing static ownership contract parsing remains stable.

## Validation results
- `python -m py_compile modal_compute/app.py modal_compute/config.py`: PASS
- `npm test`: PASS
- `git diff --check`: PASS
- `git diff --name-status origin/main...HEAD`: only `modal_compute/app.py`, `modal_compute/config.py`

## Explicit non-goals
- No SQL condition changes.
- No route/path changes.
- No response shape changes.
- No auth, entitlement, visibility, or public-first policy changes.
- No DB migration or provider setting changes.
- No JS, pages, CSS, docs, tests, functions, netlify, or prototype/reference/demo/variant changes.

## Browser verification
- Not required. This is a backend pure extraction of env/config helper logic with no browser-facing UI/runtime route behavior change.