### PR TITLE
fix(settings): stabilize return navigation

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -13,8 +13,27 @@
     defaultVisibility: 'private'
   };
 
+  function isSettingsPath(pathname) {
+    return /(?:^|\/)settings(?:\.html)?$/.test(pathname || '');
+  }
+
+  function normalizeReturnTarget(value) {
+    var url = new URL(value || '/', window.location.origin);
+    return url.pathname + url.search + url.hash;
+  }
+
   function isSafeReturnTarget(value) {
-    return /^\.?\/?[a-zA-Z0-9_\-/]+\.html(?:\?.*)?$/.test(value || '');
+    if (!value || typeof value !== 'string') return false;
+    if (/^\s*(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(value)) return false;
+
+    try {
+      var url = new URL(value, window.location.origin);
+      var sameOrigin = url.origin === window.location.origin;
+      if (!sameOrigin || isSettingsPath(url.pathname)) return false;
+      return url.pathname === '/' || /\/[a-zA-Z0-9_-]+\.html$/.test(url.pathname);
+    } catch (e) {
+      return false;
+    }
   }
 
   function getReturnToHref() {
@@ -22,7 +41,7 @@
       var params = new URLSearchParams(window.location.search || '');
       var returnTo = params.get('returnTo');
       if (returnTo && isSafeReturnTarget(returnTo)) {
-        return returnTo;
+        return normalizeReturnTarget(returnTo);
       }
     } catch (e) {
       console.warn('[settings] Failed to parse returnTo:', e);
@@ -31,10 +50,9 @@
     try {
       if (document.referrer) {
         var refUrl = new URL(document.referrer, window.location.origin);
-        var sameOrigin = refUrl.origin === window.location.origin;
-        var isSettingsRef = /\/settings\.html(?:$|\?)/.test(refUrl.pathname);
-        if (sameOrigin && !isSettingsRef) {
-          return refUrl.pathname + refUrl.search + refUrl.hash;
+        var refTarget = refUrl.pathname + refUrl.search + refUrl.hash;
+        if (isSafeReturnTarget(refTarget)) {
+          return refTarget;
         }
       }
     } catch (e) {
@@ -47,6 +65,11 @@
   function closeSettings() {
     var fallbackHref = getReturnToHref();
 
+    if (fallbackHref) {
+      window.location.href = fallbackHref;
+      return;
+    }
+
     try {
       if (window.history.length > 1 && document.referrer) {
         window.history.back();
@@ -56,7 +79,7 @@
       console.warn('[settings] history.back failed:', e);
     }
 
-    window.location.href = fallbackHref;
+    window.location.href = '../index.html';
   }
 
   // 설정 불러오기

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -137,6 +137,32 @@
         return null;
     }
 
+    function isSettingsPath(pathname) {
+        return /(?:^|\/)settings(?:\.html)?$/.test(pathname || '');
+    }
+
+    function getCurrentReturnToTarget() {
+        try {
+            var pathname = window.location.pathname || '';
+            if (isSettingsPath(pathname)) return '';
+            var target = pathname + (window.location.search || '') + (window.location.hash || '');
+            return target || '/';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    function appendSettingsReturnTo(settingsHref) {
+        var returnTo = getCurrentReturnToTarget();
+        if (!returnTo) return settingsHref;
+        try {
+            var url = new URL(settingsHref, window.location.href);
+            if (url.searchParams.get('returnTo')) return settingsHref;
+        } catch (e) {}
+        var separator = settingsHref.indexOf('?') === -1 ? '?' : '&';
+        return settingsHref + separator + 'returnTo=' + encodeURIComponent(returnTo);
+    }
+
     // 캐시된 유저 정보로부터 아바타 HTML 생성
     function buildCachedUserAvatar(cachedUser) {
         if (!cachedUser) return '';
@@ -145,9 +171,11 @@
 
         // 현재 페이지가 설정 페이지면 내 트리로 링크, 아니면 설정으로 링크
         var currentPage = getCurrentPage();
+        var myTreesHref = getContextType() === 'root' ? 'pages/my-trees.html' : './my-trees.html';
+        var settingsHref = appendSettingsReturnTo(getContextType() === 'root' ? 'pages/settings.html' : './settings.html');
         var avatarHref = currentPage === 'settings.html'
-            ? (getContextType() === 'root' ? 'pages/my-trees.html' : './my-trees.html')
-            : (getContextType() === 'root' ? 'pages/settings.html' : './settings.html');
+            ? myTreesHref
+            : settingsHref;
         var avatarLabel = currentPage === 'settings.html' ? '내 러브트리로 돌아가기' : '설정 열기';
 
         return [
@@ -351,6 +379,27 @@
         console.log('[shared-header] Rendered for:', getCurrentPage(), '| context:', getContextType());
     };
 
+    function bindSettingsReturnLinkCapture() {
+        if (window.__lovebudSettingsReturnLinkBound) return;
+        window.__lovebudSettingsReturnLinkBound = true;
+
+        document.addEventListener('click', function(e) {
+            var link = e.target.closest && e.target.closest('a[href]');
+            if (!link) return;
+            var href = link.getAttribute('href') || '';
+            try {
+                var url = new URL(href, window.location.href);
+                if (!isSettingsPath(url.pathname)) return;
+            } catch (error) {
+                return;
+            }
+            var nextHref = appendSettingsReturnTo(href);
+            if (nextHref !== href) {
+                link.setAttribute('href', nextHref);
+            }
+        }, true);
+    }
+
     function bindSharedHeaderLangRefresh() {
         if (window.__lovebudSharedHeaderLangBound) return;
         window.__lovebudSharedHeaderLangBound = true;
@@ -361,6 +410,7 @@
         });
     }
 
+    bindSettingsReturnLinkCapture();
     bindSharedHeaderLangRefresh();
 
     // DOM 준비 완료 시 자동 렌더링 (선택적)


### PR DESCRIPTION
Refs #243

## Summary
- Preserve the current page as a Settings `returnTo` target when Settings links are used from the shared header.
- Prefer a safe explicit return target in Settings close handling before falling back to browser history.
- Keep the change scoped to frontend Settings navigation stability.

## Non-changes
- no backend/API changes
- no visual UX changes
- PR #7 untouched
- no Editor/prototype/reference/demo/variant changes
- no auth cache/session/Firebase route changes

## Validation
- `node --check js/shared-header.js`
- `node --check js/settings.js`
- changed files limited to Settings navigation-related JS

## Browser smoke
- Not run in this environment; CTO/browser validation still required for Home/Search/Detail/My Trees direct return flows.