### PR TITLE
refactor(login): harden inactive controller bindings

### DIFF
--- a/js/login/login-page.js
+++ b/js/login/login-page.js
@@ -38,6 +38,15 @@
     return {};
   }
 
+  function replaceEventListener(element, handlerKey, eventName, handler) {
+    if (!element || typeof element.addEventListener !== 'function') return;
+    if (element[handlerKey] && typeof element.removeEventListener === 'function') {
+      element.removeEventListener(eventName, element[handlerKey]);
+    }
+    element[handlerKey] = handler;
+    element.addEventListener(eventName, handler);
+  }
+
   function syncEmailAuthModeUi(options) {
     var emailAuthMode = options && options.emailAuthMode;
     var titleEl = options && options.titleEl;
@@ -100,9 +109,17 @@
       setEmailAuthMode(emailAuthMode);
     }
 
+    var redirect = '';
+    try {
+      var params = new URLSearchParams(global.location ? global.location.search : '');
+      redirect = params.get('redirect') || '';
+    } catch (error) {
+      redirect = '';
+    }
+
     var noticeEl = byId(getSelector('redirectNotice') || 'redirect-notice', root);
     if (noticeEl) {
-      noticeEl.style.display = global.location && global.location.search ? 'block' : 'none';
+      noticeEl.style.display = redirect ? 'block' : 'none';
     }
 
     if (typeof syncEmailAuthModeUiFn === 'function') {
@@ -123,7 +140,7 @@
     var googleBtn = byId(getSelector('loginGoogleButton') || 'login-btn-google', root);
     if (!googleBtn) return;
 
-    googleBtn.addEventListener('click', function (event) {
+    replaceEventListener(googleBtn, '__lovebudLoginControllerGoogleClick', 'click', function (event) {
       event.preventDefault();
       if (typeof signInWithGoogle === 'function') {
         signInWithGoogle();
@@ -132,12 +149,12 @@
   }
 
   function setupSignupGoogleBtn(options) {
-    var signUpWithGoogle = options && options.signUpWithGoogle;
+    var signUpWithGoogle = options && (options.signUpWithGoogle || options.fallbackSignUpWithGoogle);
     var root = options && options.root;
     var signupGoogleBtn = byId(getSelector('signupGoogleButton') || 'signup-btn-google', root);
     if (!signupGoogleBtn) return;
 
-    signupGoogleBtn.addEventListener('click', function (event) {
+    replaceEventListener(signupGoogleBtn, '__lovebudLoginControllerSignupGoogleClick', 'click', function (event) {
       event.preventDefault();
       if (typeof signUpWithGoogle === 'function') {
         signUpWithGoogle();
@@ -192,7 +209,7 @@
     syncDisplayNameVisibility();
 
     if (toggleBtn) {
-      toggleBtn.addEventListener('click', function () {
+      replaceEventListener(toggleBtn, '__lovebudLoginControllerEmailToggleClick', 'click', function () {
         var nextMode = getMode() === 'login' ? 'signup' : 'login';
         if (typeof setEmailAuthMode === 'function') {
           setEmailAuthMode(nextMode);
@@ -203,20 +220,20 @@
     }
 
     if (emailBtn) {
-      emailBtn.addEventListener('click', function (event) {
+      replaceEventListener(emailBtn, '__lovebudLoginControllerEmailOpenClick', 'click', function (event) {
         event.preventDefault();
         if (modal) modal.style.display = 'flex';
       });
     }
 
     if (closeBtn) {
-      closeBtn.addEventListener('click', function () {
+      replaceEventListener(closeBtn, '__lovebudLoginControllerEmailCloseClick', 'click', function () {
         if (modal) modal.style.display = 'none';
       });
     }
 
     if (modal) {
-      modal.addEventListener('click', function (event) {
+      replaceEventListener(modal, '__lovebudLoginControllerEmailBackdropClick', 'click', function (event) {
         if (event.target === modal) modal.style.display = 'none';
       });
     }

--- a/tests/contracts/login-controller-skeleton-contract.test.js
+++ b/tests/contracts/login-controller-skeleton-contract.test.js
@@ -25,6 +25,8 @@ test('login controller skeleton defines the LoveBudAuthLoginPage-compatible meth
   ]) {
     assert.match(source, new RegExp(`${methodName}\\s*:`), `skeleton must define ${methodName}`);
   }
+
+  assert.match(source, /setupSignupForm\s*:\s*noop/, 'controller signup form auth execution must remain noop');
 });
 
 test('login controller remains isolated from auth core and redirect/session policy', () => {
@@ -32,7 +34,10 @@ test('login controller remains isolated from auth core and redirect/session poli
 
   assert.doesNotMatch(source, /LoveBudLoginPageController\s*=\s*[^;]*LoveBudAuthLoginPage/, 'inactive controller must not alias the active provider');
   assert.doesNotMatch(source, /LoveBudAuthLoginPage\s*=/, 'inactive controller must not assign the active provider');
+  assert.doesNotMatch(source, /firebase\.auth\(\)/, 'inactive controller must not call Firebase auth directly');
   assert.doesNotMatch(source, /firebase\.auth\(\)\.onAuthStateChanged/, 'inactive controller must not install auth state listeners');
+  assert.doesNotMatch(source, /signInWithEmailAndPassword|createUserWithEmailAndPassword|updateProfile/, 'inactive controller must not implement email auth execution');
+  assert.doesNotMatch(source, /persistConfirmedAuthSession|preloadRedirectTargetData|getRedirectTarget/, 'inactive controller must not move session or redirect execution');
   assert.doesNotMatch(source, /localStorage|sessionStorage/, 'inactive controller must not touch auth/session cache');
   assert.doesNotMatch(source, /lovebud_auth_cache|lovebud_auth_confirmed|lovebud_auth_token/, 'inactive controller must not reference auth cache keys');
   assert.doesNotMatch(source, /location\.href|location\.assign|location\.replace/, 'inactive controller must not perform redirects');
@@ -60,6 +65,33 @@ test('login controller inactive parity covers UI selectors and i18n contracts', 
     'authModeBadge',
   ]) {
     assert.match(source, new RegExp(token), `inactive controller must include ${token}`);
+  }
+});
+
+test('login controller redirect notice is gated by explicit redirect query param', () => {
+  const source = readRepoFile('js/login/login-page.js');
+
+  assert.match(source, /new URLSearchParams\(global\.location \? global\.location\.search : ''\)/, 'controller must parse query params without performing navigation');
+  assert.match(source, /params\.get\('redirect'\)/, 'redirect notice must use the explicit redirect query param');
+  assert.match(source, /noticeEl\.style\.display\s*=\s*redirect \? 'block' : 'none'/, 'redirect notice display must depend on redirect param only');
+  assert.doesNotMatch(source, /noticeEl\.style\.display\s*=\s*global\.location\s*&&\s*global\.location\.search/, 'redirect notice must not depend on any query string presence');
+});
+
+test('login controller uses idempotent binding guards for UI-only listeners', () => {
+  const source = readRepoFile('js/login/login-page.js');
+
+  assert.match(source, /function\s+replaceEventListener\s*\(/, 'controller must centralize idempotent listener replacement');
+  assert.match(source, /removeEventListener\(eventName, element\[handlerKey\]\)/, 'controller must remove prior listener before re-binding');
+
+  for (const key of [
+    '__lovebudLoginControllerGoogleClick',
+    '__lovebudLoginControllerSignupGoogleClick',
+    '__lovebudLoginControllerEmailToggleClick',
+    '__lovebudLoginControllerEmailOpenClick',
+    '__lovebudLoginControllerEmailCloseClick',
+    '__lovebudLoginControllerEmailBackdropClick',
+  ]) {
+    assert.match(source, new RegExp(key), `controller must keep idempotent binding guard ${key}`);
   }
 });
 


### PR DESCRIPTION
## Summary
- Harden `window.LoveBudLoginPageController` before active provider transition.
- Align redirect notice display with explicit `redirect` query param.
- Add idempotent guards for UI-only login controller bindings.
- Keep signup form auth execution as noop in the controller.

## Scope
- `window.LoveBudAuthLoginPage` remains the active provider.
- `pages/login.html` is unchanged.
- `js/auth.js` is unchanged.
- `js/auth/auth-login-page.js` is unchanged.
- Firebase/session/cache/redirect behavior is unchanged.
- Email auth execution is not moved in this PR.

## Changed files
- `js/login/login-page.js`
- `tests/contracts/login-controller-skeleton-contract.test.js`

## Verification
- `node --check js/login/login-page.js`
- `node --test tests/contracts/login-controller-skeleton-contract.test.js`
- `node --test tests/contracts/auth-bootstrap-contract.test.js`
- `npm test`