### PR TITLE
fix(search): harden thumbnail fallback guards

### DIFF
--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -49,6 +49,8 @@
 
     function showImageFallback(img) {
         if (!img) return;
+        if (img.dataset.fallbackTriggered) return;
+        img.dataset.fallbackTriggered = 'true';
         img.style.display = 'none';
         const fallback = img.nextElementSibling;
         if (fallback) {

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -372,6 +372,8 @@
 
     function showPreviewImageFallback(img) {
         if (!img) return;
+        if (img.dataset.fallbackTriggered) return;
+        img.dataset.fallbackTriggered = 'true';
         img.style.display = 'none';
         const wrapper = img.parentElement;
         if (!wrapper) return;


### PR DESCRIPTION
## Summary

Search card / preview thumbnail fallback에 data-fallback-triggered guard를 추가하여 중복 fallback 호출로 인해 overlay가 남는 문제를 방지합니다.

- showImageFallback() guard 추가 (js/search-card-renderer.js)
- showPreviewImageFallback() guard 추가 (js/search-preview-renderer.js)
- preview fallback 함수 노출 확인 (window.LoveBudSearchPreviewRenderer)
- 기존 preview renderer 흐름 유지 (updatePreview / iframe / sourceUrl / no-memory 경로 변경 없음)

## Changed files

- js/search-card-renderer.js
- js/search-preview-renderer.js

## Scope

- ✅ No API/data schema changes
- ✅ No auth/login/shared-header changes
- ✅ No search/browse logic changes
- ✅ No preview renderer rewrite
- ✅ No empty/error polish changes
- ✅ No CSS changes (inline style guard only)
- ✅ No URL state changes

## Validation

- git diff --check: **PASS** (no whitespace issues)
- 
pm test: **81/81 PASS** (no failures)
- Local browser smoke (http://localhost:8888/pages/search.html): **PASS**
  - console fatal error 없음
  - Search 모듈 정상 로드
  - LoveBudSearchCardRenderer exposed
  - LoveBudSearchPreviewRenderer exposed
  - showImageFallback / showPreviewImageFallback exposed

## Remaining verification

- **Cloudflare PR Preview**에서 thumbnail 404 / suspicious YouTube 120×90 fallback visual 확인 필요
- local static server에서는 API routes 미동작으로 실제 thumbnail fallback visual 확인 불가

## Base & Head

- Base: origin/main (411c3bb0d72f331ff532cf429e4b20cc7c4ebe76)
- Head: ix/search-thumbnail-fallback-v3 (4c3ae13...)