### PR TITLE
docs(architecture): add modular thin entrypoint policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,25 @@ LoveBud / LoveTree는 다음과 같은 서비스가 아닙니다.
 - 요청 범위 밖 파일 수정 금지
 - 코드 로직 변경이 필요하면 관련 문서 기준과 충돌하지 않는지 먼저 확인
 
+### Module size / thin entrypoint policy
+
+LoveBud 신규 코드 작업은 `docs/engineering/CODE_ARCHITECTURE.md`를 따릅니다.
+
+핵심 원칙:
+- 신규 파일은 가능한 한 500줄 이하로 유지합니다.
+- 500줄을 넘을 가능성이 있는 기능은 설계 단계부터 모듈 분리합니다.
+- entry file은 thin entrypoint / orchestration shell로 유지합니다.
+- 실제 로직은 feature별 helper/module 파일로 분리합니다.
+- 한 파일에 UI, API, state, cache, validation, rendering, auth, fallback 책임을 누적하지 않습니다.
+- reusable logic은 focused helper module로 이동합니다.
+- 기존 프로젝트 loading model을 보존합니다.
+- ES module `import/export` 또는 `type="module"` 전환은 명시 승인 없이는 하지 않습니다.
+- 현재 HTML script 기반 구조에서는 browser-global module split 방식을 우선 사용합니다.
+
+표준 문구:
+
+> Do not grow a single file into a large fallback bundle. Keep entrypoint files thin: orchestration only. Move reusable logic into focused helper modules. Preserve the current project loading model; do not convert to `type="module"` unless the task explicitly authorizes it.
+
 ### 파일 크기 / 분리 기준
 
 LoveBud는 여러 에이전트가 동시에 검토하고 작업할 수 있도록 작고 검토 가능한 파일을 지향합니다.

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -115,6 +115,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [API_CONTRACT.md](./engineering/API_CONTRACT.md) - flat camelCase API 계약
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
+- [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙

--- a/docs/engineering/CODE_ARCHITECTURE.md
+++ b/docs/engineering/CODE_ARCHITECTURE.md
@@ -1,0 +1,246 @@
+# Code Architecture
+
+This document defines LoveBud's default code architecture policy for new work and safe refactoring.
+
+LoveBud still contains HTML script loading and browser-global module patterns. Do not assume that ES module `import/export` or `type="module"` conversion is safe by default.
+
+---
+
+## 1. Module Size and Thin Entrypoint Policy
+
+New files should stay small, focused, and reviewable.
+
+Guidelines:
+
+- Keep new files at or below 500 lines whenever practical.
+- If a feature is likely to exceed 500 lines, split it during the design phase.
+- Do not wait until a file becomes a large monolith before extracting helpers.
+- Entry files should remain thin entrypoints or orchestration layers.
+- Actual logic should live in feature-specific helper/module files.
+- Do not accumulate UI, API, state, cache, validation, rendering, auth, fallback, and compatibility responsibilities in one file.
+
+Standard policy wording:
+
+> Do not grow a single file into a large fallback bundle. Keep entrypoint files thin: orchestration only. Move reusable logic into focused helper modules. Preserve the current project loading model; do not convert to `type="module"` unless the task explicitly authorizes it.
+
+---
+
+## 2. Modularization and Separation of Concerns
+
+Separation of concerns is the default design principle.
+
+A file should have one clear primary responsibility. Avoid mixing these responsibilities in one file:
+
+- UI rendering
+- API transport
+- normalization
+- state management
+- cache/session handling
+- validation
+- auth/bootstrap logic
+- fallback compatibility
+- DOM event delegation
+- route/runtime orchestration
+
+Reusable logic should move into focused helper modules.
+
+Current repository examples:
+
+- `js/auth/auth-ui.js` owns auth UI builders and dropdown behavior.
+- `js/auth/auth-session.js` owns auth session helpers.
+- `js/auth/auth-cache.js` owns auth cache helpers.
+- `js/auth/auth-firebase.js` owns Firebase auth integration and protected-route fallback behavior.
+- `js/api/public-tree-adapter.js` owns public tree/memory adapter and compatibility normalization for browse paths.
+
+Illustrative example only:
+
+```text
+Preferred split for a growing feature:
+- feature-state.js
+- feature-api.js
+- feature-renderer.js
+- feature-validation.js
+- feature-entry.js as orchestration only
+
+Avoid:
+- one file that handles API calls, rendering, state, validation, fallback, auth, and UI events together
+```
+
+---
+
+## 3. Browser-Global Module Split Policy
+
+LoveBud currently uses HTML script loading and browser-global module patterns in several areas.
+
+Therefore, modularization does not automatically mean ES module conversion.
+
+Default split approach:
+
+- keep the existing HTML script loading model;
+- split code into focused files that attach explicit browser globals where needed;
+- preserve script order;
+- preserve existing public global APIs;
+- preserve auth bootstrap behavior;
+- preserve shared-header initialization behavior;
+- preserve Firebase initialization behavior.
+
+Do not convert scripts to ES modules unless the task explicitly authorizes it.
+
+Prohibited unless explicitly approved:
+
+```html
+<script type="module" src="..."></script>
+```
+
+```js
+import { something } from './module.js';
+export function something() {}
+```
+
+Reason:
+
+`type="module"` changes script execution timing, scope, loading order, and global availability. In LoveBud this can affect:
+
+- script order;
+- global API availability;
+- auth bootstrap;
+- shared-header rendering;
+- Firebase initialization;
+- fallback compatibility paths.
+
+---
+
+## 4. Entrypoint and Shell Policy
+
+Root files and page entry files should not become large fallback bundles.
+
+Preferred roles:
+
+| File type | Preferred role |
+|-----------|----------------|
+| page entry script | orchestration shell |
+| root compatibility file | compatibility shell |
+| feature helper file | focused logic owner |
+| renderer file | DOM rendering only |
+| API file | API transport / response handling only |
+| state file | state transitions only |
+| validation file | validation only |
+
+A root file may coordinate modules, preserve compatibility globals, or expose a stable facade. It should not accumulate all feature logic.
+
+Current repository example:
+
+- `js/auth.js` should be managed as a compatibility/orchestration shell.
+- `js/auth/auth-ui.js`, `js/auth/auth-session.js`, `js/auth/auth-cache.js`, and `js/auth/auth-firebase.js` should continue to own focused auth responsibilities.
+
+Avoid growing root files into large fallback bundles that contain UI, auth, state, cache, rendering, route guard, Firebase bootstrap, and compatibility logic together.
+
+---
+
+## 5. Large File Refactor Safety Sequence
+
+Do not turn a large existing file into a thin shell in one broad PR.
+
+Use a staged safety sequence:
+
+1. Add or identify contract tests, route tests, or runtime tests.
+2. Extract focused helper modules without changing behavior.
+3. Sync page script order or loading order.
+4. Keep compatibility globals stable.
+5. Verify browser/runtime behavior.
+6. Shrink fallback/root shell only after helper behavior is proven.
+7. Remove obsolete fallback logic in a separate PR when safe.
+
+Recommended sequence:
+
+```text
+contract test
+→ helper extraction
+→ page/script order sync
+→ browser/runtime verification
+→ fallback shrink
+```
+
+Do not combine broad extraction, behavior changes, module-system conversion, and UI polish in one PR.
+
+---
+
+## 6. Area-Specific Notes
+
+### Auth
+
+Auth code is especially sensitive.
+
+Auth changes can affect:
+
+- Firebase initialization;
+- session/cache handling;
+- protected route behavior;
+- shared header auth state;
+- dropdown UI;
+- login/logout behavior;
+- fallback compatibility.
+
+New auth work should start with thin entrypoints and focused helpers. Do not grow `js/auth.js` into a large fallback bundle.
+
+### Search / Browse
+
+Search/Browse code should keep separate:
+
+- API fetching;
+- adapter/normalization;
+- rendering;
+- preview hydration;
+- state;
+- filters;
+- UI events.
+
+Do not mix display filters and publication/write guards.
+
+### Editor
+
+Editor code should keep separate:
+
+- rendering;
+- state;
+- persistence;
+- validation;
+- autosave/cache;
+- UI events;
+- API calls.
+
+### Modal / API
+
+Modal/API refactors should keep route behavior, response shape, auth, entitlement, SQL conditions, and runtime environment behavior stable unless the task explicitly authorizes changes.
+
+---
+
+## 7. Review Checklist
+
+For new code or refactor PRs, check:
+
+- Is any new file likely to exceed 500 lines?
+- If yes, was it split during design rather than after becoming a monolith?
+- Is the entry file thin?
+- Are reusable helpers in focused modules?
+- Are unrelated responsibilities mixed in one file?
+- Does the PR preserve the current loading model?
+- Does the PR avoid unauthorized `type="module"` conversion?
+- Does the PR avoid broad fallback bundle growth?
+- If refactoring a large file, are contract tests, route tests, or runtime tests in place first?
+- Are script order and browser globals preserved?
+
+---
+
+## 8. Non-Goals
+
+This policy does not require:
+
+- immediate refactoring of all existing large files;
+- converting the project to a bundler;
+- converting scripts to ES modules;
+- deleting compatibility shells;
+- shrinking fallback files without tests;
+- splitting files mechanically just to reduce line count.
+
+The goal is to prevent new large monoliths and to make future refactors safe, staged, and reviewable.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -19,9 +19,10 @@
 
 1. [API_CONTRACT.md](./API_CONTRACT.md) - API 응답 계약 (flat camelCase)
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
-3. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-4. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-5. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
+4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+5. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+6. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -31,6 +32,7 @@
 |------|------|
 | [API_CONTRACT.md](./API_CONTRACT.md) | 프론트와 API가 따르는 flat camelCase 계약 |
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
+| [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 순서 |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지와 리뷰 규칙 |
@@ -51,6 +53,7 @@
 - 엔지니어링 문서는 현재 계약, 구조, 분리 기준, 전환 원칙을 설명하는 용도로 사용합니다.
 - 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
+- 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 
 ---


### PR DESCRIPTION
## Summary

Docs-only update that adds LoveBud's modular code architecture and thin entrypoint policy.

## Changed files

- `docs/engineering/CODE_ARCHITECTURE.md`
- `docs/doc_index.md`
- `docs/engineering/engineering_index.md`
- `AGENTS.md`

## Policy sections added

- Module Size and Thin Entrypoint Policy
- Modularization and Separation of Concerns
- Browser-Global Module Split Policy
- Entrypoint and Shell Policy
- Large File Refactor Safety Sequence
- Area-Specific Notes
- Review Checklist
- Non-Goals

## AGENTS.md update summary

- Adds a short Module size / thin entrypoint policy section.
- References `docs/engineering/CODE_ARCHITECTURE.md` as the source of truth.
- Keeps existing HTML/CSS file size guidance.
- Includes the standard policy wording.

## Validation results

- Base SHA confirmed: `9ebf23db8798ca9437a95b0bf3bb93af24650a13`.
- GitHub compare shows the branch is ahead by 4 and behind by 0.
- Changed files are limited to the allowed docs-only set.
- No code, CSS, JS, test, runtime, API, Modal, Cloudflare, Netlify, README, or docs/ops changes.
- Markdown lint and `git diff --check` were not run because this Web executor environment has no repository-local shell.

## Explicit non-goals

- No code changes.
- No CSS/JS/test/runtime changes.
- No ES module conversion.
- No `type="module"` conversion.
- No broad refactor.
- No PR #7 or prototype/reference/demo/variant changes.