### PR TITLE
fix(netlify): include Pages production origin in default CORS allowlist

### DIFF
--- a/netlify/functions/_lib/http.js
+++ b/netlify/functions/_lib/http.js
@@ -7,6 +7,7 @@
  */
 
 const DEFAULT_ALLOWED_ORIGINS = [
+  'https://lovebud.pages.dev',
   'https://lovebud.netlify.app',
   'https://lovebud.vercel.app',
 ];


### PR DESCRIPTION
## 변경 파일
- netlify/functions/_lib/http.js

## 변경 이유
- Cloudflare Pages (`https://lovebud.pages.dev`)가 현재 production origin이므로 기본 CORS allowlist에 포함 필요

## Issue #224 대응
- [x] 1번 항목: Netlify CORS default production origin 추가

## 테스트
- 별도 CORS 테스트 없음
- 코드 diff 검증 완료 (DEFAULT_ALLOWED_ORIGINS에 origin 추가만 수행)

## 영향 범위 확인
- Cloudflare Functions: 미수정
- Modal: 미수정
- prototype / reference / demo / variant: 미수정
- PR #7: 미수정
