### PR TITLE
refactor(search): delegate card selection events

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -14,7 +14,7 @@
         } = refs;
         const { PreviewRenderer } = renderers;
         const treeDataMap = new WeakMap();
-        let _isDelegationBound = false;
+        const boundContainers = new WeakSet();
 
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
@@ -58,7 +58,6 @@
             if (!preserveOpenState && isMobilePreviewMode()) {
                 setMobilePreviewOpen(false);
             }
-            callbacks.updateUrlState?.();
         }
 
         function getSearchCopy(key, fallbackKo, fallbackEn) {
@@ -307,44 +306,42 @@
             }
         }
 
-        function bindDelegatedCardEvents() {
-            if (_isDelegationBound) return;
-            _isDelegationBound = true;
+        function bindDelegatedCardEvents(container) {
+            if (!container || boundContainers.has(container)) return;
+            boundContainers.add(container);
 
-            const containers = [resultsList, growingList].filter(Boolean);
-            containers.forEach(container => {
-                container.addEventListener('click', (event) => {
-                    const card = event.target.closest('.tree-card');
-                    if (!card) return;
+            container.addEventListener('click', (event) => {
+                if (event.defaultPrevented) return;
 
-                    // Ignore clicks on nested interactive elements (links, buttons, etc.)
-                    const interactiveChild = event.target.closest('a, button, input, textarea, [role="button"]');
-                    if (interactiveChild && interactiveChild !== card) return;
+                const card = event.target.closest('.tree-card[data-tree-id]');
+                if (!card || !container.contains(card)) return;
 
-                    const tree = treeDataMap.get(card);
-                    if (tree) {
-                        callbacks.selectTree(tree, card);
-                        callbacks.updateUrlState?.();
-                    }
-                });
+                // Ignore clicks on nested interactive elements
+                const interactiveSelector = 'a, button, input, select, textarea, [data-share-tree-link], [data-action], [role="button"]';
+                const interactiveChild = event.target.closest(interactiveSelector);
+                if (interactiveChild && interactiveChild !== card) return;
 
-                container.addEventListener('keydown', (event) => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                const tree = treeDataMap.get(card);
+                if (tree) {
+                    callbacks.selectTree(tree, card);
+                }
+            });
 
-                    const card = event.target.closest('.tree-card');
-                    if (!card) return;
+            container.addEventListener('keydown', (event) => {
+                if (event.defaultPrevented || (event.key !== 'Enter' && event.key !== ' ')) return;
 
-                    // Ignore events on nested interactive elements if target is not the card itself
-                    const interactiveChild = event.target.closest('a, button, input, textarea, [role="button"]');
-                    if (interactiveChild && interactiveChild !== card) return;
+                const card = event.target.closest('.tree-card[data-tree-id]');
+                if (!card || !container.contains(card)) return;
 
-                    event.preventDefault();
-                    const tree = treeDataMap.get(card);
-                    if (tree) {
-                        callbacks.selectTree(tree, card);
-                        callbacks.updateUrlState?.();
-                    }
-                });
+                const interactiveSelector = 'a, button, input, select, textarea, [data-share-tree-link], [data-action], [role="button"]';
+                const interactiveChild = event.target.closest(interactiveSelector);
+                if (interactiveChild && interactiveChild !== card) return;
+
+                event.preventDefault();
+                const tree = treeDataMap.get(card);
+                if (tree) {
+                    callbacks.selectTree(tree, card);
+                }
             });
         }
 
@@ -367,8 +364,8 @@
                 treeDataMap.set(card, tree);
             });
             
-            // Ensure container listeners are bound
-            bindDelegatedCardEvents();
+            // Ensure container listener is bound
+            bindDelegatedCardEvents(listElement);
         }
 
         function bindShareCopyHandler() {

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -13,6 +13,8 @@
             mobilePreviewMediaQuery
         } = refs;
         const { PreviewRenderer } = renderers;
+        const treeDataMap = new WeakMap();
+        let _isDelegationBound = false;
 
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
@@ -56,6 +58,7 @@
             if (!preserveOpenState && isMobilePreviewMode()) {
                 setMobilePreviewOpen(false);
             }
+            callbacks.updateUrlState?.();
         }
 
         function getSearchCopy(key, fallbackKo, fallbackEn) {
@@ -304,6 +307,47 @@
             }
         }
 
+        function bindDelegatedCardEvents() {
+            if (_isDelegationBound) return;
+            _isDelegationBound = true;
+
+            const containers = [resultsList, growingList].filter(Boolean);
+            containers.forEach(container => {
+                container.addEventListener('click', (event) => {
+                    const card = event.target.closest('.tree-card');
+                    if (!card) return;
+
+                    // Ignore clicks on nested interactive elements (links, buttons, etc.)
+                    const interactiveChild = event.target.closest('a, button, input, textarea, [role="button"]');
+                    if (interactiveChild && interactiveChild !== card) return;
+
+                    const tree = treeDataMap.get(card);
+                    if (tree) {
+                        callbacks.selectTree(tree, card);
+                        callbacks.updateUrlState?.();
+                    }
+                });
+
+                container.addEventListener('keydown', (event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+                    const card = event.target.closest('.tree-card');
+                    if (!card) return;
+
+                    // Ignore events on nested interactive elements if target is not the card itself
+                    const interactiveChild = event.target.closest('a, button, input, textarea, [role="button"]');
+                    if (interactiveChild && interactiveChild !== card) return;
+
+                    event.preventDefault();
+                    const tree = treeDataMap.get(card);
+                    if (tree) {
+                        callbacks.selectTree(tree, card);
+                        callbacks.updateUrlState?.();
+                    }
+                });
+            });
+        }
+
         function attachCardEvents(listElement, trees) {
             if (!listElement) return;
             const cards = listElement.querySelectorAll('.tree-card');
@@ -312,21 +356,19 @@
                 const tree = trees.find(t => t.id === treeId);
                 if (!tree) return;
 
+                // Set accessibility attributes for delegation
                 card.setAttribute('tabindex', '0');
                 card.setAttribute('role', 'button');
+
+                // Sync initial aria-pressed state
                 card.setAttribute('aria-pressed', tree.id === state.selectedTreeId ? 'true' : 'false');
-
-                card.addEventListener('click', () => {
-                    callbacks.selectTree(tree, card);
-                });
-
-                card.addEventListener('keydown', (event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        callbacks.selectTree(tree, card);
-                    }
-                });
+                
+                // Map tree data for delegated event handler
+                treeDataMap.set(card, tree);
             });
+            
+            // Ensure container listeners are bound
+            bindDelegatedCardEvents();
         }
 
         function bindShareCopyHandler() {

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -47,3 +47,20 @@ test('search UI module preserves orchestrator contract methods', () => {
     assert.match(uiModule, new RegExp(`\\b${method}\\b`));
   }
 });
+
+test('search UI module implements card accessibility and event delegation', () => {
+  const uiModule = read('js/search/search-ui.js');
+  
+  // Verify accessibility attributes are set
+  assert.match(uiModule, /card\.setAttribute\(['"]tabindex['"],\s*['"]0['"]\)/);
+  assert.match(uiModule, /card\.setAttribute\(['"]role['"],\s*['"]button['"]\)/);
+  
+  // Verify event delegation pattern
+  assert.match(uiModule, /container\.addEventListener\(['"]click['"]/);
+  assert.match(uiModule, /container\.addEventListener\(['"]keydown['"]/);
+  assert.match(uiModule, /event\.target\.closest\(['"]\.tree-card['"]\)/);
+  
+  // Verify URL state sync on selection
+  assert.match(uiModule, /callbacks\.updateUrlState\?\.\(\)/);
+});
+

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -58,9 +58,5 @@ test('search UI module implements card accessibility and event delegation', () =
   // Verify event delegation pattern
   assert.match(uiModule, /container\.addEventListener\(['"]click['"]/);
   assert.match(uiModule, /container\.addEventListener\(['"]keydown['"]/);
-  assert.match(uiModule, /event\.target\.closest\(['"]\.tree-card['"]\)/);
-  
-  // Verify URL state sync on selection
-  assert.match(uiModule, /callbacks\.updateUrlState\?\.\(\)/);
+  assert.match(uiModule, /event\.target\.closest\(['"]\.tree-card\[data-tree-id\]['"]\)/);
 });
-


### PR DESCRIPTION
Refactored search card interactions from per-card listeners to container-level event delegation in `js/search/search-ui.js`.

Key Changes:
- Replaced direct listeners with centralized delegation in `bindDelegatedCardEvents`.
- Implemented `treeDataMap` (WeakMap) for robust DOM-to-data association.
- Added interactive element protection (ignoring clicks on nested buttons/links).
- Enhanced accessibility: `tabindex="0"`, `role="button"`, and `aria-pressed` hydration.
- Strictly adheres to the project's Thin Entrypoint and browser-global logic policies.

Verification:
- All runtime contract tests in `tests/routes/search-runtime-modules.test.js` passed.
- No changes to API, rendering logic, or global CSS.
