### PR TITLE
refactor(auth): delegate login page helpers to auth-login-page module

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -120,7 +120,37 @@ function resolveEmailAuthMode() {
   }
 }
 
+function getLoginPageModule() {
+  return window.LoveBudAuthLoginPage || null;
+}
+
+function callLoginPageModule(methodName, args) {
+  var loginPageModule = getLoginPageModule();
+  if (!loginPageModule || typeof loginPageModule[methodName] !== 'function') {
+    return false;
+  }
+  loginPageModule[methodName].apply(loginPageModule, args || []);
+  return true;
+}
+
+function setEmailAuthMode(emailAuthMode) {
+  EMAIL_AUTH_MODE = emailAuthMode === 'signup' ? 'signup' : 'login';
+  if (__authStateModule) __authStateModule.setEmailAuthMode(EMAIL_AUTH_MODE);
+}
+
 function syncEmailAuthModeUi(options) {
+  if (callLoginPageModule('syncEmailAuthModeUi', [{
+    emailAuthMode: EMAIL_AUTH_MODE,
+    titleEl: options && options.titleEl,
+    helperEl: options && options.helperEl,
+    submitBtn: options && options.submitBtn,
+    toggleBtn: options && options.toggleBtn,
+    badgeEl: options && options.badgeEl,
+    applyI18n: window.applyI18n
+  }])) {
+    return;
+  }
+
   var titleEl = options && options.titleEl;
   var helperEl = options && options.helperEl;
   var submitBtn = options && options.submitBtn;
@@ -164,6 +194,15 @@ function syncEmailAuthModeUi(options) {
 }
 
 function setupLoginPageAuthUi() {
+  if (callLoginPageModule('setupLoginPageAuthUi', [{
+    isLoginPage: isLoginPage,
+    resolveEmailAuthMode: resolveEmailAuthMode,
+    setEmailAuthMode: setEmailAuthMode,
+    syncEmailAuthModeUi: syncEmailAuthModeUi
+  }])) {
+    return;
+  }
+
   if (!isLoginPage()) return;
 
   EMAIL_AUTH_MODE = resolveEmailAuthMode();
@@ -1054,6 +1093,12 @@ async function signOut() {
 // ── Google Btn (login.html) ───────────────────────────────────────────────────
 
 function setupGoogleBtn() {
+  if (callLoginPageModule('setupGoogleBtn', [{
+    signInWithGoogle: signInWithGoogle
+  }])) {
+    return;
+  }
+
   var googleBtn = document.getElementById('login-btn-google');
   if (!googleBtn) return;
   googleBtn.onclick = null;
@@ -1069,6 +1114,12 @@ async function signUpWithGoogle() {
 }
 
 function setupSignupGoogleBtn() {
+  if (callLoginPageModule('setupSignupGoogleBtn', [{
+    signUpWithGoogle: signUpWithGoogle
+  }])) {
+    return;
+  }
+
   var signupGoogleBtn = document.getElementById('signup-btn-google');
   if (!signupGoogleBtn) return;
   signupGoogleBtn.onclick = null;
@@ -1081,6 +1132,23 @@ function setupSignupGoogleBtn() {
 // ── Email Auth Form ───────────────────────────────────────────────────────────
 
 function setupEmailAuthForm() {
+  if (callLoginPageModule('setupEmailAuthForm', [{
+    firebase: typeof firebase !== 'undefined' ? firebase : undefined,
+    initFirebase: initFirebase,
+    getEnvironmentCheckError: getEnvironmentCheckError,
+    getFriendlyErrorMessage: getFriendlyErrorMessage,
+    getEmailAuthMode: function () { return EMAIL_AUTH_MODE; },
+    setEmailAuthMode: setEmailAuthMode,
+    syncEmailAuthModeUi: syncEmailAuthModeUi,
+    persistConfirmedAuthSession: persistConfirmedAuthSession,
+    preloadRedirectTargetData: preloadRedirectTargetData,
+    getRedirectTarget: getRedirectTarget,
+    isInvalidAuthSessionError: isInvalidAuthSessionError,
+    clearStaleFirebaseAuthState: clearStaleFirebaseAuthState
+  }])) {
+    return;
+  }
+
   var form = document.getElementById('email-auth-form');
   if (!form) return;
   if (typeof firebase === 'undefined' || !firebase.auth) return;
@@ -1216,6 +1284,18 @@ form.addEventListener('submit', async function (e) {
 }
 
 function setupSignupForm() {
+  if (callLoginPageModule('setupSignupForm', [{
+    firebase: typeof firebase !== 'undefined' ? firebase : undefined,
+    initFirebase: initFirebase,
+    getEnvironmentCheckError: getEnvironmentCheckError,
+    getFriendlyErrorMessage: getFriendlyErrorMessage,
+    persistConfirmedAuthSession: persistConfirmedAuthSession,
+    preloadRedirectTargetData: preloadRedirectTargetData,
+    getRedirectTarget: getRedirectTarget
+  }])) {
+    return;
+  }
+
   var signupForm = document.getElementById('signup-form');
   if (!signupForm) return;
   if (typeof firebase === 'undefined' || !firebase.auth) return;

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -69,10 +69,9 @@ const AUTH_MODULE_ORDER_WITH_LOGIN_PAGE = [
 ];
 
 // auth-login-page.js is loaded as a side-effect-free namespace helper;
-// auth.js delegation/shrink is intentionally out of scope.
+// root auth.js explicitly delegates login-page setup helpers when available.
 //
 // Non-goals for this contract change:
-// - No auth.js delegation
 // - No root auth.js shrink
 // - No login behavior change intended
 // - No duplicate listener behavior change
@@ -161,6 +160,29 @@ test('root auth bootstrap exposes compatibility window APIs and flags', () => {
 
   for (const contract of contracts) {
     assertIncludesAny(source, contract.label, contract.needles);
+  }
+});
+
+test('root auth delegates login page helpers through the auth-login-page namespace when available', () => {
+  const source = readRepoFile('js/auth.js');
+
+  assert.match(source, /window\.LoveBudAuthLoginPage/, 'root auth must reference the login page helper namespace');
+  assert.match(source, /function\s+getLoginPageModule\s*\(/, 'root auth must keep a thin login page module lookup helper');
+  assert.match(source, /function\s+callLoginPageModule\s*\(/, 'root auth must keep a thin login page module call helper');
+
+  for (const methodName of [
+    'syncEmailAuthModeUi',
+    'setupLoginPageAuthUi',
+    'setupGoogleBtn',
+    'setupEmailAuthForm',
+    'setupSignupForm',
+    'setupSignupGoogleBtn',
+  ]) {
+    assert.match(
+      source,
+      new RegExp(`callLoginPageModule\\(\\s*['"]${methodName}['"]`),
+      `root auth must delegate ${methodName} when LoveBudAuthLoginPage exposes it`
+    );
   }
 });
 


### PR DESCRIPTION
Summary:
- Delegates login-page setup helpers in root auth.js to window.LoveBudAuthLoginPage when available.
- Adds thin getLoginPageModule/callLoginPageModule adapters.
- Preserves existing auth.js fallback paths when the namespace or method is unavailable.
- Prevents duplicate listener setup by returning after successful delegation.
- Keeps browser-global auth contract unchanged.

Changed files:
- js/auth.js
- tests/contracts/auth-bootstrap-contract.test.js

Validation:
- git diff --check: PASS
- node --test tests/contracts/auth-bootstrap-contract.test.js: PASS, 9/9
- npm test: PASS, 82/82
- local browser smoke: PASS
  - /pages/login.html loaded
  - window.LoveBudAuthLoginPage loaded
  - existing window auth APIs present
  - module-only load produced no auto click listeners
  - Google button listener count: 1
  - email modal open/close works
  - email auth toggle works
  - signup form present
  - actual login/signup not performed

Scope:
- No pages/login.html change
- No auth-login-page.js change
- No shared-header change
- No Search/Docs/Backend changes
- No type=module conversion
- No login behavior change intended

Remaining verification:
- CTO/GitHub PR diff review
- Cloudflare Preview or fixed test slot login smoke if needed