### PR TITLE
polish(search): quiet empty and error states

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -5,3 +5,76 @@
 @import url("./search/tree-card.css");
 @import url("./search/preview-sidebar.css");
 @import url("./search/responsive.css");
+
+.search-empty-state {
+    grid-column: 1 / -1;
+    padding: clamp(44px, 6vw, 64px) 24px;
+    text-align: center;
+    color: var(--on-surface-variant);
+}
+
+.search-empty-icon,
+.search-error-icon {
+    display: block;
+    margin: 0 auto 16px;
+    font-size: 48px;
+    line-height: 1;
+    opacity: 0.42;
+}
+
+.search-empty-icon {
+    color: var(--primary);
+}
+
+.search-error-icon {
+    color: var(--on-surface-variant);
+}
+
+.search-empty-heading {
+    margin: 0 0 8px;
+    color: var(--on-surface);
+    font-size: 1.08rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.search-empty-body {
+    max-width: 420px;
+    margin: 0 auto;
+    color: var(--on-surface-variant);
+    font-size: 0.94rem;
+    line-height: 1.6;
+}
+
+.search-empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 22px;
+}
+
+@media (max-width: 420px) {
+    .search-empty-state {
+        padding: 36px 18px;
+    }
+
+    .search-empty-icon,
+    .search-error-icon {
+        margin-bottom: 14px;
+        font-size: 40px;
+    }
+
+    .search-empty-heading {
+        font-size: 1rem;
+    }
+
+    .search-empty-body {
+        font-size: 0.9rem;
+    }
+
+    .search-empty-actions {
+        gap: 8px;
+        margin-top: 18px;
+    }
+}

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -34,6 +34,36 @@
       en: 'Growing'
     },
 
+    // 빈 상태 / 오류 상태
+    'search.noTreesHeading': {
+      ko: '아직 공개된 러브트리가 없어요',
+      en: 'No public LoveTrees yet'
+    },
+    'search.noTreesBody': {
+      ko: '다른 팬이 공개한 러브트리가 생기면 이곳에서 만날 수 있어요.',
+      en: 'Public LoveTrees will appear here once someone shares one.'
+    },
+    'search.emptySearchHeading': {
+      ko: '조건에 맞는 트리가 없어요',
+      en: 'No matches found'
+    },
+    'search.emptySearchBody': {
+      ko: '다른 키워드나 필터로 다시 찾아보세요.',
+      en: 'Try a different keyword or filter.'
+    },
+    'search.errorHeading': {
+      ko: '불러오지 못했어요',
+      en: 'Could not load'
+    },
+    'search.errorBody': {
+      ko: '네트워크 상태를 확인하고 다시 시도해 주세요.',
+      en: 'Check your connection and try again.'
+    },
+    'search.retryButton': {
+      ko: '다시 시도',
+      en: 'Retry'
+    },
+
     // 미리보기
     'search.previewTitle': {
       ko: '감상 허브',

--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -211,36 +211,31 @@
      }
 
     function renderNoTreesState() {
-        const basePath = getBasePath();
+        const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
+        const isEnglish = String(locale).toLowerCase().startsWith('en');
+        const heading = window.i18nSearch?.['search.noTreesHeading']?.[isEnglish ? 'en' : 'ko'] || (isEnglish ? 'No public LoveTrees yet' : '아직 공개된 러브트리가 없어요');
+        const body = window.i18nSearch?.['search.noTreesBody']?.[isEnglish ? 'en' : 'ko'] || (isEnglish ? 'Public LoveTrees will appear here once someone shares one.' : '다른 팬이 공개한 러브트리가 생기면 이곳에서 만날 수 있어요.');
 
         return `
-            <div style="grid-column:1 / -1;text-align: center; padding: 60px 24px; color: var(--on-surface-variant);">
-                <span class="material-symbols-outlined" style="font-size: 56px; color: var(--primary); opacity: 0.6; margin-bottom: 20px; display: block;">public</span>
-                <p style="font-size: 1.25rem; font-weight: 800; margin-bottom: 12px; color: var(--on-surface);">아직 공개된 러브트리가 없어요</p>
-                <p style="font-size: 0.95rem; opacity: 0.8; margin-bottom: 24px; line-height: 1.6;">
-                    다른 팬이 공개한 러브트리가 생기면 이곳이 감상 허브가 됩니다.<br>
-                    지금은 첫 공개 러브트리를 기다리는 중이에요.
-                </p>
-                <div style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
-                    <a href="${basePath}my-trees.html" class="btn-round btn-primary" style="text-decoration: none; font-size: 14px; padding: 10px 20px;">
-                        <span class="material-symbols-outlined" style="font-size: 16px; vertical-align: middle; margin-right: 4px;">account_tree</span>
-                        내 러브트리 시작하기
-                    </a>
-                    <a href="${basePath}index.html" class="btn-round btn-outline" style="text-decoration: none; font-size: 14px; padding: 10px 20px;">
-                        <span class="material-symbols-outlined" style="font-size: 16px; vertical-align: middle; margin-right: 4px;">home</span>
-                        소개 보기
-                    </a>
-                </div>
+            <div class="search-empty-state">
+                <span class="material-symbols-outlined search-empty-icon" aria-hidden="true">public</span>
+                <h3 class="search-empty-heading">${escapeHtml(heading)}</h3>
+                <p class="search-empty-body">${escapeHtml(body)}</p>
             </div>
         `;
     }
 
     function renderEmptySearchState() {
+        const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
+        const isEnglish = String(locale).toLowerCase().startsWith('en');
+        const heading = window.i18nSearch?.['search.emptySearchHeading']?.[isEnglish ? 'en' : 'ko'] || (isEnglish ? 'No matches found' : '조건에 맞는 트리가 없어요');
+        const body = window.i18nSearch?.['search.emptySearchBody']?.[isEnglish ? 'en' : 'ko'] || (isEnglish ? 'Try a different keyword or filter.' : '다른 키워드나 필터로 다시 찾아보세요.');
+
         return `
-            <div style="grid-column:1 / -1;text-align: center; padding: 80px 24px; color: var(--on-surface-variant);">
-                <span class="material-symbols-outlined" style="font-size: 48px; opacity: 0.3; margin-bottom: 16px; display: block;">search_off</span>
-                <p style="font-size: 1.1rem; font-weight: 700; margin-bottom: 8px;">조건에 맞는 공개 러브트리가 아직 보이지 않아요</p>
-                <p style="font-size: 0.9rem; opacity: 0.7;">다른 이름이나 감정 결로 다시 좁혀보면 새로운 공개 트리를 만날 수 있어요.</p>
+            <div class="search-empty-state">
+                <span class="material-symbols-outlined search-empty-icon" aria-hidden="true">search_off</span>
+                <h3 class="search-empty-heading">${escapeHtml(heading)}</h3>
+                <p class="search-empty-body">${escapeHtml(body)}</p>
             </div>
         `;
     }

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -270,15 +270,13 @@
 
         function renderLoadErrorState() {
             resultsList.innerHTML = `
-                <div class="empty-state" style="padding:60px 24px; text-align:center; color: var(--on-surface-variant);">
-                    <span class="material-symbols-outlined" style="font-size: 56px; color: var(--error); opacity: 0.6; margin-bottom: 20px; display: block;">cloud_off</span>
-                    <h3 style="font-size: 1.25rem; font-weight: 800; margin-bottom: 12px; color: var(--on-surface);">${getCurrentLocale() === 'en' ? 'Failed to load' : '불러오기 실패'}</h3>
-                    <p style="font-size: 0.95rem; opacity: 0.8; margin-bottom: 24px; line-height: 1.6;">
-                        ${getCurrentLocale() === 'en'
-                            ? 'There was a problem reaching the server.<br>Please check your network and try again in a moment.'
-                            : '서버 연결에 문제가 발생했습니다.<br>네트워크 상태를 확인하고 잠시 뒤 다시 시도해 주세요.'}
-                    </p>
-                    <button type="button" id="retryLoadBtn" class="btn-round btn-primary" style="padding: 10px 24px;">${getCurrentLocale() === 'en' ? 'Try again' : '다시 시도'}</button>
+                <div class="search-empty-state">
+                    <span class="material-symbols-outlined search-error-icon" aria-hidden="true">cloud_off</span>
+                    <h3 class="search-empty-heading">${getSearchCopy('search.errorHeading', '불러오지 못했어요', 'Could not load')}</h3>
+                    <p class="search-empty-body">${getSearchCopy('search.errorBody', '네트워크 상태를 확인하고 다시 시도해 주세요.', 'Check your connection and try again.')}</p>
+                    <div class="search-empty-actions">
+                        <button type="button" id="retryLoadBtn" class="btn-round btn-primary">${getSearchCopy('search.retryButton', '다시 시도', 'Retry')}</button>
+                    </div>
                 </div>
             `;
 


### PR DESCRIPTION
Summary:
- Quiet-first polish for Search/Browse no-trees, empty-search, and load-error states.
- Moves repeated inline empty/error styling into css/search.css classes.
- Adds empty/error i18n keys without changing preview/timeline keys.
- Keeps search/filter/API/thumbnail/preview behavior unchanged.

Changed files:
- css/search.css
- js/search-card-renderer.js
- js/search/search-ui.js
- js/i18n/i18n-search.js

Validation:
- git diff --check: PASS
- npm test: PASS, 81/81
- Desktop smoke 1920x1080: PASS
- Mobile smoke 390x844: PASS
- Console fatal error: none
- Local static API 404 handled gracefully with error state
- same-origin /api/community/trees and /api/community/growing-trees paths preserved

Copy / typo verification:
- No forbidden typo strings found:
  - 첫음
  - 또렴
  - 또렷
  - 잘렐
  - 만나 수
  - 이어진 열려요
- Existing preview/timeline copy preserved:
  - 처음 남긴 날
  - 아직 흐름이 또렷하지 않아요
  - 다음 순간이 이어지면 열려요.

Scope:
- No Search thumbnail fallback changes
- No search adapter/API changes
- No preview renderer changes
- No Auth/Login/Shared Header changes
- No docs/backend/Netlify changes
- No new files

Remaining verification:
- CTO PR diff review
- Cloudflare PR Preview smoke if needed