### PR TITLE
refactor(login): add controller skeleton

### DIFF
--- a/js/login/login-dom.js
+++ b/js/login/login-dom.js
@@ -1,0 +1,36 @@
+(function (global) {
+  'use strict';
+
+  var SELECTORS = Object.freeze({
+    loginGoogleButton: 'login-btn-google',
+    signupGoogleButton: 'signup-btn-google',
+    emailAuthForm: 'email-auth-form',
+    signupForm: 'signup-form',
+    emailAuthModal: 'email-auth-modal',
+    emailAuthToggle: 'email-auth-toggle',
+    signupDisplayName: 'signup-display-name'
+  });
+
+  function byId(id, root) {
+    var scope = root && typeof root.getElementById === 'function' ? root : global.document;
+    return scope && id ? scope.getElementById(id) : null;
+  }
+
+  function getLoginElements(root) {
+    return {
+      loginGoogleButton: byId(SELECTORS.loginGoogleButton, root),
+      signupGoogleButton: byId(SELECTORS.signupGoogleButton, root),
+      emailAuthForm: byId(SELECTORS.emailAuthForm, root),
+      signupForm: byId(SELECTORS.signupForm, root),
+      emailAuthModal: byId(SELECTORS.emailAuthModal, root),
+      emailAuthToggle: byId(SELECTORS.emailAuthToggle, root),
+      signupDisplayName: byId(SELECTORS.signupDisplayName, root)
+    };
+  }
+
+  global.LoveBudLoginDom = Object.freeze({
+    SELECTORS: SELECTORS,
+    byId: byId,
+    getLoginElements: getLoginElements
+  });
+})(window);

--- a/js/login/login-page.js
+++ b/js/login/login-page.js
@@ -1,0 +1,16 @@
+(function (global) {
+  'use strict';
+
+  function noop() {}
+
+  var LoginPageController = Object.freeze({
+    syncEmailAuthModeUi: noop,
+    setupLoginPageAuthUi: noop,
+    setupGoogleBtn: noop,
+    setupSignupGoogleBtn: noop,
+    setupEmailAuthForm: noop,
+    setupSignupForm: noop
+  });
+
+  global.LoveBudLoginPageController = LoginPageController;
+})(window);

--- a/tests/contracts/login-controller-skeleton-contract.test.js
+++ b/tests/contracts/login-controller-skeleton-contract.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+test('login controller skeleton defines the LoveBudAuthLoginPage-compatible method shape without runtime wiring', () => {
+  const source = readRepoFile('js/login/login-page.js');
+
+  assert.match(source, /LoveBudLoginPageController/, 'skeleton must expose the isolated login page controller namespace');
+  assert.doesNotMatch(source, /LoveBudAuthLoginPage\s*=/, 'skeleton must not replace the active auth-login-page provider before wiring is approved');
+
+  for (const methodName of [
+    'syncEmailAuthModeUi',
+    'setupLoginPageAuthUi',
+    'setupGoogleBtn',
+    'setupSignupGoogleBtn',
+    'setupEmailAuthForm',
+    'setupSignupForm',
+  ]) {
+    assert.match(source, new RegExp(`${methodName}\\s*:`), `skeleton must define ${methodName}`);
+  }
+});
+
+test('login DOM skeleton stays isolated from auth core and records login page selector contracts', () => {
+  const source = readRepoFile('js/login/login-dom.js');
+
+  for (const selector of [
+    'login-btn-google',
+    'signup-btn-google',
+    'email-auth-form',
+    'signup-form',
+    'email-auth-modal',
+    'email-auth-toggle',
+    'signup-display-name',
+  ]) {
+    assert.match(source, new RegExp(selector), `login DOM skeleton must keep selector ${selector}`);
+  }
+
+  assert.doesNotMatch(source, /firebase/i, 'login DOM skeleton must not depend on Firebase');
+  assert.doesNotMatch(source, /localStorage|sessionStorage/, 'login DOM skeleton must not touch auth/session cache');
+  assert.doesNotMatch(source, /location\.href|location\.assign|location\.replace/, 'login DOM skeleton must not perform redirects');
+});


### PR DESCRIPTION
## Summary
- Add an isolated `js/login/` skeleton for the future login page controller extraction.
- Add `LoveBudLoginDom` selector helpers and a `LoveBudLoginPageController` no-op method shape matching the existing 6 login helper methods.
- Add a contract test that verifies the skeleton shape remains isolated from auth core/session/redirect behavior.

## Scope
- Runtime wiring is intentionally unchanged.
- `pages/login.html` is unchanged.
- `js/auth.js` is unchanged.
- `js/auth/auth-login-page.js` is unchanged.
- No Firebase/auth/session/cache/protected-route policy changes.

## Changed files
- `js/login/login-dom.js`
- `js/login/login-page.js`
- `tests/contracts/login-controller-skeleton-contract.test.js`

## Validation
- GitHub connector diff check: changed files limited to the 3 allowed files.
- Line counts: `login-page.js` 16 lines, `login-dom.js` 36 lines, skeleton contract 48 lines.
- No local `npm test` or browser smoke was run in this environment.
- Runtime behavior should be unchanged because the new files are not loaded by `pages/login.html`.

## Notes
This is Phase 1 skeleton only. Controlled `pages/login.html` wiring and any `auth.js` fallback shrink must remain separate follow-up work after review.