### PR TITLE
feat: support PUT/DELETE for private tree and memory resources

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -81,7 +81,10 @@ function buildModalUrl(request, env) {
 
   const memoryMatch = path.match(/^\/api\/memories\/([^/]+)$/);
   if (memoryMatch) {
-    target.pathname = `/modal/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`;
+    const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
+    target.pathname = authHeader
+      ? `/modal/private/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`
+      : `/modal/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`;
     return target;
   }
 
@@ -114,12 +117,24 @@ function isModalOwnedGetRoute(request, env) {
 }
 
 function isModalOwnedWriteRoute(request, env) {
-  if (request.method.toUpperCase() !== 'POST') return false;
+  const method = request.method.toUpperCase();
+  if (!['POST', 'PUT', 'DELETE'].includes(method)) return false;
+
   const url = new URL(request.url);
   const path = url.pathname.replace(/\/+$/, '');
-  if (!['/api/trees', '/api/memories'].includes(path)) return false;
-  const modalUrl = buildModalUrl(request, env || {});
-  return modalUrl !== null;
+
+  // POST is for collection paths
+  if (method === 'POST' && ['/api/trees', '/api/memories'].includes(path)) {
+    return buildModalUrl(request, env || {}) !== null;
+  }
+
+  // PUT/DELETE are for detail paths
+  const isDetail = path.match(/^\/api\/(trees|memories)\/[^/]+$/);
+  if (['PUT', 'DELETE'].includes(method) && isDetail) {
+    return buildModalUrl(request, env || {}) !== null;
+  }
+
+  return false;
 }
 
 function buildNotFoundResponse() {
@@ -198,7 +213,8 @@ async function tryModalRead(request, env) {
 }
 
 async function tryModalWrite(request, env) {
-  if (request.method.toUpperCase() !== 'POST') return null;
+  const method = request.method.toUpperCase();
+  if (!['POST', 'PUT', 'DELETE'].includes(method)) return null;
   if (!isModalOwnedWriteRoute(request, env || {})) return null;
 
   const modalUrl = buildModalUrl(request, env || {});
@@ -213,9 +229,9 @@ async function tryModalWrite(request, env) {
   };
 
   const response = await fetch(modalUrl.toString(), {
-    method: 'POST',
+    method,
     headers,
-    body: request.body
+    body: method !== 'DELETE' ? request.body : null
   });
 
   return withUpstreamHeader(response, 'modal');
@@ -275,7 +291,9 @@ export async function onRequest(context) {
   if (modalUrl) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/\/+$/, '');
-    const allow = ['/api/trees', '/api/memories'].includes(path) ? 'GET, POST' : 'GET';
+    const isCollection = ['/api/trees', '/api/memories'].includes(path);
+    const isDetail = path.match(/^\/api\/(trees|memories)\/[^/]+$/);
+    const allow = isCollection ? 'GET, POST' : (isDetail ? 'GET, PUT, DELETE' : 'GET');
     return buildMethodNotAllowedResponse(allow);
   }
 

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -81,20 +81,21 @@ function buildModalUrl(request, env) {
 
   const memoryMatch = path.match(/^\/api\/memories\/([^/]+)$/);
   if (memoryMatch) {
-    const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
-    // For memories, only use private path for write operations (PUT, DELETE).
-    // GET always uses public route as there is no private detail route in backend.
+    const memoryId = encodeURIComponent(decodeURIComponent(memoryMatch[1]));
     const isWrite = ['PUT', 'DELETE'].includes(method);
-    target.pathname = (authHeader && isWrite)
-      ? `/modal/private/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`
-      : `/modal/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`;
+    target.pathname = isWrite
+      ? `/modal/private/memories/${memoryId}`
+      : `/modal/memories/${memoryId}`;
     return target;
   }
 
   const treeMatch = path.match(/^\/api\/trees\/([^/]+)$/);
   if (treeMatch) {
     const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
-    target.pathname = authHeader
+    const isWrite = ['PUT', 'DELETE'].includes(method);
+    // GET: uses private path ONLY IF auth exists (for owner view), else public.
+    // PUT/DELETE: always uses private path (auth failure handled by backend).
+    target.pathname = (isWrite || authHeader)
       ? `/modal/private/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`
       : `/modal/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`;
     return target;

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -82,7 +82,10 @@ function buildModalUrl(request, env) {
   const memoryMatch = path.match(/^\/api\/memories\/([^/]+)$/);
   if (memoryMatch) {
     const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
-    target.pathname = authHeader
+    // For memories, only use private path for write operations (PUT, DELETE).
+    // GET always uses public route as there is no private detail route in backend.
+    const isWrite = ['PUT', 'DELETE'].includes(method);
+    target.pathname = (authHeader && isWrite)
       ? `/modal/private/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`
       : `/modal/memories/${encodeURIComponent(decodeURIComponent(memoryMatch[1]))}`;
     return target;

--- a/functions/api/memories/[id].js
+++ b/functions/api/memories/[id].js
@@ -61,32 +61,6 @@ export async function onRequestPut(context) {
   return withModalHeader(response);
 }
 
-export async function onRequestPatch(context) {
-  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
-  if (!modalBaseUrl) {
-    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
-      status: 503,
-      headers: { 'content-type': 'application/json; charset=utf-8' }
-    });
-  }
-
-  const memoryId = context.params?.id;
-  const target = new URL(`/modal/private/memories/${memoryId}`, modalBaseUrl);
-  const response = await fetch(target.toString(), {
-    method: 'PATCH',
-    headers: {
-      accept: 'application/json',
-      'content-type': context.request.headers.get('content-type') || 'application/json',
-      ...(context.request.headers.get('authorization')
-        ? { authorization: context.request.headers.get('authorization') }
-        : {})
-    },
-    body: context.request.body
-  });
-
-  return withModalHeader(response);
-}
-
 export async function onRequestDelete(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {

--- a/functions/api/trees/[id].js
+++ b/functions/api/trees/[id].js
@@ -69,32 +69,6 @@ export async function onRequestPut(context) {
   return withModalHeader(response);
 }
 
-export async function onRequestPatch(context) {
-  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
-  if (!modalBaseUrl) {
-    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
-      status: 503,
-      headers: { 'content-type': 'application/json; charset=utf-8' }
-    });
-  }
-
-  const treeId = context.params?.id;
-  const target = new URL(`/modal/private/trees/${treeId}`, modalBaseUrl);
-  const response = await fetch(target.toString(), {
-    method: 'PATCH',
-    headers: {
-      accept: 'application/json',
-      'content-type': context.request.headers.get('content-type') || 'application/json',
-      ...(context.request.headers.get('authorization')
-        ? { authorization: context.request.headers.get('authorization') }
-        : {})
-    },
-    body: context.request.body
-  });
-
-  return withModalHeader(response);
-}
-
 export async function onRequestDelete(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {

--- a/tests/contracts/api-route-mapping.test.js
+++ b/tests/contracts/api-route-mapping.test.js
@@ -212,10 +212,22 @@ test('cloudflare api catch-all routes memories/:memoryId to modal/memories/:memo
     'catch-all should handle /api/memories path'
   );
   
-  // /modal/memories/:memoryId 매핑 확인
+  // GET /api/memories/:id (with/without auth) -> /modal/memories/:id
   assert.ok(
     hasString(content, '/modal/memories/'),
-    'catch-all should route to /modal/memories/'
+    'catch-all should route memory GET to /modal/memories/'
+  );
+  
+  // PUT/DELETE /api/memories/:id -> /modal/private/memories/:id
+  assert.ok(
+    hasString(content, '/modal/private/memories/'),
+    'catch-all should route memory PUT/DELETE to /modal/private/memories/'
+  );
+  
+  // Method check for memories
+  assert.ok(
+    hasString(content, "['PUT', 'DELETE'].includes(method)"),
+    'catch-all should check for PUT/DELETE method for memories'
   );
 });
 

--- a/tests/contracts/api-route-mapping.test.js
+++ b/tests/contracts/api-route-mapping.test.js
@@ -69,10 +69,6 @@ test('cloudflare api tree detail route exports private write handlers', () => {
     'tree detail route should export onRequestPut'
   );
   assert.ok(
-    hasRegex(content, /export\s+async\s+function\s+onRequestPatch\s*\(/),
-    'tree detail route should export onRequestPatch'
-  );
-  assert.ok(
     hasRegex(content, /export\s+async\s+function\s+onRequestDelete\s*\(/),
     'tree detail route should export onRequestDelete'
   );
@@ -88,10 +84,6 @@ test('cloudflare api tree detail route forwards writes to modal private trees wi
   assert.ok(
     hasRegex(content, /method:\s*'PUT'/),
     'tree detail route should forward PUT method'
-  );
-  assert.ok(
-    hasRegex(content, /method:\s*'PATCH'/),
-    'tree detail route should forward PATCH method'
   );
   assert.ok(
     hasRegex(content, /method:\s*'DELETE'/),
@@ -111,10 +103,6 @@ test('cloudflare api memory detail route exports private write handlers', () => 
     'memory detail route should export onRequestPut'
   );
   assert.ok(
-    hasRegex(content, /export\s+async\s+function\s+onRequestPatch\s*\(/),
-    'memory detail route should export onRequestPatch'
-  );
-  assert.ok(
     hasRegex(content, /export\s+async\s+function\s+onRequestDelete\s*\(/),
     'memory detail route should export onRequestDelete'
   );
@@ -130,10 +118,6 @@ test('cloudflare api memory detail route forwards writes to modal private memori
   assert.ok(
     hasRegex(content, /method:\s*'PUT'/),
     'memory detail route should forward PUT method'
-  );
-  assert.ok(
-    hasRegex(content, /method:\s*'PATCH'/),
-    'memory detail route should forward PATCH method'
   );
   assert.ok(
     hasRegex(content, /method:\s*'DELETE'/),

--- a/tests/contracts/api-route-mapping.test.js
+++ b/tests/contracts/api-route-mapping.test.js
@@ -178,56 +178,38 @@ test('cloudflare api catch-all routes community/memories to modal/community/memo
 test('cloudflare api catch-all routes trees/:treeId with auth split', () => {
   const content = readFileContent(CATCHALL_JS);
   
-  // /api/trees 패턴 확인
+  // 인증 있음 또는 Write: /modal/private/trees/:treeId
   assert.ok(
-    hasString(content, '/api/trees'),
-    'catch-all should handle /api/trees path'
+    hasString(content, '(isWrite || authHeader)'),
+    'catch-all should check for (isWrite || authHeader) for trees'
   );
-  
-  // 인증 있음: /modal/private/trees/:treeId
   assert.ok(
-    hasString(content, '/modal/private/trees/'),
-    'catch-all should route to /modal/private/trees/ with auth'
-  );
-  
-  // 인증 없음: /modal/trees/:treeId
-  assert.ok(
-    hasString(content, '/modal/trees/'),
-    'catch-all should route to /modal/trees/ without auth'
-  );
-  
-  // authorization header 확인
-  assert.ok(
-    hasString(content, 'authorization'),
-    'catch-all should check authorization header'
+    hasString(content, '`/modal/private/trees/'),
+    'catch-all should route trees to private path when auth or write'
   );
 });
 
 test('cloudflare api catch-all routes memories/:memoryId to modal/memories/:memoryId', () => {
   const content = readFileContent(CATCHALL_JS);
-  
-  // /api/memories 패턴 확인
+
+  // Memory route selection does not use authHeader
   assert.ok(
-    hasString(content, '/api/memories'),
-    'catch-all should handle /api/memories path'
+    !hasString(content, 'authHeader && isWrite'),
+    'memory route selection should not use authHeader && isWrite'
   );
-  
-  // GET /api/memories/:id (with/without auth) -> /modal/memories/:id
+
+  // GET -> public, Write -> private
   assert.ok(
-    hasString(content, '/modal/memories/'),
-    'catch-all should route memory GET to /modal/memories/'
+    hasString(content, 'isWrite'),
+    'catch-all should check for isWrite for memories'
   );
-  
-  // PUT/DELETE /api/memories/:id -> /modal/private/memories/:id
   assert.ok(
-    hasString(content, '/modal/private/memories/'),
-    'catch-all should route memory PUT/DELETE to /modal/private/memories/'
+    hasString(content, '`/modal/private/memories/'),
+    'catch-all should route memory write to private path'
   );
-  
-  // Method check for memories
   assert.ok(
-    hasString(content, "['PUT', 'DELETE'].includes(method)"),
-    'catch-all should check for PUT/DELETE method for memories'
+    hasString(content, '`/modal/memories/'),
+    'catch-all should route memory GET to public path'
   );
 });
 


### PR DESCRIPTION
## Summary
This PR enables private write operations (PUT and DELETE) for trees and memories through the Cloudflare proxy gateway. It ensures that update and delete requests are correctly routed to the Modal backend with proper authorization forwarding.

### Changes
- **Cloudflare Gateway (\[[path]].js\):** Updated routing logic to ensure PUT and DELETE operations for trees and memories always target private Modal paths, while preserving public GET routing for memories.
- **Method Hardening:** Removed PATCH support from the gateway and detail route handlers (\trees/[id].js\, \memories/[id].js\) to match Modal backend capabilities.
- **Contract Tests:** Updated \tests/contracts/api-route-mapping.test.js\ to strictly verify write operations target private routes and GET requests follow public/private fallback rules.

### Verification
- \node --test tests/contracts/api-route-mapping.test.js\ (All 17 contract tests passed)
- \npm test\ (Passed)
- \npm run lint\ (Passed)
- Python compilation check (Passed for \modal_compute/app.py\, \^Guth.py\, \db.py\, \u000balidation.py\)

### Browser smoke
- Test slot: https://test1.lovebud.pages.dev
- Head SHA: 304d6135ebf8a41cb663eca7038d17c47432bf0f
- Editor load: PASS
- PUT \/api/trees/:id\: 200
- POST \/api/memories\: 200
- PUT \/api/memories/:id\: 200
- DELETE \/api/memories/:id\: 200
- PATCH \/api/trees/:id\: 405
- PATCH \/api/memories/:id\: 405
- Public search/detail regression: PASS
- Console fatal errors: none
- Note: YouTube thumbnail 404s observed as external resource issue, not blocking this PR.
- Test account was newly created because no reusable test account file was available. Account/tree retained for future retest; password/token not reported.

Relates to fix/editor-private-write-path-v2