### PR TITLE
docs(engineering): document page script load order

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -119,6 +119,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
 - [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
+- [SCRIPT_LOAD_ORDER.md](./engineering/SCRIPT_LOAD_ORDER.md) - pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, 금지 조합, fixed test slot 검증 기준
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획

--- a/docs/engineering/SCRIPT_LOAD_ORDER.md
+++ b/docs/engineering/SCRIPT_LOAD_ORDER.md
@@ -1,0 +1,323 @@
+# Page Script Load Order Runtime Contract
+
+## Status
+
+Documentation only. This document records the current page script load order contract and the review checklist for future changes.
+
+This document does not change runtime behavior.
+
+Out of scope:
+
+```text
+- pages/*.html edits
+- js/*.js edits
+- CSS edits
+- Auth/Login behavior changes
+- package.json creation
+- bundler or build-step introduction
+```
+
+---
+
+## Baseline architecture
+
+LoveBud currently uses a bundler-free static multipage structure.
+
+The browser loads each page directly from `pages/*.html` or the root entry pages. Those HTML files include scripts with classic `<script src="..."></script>` tags rather than an ES module graph or a bundler-generated dependency graph.
+
+Because of that structure, script tag order is a runtime contract.
+
+A script may:
+
+```text
+- define a browser global on window
+- read a browser global that was defined by an earlier script
+- register callbacks for a later script
+- bind DOM events after earlier page markup exists
+- assume Firebase, i18n, shared header, auth cache, or auth session helpers already exist
+```
+
+Changing script order is therefore not just formatting. It can change which provider is selected, whether a fallback path runs, or whether the same login form is bound more than once.
+
+---
+
+## General rule
+
+For `pages/*.html`, do not reorder scripts unless the PR explicitly proves the affected dependency chain.
+
+A safe script-order change must identify:
+
+```text
+1. what global each moved script creates
+2. what globals it reads
+3. whether it binds DOM events
+4. whether it changes auth/session/cache state
+5. whether an older fallback path becomes active by accident
+6. whether a page controller can now run before its dependencies exist
+```
+
+---
+
+## Auth/Login load order contract
+
+Auth/Login is the highest-risk script-order area because it combines Firebase SDK loading, browser-global auth modules, login-page controllers, redirect handling, session cache, and UI binding.
+
+The high-level dependency order is:
+
+```text
+1. Firebase SDK
+2. firebase-config
+3. i18n scripts
+4. shared-header
+5. auth-state
+6. auth-callbacks
+7. auth-cache
+8. auth-ui
+9. auth-session
+10. auth-firebase
+11. login page controller family
+12. auth.js
+13. final page-specific controller scripts
+```
+
+### 1. Firebase SDK
+
+Firebase SDK scripts must load before any LoveBud code that calls `firebase`, `firebase.auth`, or `initFirebase`.
+
+Typical order:
+
+```html
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+```
+
+### 2. firebase-config
+
+`js/firebase-config.js` must load after the Firebase SDK and before auth runtime modules that initialize Firebase.
+
+Expected role:
+
+```text
+- define Firebase client config helpers
+- expose initFirebase behavior used by Auth/Login runtime
+```
+
+### 3. i18n scripts
+
+The i18n scripts must load before page controllers that call `applyI18n`, `onLangChange`, or language-specific UI synchronization.
+
+Expected role:
+
+```text
+- register translation dictionaries
+- expose language helpers
+- provide applyI18n for page and header controllers
+```
+
+### 4. shared-header
+
+`js/shared-header.js` should load before page-specific controllers that call `renderSharedHeader`.
+
+Expected role:
+
+```text
+- define shared header rendering helpers
+- provide header containers that Auth UI may later fill or update
+```
+
+### 5. Auth submodules
+
+The auth submodules are browser-global support modules. They should load before the broad auth entrypoint `js/auth.js`.
+
+Expected order:
+
+```html
+<script src="../js/auth/auth-state.js"></script>
+<script src="../js/auth/auth-callbacks.js"></script>
+<script src="../js/auth/auth-cache.js"></script>
+<script src="../js/auth/auth-ui.js"></script>
+<script src="../js/auth/auth-session.js"></script>
+<script src="../js/auth/auth-firebase.js"></script>
+```
+
+Dependency purpose:
+
+| Script | Runtime role |
+| --- | --- |
+| `auth-state.js` | shared flags, cache keys, login page detection, email auth mode helpers |
+| `auth-callbacks.js` | auth-ready callback registration and callback firing helpers |
+| `auth-cache.js` | confirmed user cache, token cache, stale Firebase state clearing helpers |
+| `auth-ui.js` | login button, dropdown, loading/ready nav UI, auth UI rendering helpers |
+| `auth-session.js` | redirect target and post-login preload/session helpers |
+| `auth-firebase.js` | Firebase-specific adapter, sign-in/sign-out, auth observer, offline fallback |
+
+### 6. Login page controller family
+
+Login page controller scripts must be loaded before `js/auth.js` if `auth.js` is expected to discover or delegate to them at startup.
+
+Current controller-family order should preserve this shape:
+
+```html
+<script src="../js/login/login-dom.js"></script>
+<script src="../js/login/login-page.js"></script>
+<script src="../js/auth/auth-login-page.js"></script>
+```
+
+Expected globals:
+
+| Script | Expected global |
+| --- | --- |
+| `js/login/login-dom.js` | `window.LoveBudLoginDom` |
+| `js/login/login-page.js` | `window.LoveBudLoginPageController` |
+| `js/auth/auth-login-page.js` | `window.LoveBudAuthLoginPage` |
+
+`js/login/login-page.js` may use `window.LoveBudLoginDom` when available. Therefore, `login-dom.js` should stay before `login-page.js`.
+
+### 7. auth.js
+
+`js/auth.js` is the broad legacy/global auth entrypoint. It reads previously loaded auth module globals and chooses/delegates login-page behavior through the available login provider boundary.
+
+Because `auth.js` makes provider-selection and bootstrap decisions, it should not run before the intended provider globals exist.
+
+High-risk globals:
+
+```text
+window.LoveBudLoginPageController
+window.LoveBudAuthLoginPage
+window.LoveBudAuthFirebase
+window.LoveBudAuthState
+window.LoveBudAuthCallbacks
+window.LoveBudAuthCache
+window.LoveBudAuthUI
+window.LoveBudAuthSession
+```
+
+### 8. Page-specific controller scripts
+
+Final page-specific controller scripts, such as the login page shell controller, may assume that i18n, shared header, and auth globals already exist.
+
+For the login page, this final layer includes behavior such as:
+
+```text
+- render shared header on DOMContentLoaded
+- apply i18n after header/page elements are available
+- synchronize language UI
+- prepare inline error display hooks
+```
+
+---
+
+## PR #211 active provider transition risk
+
+PR #211 is an active provider transition area for Auth/Login. It is especially sensitive to script order.
+
+The risk centers on three runtime boundaries:
+
+```text
+window.LoveBudLoginPageController
+window.LoveBudAuthLoginPage
+js/auth.js provider selection
+```
+
+The intended transition must not accidentally occur through script reordering alone.
+
+Risk examples:
+
+```text
+- auth.js runs before the intended provider global exists
+- the legacy provider remains active because the new controller was loaded too late
+- the new controller becomes active before contract coverage expects it
+- both old and new providers bind the same submit or click handler
+- redirect query handling changes because setup ownership changed
+- invalid credential UI changes because a different provider path handled the error
+- Google login and email login stop sharing the same session/cache semantics
+```
+
+For active provider transition work, script order must be reviewed together with the Auth/Login transition plan and fixed-slot browser verification requirements.
+
+---
+
+## Contributor checklist before changing script order
+
+Before changing any `pages/*.html` script order, answer all of the following:
+
+```text
+- Is this PR explicitly allowed to edit HTML?
+- Is this PR explicitly allowed to edit Auth/Login runtime behavior?
+- Which script tags are moving?
+- Which window globals do those scripts create?
+- Which window globals do those scripts consume?
+- Does any moved script bind DOM events?
+- Does any moved script initialize Firebase, auth state, cache, session, redirect, or header UI?
+- Could the move activate a fallback path that was previously inactive?
+- Could the move bind the same form/button more than once?
+- Does the affected page still load i18n before applyI18n/onLangChange users?
+- Does the affected page still load shared-header before renderSharedHeader users?
+```
+
+For Auth/Login pages, also confirm:
+
+```text
+- Firebase SDK loads before firebase-config.
+- firebase-config loads before auth-firebase/auth.js initialization.
+- auth-state loads before auth modules that read flags/cache keys/page mode helpers.
+- auth-callbacks loads before auth.js callback registration delegation.
+- auth-cache loads before auth-firebase/auth.js cache/session logic.
+- auth-ui loads before auth.js nav/dropdown rendering delegation.
+- auth-session loads before redirect/preload behavior is used.
+- auth-firebase loads before auth.js delegates Firebase runtime behavior.
+- login-dom loads before login-page controller code that may read LoveBudLoginDom.
+- LoveBudLoginPageController and/or LoveBudAuthLoginPage load before auth.js provider selection.
+- The expected active provider matches the current PR phase.
+```
+
+---
+
+## Verification expectations
+
+For this documentation PR:
+
+```text
+- changed files must be docs only
+- new document link must be reachable from the engineering docs index
+- no runtime test is required because runtime files are not changed
+```
+
+For a future implementation PR that changes page script order:
+
+```text
+- run syntax checks for changed JS files
+- run relevant contract tests
+- perform browser smoke on the affected page
+- for Auth/Login, use the required fixed test slot flow before declaring runtime PASS
+```
+
+Auth/Login smoke should include at minimum:
+
+```text
+- login page loads without fatal console error
+- Google login button still binds exactly once
+- email modal opens and closes
+- login/signup toggle does not double-bind
+- invalid credential path is visible and stable
+- valid login persists session/cache as expected
+- explicit redirect query still controls post-login redirect
+- logout returns the user to non-auth state
+```
+
+---
+
+## Bundler note
+
+A bundler, module loader, or ES module conversion may eventually reduce this class of risk, but that is not part of this document or this PR.
+
+Until a separate architecture PR explicitly introduces and verifies such a change, `pages/*.html` script order remains the runtime dependency contract.
+
+---
+
+## Related documents
+
+- [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md)
+- [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md)
+- [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md)
+- [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md)

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -21,10 +21,11 @@
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-5. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-6. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-7. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-8. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+5. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+8. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+9. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -36,6 +37,7 @@
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
 | [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 순서 |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
+| [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
@@ -58,6 +60,7 @@
 - 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
 - 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
+- pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 


### PR DESCRIPTION
## Summary
- Add `docs/engineering/SCRIPT_LOAD_ORDER.md` documenting the current bundler-free static multipage script-order contract.
- Record Auth/Login load order dependencies, including Firebase SDK/config, i18n, shared header, auth submodules, login controller boundaries, and `auth.js`.
- Document PR #211 active provider transition risk around `LoveBudLoginPageController`, `LoveBudAuthLoginPage`, and `auth.js` provider selection.
- Add contributor checklist before changing `pages/*.html` script order.
- Link the new document from `docs/engineering/engineering_index.md` and `docs/doc_index.md`.

## Scope
- Documentation only.
- No `pages/*.html`, `js/*.js`, CSS, Auth/Login runtime, package, bundler, or build-step changes.

## Verification
- Confirmed compare against `73eecc8996052d93ae1ccc8272012381042a8e73` is docs-only.
- Changed files are limited to:
  - `docs/engineering/SCRIPT_LOAD_ORDER.md`
  - `docs/engineering/engineering_index.md`
  - `docs/doc_index.md`

## Note
The requested branch name `docs/page-script-load-order` was blocked by the connector branch-creation safety check, so this draft PR uses the safe equivalent branch `docs-page-script-load-order`.