### PR TITLE
refactor(editor): extract local http status helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -58,6 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
 
+    const getHttpStatus = (error) => Number(error?.status || error?.statusCode || error?.response?.status || 0);
+
     const readConfirmedAuthCache = editorAuthHelpers.readConfirmedAuthCache || function() {
         try {
             if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
@@ -728,7 +730,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     );
                 } catch (error) {
                     console.error('[editor] Failed to toggle sidebar visibility:', error);
-                    const status = Number(error?.status || error?.statusCode || error?.response?.status || 0);
+                    const status = getHttpStatus(error);
                     const message = String(error?.message || '');
                     const isPublicationGuard = status === 409 || /공개 순간이|at least 3 public moments/i.test(message);
                     showToast(


### PR DESCRIPTION
## Summary
Extract local getHttpStatus helper in js/editor.js to DRY up repeated HTTP status extraction pattern.

## Scope
- js/editor.js only
- no script order changes
- no fallback removal
- no global state changes
- no UI/CSS changes
- no Auth/Search/API changes

## Changes
- Added local getHttpStatus helper
- Replaced inline status extraction with helper call

## Verified
- node --check js/editor.js passes
- git diff --check passes
- 409 publication guard behavior preserved