### PR TITLE
refactor(login): load controller skeleton

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -188,6 +188,8 @@
      <script src="../js/auth/auth-ui.js?v=20260421-2"></script>
      <script src="../js/auth/auth-session.js?v=20260417-31"></script>
      <script src="../js/auth/auth-firebase.js?v=20260420-2"></script>
+     <script src="../js/login/login-dom.js?v=20260427-1"></script>
+     <script src="../js/login/login-page.js?v=20260427-1"></script>
      <script src="../js/auth/auth-login-page.js?v=20260427-1"></script>
      <script src="../js/auth.js?v=20260427-1"></script>
     <script src="../js/login-page.js?v=20260427-1"></script>

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -63,6 +63,13 @@ const AUTH_MODULE_ORDER = [
   'js/auth/auth-firebase.js',
 ];
 
+const LOGIN_CONTROLLER_LOAD_ORDER = [
+  ...AUTH_MODULE_ORDER,
+  'js/login/login-dom.js',
+  'js/login/login-page.js',
+  'js/auth/auth-login-page.js',
+];
+
 const AUTH_MODULE_ORDER_WITH_LOGIN_PAGE = [
   ...AUTH_MODULE_ORDER,
   'js/auth/auth-login-page.js',
@@ -84,7 +91,7 @@ test('login page preserves firebase/config/i18n/shared-header before auth submod
     'js/i18n/i18n-core.js',
     'js/i18n.js',
     'js/shared-header.js',
-    ...AUTH_MODULE_ORDER_WITH_LOGIN_PAGE,
+    ...LOGIN_CONTROLLER_LOAD_ORDER,
     'js/auth.js',
     'js/login-page.js',
   ]);


### PR DESCRIPTION
## Summary
- Load the Phase 1 login controller skeleton files from `pages/login.html`.
- Keep `window.LoveBudAuthLoginPage` owned by `js/auth/auth-login-page.js`.
- Add auth bootstrap contract coverage for the explicit load-only order.

## Scope
- Base branch: `refactor/login-controller-skeleton`.
- Runtime bridge/alias is intentionally not added.
- `js/auth.js` is unchanged.
- `js/auth/auth-login-page.js` is unchanged.
- No Firebase/session/cache/redirect policy changes.

## Script order
- `auth-firebase.js`
- `login-dom.js`
- `login-page.js`
- `auth-login-page.js`
- `auth.js`
- root `js/login-page.js`

## Validation
- Changed files limited to `pages/login.html` and `tests/contracts/auth-bootstrap-contract.test.js` by connector compare.
- Browser smoke not run in this environment because shell GitHub DNS/checkout remains unavailable.
