### PR TITLE
refactor(login): transition active provider to controller

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -120,13 +120,22 @@ function resolveEmailAuthMode() {
   }
 }
 
-function getLoginPageModule() {
+var EMAIL_AUTH_EXECUTION_METHODS = {
+  setupEmailAuthForm: true,
+  setupSignupForm: true
+};
+
+function getLoginPageModule(methodName) {
+  if (methodName && EMAIL_AUTH_EXECUTION_METHODS[methodName]) {
+    if (window.LoveBudAuthLoginPage) return window.LoveBudAuthLoginPage;
+    return null;
+  }
   if (window.LoveBudLoginPageController) return window.LoveBudLoginPageController;
   return window.LoveBudAuthLoginPage || null;
 }
 
 function callLoginPageModule(methodName, args) {
-  var loginPageModule = getLoginPageModule();
+  var loginPageModule = getLoginPageModule(methodName);
   if (!loginPageModule || typeof loginPageModule[methodName] !== 'function') {
     return false;
   }
@@ -566,7 +575,7 @@ function initAuth() {
 
   firebase.auth().onAuthStateChanged(async function (user) {
     clearTimeout(authTimeout); // 정상 응답 - 타임아웃 취소
-    
+
     if (user) {
       try {
         if (typeof user.reload === 'function') await user.reload();
@@ -781,13 +790,13 @@ function buildUserDropdown(user) {
  * Update right-side nav area based on auth state.
  * Container #auth-nav / #auth-nav-container is never destroyed -
  * only its innerHTML is replaced.
- * 
+ *
  * Called by onAuthStateChanged whenever Firebase auth state changes.
  */
 function updateHeaderLangToggleVisibility(isLoggedIn) {
     var headerLangToggle = document.querySelector('.header-lang-toggle');
     if (!headerLangToggle) return;
-    
+
     if (isLoggedIn) {
           headerLangToggle.hidden = true;
           headerLangToggle.style.setProperty('display', 'none', 'important');
@@ -799,7 +808,7 @@ function updateHeaderLangToggleVisibility(isLoggedIn) {
 
 function updateNavUI(user) {
     updateHeaderLangToggleVisibility(!!user);
-  
+
   if (__authUiModule) {
     __authUiModule.updateNavUI({
       user: user,
@@ -940,7 +949,7 @@ function getFriendlyErrorMessage(error, isGoogleLogin) {
   var message = error.message || '';
   // Log full error for devs
   console.error('Auth error (developer only):', error);
-  
+
   // Environment-related errors
   if (message.indexOf('location.protocol') !== -1 || message.indexOf('not supported in the environment') !== -1) {
     return '이 브라우저 환경에서는 로그인할 수 없습니다. http:// 또는 https:// 주소(localhost 가능)에서 다시 시도해 주세요.';
@@ -948,7 +957,7 @@ function getFriendlyErrorMessage(error, isGoogleLogin) {
   if (message.indexOf('web storage') !== -1 || message.indexOf('storage') !== -1) {
     return '브라우저 저장소(storage)가 비활성화되어 있습니다. 쿠키와 저장소를 허용한 후 다시 시도해 주세요.';
   }
-   
+
    // Common auth errors
    switch (code) {
      case 'auth/popup-closed-by-user':
@@ -1215,14 +1224,14 @@ function setupEmailAuthForm() {
 
 form.addEventListener('submit', async function (e) {
     e.preventDefault();
-    
+
     // Environment check
     var envError = getEnvironmentCheckError();
     if (envError) {
       alert(envError);
       return;
     }
-    
+
     if (!emailInput || !passwordInput || !submitBtn) return;
 
      var email = String(emailInput.value || '').trim();

--- a/js/auth.js
+++ b/js/auth.js
@@ -121,6 +121,7 @@ function resolveEmailAuthMode() {
 }
 
 function getLoginPageModule() {
+  if (window.LoveBudLoginPageController) return window.LoveBudLoginPageController;
   return window.LoveBudAuthLoginPage || null;
 }
 

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
-const path = require('node:path');
+const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -75,14 +75,6 @@ const AUTH_MODULE_ORDER_WITH_LOGIN_PAGE = [
   'js/auth/auth-login-page.js',
 ];
 
-// auth-login-page.js is loaded as a side-effect-free namespace helper;
-// root auth.js explicitly delegates login-page setup helpers when available.
-//
-// Non-goals for this contract change:
-// - No root auth.js shrink
-// - No login behavior change intended
-// - No duplicate listener behavior change
-// - No Firebase/Auth policy changes
 test('login page preserves firebase/config/i18n/shared-header before auth submodules and root auth.js', () => {
   assertOrderedScripts('pages/login.html', [
     'firebase-app.js',
@@ -170,14 +162,15 @@ test('root auth bootstrap exposes compatibility window APIs and flags', () => {
   }
 });
 
-test('root auth delegates login page helpers through the active login page namespace with LoveBudLoginPageController as primary', () => {
+test('root auth delegates login page helpers through method-aware provider selection', () => {
   const source = readRepoFile('js/auth.js');
 
   assert.match(source, /window\.LoveBudLoginPageController/, 'root auth must reference LoveBudLoginPageController as primary active provider');
   assert.match(source, /window\.LoveBudAuthLoginPage/, 'root auth must keep LoveBudAuthLoginPage as compatibility/fallback namespace');
   assert.match(source, /function\s+getLoginPageModule\s*\(/, 'root auth must keep a thin login page module lookup helper');
   assert.match(source, /function\s+callLoginPageModule\s*\(/, 'root auth must keep a thin login page module call helper');
-  assert.match(source, /LoveBudLoginPageController[\s\S]*LoveBudAuthLoginPage/, 'getLoginPageModule must check LoveBudLoginPageController first, then fallback to LoveBudAuthLoginPage');
+  assert.match(source, /EMAIL_AUTH_EXECUTION_METHODS/, 'root auth must define method-to-auth-provider mapping for method-aware selection');
+  assert.match(source, /setupEmailAuthForm[\s\S]*setupSignupForm|setupSignupForm[\s\S]*setupEmailAuthForm/, 'method mapping must include setupEmailAuthForm and setupSignupForm');
 
   for (const methodName of [
     'syncEmailAuthModeUi',
@@ -191,6 +184,48 @@ test('root auth delegates login page helpers through the active login page names
       source,
       new RegExp(`callLoginPageModule\\(\\s*['"]${methodName}['"]`),
       `root auth must delegate ${methodName} when active login page module exposes it`
+    );
+  }
+});
+
+test('root auth uses LoveBudAuthLoginPage directly for email auth execution methods', () => {
+  const source = readRepoFile('js/auth.js');
+
+  assert.match(
+    source,
+    /EMAIL_AUTH_EXECUTION_METHODS\s*=\s*\{[\s\S]*setupEmailAuthForm[\s\S]*\}/,
+    'setupEmailAuthForm must be in the email auth execution methods map'
+  );
+  assert.match(
+    source,
+    /EMAIL_AUTH_EXECUTION_METHODS\s*=\s*\{[\s\S]*setupSignupForm[\s\S]*\}/,
+    'setupSignupForm must be in the email auth execution methods map'
+  );
+  assert.match(
+    source,
+    /getLoginPageModule\(methodName\)[\s\S]*EMAIL_AUTH_EXECUTION_METHODS\[methodName\][\s\S]*LoveBudAuthLoginPage/,
+    'auth execution methods must bypass LoveBudLoginPageController and use LoveBudAuthLoginPage directly'
+  );
+  assert.match(
+    source,
+    /EMAIL_AUTH_EXECUTION_METHODS\[methodName\][\s\S]*LoveBudLoginPageController/,
+    'UI methods must use LoveBudLoginPageController when available'
+  );
+});
+
+test('root auth preserves LoveBudLoginPageController as primary for UI-only methods', () => {
+  const source = readRepoFile('js/auth.js');
+
+  for (const methodName of [
+    'syncEmailAuthModeUi',
+    'setupLoginPageAuthUi',
+    'setupGoogleBtn',
+    'setupSignupGoogleBtn',
+  ]) {
+    assert.match(
+      source,
+      new RegExp(`'${methodName}'`),
+      `root auth must reference ${methodName} in login page delegation`
     );
   }
 });

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -170,12 +170,14 @@ test('root auth bootstrap exposes compatibility window APIs and flags', () => {
   }
 });
 
-test('root auth delegates login page helpers through the auth-login-page namespace when available', () => {
+test('root auth delegates login page helpers through the active login page namespace with LoveBudLoginPageController as primary', () => {
   const source = readRepoFile('js/auth.js');
 
-  assert.match(source, /window\.LoveBudAuthLoginPage/, 'root auth must reference the login page helper namespace');
+  assert.match(source, /window\.LoveBudLoginPageController/, 'root auth must reference LoveBudLoginPageController as primary active provider');
+  assert.match(source, /window\.LoveBudAuthLoginPage/, 'root auth must keep LoveBudAuthLoginPage as compatibility/fallback namespace');
   assert.match(source, /function\s+getLoginPageModule\s*\(/, 'root auth must keep a thin login page module lookup helper');
   assert.match(source, /function\s+callLoginPageModule\s*\(/, 'root auth must keep a thin login page module call helper');
+  assert.match(source, /LoveBudLoginPageController[\s\S]*LoveBudAuthLoginPage/, 'getLoginPageModule must check LoveBudLoginPageController first, then fallback to LoveBudAuthLoginPage');
 
   for (const methodName of [
     'syncEmailAuthModeUi',
@@ -188,7 +190,7 @@ test('root auth delegates login page helpers through the auth-login-page namespa
     assert.match(
       source,
       new RegExp(`callLoginPageModule\\(\\s*['"]${methodName}['"]`),
-      `root auth must delegate ${methodName} when LoveBudAuthLoginPage exposes it`
+      `root auth must delegate ${methodName} when active login page module exposes it`
     );
   }
 });

--- a/tests/contracts/login-controller-skeleton-contract.test.js
+++ b/tests/contracts/login-controller-skeleton-contract.test.js
@@ -9,11 +9,11 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
-test('login controller skeleton defines the LoveBudAuthLoginPage-compatible method shape without runtime wiring', () => {
+test('login controller defines LoveBudLoginPageController as active boundary with LoveBudAuthLoginPage-compatible method shape', () => {
   const source = readRepoFile('js/login/login-page.js');
 
-  assert.match(source, /LoveBudLoginPageController/, 'skeleton must expose the isolated login page controller namespace');
-  assert.doesNotMatch(source, /LoveBudAuthLoginPage\s*=/, 'skeleton must not replace the active auth-login-page provider before wiring is approved');
+  assert.match(source, /LoveBudLoginPageController/, 'controller must expose LoveBudLoginPageController as active boundary');
+  assert.doesNotMatch(source, /LoveBudAuthLoginPage\s*=/, 'controller must not assign LoveBudAuthLoginPage (it is compatibility/fallback only)');
 
   for (const methodName of [
     'syncEmailAuthModeUi',
@@ -23,10 +23,10 @@ test('login controller skeleton defines the LoveBudAuthLoginPage-compatible meth
     'setupEmailAuthForm',
     'setupSignupForm',
   ]) {
-    assert.match(source, new RegExp(`${methodName}\\s*:`), `skeleton must define ${methodName}`);
+    assert.match(source, new RegExp(`${methodName}\\s*:`), `controller must define ${methodName}`);
   }
 
-  assert.match(source, /setupSignupForm\s*:\s*noop/, 'controller signup form auth execution must remain noop');
+  assert.match(source, /setupSignupForm\s*:\s*noop/, 'controller signup form auth execution must remain noop (auth execution delegated to auth.js via injected callbacks)');
 });
 
 test('login controller remains isolated from auth core and redirect/session policy', () => {

--- a/tests/contracts/login-controller-skeleton-contract.test.js
+++ b/tests/contracts/login-controller-skeleton-contract.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
-const path = require('node:path');
+const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -9,7 +9,7 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
-test('login controller defines LoveBudLoginPageController as active boundary with LoveBudAuthLoginPage-compatible method shape', () => {
+test('login controller defines LoveBudLoginPageController as active boundary for UI methods', () => {
   const source = readRepoFile('js/login/login-page.js');
 
   assert.match(source, /LoveBudLoginPageController/, 'controller must expose LoveBudLoginPageController as active boundary');
@@ -26,7 +26,8 @@ test('login controller defines LoveBudLoginPageController as active boundary wit
     assert.match(source, new RegExp(`${methodName}\\s*:`), `controller must define ${methodName}`);
   }
 
-  assert.match(source, /setupSignupForm\s*:\s*noop/, 'controller signup form auth execution must remain noop (auth execution delegated to auth.js via injected callbacks)');
+  assert.match(source, /setupSignupForm\s*:\s*noop/, 'controller signup form auth execution must remain noop (auth execution handled by LoveBudAuthLoginPage via method-aware provider selection)');
+  assert.match(source, /setupEmailAuthForm\s*:/, 'controller must define setupEmailAuthForm for UI wiring (modal open/close/toggle/mode sync; auth execution is handled by LoveBudAuthLoginPage)');
 });
 
 test('login controller remains isolated from auth core and redirect/session policy', () => {


### PR DESCRIPTION
## Summary
- Transition login page setup delegation to window.LoveBudLoginPageController as the active login-page boundary.
- Preserve existing Firebase email/Google auth semantics and post-login redirect behavior.
- Keep window.LoveBudAuthLoginPage only as compatibility/fallback where needed.
- Update contract tests for the new active provider boundary.

## Scope
- Auth/Login provider boundary only.
- No UI/CSS polish.
- No Firebase/session/cache/redirect policy change.
- No Editor/Search/Modal/API/Shared Header changes.

## Verification
- 
ode --check js/login/login-page.js
- 
ode --check js/auth/auth-login-page.js
- 
ode --check js/auth.js
- 
ode --test tests/contracts/login-controller-skeleton-contract.test.js
- 
ode --test tests/contracts/auth-bootstrap-contract.test.js

## Browser verification required
Fixed test slot required before Ready for Review:
- Desktop 1920x1080
- Mobile 390x844
- /pages/login.html
- ?redirect=my-trees.html
- Google login
- email modal login/signup toggle
- valid email login
- invalid credential behavior
- post-login redirect
- logout
- no duplicate submit/binding
- no fatal console error