### PR TITLE
docs(ops): sync ops_index and doc_index Netlify legacy expressions

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -2,11 +2,13 @@
 
 이 문서는 LoveBud 프로젝트의 문서 구조와 읽기 순서를 정리한 최상위 인덱스입니다.
 
-실서비스 프론트 주소는 `https://lovebud.pages.dev/` 이며, 현재 운영 기준 인프라 우선순위는 **Modal > Cloudflare Pages > Vercel > Netlify** 입니다.
+실서비스 프론트 주소는 `https://lovebud.pages.dev/` 이며, 현재 운영 기준 인프라 우선순위는 **Cloudflare Pages Entry + Modal Runtime > Vercel > Netlify** 입니다.
 
 중요:
 - 브라우저는 가능하면 **same-origin `/api`** 만 사용합니다.
 - 공식 사용자-facing 주소는 `pages.dev` 기준으로 설명합니다.
+- active runtime entry: Cloudflare Pages (same-origin `/api/*` router + 정적 프런트)
+- active backend target: Modal (browse summary, private/community read/write compute)
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
 - Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 제품/브랜드/UI 판단의 source of truth 입니다.
@@ -59,6 +61,7 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 운영/배포 판단이 필요하면 아래를 추가로 읽습니다.
 
 - `./ops/OPERATIONS.md`
+- `./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`
 - `./ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
 - `./ops/BROWSER_VERIFICATION_URL_POLICY.md`
 - `./ops/KNOWN_CI_E2E_BLOCKERS.md`
@@ -133,6 +136,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 
 - **index**: [ops_index.md](./ops/ops_index.md)
 - [OPERATIONS.md](./ops/OPERATIONS.md) - 현재 운영 전략 및 인프라 우선순위
+- [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md) - Netlify legacy artifact / removal candidate 감사 기준 및 현황. `netlify/functions/*`, `netlify.toml` removal audit 진행 상태
 - [PARALLEL_WORKTREE_AGENT_POLICY.md](./ops/PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준
 - [BROWSER_VERIFICATION_URL_POLICY.md](./ops/BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준
 - [DEPLOY_CHECKLIST.md](./ops/DEPLOY_CHECKLIST.md) - 배포 체크리스트

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -5,8 +5,10 @@
 현재 운영 기준은 아래와 같습니다.
 
 - 실서비스 프론트: `https://lovebud.pages.dev/`
-- 인프라 우선순위: **Modal > Cloudflare Pages > Vercel > Netlify**
+- 인프라 우선순위: **Cloudflare Pages Entry + Modal Runtime > Vercel > Netlify**
 - 브라우저 호출 원칙: 가능하면 **same-origin `/api`** 만 사용
+- active runtime entry: **Cloudflare Pages** (same-origin `/api/*` router + 정적 프런트)
+- active backend target: **Modal** (browse summary, private/community read/write compute)
 - Vercel은 upstream / secondary / transitional 계층
 - Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
 
@@ -64,6 +66,12 @@
 | [ENV_DEPENDENCY.md](ENV_DEPENDENCY.md) | 환경 변수 의존성 |
 | [FILE_BASELINE.md](FILE_BASELINE.md) | 파일 분류 기준 |
 | [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 구분 |
+
+## Netlify Legacy Artifact 감사
+
+| 파일명 | 설명 |
+|--------|------|
+| [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](NETLIFY_LEGACY_ARTIFACT_AUDIT.md) | Netlify legacy artifact / removal candidate 감사 기준 및 현황. `netlify/functions/*`, `netlify.toml`의 removal audit 진행 상태와 보존/제거 판단 기준 |
 
 ## 문서 / 스킬 운영
 


### PR DESCRIPTION
## 작업 목표

`ops_index.md`와 `doc_index.md`에서 Netlify 표현 정합성 및 누락 링크를 최소 수정합니다.

## 변경 파일

- `docs/ops/ops_index.md`
- `docs/doc_index.md`

## 변경 내용 요약

### docs/ops/ops_index.md

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 인프라 우선순위 표현 | `Modal > Cloudflare Pages > Vercel > Netlify` | `Cloudflare Pages Entry + Modal Runtime > Vercel > Netlify` |
| active runtime / backend 구분 | 명시 없음 | `active runtime entry: Cloudflare Pages` / `active backend target: Modal` 추가 |
| NETLIFY_LEGACY_ARTIFACT_AUDIT.md | 파일 목록 테이블에 없음 | **Netlify Legacy Artifact 감사** 섹션 신설 후 항목 추가 |

### docs/doc_index.md

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 인프라 우선순위 표현 | `Modal > Cloudflare Pages > Vercel > Netlify` | `Cloudflare Pages Entry + Modal Runtime > Vercel > Netlify` |
| active runtime / backend 구분 | 명시 없음 | `active runtime entry: Cloudflare Pages` / `active backend target: Modal` 추가 |
| NETLIFY_LEGACY_ARTIFACT_AUDIT.md (ops 운영/배포 판단 섹션) | 링크 없음 | `./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md` 링크 추가 |
| NETLIFY_LEGACY_ARTIFACT_AUDIT.md (ops 문서군 목록) | 항목 없음 | 설명 포함 항목 추가 |

## 수정하지 않은 파일

- `docs/ops/OPERATIONS.md` — 이미 canonical 표현 정확함
- `docs/ops/DEPLOYED_ENTRY_MAP.md` — 이미 정확함
- `docs/engineering/engineering_index.md` — 이미 정확함
- `README.md` — 이미 정확함, 수정 불필요
- `functions/api/*`, `modal_compute/*`, `netlify/*`, `pages/*`, `js/*`, `css/*` — 수정 금지 파일

## 검증

- `git diff --name-only origin/main...HEAD`: `docs/ops/ops_index.md`, `docs/doc_index.md` 2개만 변경
- `git diff --check`: whitespace 오류 없음
- Netlify active fallback 신규 표현 없음 (기존 `legacy artifact / removal candidate / active production fallback이 아님` 표현 유지)
- `README.md`, `OPERATIONS.md`, `DEPLOYED_ENTRY_MAP.md`, `engineering_index.md` 변경 없음

## 관련 기준 문서

- `docs/ops/OPERATIONS.md` — Netlify canonical 계층 정의 source of truth
- `docs/ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md` — removal audit 기준

---

Docs-only change. No runtime code changes.