### PR TITLE
fix(editor-css): correct global import path

### DIFF
--- a/css/editor/base.css
+++ b/css/editor/base.css
@@ -1,4 +1,4 @@
-@import url('global.css?v=20260415-10');
+@import url('../global.css?v=20260415-10');
 
 :root {
     /* Editor Specific Layout Constants */


### PR DESCRIPTION
## Summary
- Fix the existing `origin/main` editor CSS import path issue in `css/editor/base.css`.
- Change the global stylesheet import from `global.css` to `../global.css` so the editor CSS chain resolves the real `css/global.css` file.
- Keep this separate from PR #197 editor entry fallback refactor.

## Scope
- Changed file: `css/editor/base.css` only.
- `css/editor.css` import order is unchanged.
- `pages/editor.html` stylesheet link is unchanged.
- No JS/Auth/API/runtime changes.

## Validation needed
- Confirm `/css/editor/global.css?v=20260415-10` 404 is gone.
- Confirm `/css/global.css?v=20260415-10` or equivalent resolved global CSS path returns 200.
- Run desktop editor layout smoke.
- Run mobile 390x844 editor layout smoke.
- Confirm no fatal console errors.