### PR TITLE
refactor(editor): mount entry fallback script

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -264,6 +264,7 @@
     <script src="../js/editor/editor-auth-helpers.js?v=20260420-1"></script>
     <script src="../js/editor/editor-data-loader.js?v=20260422-1"></script>
     <script src="../js/editor/editor-data-loader-fallbacks.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-entry-fallbacks.js?v=20260422-1"></script>
 
     <script src="../js/editor.js?v=20260422-4"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -71,14 +71,14 @@ test('data-loader fallback boundary is explicitly mounted before editor entry', 
   assertLoadedBefore(sources, 'js/editor/editor-data-loader-fallbacks.js', 'js/editor.js');
 });
 
-test('entry and resolver fallback modules remain explicit audit gaps', () => {
+test('entry fallback boundary is explicitly mounted before editor entry', () => {
   const sources = scriptSources(editorHtml());
 
-  assert.equal(
-    sourceIndex(sources, 'js/editor/editor-entry-fallbacks.js'),
-    -1,
-    'editor-entry-fallbacks.js exists but is not currently mounted by pages/editor.html'
-  );
+  assertLoadedBefore(sources, 'js/editor/editor-entry-fallbacks.js', 'js/editor.js');
+});
+
+test('resolver fallback module remains explicit audit gap', () => {
+  const sources = scriptSources(editorHtml());
 
   assert.equal(
     sourceIndex(sources, 'js/editor/editor-resolver-fallbacks.js'),


### PR DESCRIPTION
## Summary
- Mount \js/editor/editor-entry-fallbacks.js\ before \js/editor.js\.
- Update editor script order contract tests to lock the entry fallback boundary.
- Keep resolver fallback gap unchanged for a later PR.

## Scope
- \pages/editor.html\
- \	ests/contracts/editor-script-order-contract.test.js\
- No \js/editor.js\ changes.
- No runtime behavior changes intended.
- No fallback deletion.
- No Auth/API/Search/Modal/CSS changes.
- PR #7 untouched.

## Verification
- \
ode --test tests/contracts/editor-script-order-contract.test.js\
- \
pm test\
- \
pm run lint\
- \git diff --check\

## Browser smoke required
- \/pages/editor.html\ loads while authenticated.
- Editor does not fatal blank.
- Existing tree/memory load still works.
- Console fatal errors: none.