### PR TITLE
docs(css): document stylesheet import hubs and visual verification

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -114,6 +114,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - **index**: [engineering_index.md](./engineering/engineering_index.md)
 - [API_CONTRACT.md](./engineering/API_CONTRACT.md) - flat camelCase API 계약
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
+- [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙

--- a/docs/engineering/CSS_ARCHITECTURE.md
+++ b/docs/engineering/CSS_ARCHITECTURE.md
@@ -1,0 +1,103 @@
+# CSS Architecture
+
+This document records the current stylesheet entry points and verification expectations after the CSS split work in PR #181 and PR #182.
+
+This is an architecture/verification reference only. It does not introduce new CSS behavior.
+
+---
+
+## 1. Global stylesheet import hub
+
+`css/global.css` is the global stylesheet import hub.
+
+Current import order:
+
+1. `css/global/tokens.css`
+2. `css/global/base.css`
+3. `css/global/header.css`
+
+Do not reorder these imports without explicit review and browser visual verification.
+
+`tokens.css` must load before files that consume CSS variables. `base.css` depends on the global token layer. `header.css` consumes shared tokens and owns shared header-related surfaces.
+
+---
+
+## 2. Shared header stylesheet
+
+`css/global/header.css` owns shared header, navigation, authentication, language, and mobile header styles.
+
+Current ownership includes:
+
+- `.nav-bar`
+- `.nav-links`
+- `.main-nav`
+- `.main-nav-panel`
+- `.nav-actions`
+- language dropdown styles
+- auth/user dropdown styles
+- mobile nav controls
+- header-scoped Material Symbols FOUC guard
+- `#shared-header` CLS reserve rules
+
+Changes to `css/global/header.css` can affect every page that renders the shared header. Treat these changes as shared-surface changes, not as page-local polish.
+
+---
+
+## 3. My Trees page stylesheet import hub
+
+`css/my-trees.css` is the page-specific stylesheet import hub for `pages/my-trees.html`.
+
+Current import order:
+
+1. `css/my-trees/layout.css`
+2. `css/my-trees/header.css`
+3. `css/my-trees/cards.css`
+4. `css/my-trees/states.css`
+5. `css/my-trees/create-modal.css`
+6. `css/my-trees/responsive.css`
+
+Do not move My Trees page-specific rules into `css/global.css` unless the selector is intentionally shared across pages and the change is reviewed as a global style change.
+
+---
+
+## 4. My Trees split ownership
+
+The current My Trees split is role-based:
+
+| File | Ownership |
+|------|-----------|
+| `css/my-trees/layout.css` | page layout shell and content container |
+| `css/my-trees/header.css` | My Trees page header, sort control, create button |
+| `css/my-trees/cards.css` | tree grid, tree cards, card menu/dropdown |
+| `css/my-trees/states.css` | empty/error states and create entry icon |
+| `css/my-trees/create-modal.css` | create-tree modal, fields, goal card, modal actions |
+| `css/my-trees/responsive.css` | My Trees responsive overrides |
+
+Keep responsive overrides in `responsive.css` unless a rule must live next to a base rule for clarity and the split decision is documented in the PR.
+
+---
+
+## 5. Review and verification expectations
+
+For CSS import hub or split changes, review should include:
+
+- changed files are limited to the intended stylesheet/docs scope;
+- import order is preserved unless the PR explicitly explains the dependency change;
+- Network check confirms imported CSS files do not return 404;
+- shared header smoke is performed when `css/global/header.css` changes;
+- page-specific smoke is performed when a page stylesheet hub changes.
+
+Visual verification must follow `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`. Do not report a visual PASS from an invented preview URL.
+
+---
+
+## 6. Non-goals
+
+This document does not authorize:
+
+- CSS code changes;
+- `css/global.css` import order changes;
+- `css/my-trees.css` import order changes;
+- header/nav/auth/language/mobile CSS relocation;
+- page cache-bust changes;
+- prototype/reference/demo/variant cleanup or movement.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -19,8 +19,9 @@
 
 1. [API_CONTRACT.md](./API_CONTRACT.md) - API 응답 계약 (flat camelCase)
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
-3. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-4. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+3. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+4. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+5. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -30,6 +31,7 @@
 |------|------|
 | [API_CONTRACT.md](./API_CONTRACT.md) | 프론트와 API가 따르는 flat camelCase 계약 |
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
+| [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지와 리뷰 규칙 |
 | [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 내역 |
@@ -49,6 +51,7 @@
 - 엔지니어링 문서는 현재 계약, 구조, 분리 기준, 전환 원칙을 설명하는 용도로 사용합니다.
 - 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
+- CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 
 ---
 

--- a/docs/ops/BROWSER_VERIFICATION_URL_POLICY.md
+++ b/docs/ops/BROWSER_VERIFICATION_URL_POLICY.md
@@ -150,6 +150,31 @@ production: https://lovebud.pages.dev/
 
 Production에서 직접 검증할 때도 변경 PR과 production 배포 상태를 혼동하지 않도록 보고해야 합니다.
 
+### 5.4 CSS split / stylesheet import verification
+
+CSS split, stylesheet import hub, or shared stylesheet changes are visual verification tasks and must still follow the URL provenance rules in this document.
+
+For CSS split PRs, browser verification should include:
+
+```text
+- Network check: no CSS import returns 404.
+- global styles 변경 시 css/global.css import order 보존 확인.
+- css/global/header.css 변경 시 shared header smoke:
+  - desktop header
+  - mobile nav toggle
+  - language dropdown
+  - auth/user dropdown visual state where applicable
+- page stylesheet hub 변경 시 page-specific smoke:
+  - css/my-trees.css 변경 시 /pages/my-trees.html desktop/mobile layout 확인
+- invented preview URL로 visual PASS 보고 금지.
+```
+
+Notes:
+
+- `css/global.css` is the global import hub. Its import order is documented in `../engineering/CSS_ARCHITECTURE.md`.
+- `css/my-trees.css` is a page-specific import hub. A change there requires My Trees page smoke rather than unrelated page smoke.
+- If no CTO-provided URL or confirmed current PR Preview URL is available, report browser verification as `not run` or `BLOCKED`, not PASS.
+
 ---
 
 ## 6. 필수 보고 형식


### PR DESCRIPTION
## Summary

Docs-only update for stylesheet architecture and browser verification guidance.

## Changed files

- docs/engineering/CSS_ARCHITECTURE.md
- docs/doc_index.md
- docs/engineering/engineering_index.md
- docs/ops/BROWSER_VERIFICATION_URL_POLICY.md

## Validation

- Base SHA: ca3aec6ee39db0ce77392695473ae7193f2140e2
- GitHub compare: ahead by 4, behind by 0
- Changed files are limited to the allowed docs files
- No code, CSS, JS, page, runtime, test, README, or ops index changes

## Non-goals

- No code changes
- No import order changes
- No browser visual PASS claimed
- No prototype/reference/demo/variant changes