### PR TITLE
docs: preserve reference artifact folders

### DIFF
--- a/docs/design/PROTOTYPE_REFERENCE_POLICY.md
+++ b/docs/design/PROTOTYPE_REFERENCE_POLICY.md
@@ -1,33 +1,53 @@
 # Prototype Reference Preservation Policy
 
-이 문서는 LoveBud 저장소의 prototype / reference 폴더를 repo cleanup 과정에서 자동 삭제하거나 이동하지 않기 위한 보존 정책입니다.
+이 문서는 LoveBud 저장소의 prototype / reference / demo / variant 폴더를 repo cleanup 과정에서 자동 정리하지 않기 위한 보존 정책입니다.
 
-Detailed prototype / variant path inventory is maintained in [`docs/reference/PROTOTYPE_INDEX.md`](../reference/PROTOTYPE_INDEX.md) as reference only.
+Detailed prototype / variant / demo / reference path inventory is maintained in [`docs/reference/PROTOTYPE_INDEX.md`](../reference/PROTOTYPE_INDEX.md) as the canonical reference-only inventory.
 
 ## 1. Policy summary
 
-Prototype / reference 폴더는 현재 production flow에 직접 연결되어 있지 않더라도 삭제 후보로 단정하지 않습니다.
+Prototype / reference / demo / variant 폴더는 현재 production flow에 직접 연결되어 있지 않더라도 cleanup 후보로 단정하지 않습니다.
 
-아래 성격의 파일과 폴더는 LoveBud 디자인 탐색, 둘러보기 경험, 트리 시각화, 랜딩 스타일 비교를 위한 reference asset으로 보존합니다.
+아래 성격의 파일과 폴더는 LoveBud 디자인 탐색, 둘러보기 경험, 트리 시각화, 랜딩 스타일 비교, 인터랙션 비교를 위한 reference asset으로 보존합니다.
 
 - landing / browse / editor visual experiment
 - tree visualization prototype
 - scrapbook / hotspot / demo interaction reference
 - AI-generated or GPT-generated UI prototype
+- quiet home landing visual experiment
 - hidden experiment page
 - PR discussion에 남은 design exploration artifact
 
 ## 2. Protected prototype/reference paths
 
-다음 경로는 repo hygiene, cleanup, unused-file 정리 과정에서 자동 삭제/이동/ignore 대상이 아닙니다.
+다음 경로는 repo hygiene, cleanup, unused-file 정리 과정에서 자동 cleanup 대상이 아닙니다.
 
 ```text
 pages/gpt-v2/
+css/gpt-v2/
 assets/gpt-v2/
+
+pages/gemini-v2/
+css/gemini-v2/
+
+pages/gemini-v3/
+css/gemini-v3/
+
+pages/v2/
+css/v2/
+
+pages/kimi-v2/
+assets/css/kimi-v2/
+assets/js/kimi-v2/
+
+hotspot-prototype/
+scrapbook-demo/
+quiet/
+
 pages/gpt-svg-tree/
 ```
 
-또한 아래 패턴의 demo/reference 폴더도 파일명만 보고 삭제 후보로 단정하지 않습니다.
+또한 아래 패턴의 demo/reference 폴더도 파일명만 보고 cleanup 후보로 단정하지 않습니다.
 
 ```text
 hotspot-prototype*
@@ -35,25 +55,30 @@ scrapbook-demo*
 prototype*
 reference*
 demo*
+variant*
 ```
 
 중요:
 
+- `hotspot-prototype/`는 hotspot interaction / layout exploration / prototype reference artifact입니다.
+- `scrapbook-demo/`는 scrapbook interaction / visual storytelling / demo reference artifact입니다.
+- `quiet/`는 quiet home landing visual experiment / historical UI reference artifact입니다.
+- `quiet/`는 이름에 `prototype`, `demo`, `variant`가 없더라도 보존 대상입니다.
 - `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.
-- PR #7을 close하거나 branch를 삭제하지 않습니다.
+- PR #7을 close하거나 branch를 정리하지 않습니다.
 - production artifact 우려가 있더라도 현재 정책은 보존 우선입니다.
-- 실제 이동/삭제/ignore 처리가 필요하면 CTO 별도 승인이 필요합니다.
+- 실제 정리가 필요하면 CTO 별도 승인이 필요합니다.
 
 ## 3. Repo hygiene rule
 
 Repo hygiene 작업자는 다음을 금지합니다.
 
-- prototype/reference 폴더 자동 삭제
-- prototype/reference 폴더 자동 이동
-- prototype/reference 폴더 `.gitignore` 추가
-- PR #7 관련 파일 삭제
-- `pages/gpt-svg-tree/` 삭제 또는 branch cleanup
-- 파일명만 보고 unused artifact로 단정
+- prototype/reference/demo/variant 폴더 자동 cleanup
+- protected reference artifact를 파일명만 보고 unused artifact로 단정
+- protected reference artifact를 `.gitignore`에 추가
+- protected reference artifact를 route 차단 또는 hide 처리
+- PR #7 관련 파일 정리
+- `hotspot-prototype/`, `scrapbook-demo/`, `quiet/`를 이름만 보고 unused artifact로 단정
 
 정리가 필요해 보이는 경우에는 먼저 아래 정보를 보고해야 합니다.
 
@@ -61,21 +86,21 @@ Repo hygiene 작업자는 다음을 금지합니다.
 2. 현재 production navigation/API와 연결 여부
 3. 디자인 reference로 남길 가치
 4. production artifact 우려
-5. 삭제/이동/보존 중 권장 판단
+5. 보존 또는 별도 정리 중 권장 판단
 6. CTO 승인 필요 여부
 
 ## 4. Production artifact concern
 
-Prototype/reference 폴더가 `pages/` 또는 `assets/` 아래에 있으면 정적 배포 산출물에 포함될 수 있습니다.
+Prototype/reference/demo/variant 폴더가 `pages/`, `assets/`, `css/`, 또는 top-level static folder 아래에 있으면 정적 배포 산출물에 포함될 수 있습니다.
 
 그러나 현재 정책은 다음 순서로 판단합니다.
 
 1. 먼저 보존한다.
 2. production 노출 우려를 문서화한다.
 3. 숨김 경로, 라우팅 차단, archive 이동, 삭제 중 어떤 처리가 필요한지 별도 검토한다.
-4. CTO 승인 전에는 이동/삭제하지 않는다.
+4. CTO 승인 전에는 정리하지 않는다.
 
-즉, production artifact 우려는 삭제의 자동 근거가 아닙니다.
+즉, production artifact 우려는 자동 cleanup의 근거가 아닙니다.
 
 ## 5. Specific PR #7 rule
 
@@ -84,22 +109,33 @@ PR #7 `experiment: SVG tree prototype`은 오래된 open/draft PR이지만, tree
 정책:
 
 - PR #7 close 금지
-- PR #7 branch 삭제 금지
-- PR #7 관련 `pages/gpt-svg-tree/` 파일 삭제 금지
+- PR #7 branch cleanup 금지
+- PR #7 관련 `pages/gpt-svg-tree/` 파일 cleanup 금지
 - PR #7을 main에 merge할지, archive할지, close할지는 CTO가 별도 판단합니다.
 
-## 6. Review checklist
+## 6. Production promotion rule
+
+보존 reference artifact를 운영에 편입하려면 다음 기준을 따릅니다.
+
+- prototype/reference/demo/variant 경로를 그대로 production navigation에 연결하지 않습니다.
+- current production page, CSS, JS, API 구조에 맞춰 별도 production implementation PR에서 재구현합니다.
+- 해당 PR에는 CTO의 명시 승인이 필요합니다.
+- active runtime source of truth는 운영 `pages/*.html`, active CSS/JS, Cloudflare Pages Functions, Modal runtime 기준으로 판단합니다.
+
+## 7. Review checklist
 
 Prototype/reference 관련 변경 PR을 검토할 때 아래를 확인합니다.
 
-- 변경 파일에 `pages/gpt-v2/`, `assets/gpt-v2/`, `pages/gpt-svg-tree/`가 포함되어 있는가
-- `hotspot-prototype*`, `scrapbook-demo*`, `prototype*`, `reference*`, `demo*` 패턴의 폴더가 포함되어 있는가
-- 삭제/이동/ignore가 포함되어 있는가
+- 변경 파일에 protected reference artifact 경로가 포함되어 있는가
+- `hotspot-prototype*`, `scrapbook-demo*`, `prototype*`, `reference*`, `demo*`, `variant*` 패턴의 폴더가 포함되어 있는가
+- `quiet/`가 포함되어 있는가
+- cleanup/route-block/hide 처리가 포함되어 있는가
 - CTO 별도 승인이 명시되어 있는가
 - production artifact 우려와 design reference 가치가 함께 기록되어 있는가
+- `docs/reference/PROTOTYPE_INDEX.md`의 canonical inventory와 충돌하지 않는가
 
-## 7. One-line rule
+## 8. One-line rule
 
 ```text
-Prototype/reference folders are preserved design assets, not automatic cleanup targets.
+Prototype/reference/demo/variant folders are preserved design assets, not automatic cleanup targets.
 ```

--- a/docs/design/design_index.md
+++ b/docs/design/design_index.md
@@ -8,7 +8,7 @@
 - 색상, 타이포그래피, 레이아웃 기준
 - UI polish 단계 분리 기준
 - button / badge / chip tone 기준
-- prototype/reference 폴더 보존 기준
+- prototype/reference/demo/variant 폴더 보존 기준
 
 ## 폴더 구조
 
@@ -27,7 +27,7 @@ design/
 | [UI_POLISH_ROADMAP.md](UI_POLISH_ROADMAP.md) | PR #49, #51, #62, #63, #66, #67, #69, #70 이후 public UI polish와 Search 후속 작업 범위 분리 기준 |
 | [BUTTON_BADGE_CHIP_BASELINE.md](BUTTON_BADGE_CHIP_BASELINE.md) | button / badge / chip tone 통일 기준 |
 | [BUTTON_BASELINE_CONSOLIDATION_PLAN.md](BUTTON_BASELINE_CONSOLIDATION_PLAN.md) | global.css button baseline 중복 정의 정리 계획 |
-| [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md) | pages/assets 하위 prototype/reference 폴더 보존 정책 |
+| [PROTOTYPE_REFERENCE_POLICY.md](PROTOTYPE_REFERENCE_POLICY.md) | pages/assets/css 및 top-level prototype/reference/demo/variant 폴더 보존 정책 |
 
 ### 프롬프트 (Prompts)
 
@@ -44,20 +44,34 @@ design/
 
 ## Prototype / reference 보존 원칙
 
-아래 경로와 패턴은 repo cleanup 과정에서 자동 삭제/이동/ignore 대상으로 분류하지 않습니다.
+Prototype / reference / demo / variant 계열의 canonical inventory는 `../reference/PROTOTYPE_INDEX.md`입니다.
 
-- `pages/gpt-v2/`
-- `assets/gpt-v2/`
-- `pages/gpt-svg-tree/`
-- `hotspot-prototype*`
-- `scrapbook-demo*`
-- `prototype*`
-- `reference*`
-- `demo*`
+보존 대상 예시는 아래와 같습니다.
 
-삭제, 이동, ignore 처리가 필요하면 CTO 별도 승인이 필요합니다.
+```text
+pages/gpt-v2/
+css/gpt-v2/
+assets/gpt-v2/
+pages/gemini-v2/
+css/gemini-v2/
+pages/gemini-v3/
+css/gemini-v3/
+pages/v2/
+css/v2/
+pages/kimi-v2/
+assets/css/kimi-v2/
+assets/js/kimi-v2/
+hotspot-prototype/
+scrapbook-demo/
+quiet/
+pages/gpt-svg-tree/
+```
+
+특히 `hotspot-prototype/`, `scrapbook-demo/`, `quiet/`는 active production route가 아니지만 디자인·인터랙션·랜딩 실험 레퍼런스로 보존합니다. 운영 편입이 필요하면 current production 구조에 맞춰 별도 implementation PR에서 재구현합니다.
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`
+- Prototype / reference 보존 정책: `./PROTOTYPE_REFERENCE_POLICY.md`
+- Prototype / variant canonical inventory: `../reference/PROTOTYPE_INDEX.md`
 - 대화 기록: `../conversation/`
 - 제품 정체성: `../product/PRODUCT_IDENTITY.md`

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -12,8 +12,9 @@
 - Vercel은 upstream / secondary entry / 전이기 보조 계층입니다.
 - Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
 - `PRODUCT_IDENTITY / BRAND_EXPERIENCE / UI_DESIGN_SYSTEM` 은 제품/브랜드/UI 판단의 source of truth 입니다.
-- prototype/reference 폴더는 repo hygiene에서 자동 삭제/이동/ignore 대상으로 분류하지 않습니다.
-- `pages/gpt-v2/`, `assets/gpt-v2/`, `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.
+- prototype/reference/demo/variant 폴더는 repo hygiene에서 자동 cleanup 대상으로 분류하지 않습니다.
+- `pages/gpt-v2/`, `css/gpt-v2/`, `assets/gpt-v2/`, `pages/gemini-v2/`, `css/gemini-v2/`, `pages/gemini-v3/`, `css/gemini-v3/`, `pages/v2/`, `css/v2/`, `pages/kimi-v2/`, `assets/css/kimi-v2/`, `assets/js/kimi-v2/`, `hotspot-prototype/`, `scrapbook-demo/`, `quiet/`, `pages/gpt-svg-tree/` 및 PR #7 관련 prototype은 보존합니다.
+- prototype/reference/demo/variant의 canonical inventory는 `docs/reference/PROTOTYPE_INDEX.md`입니다.
 - 신규 tree의 정책상 기본 visibility는 `public`입니다.
 - private storage는 Plus entitlement가 필요합니다.
 - memory visibility가 생략되면 parent tree visibility를 상속합니다.
@@ -45,10 +46,10 @@ Visibility, private storage, anonymous public exposure, Browse/Search eligibilit
 - `./product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
 - `./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
 
-Prototype/reference 폴더 정리, 보존, repo hygiene 판단이 필요하면 아래를 추가로 읽습니다.
+Prototype/reference/demo/variant 폴더 정리, 보존, repo hygiene 판단이 필요하면 아래를 추가로 읽습니다.
 
 - `./design/PROTOTYPE_REFERENCE_POLICY.md`
-- `./reference/PROTOTYPE_INDEX.md` - reference only: prototype / variant 경로 목록과 active production route 아님을 명시한 인덱스
+- `./reference/PROTOTYPE_INDEX.md` - reference only: prototype / variant / demo / reference 경로 목록과 active production route 아님을 명시한 canonical inventory
 
 UI polish 단계 분리, PR3/PR4/PR5 범위 판단이 필요하면 아래를 추가로 읽습니다.
 
@@ -99,7 +100,7 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 - [UI_DESIGN_SYSTEM.md](./design/UI_DESIGN_SYSTEM.md) - UI 구조 / 감정 위계 / 컴포넌트 규칙 source of truth
 - [UI_POLISH_ROADMAP.md](./design/UI_POLISH_ROADMAP.md) - PR #49, #51, #62, #63, #66, #67, #69, #70 이후 public UI polish와 Search 후속 작업 범위 분리 기준
 - [BUTTON_BADGE_CHIP_BASELINE.md](./design/BUTTON_BADGE_CHIP_BASELINE.md) - button / badge / chip tone 통일 기준
-- [PROTOTYPE_REFERENCE_POLICY.md](./design/PROTOTYPE_REFERENCE_POLICY.md) - prototype/reference 폴더 보존 정책
+- [PROTOTYPE_REFERENCE_POLICY.md](./design/PROTOTYPE_REFERENCE_POLICY.md) - prototype/reference/demo/variant 폴더 보존 정책
 - [prompts/image-generation-prompts.md](./design/prompts/image-generation-prompts.md) - 이미지 생성 프롬프트 모음
 - [prompts/home-hero-slide-prompts.txt](./design/prompts/home-hero-slide-prompts.txt) - 홈 히어로 슬라이드 프롬프트
 - [stitch_image_to_website/DESIGN.md](./design/stitch_image_to_website/DESIGN.md) - Stitch image-to-website reference design note. 현재 active UI polish source of truth는 아님
@@ -108,7 +109,7 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 
 Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 
-- [PROTOTYPE_INDEX.md](./reference/PROTOTYPE_INDEX.md) - reference only: prototype / variant 경로 목록과 운영 편입 금지 기준
+- [PROTOTYPE_INDEX.md](./reference/PROTOTYPE_INDEX.md) - reference only: prototype / variant / demo / reference 경로 목록과 운영 편입 금지 기준
 
 ## engineering 문서군
 

--- a/docs/reference/PROTOTYPE_INDEX.md
+++ b/docs/reference/PROTOTYPE_INDEX.md
@@ -1,14 +1,14 @@
 # Prototype / Variant Reference Index
 
-이 문서는 LoveBud 저장소에 남아 있는 prototype / variant 계열 파일을 삭제하거나 차단하지 않고, reference artifact로 보존하기 위한 canonical index입니다.
+이 문서는 LoveBud 저장소의 prototype / variant / demo / reference 계열 파일을 reference artifact로 보존하기 위한 canonical inventory입니다.
 
-공식 사용자-facing 주소는 `https://lovebud.pages.dev/`입니다. 현재 active production route는 운영 `pages/*.html` 구조를 기준으로 판단하며, 아래 prototype / variant 경로는 active production route 또는 active production candidate가 아닙니다.
+공식 사용자-facing 주소는 `https://lovebud.pages.dev/`입니다. 현재 active production route는 운영 `pages/*.html` 구조를 기준으로 판단합니다. 아래 경로는 active production route 또는 active production candidate가 아닙니다.
 
 ## 1. Purpose
 
-- prototype / variant 파일을 삭제하지 않고 reference artifact로 보존합니다.
+- prototype / variant / demo / reference 파일을 reference artifact로 보존합니다.
 - 운영 사용자-facing 화면과 혼동되지 않도록 분류합니다.
-- 향후 cleanup 작업자가 임의로 삭제, 이동, 이름 변경, route 차단, ignore 처리하지 않도록 기준을 제공합니다.
+- 향후 cleanup 작업자가 임의로 정리하지 않도록 기준을 제공합니다.
 - PR #7 관련 artifact와 prototype / reference / demo / variant 계열 파일은 자동 cleanup 대상이 아님을 명시합니다.
 
 ## 2. Operating standard
@@ -16,89 +16,90 @@
 - 아래 경로들은 현재 공식 운영 navigation에 노출하지 않습니다.
 - 아래 경로들은 신규 기능 구현 대상이 아닙니다.
 - 아래 경로들은 active production route가 아닙니다.
-- 아래 경로들은 자동 삭제 또는 cleanup 대상이 아닙니다.
+- 아래 경로들은 active runtime source of truth가 아닙니다.
+- 아래 경로들은 자동 cleanup 대상이 아닙니다.
 - 직접 URL 접근은 reference 확인 목적상 허용합니다.
 - production 사용자-facing 경로로 홍보하거나 연결하지 않습니다.
 - 운영 편입이 필요하면 별도 PR에서 current production 구조로 재구현합니다.
-- 운영 편입 시 prototype 경로를 그대로 production route로 사용하지 않습니다.
 
 ## 3. Preservation standard
 
 - PR #7 관련 artifact는 반드시 보존합니다.
-- prototype / variant 원본 파일의 이동, 삭제, 이름 변경은 CTO 승인 전까지 금지합니다.
+- prototype / variant / demo / reference 원본 파일의 변경은 CTO 승인 전까지 금지합니다.
 - 원본성 보존을 우선합니다.
-- 배너 삽입, route 차단, archive 이동, 리네임도 별도 CTO 승인 필요 항목입니다.
 - README 또는 `docs/doc_index.md`에서 링크할 경우 `reference only` 라벨을 명시합니다.
 
-## 4. Current prototype / variant paths
+## 4. Current preserved reference artifact paths
 
 | Path | Current tree status | Classification | Production status | Policy |
 | --- | --- | --- | --- | --- |
-| `pages/gemini-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `pages/gemini-v3/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `pages/gpt-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `pages/kimi-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `pages/v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `css/gemini-v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `css/gemini-v3/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `css/gpt-v2/` | Requested but not confirmed in current tree | Design Variant, if restored or found later | Not active production route | Do not infer existence; verify before changing |
-| `css/v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `assets/css/kimi-v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Reference Artifact |
-| `assets/gpt-v2/` | Present in current main | Prototype asset / Design Variant support | Not active production route | Reference Artifact |
-| `assets/js/kimi-v2/` | Present in current main | Prototype interaction support / Historical UI Exploration | Not active production route | Reference Artifact |
+| `pages/gpt-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `css/gpt-v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `assets/gpt-v2/` | Present in current main | Prototype Asset / Design Variant Support | Not active production route | Protected Reference Artifact |
+| `pages/gemini-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `css/gemini-v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `pages/gemini-v3/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `css/gemini-v3/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `pages/v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `css/v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `pages/kimi-v2/` | Present in current main | Prototype / Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `assets/css/kimi-v2/` | Present in current main | Design Variant / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `assets/js/kimi-v2/` | Present in current main | Prototype Interaction Support / Historical UI Exploration | Not active production route | Protected Reference Artifact |
+| `hotspot-prototype/` | Present in current main | Hotspot Interaction / Layout Exploration / Prototype Reference | Not active production route | Protected Reference Artifact |
+| `scrapbook-demo/` | Present in current main | Scrapbook Interaction / Visual Storytelling / Demo Reference | Not active production route | Protected Reference Artifact |
+| `quiet/` | Present in current main | Quiet Home Landing Visual Experiment / Historical UI Reference | Not active production route | Protected Reference Artifact |
+| `quiet/home.html` | Present in current main | Quiet Home Mobile/Narrow Landing Prototype | Not active production route | Protected Reference Artifact |
+| `quiet/home-desktop.html` | Present in current main | Quiet Home Desktop Landing Prototype | Not active production route | Protected Reference Artifact |
+| `pages/gpt-svg-tree/` | PR #7 preserved artifact | Hidden Tree Visualization Experiment | Not active production route | Protected Reference Artifact / PR #7 untouched |
 
 ## 5. Path notes
 
-### `pages/gemini-v2/`
+### `pages/gpt-v2/`, `css/gpt-v2/`, and `assets/gpt-v2/`
 
-Gemini v2 page explorations. Preserve as prototype and design variant reference. Do not connect to active navigation without a separate production implementation PR.
+GPT v2 page, style, and asset explorations. Preserve as reference artifacts. These paths are not production route sources of truth.
 
-### `pages/gemini-v3/`
+### `pages/gemini-v2/` and `css/gemini-v2/`
 
-Gemini v3 page explorations. Preserve as prototype and design variant reference. Do not treat as the canonical current UI.
+Gemini v2 page and style explorations. Preserve as prototype and design variant references. Do not connect to active navigation without a separate production implementation PR.
 
-### `pages/gpt-v2/`
+### `pages/gemini-v3/` and `css/gemini-v3/`
 
-GPT v2 page explorations and related notes. Preserve as reference artifact. This path is not a production route source of truth.
+Gemini v3 page and style explorations. Preserve as prototype and design variant references. Do not treat as the canonical current UI.
 
-### `pages/kimi-v2/`
+### `pages/v2/` and `css/v2/`
 
-Kimi v2 page explorations. Preserve as prototype and historical UI exploration.
+Generic v2 page and styling explorations. Preserve as design variant references, not as active production routes.
 
-### `pages/v2/`
+### `pages/kimi-v2/`, `assets/css/kimi-v2/`, and `assets/js/kimi-v2/`
 
-Generic v2 page explorations. Preserve as design variant reference, not as active production route.
+Kimi v2 page, styling, and interaction references. Preserve with the page variant set.
 
-### `css/gemini-v2/` and `css/gemini-v3/`
+### `hotspot-prototype/`
 
-Gemini variant styling references. Preserve with the matching page variants. Do not migrate, deduplicate, or remove automatically.
+Hotspot interaction, layout exploration, and prototype reference artifact. It is not an active production route or active runtime source of truth, but it has interaction reference value.
 
-### `css/gpt-v2/`
+### `scrapbook-demo/`
 
-This path was requested for tracking, but it was not confirmed in the current main tree during this documentation pass. Do not claim it exists without a fresh tree/listing check. If it appears later, classify it as Design Variant / Historical UI Exploration / Reference Artifact unless CTO directs otherwise.
+Scrapbook interaction, visual storytelling, and demo reference artifact. It is not an active production route or active runtime source of truth, but it has visual and interaction reference value.
 
-### `css/v2/`
+### `quiet/`
 
-Generic v2 styling reference. Preserve as design variant support.
+Quiet Home landing visual experiment and historical UI reference artifact. The folder currently includes `quiet/home.html` and `quiet/home-desktop.html`. It is not an active production route or active runtime source of truth. Because its name does not include `prototype`, `demo`, or `variant`, cleanup work must still treat it as a protected reference artifact.
 
-### `assets/css/kimi-v2/` and `assets/js/kimi-v2/`
+### `pages/gpt-svg-tree/`
 
-Kimi v2 asset and interaction references. Preserve with the page variant set.
-
-### `assets/gpt-v2/`
-
-GPT v2 asset reference. Preserve as prototype support artifact.
+PR #7 `experiment: SVG tree prototype` related hidden tree visualization reference. Preserve the PR #7 artifact without touching PR #7 unless CTO gives explicit approval.
 
 ## 6. Future change rules
 
 - To promote any prototype into production, open a separate PR with explicit CTO approval.
-- Do not wire prototype paths directly into production navigation.
+- Do not wire prototype / reference paths directly into production navigation.
 - Reimplement production-bound work in the current production page, CSS, JS, and API structure.
 - Reference documents may link to these paths with `reference only` labeling.
-- Cleanup PRs must not delete, move, rename, hide, or route-block these paths without explicit CTO approval.
+- Cleanup PRs must not modify these protected paths without explicit CTO approval.
 
 ## 7. One-line rule
 
 ```text
-Prototype and variant paths are reference artifacts, not active production routes and not automatic cleanup targets.
+Prototype, variant, demo, and reference paths are protected reference artifacts, not active production routes and not automatic cleanup targets.
 ```


### PR DESCRIPTION
## Summary
- Update prototype/reference inventory docs.
- Add protected reference entries for `hotspot-prototype/`, `scrapbook-demo/`, and `quiet/`.
- Mark `css/gpt-v2/` as present in current main.
- Keep this as a docs-only preservation policy update.

## Changed files
- `docs/reference/PROTOTYPE_INDEX.md`
- `docs/design/PROTOTYPE_REFERENCE_POLICY.md`
- `docs/design/design_index.md`
- `docs/doc_index.md`

## Runtime impact
None. No app code, routing, assets, or runtime files changed.