### PR TITLE
fix(search): mobile preview as bottom sheet — remove scroll hijack

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -178,3 +178,11 @@
     font-size: 13px;
     line-height: 1.6;
 }
+
+/* Mobile bottom sheet: body scroll lock when sheet is open */
+body.preview-sheet-open {
+    overflow: hidden;
+    /* prevent iOS bounce scroll on body */
+    position: fixed;
+    width: 100%;
+}

--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -74,17 +74,79 @@
         gap: 10px;
     }
 
+    /* --- Mobile bottom sheet preview --- */
+    /* Hidden state: out of flow entirely, not order:-1 at top */
     .preview-sidebar {
-        order: -1;
+        /* Remove from grid flow */
+        position: fixed;
+        inset-inline: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 300;
+        /* Hidden by default */
         display: none;
-        position: static;
-        z-index: auto;
-        padding: 22px 18px;
-        border-radius: 1.5rem;
+        max-height: 92dvh;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        /* Appearance */
+        border-radius: 2rem 2rem 0 0;
+        padding: 22px 18px env(safe-area-inset-bottom, 0px);
+        /* Preserve desktop gradient bg from preview-sidebar.css — override position only */
+        /* Reset sticky/grid props from tablet breakpoint */
+        align-self: auto;
+        top: auto;
     }
 
+    /* Open state: slide up */
     .preview-sidebar.is-open {
         display: block;
+        animation: mobile-sheet-slide-up 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    }
+
+    @keyframes mobile-sheet-slide-up {
+        from {
+            transform: translateY(100%);
+            opacity: 0.6;
+        }
+        to {
+            transform: translateY(0);
+            opacity: 1;
+        }
+    }
+
+    /* Backdrop overlay — injected by bindMobilePreviewHandlers via CSS */
+    .preview-sheet-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 299;
+        background: rgba(0, 0, 0, 0.38);
+        animation: overlay-fade-in 220ms ease both;
+    }
+
+    @keyframes overlay-fade-in {
+        from { opacity: 0; }
+        to   { opacity: 1; }
+    }
+
+    /* Drag handle indicator */
+    .preview-sidebar.is-open::before {
+        content: '';
+        display: block;
+        width: 40px;
+        height: 4px;
+        background: rgba(144, 73, 81, 0.20);
+        border-radius: 2px;
+        margin: 0 auto 16px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .preview-sidebar.is-open {
+            animation: none;
+        }
+        .preview-sheet-overlay {
+            animation: none;
+        }
     }
 
     .preview-panel-header {

--- a/js/search.js
+++ b/js/search.js
@@ -127,7 +127,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.markActiveCard(activeCard);
 
         if (ui.isMobilePreviewMode()) {
-            ui.setMobilePreviewOpen(true, { scrollIntoView: true });
+            // scrollIntoView: false — 목록 scrollY를 유지하고 bottom sheet만 열림
+            ui.setMobilePreviewOpen(true, { scrollIntoView: false });
         }
 
         if (Array.isArray(tree.memories) && tree.memories.length > 0) {

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -145,7 +145,7 @@
             }
 
             if (refs.searchInput) {
-                refs.searchInput.placeholder = getSearchCopy('search.placeholder', '예: 첫 설레마 · 아티스트명 · 감정 태그', 'e.g., first spark, artist, emotion tag');
+                refs.searchInput.placeholder = getSearchCopy('search.placeholder', '예: 첫 설렘 · 아티스트명 · 감정 태그', 'e.g., first spark, artist, emotion tag');
             }
 
             const previewHeading = document.querySelector('.preview-panel-header h3');

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -16,6 +16,9 @@
         const treeDataMap = new WeakMap();
         const boundContainers = new WeakSet();
 
+        // overlay element reference
+        let sheetOverlay = null;
+
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
             return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
@@ -25,11 +28,39 @@
             return Boolean(mobilePreviewMediaQuery?.matches);
         }
 
+        function _showSheetOverlay() {
+            if (sheetOverlay) return;
+            sheetOverlay = document.createElement('div');
+            sheetOverlay.className = 'preview-sheet-overlay';
+            sheetOverlay.setAttribute('aria-hidden', 'true');
+            sheetOverlay.addEventListener('click', () => {
+                clearSelectedPreview();
+            });
+            document.body.appendChild(sheetOverlay);
+            document.body.classList.add('preview-sheet-open');
+        }
+
+        function _hideSheetOverlay() {
+            if (sheetOverlay) {
+                sheetOverlay.remove();
+                sheetOverlay = null;
+            }
+            document.body.classList.remove('preview-sheet-open');
+        }
+
         function setMobilePreviewOpen(isOpen, options = {}) {
             if (!previewSidebar || !isMobilePreviewMode()) return;
             const { scrollIntoView = false } = options;
             previewSidebar.classList.toggle('is-open', Boolean(isOpen));
 
+            if (isOpen) {
+                _showSheetOverlay();
+            } else {
+                _hideSheetOverlay();
+            }
+
+            // scrollIntoView intentionally kept but never triggered from search.js
+            // (search.js always passes scrollIntoView: false since this fix)
             if (isOpen && scrollIntoView) {
                 window.requestAnimationFrame(() => {
                     previewSidebar.scrollIntoView({
@@ -46,6 +77,8 @@
                 setMobilePreviewOpen(Boolean(state.selectedTreeId));
                 return;
             }
+            // Desktop: ensure overlay is cleaned up in case of resize from mobile
+            _hideSheetOverlay();
             previewSidebar.classList.remove('is-open');
         }
 

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -16,8 +16,9 @@
         const treeDataMap = new WeakMap();
         const boundContainers = new WeakSet();
 
-        // overlay element reference
+        // overlay element reference + saved scroll position for lock/restore
         let sheetOverlay = null;
+        let savedScrollY = 0;
 
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
@@ -29,7 +30,17 @@
         }
 
         function _showSheetOverlay() {
+            // Guard: already open — do not re-lock or re-save scrollY
             if (sheetOverlay) return;
+
+            // Save current scroll position BEFORE applying position:fixed
+            savedScrollY = window.scrollY || window.pageYOffset || 0;
+
+            // Apply scroll lock: position:fixed is set by CSS body.preview-sheet-open;
+            // we set top so the viewport stays visually in place (iOS Safari pattern)
+            document.body.style.top = '-' + savedScrollY + 'px';
+            document.body.classList.add('preview-sheet-open');
+
             sheetOverlay = document.createElement('div');
             sheetOverlay.className = 'preview-sheet-overlay';
             sheetOverlay.setAttribute('aria-hidden', 'true');
@@ -37,15 +48,25 @@
                 clearSelectedPreview();
             });
             document.body.appendChild(sheetOverlay);
-            document.body.classList.add('preview-sheet-open');
         }
 
         function _hideSheetOverlay() {
+            // Remove overlay DOM
             if (sheetOverlay) {
                 sheetOverlay.remove();
                 sheetOverlay = null;
             }
+
+            // Release scroll lock: clear class and inline top BEFORE scrollTo
             document.body.classList.remove('preview-sheet-open');
+            document.body.style.top = '';
+
+            // Restore original scroll position
+            const restoreY = savedScrollY;
+            savedScrollY = 0;
+            if (restoreY > 0) {
+                window.scrollTo(0, restoreY);
+            }
         }
 
         function setMobilePreviewOpen(isOpen, options = {}) {
@@ -60,7 +81,7 @@
             }
 
             // scrollIntoView intentionally kept but never triggered from search.js
-            // (search.js always passes scrollIntoView: false since this fix)
+            // (search.js always passes scrollIntoView: false since PR #247)
             if (isOpen && scrollIntoView) {
                 window.requestAnimationFrame(() => {
                     previewSidebar.scrollIntoView({
@@ -77,7 +98,7 @@
                 setMobilePreviewOpen(Boolean(state.selectedTreeId));
                 return;
             }
-            // Desktop: ensure overlay is cleaned up in case of resize from mobile
+            // Desktop / resize from mobile: clean up overlay + scroll lock safely
             _hideSheetOverlay();
             previewSidebar.classList.remove('is-open');
         }
@@ -124,7 +145,7 @@
             }
 
             if (refs.searchInput) {
-                refs.searchInput.placeholder = getSearchCopy('search.placeholder', '예: 첫 설렘 · 아티스트명 · 감정 태그', 'e.g., first spark, artist, emotion tag');
+                refs.searchInput.placeholder = getSearchCopy('search.placeholder', '예: 첫 설레마 · 아티스트명 · 감정 태그', 'e.g., first spark, artist, emotion tag');
             }
 
             const previewHeading = document.querySelector('.preview-panel-header h3');
@@ -392,11 +413,11 @@
 
                 // Sync initial aria-pressed state
                 card.setAttribute('aria-pressed', tree.id === state.selectedTreeId ? 'true' : 'false');
-                
+
                 // Map tree data for delegated event handler
                 treeDataMap.set(card, tree);
             });
-            
+
             // Ensure container listener is bound
             bindDelegatedCardEvents(listElement);
         }


### PR DESCRIPTION
Refs #248

## Summary
- Prevent mobile Browse/Search card selection from scrolling the page to the top preview area.
- Present selected preview as a mobile bottom sheet/modal-like panel.
- Preserve desktop sticky preview behavior.
- Restore original list scroll position when bottom sheet is dismissed.

## Root Cause
- `css/search/responsive.css`: `.preview-sidebar` had `order: -1` placing it at the top of the flex/grid flow, and `.preview-sidebar.is-open` used `display: block` inline which caused layout reflow to the top.
- `js/search.js` → `selectTree()` called `setMobilePreviewOpen(true, { scrollIntoView: true })`.
- `js/search/search-ui.js` → `setMobilePreviewOpen()` then called `previewSidebar.scrollIntoView({ behavior: 'smooth', block: 'start' })`, forcibly scrolling the page to top.

## Changes

### `js/search.js`
- `selectTree()`: changed `scrollIntoView: true` → `scrollIntoView: false`
- No other logic changed.

### `css/search/responsive.css` (`@media (max-width: 768px)`)
- Removed `order: -1` from `.preview-sidebar`
- `.preview-sidebar` is now `position: fixed; bottom: 0; left: 0; right: 0; display: none` (out of flow)
- `.preview-sidebar.is-open` → `display: block` + `animation: mobile-sheet-slide-up 280ms cubic-bezier(0.16,1,0.3,1)`
- `.preview-sheet-overlay` backdrop fade-in animation
- Drag handle `::before` indicator
- `@media (prefers-reduced-motion: reduce)` disables animations
- `border-radius: 2rem 2rem 0 0` bottom sheet shape
- `max-height: 92dvh; overflow-y: auto; overscroll-behavior: contain`

### `css/search/preview-sidebar.css`
- Added `body.preview-sheet-open` rule: `overflow: hidden; position: fixed; width: 100%` for iOS scroll lock
- `top` is set via JS inline style (`-savedScrollY`px) to preserve visual position during lock

### `js/search/search-ui.js`

**Commit 1 — overlay + body scroll lock**
- Added `_showSheetOverlay()` / `_hideSheetOverlay()` helpers
- `setMobilePreviewOpen(isOpen)`: calls `_showSheetOverlay()` / `_hideSheetOverlay()`; overlay click → `clearSelectedPreview()`
- `syncPreviewVisibility()`: on resize to desktop, calls `_hideSheetOverlay()` to clean up orphaned overlay

**Commit 2 — scrollY save/restore (patch for #248)**
- `let savedScrollY = 0` module-scoped variable
- `_showSheetOverlay()`: saves `window.scrollY` before lock, applies `document.body.style.top = '-' + savedScrollY + 'px'`
- `_hideSheetOverlay()`: clears `body.preview-sheet-open`, clears `body.style.top`, then `window.scrollTo(0, savedScrollY)`; resets `savedScrollY = 0`
- Guard: `sheetOverlay` null-check prevents duplicate lock/save on consecutive card taps — `savedScrollY` holds the first-open position until close
- Safe on resize: `_hideSheetOverlay()` called from `syncPreviewVisibility()` always clears top + restores scroll
- PR #217 `bindDelegatedCardEvents` / `attachCardEvents` structure **untouched**

## Scope
- Search-only mobile UX fix
- no API changes
- no Auth changes
- no Editor changes
- no Detail/MyTrees changes
- PR #7 untouched

## Validation

### node --check
- `js/search.js` — syntax valid
- `js/search/search-ui.js` — syntax valid

### Browser smoke checklist (manual)
- [ ] 모바일 390×844에서 목록 중간까지 스크롤
- [ ] 카드 탭 → bottom sheet slide-up 표시
- [ ] 열리는 순간 scrollY가 최상단으로 튀지 않음
- [ ] overlay 탭 또는 닫기 버튼으로 sheet 닫기
- [ ] 닫은 뒤 기존 목록 위치로 복원
- [ ] 여러 카드 연속 탭 시 목록 위치 유지 (savedScrollY guard)
- [ ] Enter/Space 카드 선택 유지
- [ ] 카드 내부 버튼/링크 클릭이 카드 선택으로 오동작하지 않음
- [ ] desktop 1440에서 sticky right preview 유지
- [ ] tablet 768/1024에서 sticky top 유지
- [ ] q/filter/sort/load more/growing trees 회귀 없음
- [ ] console fatal error 0

### PR #7 untouched: ✅