### PR TITLE
refactor(css): add primary rgb token and replace low-risk global control rgba

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -324,11 +324,11 @@ body .search-panel-header p {
     --control-secondary-border: var(--outline-variant);
     --control-chip-bg: rgba(255, 255, 255, 0.76);
     --control-chip-text: var(--on-surface-variant);
-    --control-chip-border: rgba(144, 73, 81, 0.08);
-    --control-chip-active-bg: rgba(144, 73, 81, 0.12);
+    --control-chip-border: rgba(var(--primary-rgb), 0.08);
+    --control-chip-active-bg: rgba(var(--primary-rgb), 0.12);
     --control-chip-active-text: var(--primary);
-    --control-chip-active-border: rgba(144, 73, 81, 0.16);
-    --control-focus-ring: rgba(144, 73, 81, 0.42);
+    --control-chip-active-border: rgba(var(--primary-rgb), 0.16);
+    --control-focus-ring: rgba(var(--primary-rgb), 0.42);
 }
 
 /* Primary CTA unification */

--- a/css/global/tokens.css
+++ b/css/global/tokens.css
@@ -3,6 +3,7 @@
 :root {
     /* Premium Modern Palette - Warm Scrapbook Tone */
     --primary: #904951;           /* 뮤트 로즈 - 메인 브랜드 */
+    --primary-rgb: 144, 73, 81;
     --primary-vibrant: #b85c66;   /* 채도 낮춘 로즈 - hover accent (원색 금지) */
     --primary-soft: #d4a5a9;      /* 소프트 로즈 - 감정 태그용 */
     --on-primary: #ffffff;


### PR DESCRIPTION
## Changed files
- `css/global/tokens.css`
- `css/global.css`

## Scope
- Add `--primary-rgb` token
- Replace exactly 4 PR3 Control Tokens rgba values
- No broad replace
- No visual output change expected
- No JS/HTML/Auth/API/Search/Editor changes
- No header/index/intro CSS changes
- PR #7 untouched

## Test
- CI
- Basic visual smoke if preview is available