### PR TITLE
ui(editor): simplify current memory actions

### DIFF
--- a/css/editor/detail-panel.css
+++ b/css/editor/detail-panel.css
@@ -138,6 +138,22 @@
     box-shadow: 0 6px 14px rgba(75,64,57,0.05);
 }
 
+.editor-current-moment-title .memory-edit-button {
+    display: none !important;
+}
+
+.editor-edit-actions-row .editor-edit-danger-action {
+    margin-right: auto;
+    color: #a05a63;
+    border-color: rgba(158,81,88,0.18);
+    background: rgba(255,253,249,0.72);
+    box-shadow: none;
+}
+
+.editor-edit-actions-row .editor-edit-danger-action:hover {
+    background: rgba(158,81,88,0.08);
+}
+
 .editor-memory-delete-btn {
     color: #a87b80;
     border-color: rgba(158,81,88,0.08);

--- a/js/editor/editor-bindings.js
+++ b/js/editor/editor-bindings.js
@@ -75,6 +75,68 @@
     }
   }
 
+  function moveDeleteButtonIntoEditMode(deleteMemoryBtn) {
+    if (!deleteMemoryBtn) return;
+
+    var editMode = document.getElementById('detailEditMode');
+    var editActions = editMode ? editMode.querySelector('.editor-edit-actions-row') : null;
+    if (!editActions) return;
+
+    deleteMemoryBtn.classList.add('editor-edit-danger-action');
+    deleteMemoryBtn.setAttribute('aria-label', deleteMemoryBtn.textContent || '순간 삭제');
+    deleteMemoryBtn.style.removeProperty('display');
+
+    if (deleteMemoryBtn.parentElement !== editActions) {
+      editActions.insertBefore(deleteMemoryBtn, editActions.firstChild);
+    }
+  }
+
+  function hideCurrentMemoryViewModeSecondaryActions(detailPanel, deleteMemoryBtn) {
+    if (!detailPanel) return;
+
+    var titleEditButtons = detailPanel.querySelectorAll('#detailViewMode #detailCurrentMomentTitle .memory-edit-button');
+    titleEditButtons.forEach(function(btn) {
+      btn.style.setProperty('display', 'none', 'important');
+      btn.setAttribute('aria-hidden', 'true');
+      btn.tabIndex = -1;
+    });
+
+    if (!deleteMemoryBtn) return;
+    var viewMode = document.getElementById('detailViewMode');
+    var editMode = document.getElementById('detailEditMode');
+    var isInsideViewMode = !!(viewMode && viewMode.contains(deleteMemoryBtn));
+    var isInsideEditMode = !!(editMode && editMode.contains(deleteMemoryBtn));
+
+    if (isInsideViewMode && !isInsideEditMode) {
+      deleteMemoryBtn.style.setProperty('display', 'none', 'important');
+      deleteMemoryBtn.setAttribute('aria-hidden', 'true');
+      deleteMemoryBtn.tabIndex = -1;
+    } else if (isInsideEditMode) {
+      deleteMemoryBtn.style.removeProperty('display');
+      deleteMemoryBtn.removeAttribute('aria-hidden');
+      deleteMemoryBtn.removeAttribute('tabindex');
+    }
+  }
+
+  function watchCurrentMemoryViewModeActions(detailPanel, deleteMemoryBtn) {
+    if (!detailPanel || detailPanel.dataset.currentMemoryActionWatchBound === '1') return;
+    detailPanel.dataset.currentMemoryActionWatchBound = '1';
+
+    hideCurrentMemoryViewModeSecondaryActions(detailPanel, deleteMemoryBtn);
+
+    if (typeof MutationObserver !== 'function') return;
+
+    var observer = new MutationObserver(function() {
+      moveDeleteButtonIntoEditMode(deleteMemoryBtn);
+      hideCurrentMemoryViewModeSecondaryActions(detailPanel, deleteMemoryBtn);
+    });
+
+    observer.observe(detailPanel, {
+      childList: true,
+      subtree: true
+    });
+  }
+
   function bindDetailActionButtons(options) {
     var editMemoryBtn = options && options.editMemoryBtn;
     var deleteMemoryBtn = options && options.deleteMemoryBtn;
@@ -84,9 +146,17 @@
     var deleteMemory = options && options.deleteMemory;
     var exitEditMode = options && options.exitEditMode;
     var saveMemoryEdit = options && options.saveMemoryEdit;
+    var detailPanel = document.getElementById('detailPanel');
+
+    moveDeleteButtonIntoEditMode(deleteMemoryBtn);
+    watchCurrentMemoryViewModeActions(detailPanel, deleteMemoryBtn);
 
     if (editMemoryBtn && typeof enterEditMode === 'function') {
-      editMemoryBtn.addEventListener('click', enterEditMode);
+      editMemoryBtn.addEventListener('click', function(e) {
+        moveDeleteButtonIntoEditMode(deleteMemoryBtn);
+        hideCurrentMemoryViewModeSecondaryActions(detailPanel, deleteMemoryBtn);
+        enterEditMode(e);
+      });
     }
     if (deleteMemoryBtn && typeof deleteMemory === 'function') {
       deleteMemoryBtn.addEventListener('click', deleteMemory);


### PR DESCRIPTION
## Summary
- Keep the current moment card quiet-first by leaving only the existing \editMemoryBtn\ as the visible moment edit entry point.
- Move the existing \deleteMemoryBtn\ into the edit-mode action row so delete is only available after entering the edit flow.
- Hide the inline current-title \제목 수정\ control in the default view, making \순간 수정\ the single visible edit path.

## Changed files
- \js/editor/editor-bindings.js\
- \css/editor/detail-panel.css\

## Before / after
- Before: current moment default view could show a title-specific edit control plus separate moment edit/delete actions.
- After: default view exposes the moment edit entry point only; delete is available inside edit mode as a lower-frequency danger action.

## Scope
- No Auth/Login/Search/Modal changes.
- No API/update/delete logic changes.
- No i18n key changes.
- No editor data/save/delete API changes.
- No PR #7 / prototype / reference / demo / variant changes.

## Validation
- \
ode --check js/editor/editor-bindings.js\: PASS
- \git diff --check\: PASS
- \
pm test\: PASS (94 tests)
- \
pm run lint\: PASS

## Browser smoke
- Test slot: https://test5.lovebud.pages.dev
- Head SHA: 488f248e5b0d0dfd4b69683d68c1aa971c61b853
- Editor load: PASS
- Default title-specific edit control hidden: PASS
- Default delete action hidden: PASS
- Default \순간 수정\ visible as single edit entry: PASS
- Edit mode opens with title/memo/tag fields: PASS
- Delete action visible only in edit mode: PASS
- Cancel returns to view mode: PASS
- Delete confirm/guard works: PASS
- Desktop layout: PASS
- Mobile 390x844 layout: PASS
- Console fatal errors: none