### PR TITLE
ui(landing): align intro visual rhythm

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -42,22 +42,22 @@
     z-index: 1;
     width: min(var(--page-shell-max), calc(100% - (var(--page-pad-desktop) * 2)));
     margin: 0 auto;
-    padding: 28px 0 110px;
+    padding: 44px 0 110px;
 }
 
 .home-v3-hero {
     position: relative;
     display: grid;
-    grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr);
+    grid-template-columns: minmax(0, 1.05fr) minmax(420px, 0.95fr);
     gap: var(--hero-gap);
     align-items: center;
-    min-height: min(860px, calc(100vh - 104px));
-    padding: 24px 0 20px;
+    min-height: min(820px, calc(100vh - 108px));
+    padding: 28px 0 24px;
 }
 
 .home-v3-copy {
     max-width: 600px;
-    padding: 8px 0 16px;
+    padding: 0 0 16px;
 }
 
 .home-v3-eyebrow {
@@ -349,8 +349,8 @@
 
 .reveal {
     opacity: 0;
-    transform: translateY(22px);
-    transition: opacity 0.8s ease, transform 0.8s ease;
+    transform: translateY(12px);
+    transition: opacity 0.45s ease, transform 0.45s ease;
 }
 
 .reveal.active {
@@ -361,6 +361,7 @@
 @media (max-width: 1220px) {
     .home-v3-main {
         width: min(1120px, calc(100% - 40px));
+        padding-top: 36px;
     }
 
     .home-v3-hero {
@@ -394,7 +395,7 @@
 @media (max-width: 640px) {
     .home-v3-main {
         width: min(100%, calc(100% - 24px));
-        padding-bottom: 72px;
+        padding: 24px 0 72px;
     }
 
     .home-v3-hero {

--- a/css/intro/cta.css
+++ b/css/intro/cta.css
@@ -5,7 +5,7 @@
  */
 
 .cta-section {
-  padding: 48px 40px 72px;
+  padding: 40px var(--page-pad-desktop) 64px;
   max-width: var(--page-brand-max);
   margin: 0 auto;
   width: 100%;
@@ -47,4 +47,24 @@
   color: var(--primary);
   border-color: rgba(144, 73, 81, 0.18);
   background: rgba(255, 255, 255, 0.76);
+}
+
+/* Mobile consistency */
+@media (max-width: 640px) {
+  .cta-section {
+    padding: 32px var(--page-pad-mobile, 16px) 48px;
+  }
+
+  .cta-section h2 {
+    font-size: clamp(1.5rem, 6vw, 1.9rem);
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+  }
+
+  .cta-buttons .btn-round {
+    width: 100%;
+    min-height: 54px;
+  }
 }

--- a/css/intro/cta.css
+++ b/css/intro/cta.css
@@ -37,18 +37,6 @@
   flex-wrap: wrap;
 }
 
-.cta-buttons .intro-cta-primary {
-  color: #fff;
-  background: linear-gradient(180deg, rgba(144, 73, 81, 0.98), rgba(125, 63, 70, 0.98));
-  border-color: transparent;
-}
-
-.cta-buttons .intro-cta-secondary {
-  color: var(--primary);
-  border-color: rgba(144, 73, 81, 0.18);
-  background: rgba(255, 255, 255, 0.76);
-}
-
 /* Mobile consistency */
 @media (max-width: 640px) {
   .cta-section {

--- a/css/intro/cta.css
+++ b/css/intro/cta.css
@@ -36,3 +36,15 @@
   align-items: stretch;
   flex-wrap: wrap;
 }
+
+.cta-buttons .intro-cta-primary {
+  color: #fff;
+  background: linear-gradient(180deg, rgba(144, 73, 81, 0.98), rgba(125, 63, 70, 0.98));
+  border-color: transparent;
+}
+
+.cta-buttons .intro-cta-secondary {
+  color: var(--primary);
+  border-color: rgba(144, 73, 81, 0.18);
+  background: rgba(255, 255, 255, 0.76);
+}

--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -233,13 +233,24 @@
 }
 
 .intro-cta-primary {
+  color: #fff;
+  background: linear-gradient(180deg, rgba(144, 73, 81, 0.98), rgba(125, 63, 70, 0.98));
+  border-color: transparent;
   box-shadow: 0 16px 34px rgba(144, 73, 81, 0.24);
   transition: all 0.25s ease;
 }
 
 .intro-cta-primary:hover {
+  color: #fff;
+  background: linear-gradient(180deg, rgba(154, 82, 90, 1), rgba(125, 63, 70, 1));
   transform: translateY(-2px);
   box-shadow: 0 20px 42px rgba(144, 73, 81, 0.32);
+}
+
+.intro-cta-primary:focus-visible,
+.intro-cta-secondary:focus-visible {
+  outline: 2px solid rgba(144, 73, 81, 0.38);
+  outline-offset: 3px;
 }
 
 .intro-cta-secondary {
@@ -247,7 +258,7 @@
   overflow: visible;
   background: rgba(255,255,255,0.72);
   border-color: rgba(144, 73, 81, 0.18);
-  color: var(--on-surface);
+  color: var(--primary);
   backdrop-filter: blur(10px);
   box-shadow: 0 14px 34px rgba(75, 64, 57, 0.08);
   transition: all 0.25s ease;
@@ -267,6 +278,7 @@
 }
 
 .intro-cta-secondary:hover {
+  color: var(--primary);
   border-color: rgba(144, 73, 81, 0.28);
   background: rgba(255,255,255,0.94);
   box-shadow: 0 20px 52px rgba(144, 73, 81, 0.18), 0 0 46px rgba(255, 214, 206, 0.82);

--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -222,8 +222,16 @@
   margin-top: 24px;
 }
 
-.intro-cta-link {
+.intro-cta-link,
+.intro-cta-link:link,
+.intro-cta-link:visited,
+.intro-cta-link:hover,
+.intro-cta-link:focus {
+  color: inherit;
   text-decoration: none;
+}
+
+.intro-cta-link {
   display: inline-flex;
   align-items: center;
 }
@@ -252,7 +260,9 @@
   transition: all 0.25s ease;
 }
 
-.intro-cta-primary:hover {
+.intro-cta-primary:hover,
+.intro-cta-link:hover .intro-cta-primary,
+.intro-cta-link:focus-visible .intro-cta-primary {
   color: #fff;
   background: linear-gradient(180deg, rgba(154, 82, 90, 1), rgba(125, 63, 70, 1));
   transform: translateY(-2px);
@@ -260,7 +270,9 @@
 }
 
 .intro-cta-primary:focus-visible,
-.intro-cta-secondary:focus-visible {
+.intro-cta-secondary:focus-visible,
+.intro-cta-link:focus-visible .intro-cta-primary,
+.intro-cta-link:focus-visible .intro-cta-secondary {
   outline: 2px solid rgba(144, 73, 81, 0.38);
   outline-offset: 3px;
 }
@@ -268,7 +280,7 @@
 .intro-cta-secondary {
   position: relative;
   overflow: visible;
-  background: rgba(255,255,255,0.72);
+  background: rgba(255, 255, 255, 0.72);
   border-color: rgba(144, 73, 81, 0.18);
   color: var(--primary);
   backdrop-filter: blur(10px);
@@ -289,15 +301,19 @@
   transition: opacity 0.25s ease, transform 0.25s ease;
 }
 
-.intro-cta-secondary:hover {
+.intro-cta-secondary:hover,
+.intro-cta-link:hover .intro-cta-secondary,
+.intro-cta-link:focus-visible .intro-cta-secondary {
   color: var(--primary);
   border-color: rgba(144, 73, 81, 0.28);
-  background: rgba(255,255,255,0.94);
+  background: rgba(255, 255, 255, 0.94);
   box-shadow: 0 20px 52px rgba(144, 73, 81, 0.18), 0 0 46px rgba(255, 214, 206, 0.82);
   transform: translateY(-2px);
 }
 
-.intro-cta-secondary:hover::after {
+.intro-cta-secondary:hover::after,
+.intro-cta-link:hover .intro-cta-secondary::after,
+.intro-cta-link:focus-visible .intro-cta-secondary::after {
   opacity: 1;
   transform: scale(1.08);
 }

--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -9,11 +9,11 @@
   grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.72fr);
   gap: var(--hero-gap);
   align-items: center;
-  padding: 32px var(--page-pad-desktop) 28px;
+  padding: 52px var(--page-pad-desktop) 32px;
   max-width: var(--page-shell-max);
   margin: 0 auto;
   width: 100%;
-  min-height: min(780px, calc(100vh - 100px));
+  min-height: min(820px, calc(100vh - 108px));
 }
 
 .intro-hero-copy {
@@ -45,12 +45,12 @@
 }
 
 .intro-hero h1 {
-  font-size: clamp(3.2rem, 5.6vw, 4.8rem);
+  font-size: clamp(3.45rem, 5.8vw, 5.15rem);
   font-weight: 900;
   color: var(--on-surface);
-  margin: 18px 0 14px;
-  line-height: 1.0;
-  letter-spacing: -0.045em;
+  margin: 20px 0 14px;
+  line-height: 0.99;
+  letter-spacing: -0.052em;
   max-width: 720px;
 }
 
@@ -67,7 +67,7 @@
 .intro-hero h1 .title-accent {
   color: var(--primary);
   font-weight: 900;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
 }
 
 .intro-hero h1 .title-line:nth-child(3) {
@@ -76,10 +76,10 @@
 }
 
 .intro-hero .lead {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
   color: var(--on-surface-variant);
-  line-height: 1.75;
-  margin: 0 0 1.5rem;
+  line-height: 1.78;
+  margin: 0 0 1.45rem;
   max-width: 520px;
 }
 
@@ -219,7 +219,7 @@
   gap: 14px;
   flex-wrap: wrap;
   align-items: stretch;
-  margin-top: 20px;
+  margin-top: 24px;
 }
 
 .intro-cta-link {
@@ -307,37 +307,38 @@
   .intro-hero {
     grid-template-columns: 1fr;
     min-height: auto;
-    padding-top: 22px;
+    padding-top: 36px;
   }
 }
 
 @media (max-width: 920px) {
   .intro-hero h1 {
-    font-size: clamp(2.8rem, 9vw, 4rem);
+    font-size: clamp(2.95rem, 10vw, 4.3rem);
   }
 }
 
 @media (max-width: 640px) {
   .intro-hero {
-    padding: 14px var(--page-pad-mobile, 16px) 12px;
+    padding: 24px var(--page-pad-mobile, 16px) 12px;
   }
 
   .intro-hero h1 {
-    margin-top: 14px;
-    font-size: clamp(2.2rem, 10vw, 2.6rem);
-    line-height: 1.05;
+    margin-top: 16px;
+    font-size: clamp(2.25rem, 10vw, 2.8rem);
+    line-height: 1.04;
     max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
   .intro-hero .lead {
     font-size: 0.96rem;
-    line-height: 1.7;
+    line-height: 1.72;
     max-width: 100%;
   }
 
   .intro-hero-actions {
     flex-direction: column;
-    margin-top: 16px;
+    margin-top: 20px;
   }
 
   .intro-hero-actions .btn-round {

--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -9,10 +9,11 @@
   grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.72fr);
   gap: var(--hero-gap);
   align-items: center;
-  padding: 72px var(--page-pad-desktop) 56px;
+  padding: 32px var(--page-pad-desktop) 28px;
   max-width: var(--page-shell-max);
   margin: 0 auto;
   width: 100%;
+  min-height: min(780px, calc(100vh - 100px));
 }
 
 .intro-hero-copy {
@@ -22,24 +23,34 @@
 .intro-hero-eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
+  gap: 8px;
+  min-height: 24px;
+  padding: 0;
   margin-bottom: 16px;
-  border-radius: 999px;
-  background: rgba(144, 73, 81, 0.08);
+  border-radius: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
   color: var(--primary);
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 0.83rem;
+  font-weight: 700;
   letter-spacing: 0.02em;
 }
 
+.intro-hero-eyebrow::before {
+  content: "";
+  width: 28px;
+  height: 1px;
+  background: rgba(144, 73, 81, 0.42);
+}
+
 .intro-hero h1 {
-  font-size: clamp(3rem, 5.2vw, 4.2rem);
+  font-size: clamp(3.2rem, 5.6vw, 4.8rem);
   font-weight: 900;
   color: var(--on-surface);
-  margin-bottom: 1.25rem;
-  line-height: 1.04;
-  letter-spacing: -0.04em;
+  margin: 18px 0 14px;
+  line-height: 1.0;
+  letter-spacing: -0.045em;
   max-width: 720px;
 }
 
@@ -65,11 +76,11 @@
 }
 
 .intro-hero .lead {
-  font-size: 1.15rem;
+  font-size: 1.05rem;
   color: var(--on-surface-variant);
-  line-height: 1.72;
-  margin-bottom: 2.25rem;
-  max-width: 580px;
+  line-height: 1.75;
+  margin: 0 0 1.5rem;
+  max-width: 520px;
 }
 
 .intro-hero-visual {
@@ -208,6 +219,7 @@
   gap: 14px;
   flex-wrap: wrap;
   align-items: stretch;
+  margin-top: 20px;
 }
 
 .intro-cta-link {
@@ -288,4 +300,48 @@
 .intro-cta-secondary:hover::after {
   opacity: 1;
   transform: scale(1.08);
+}
+
+/* Mobile consistency with landing */
+@media (max-width: 1220px) {
+  .intro-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    padding-top: 22px;
+  }
+}
+
+@media (max-width: 920px) {
+  .intro-hero h1 {
+    font-size: clamp(2.8rem, 9vw, 4rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .intro-hero {
+    padding: 14px var(--page-pad-mobile, 16px) 12px;
+  }
+
+  .intro-hero h1 {
+    margin-top: 14px;
+    font-size: clamp(2.2rem, 10vw, 2.6rem);
+    line-height: 1.05;
+    max-width: 100%;
+  }
+
+  .intro-hero .lead {
+    font-size: 0.96rem;
+    line-height: 1.7;
+    max-width: 100%;
+  }
+
+  .intro-hero-actions {
+    flex-direction: column;
+    margin-top: 16px;
+  }
+
+  .intro-hero-actions .btn-round {
+    width: 100%;
+    min-height: 54px;
+  }
 }


### PR DESCRIPTION
## Summary
- Align landing and intro hero rhythm with closer top spacing/grid cadence.
- Reduce the landing hero reveal to a lighter opacity/translate transition.
- Keep intro CTA buttons in the warm LoveTree rose/brown tone instead of blue-looking link text.
- Apply the same warm CTA tone to the final intro CTA section.

## Scope
- CSS-only visual consistency polish.
- No feature URL or link target changes.
- No Auth/Login, Editor, Search/Browse, Modal, shared-header, or prototype/reference/demo changes.

## Changed files
- `css/index.css`
- `css/intro/hero.css`
- `css/intro/cta.css`

## Verification
- Not run in this connector-only environment.
- Recommended smoke: desktop 1920x1080, desktop 1440x900, mobile 390x844 for hero rhythm, CTA hover/focus, no horizontal overflow, no fatal console errors.