### PR TITLE
ui(browse): remove public from section headings

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -69,11 +69,11 @@
 
         const SORT_COPY = {
             latest: {
-                title: () => getSearchCopy('search.resultsHeading', '최근 공개된 러브트리', 'Recently Shared LoveTrees'),
+                title: () => getSearchCopy('search.resultsHeading', '최근 러브트리', 'Recent LoveTrees'),
                 badge: (count) => getCurrentLocale() === 'en' ? `${count} to start with` : `지금 먼저 볼 ${count}개`
             },
             popular: {
-                title: () => getCurrentLocale() === 'en' ? 'Popular Public LoveTrees' : '인기 많은 공개 러브트리',
+                title: () => getCurrentLocale() === 'en' ? 'Popular LoveTrees' : '인기 많은 러브트리',
                 badge: (count) => getCurrentLocale() === 'en' ? `${count} trending now` : `지금 반응 좋은 ${count}개`
             }
         };


### PR DESCRIPTION
## Summary
- Remove the Korean word `공개` from browse section headings.
- Change `최근 공개된 러브트리` to `최근 러브트리`.
- Change `인기 많은 공개 러브트리` to `인기 많은 러브트리`.
- Keep the existing i18n key usage and only adjust displayed content/fallback copy.

## Scope
- No style, spacing, color, font-size, layout, filtering, sorting, or card rendering changes.
- No Auth/Login, Editor, Modal, or shared-header changes.

## Changed files
- `js/search/search-ui.js`

## Verification
- Not run in this connector-only environment.
- Recommended smoke: desktop/mobile browse headings render without overflow or layout change.