### PR TITLE
refactor(editor): extract shell helpers from entry

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -154,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail || inlineMediaResolvers.resolveMemoryThumbnail;
 
-    const getYouTubeInputErrorMessage = editorHelpers.getYouTubeInputErrorMessage || ((rawUrl) => shellHelpers.getYouTubeInputErrorMessage(rawUrl, i18n)) || ((rawUrl) => {
+    const getYouTubeInputErrorMessage = editorHelpers.getYouTubeInputErrorMessage || ((rawUrl) => {
         const value = String(rawUrl || '').trim();
         if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
         const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);
@@ -210,14 +210,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const createInlineCreateInitialMemoryFallback = dataLoaderFallbacks.createInlineCreateInitialMemoryFallback || ((options) => () => ({}));
     const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
     const createInlineRefreshMemoriesFallback = dataLoaderFallbacks.createInlineRefreshMemoriesFallback || ((options) => async () => {});
-    const createInlineFormatTimeAgoFallback = shellHelpers.createInlineFormatTimeAgoFallback || (() => (date) => {
+    const createInlineFormatTimeAgoFallback = () => (date) => {
         if (!date) return '';
         const diff = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
         if (diff < 60) return '방금';
         if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
         if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
         return `${Math.floor(diff / 86400)}일 전`;
-    });
+    };
 
     const markEditorReady = () => document.body?.classList.remove('editor-preload');
 
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setText('detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기');
     };
 
-    applyEditorShellCopy();
+        applyEditorShellCopy(safeI18nText, i18n);
 
     const createEditorDomRefs = () => ({
         canvas: document.getElementById('canvasArea'),
@@ -298,7 +298,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const prepareEditorShell = () => {
-        applyEditorShellCopy();
+    applyEditorShellCopy(safeI18nText, i18n);
         const backToMyTreesLink = document.getElementById('backToMyTreesLink');
         if (backToMyTreesLink) {
             backToMyTreesLink.setAttribute('href', getMyTreesHref());

--- a/js/editor.js
+++ b/js/editor.js
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setText('detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기');
     };
 
-        applyEditorShellCopy(safeI18nText, i18n);
+    applyEditorShellCopy(safeI18nText, i18n);
 
     const createEditorDomRefs = () => ({
         canvas: document.getElementById('canvasArea'),
@@ -298,7 +298,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const prepareEditorShell = () => {
-    applyEditorShellCopy(safeI18nText, i18n);
+        applyEditorShellCopy(safeI18nText, i18n);
         const backToMyTreesLink = document.getElementById('backToMyTreesLink');
         if (backToMyTreesLink) {
             backToMyTreesLink.setAttribute('href', getMyTreesHref());

--- a/js/editor.js
+++ b/js/editor.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    const findRootMemory = rootUtils.findRootMemory || shellHelpers.findRootMemory || function(memories) {
+    const findRootMemory = rootUtils.findRootMemory || function(memories) {
         warnRootHelperFallback();
         if (!Array.isArray(memories)) return null;
 
@@ -35,19 +35,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return memories.find(m => m.id === 'root') || null;
     };
 
-    const getRootId = rootUtils.getRootId || shellHelpers.getRootId || function(memories) {
+    const getRootId = rootUtils.getRootId || function(memories) {
         warnRootHelperFallback();
         const root = findRootMemory(memories);
         return root ? root.id : 'root';
     };
 
-    const getCanonicalRootId = rootUtils.getCanonicalRootId || shellHelpers.getCanonicalRootId || function(memories) {
+    const getCanonicalRootId = rootUtils.getCanonicalRootId || function(memories) {
         warnRootHelperFallback();
         const root = findRootMemory(memories);
         return root ? root.id : 'root';
     };
 
-    const isRootMemory = rootUtils.isRootMemory || shellHelpers.isRootMemory || function(mem, rootId) {
+    const isRootMemory = rootUtils.isRootMemory || function(mem, rootId) {
         warnRootHelperFallback();
         return !!(mem && rootId && mem.id === rootId);
     };
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const buildEditorRedirectTarget = shellHelpers.buildEditorRedirectTarget || (() =>
         getEditorBasePath() + 'editor.html' + (window.location.search || ''));
 
-    const createInlineRedirectToEditorLoginFallback = shellHelpers.createInlineRedirectToEditorLoginFallback || ((options) => (delayMs = 0) => {
+    const createInlineRedirectToEditorLoginFallback = (options) => (delayMs = 0) => {
         const opts = options || {};
         const getEditorBasePath = opts.getEditorBasePath || (() => '');
         const buildEditorRedirectTarget = opts.buildEditorRedirectTarget || (() => 'editor.html');
@@ -106,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         window.location.href = loginUrl;
-    });
+    };
 
     const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin || createInlineRedirectToEditorLoginFallback({
         getEditorBasePath,
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees.html');
     const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
 
-    const escapeHtml = editorHelpers.escapeHtml || shellHelpers.escapeHtml || ((value) => String(value ?? '')
+    const escapeHtml = editorHelpers.escapeHtml || ((value) => String(value ?? '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const dataLoaderFallbacks = window.LoveBudEditorDataLoaderFallbacks || {};
     const resolverFallbacks = window.LoveBudEditorResolverFallbacks || {};
+    const shellHelpers = window.LoveBudEditorShellHelpers || {};
 
     let rootHelperWarningShown = false;
     const rootUtils = window.LoveBudEditorUtils || {};
@@ -13,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    const findRootMemory = rootUtils.findRootMemory || function(memories) {
+    const findRootMemory = rootUtils.findRootMemory || shellHelpers.findRootMemory || function(memories) {
         warnRootHelperFallback();
         if (!Array.isArray(memories)) return null;
 
@@ -34,19 +35,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return memories.find(m => m.id === 'root') || null;
     };
 
-    const getRootId = rootUtils.getRootId || function(memories) {
+    const getRootId = rootUtils.getRootId || shellHelpers.getRootId || function(memories) {
         warnRootHelperFallback();
         const root = findRootMemory(memories);
         return root ? root.id : 'root';
     };
 
-    const getCanonicalRootId = rootUtils.getCanonicalRootId || function(memories) {
+    const getCanonicalRootId = rootUtils.getCanonicalRootId || shellHelpers.getCanonicalRootId || function(memories) {
         warnRootHelperFallback();
         const root = findRootMemory(memories);
         return root ? root.id : 'root';
     };
 
-    const isRootMemory = rootUtils.isRootMemory || function(mem, rootId) {
+    const isRootMemory = rootUtils.isRootMemory || shellHelpers.isRootMemory || function(mem, rootId) {
         warnRootHelperFallback();
         return !!(mem && rootId && mem.id === rootId);
     };
@@ -60,27 +61,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const getHttpStatus = (error) => Number(error?.status || error?.statusCode || error?.response?.status || 0);
 
-    const readConfirmedAuthCache = editorAuthHelpers.readConfirmedAuthCache || function() {
-        try {
-            if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
-                var raw = localStorage.getItem('lovebud_auth_cache');
-                if (raw && raw !== 'null') {
-                    return JSON.parse(raw);
-                }
-            }
-        } catch (e) {}
-        return null;
-    };
 
-    const createInlineShowToastFallback = () => (message, type = 'info') => {
+
+    const createInlineShowToastFallback = shellHelpers.createInlineShowToastFallback || function() {
         if (window.LoveBudUI?.showToast) {
-            window.LoveBudUI.showToast(message, type, 3000);
+            return (message, type = 'info') => window.LoveBudUI.showToast(message, type, 3000);
         } else {
-            if (!window.__editorToastWarningShown) {
-                console.warn('[editor] LoveBudUI not loaded, toast degraded to console');
-                window.__editorToastWarningShown = true;
-            }
-            console.log(`[Toast ${type}] ${message}`);
+            return (message, type = 'info') => {
+                if (!window.__editorToastWarningShown) {
+                    console.warn('[editor] LoveBudUI not loaded, toast degraded to console');
+                    window.__editorToastWarningShown = true;
+                }
+                console.log(`[Toast ${type}] ${message}`);
+            };
         }
     };
 
@@ -88,16 +81,16 @@ document.addEventListener('DOMContentLoaded', () => {
         ? editorHelpers.createToast({ warningKey: '__editorToastWarningShown' })
         : createInlineShowToastFallback();
 
-    const getI18n = editorHelpers.getI18n || (() => window.t || ((k) => k));
+    const getI18n = shellHelpers.getI18n || (() => window.t || ((k) => k));
     const i18n = getI18n();
 
-    const getEditorBasePath = editorPageHelpers.getEditorBasePath || (() =>
+    const getEditorBasePath = shellHelpers.getEditorBasePath || (() =>
         window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/');
 
-    const buildEditorRedirectTarget = editorPageHelpers.buildEditorRedirectTarget || (() =>
+    const buildEditorRedirectTarget = shellHelpers.buildEditorRedirectTarget || (() =>
         getEditorBasePath() + 'editor.html' + (window.location.search || ''));
 
-    const createInlineRedirectToEditorLoginFallback = (options) => (delayMs = 0) => {
+    const createInlineRedirectToEditorLoginFallback = shellHelpers.createInlineRedirectToEditorLoginFallback || ((options) => (delayMs = 0) => {
         const opts = options || {};
         const getEditorBasePath = opts.getEditorBasePath || (() => '');
         const buildEditorRedirectTarget = opts.buildEditorRedirectTarget || (() => 'editor.html');
@@ -113,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         window.location.href = loginUrl;
-    };
+    });
 
     const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin || createInlineRedirectToEditorLoginFallback({
         getEditorBasePath,
@@ -148,11 +141,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees.html');
     const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
 
-    const escapeHtml = editorHelpers.escapeHtml || ((value) => String(value ?? '')
+    const escapeHtml = editorHelpers.escapeHtml || shellHelpers.escapeHtml || ((value) => String(value ?? '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/\\"/g, '&quot;')
+        .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;'));
 
     const inlineMediaResolvers = editorHelpers.safeUrl
@@ -161,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail || inlineMediaResolvers.resolveMemoryThumbnail;
 
-    const getYouTubeInputErrorMessage = editorHelpers.getYouTubeInputErrorMessage || ((rawUrl) => {
+    const getYouTubeInputErrorMessage = editorHelpers.getYouTubeInputErrorMessage || ((rawUrl) => shellHelpers.getYouTubeInputErrorMessage(rawUrl, i18n)) || ((rawUrl) => {
         const value = String(rawUrl || '').trim();
         if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
         const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);
@@ -217,18 +210,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const createInlineCreateInitialMemoryFallback = dataLoaderFallbacks.createInlineCreateInitialMemoryFallback || ((options) => () => ({}));
     const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
     const createInlineRefreshMemoriesFallback = dataLoaderFallbacks.createInlineRefreshMemoriesFallback || ((options) => async () => {});
-    const createInlineFormatTimeAgoFallback = () => (date) => {
+    const createInlineFormatTimeAgoFallback = shellHelpers.createInlineFormatTimeAgoFallback || (() => (date) => {
         if (!date) return '';
         const diff = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
         if (diff < 60) return '방금';
         if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
         if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
         return `${Math.floor(diff / 86400)}일 전`;
-    };
+    });
 
     const markEditorReady = () => document.body?.classList.remove('editor-preload');
 
-    const applyEditorShellCopy = () => {
+    const applyEditorShellCopy = shellHelpers.applyEditorShellCopy || function() {
         const setText = (id, key, fallback) => {
             const el = document.getElementById(id);
             if (!el) return;

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -1,0 +1,189 @@
+// Editor Shell Helpers - Entry-only shell utilities
+// Provides fallbacks and utilities for editor initialization without affecting runtime behavior
+
+window.LoveBudEditorShellHelpers = {
+    // Root memory utilities
+    findRootMemory: function(memories) {
+        if (!Array.isArray(memories)) return null;
+
+        const parentNullNodes = memories.filter(m => m.parentId === null || m.parentId === undefined);
+        if (parentNullNodes.length === 1) {
+            return parentNullNodes[0];
+        }
+        if (parentNullNodes.length > 1) {
+            const oldest = parentNullNodes.sort((a, b) => {
+                const aTime = a.createdAt || a.timestamp || '9999';
+                const bTime = b.createdAt || b.timestamp || '9999';
+                return new Date(aTime) - new Date(bTime);
+            })[0];
+            console.log('[editor] Multiple parentId=null nodes found, using oldest as root:', oldest.id);
+            return oldest;
+        }
+
+        return memories.find(m => m.id === 'root') || null;
+    },
+
+    getRootId: function(memories) {
+        const root = this.findRootMemory(memories);
+        return root ? root.id : 'root';
+    },
+
+    getCanonicalRootId: function(memories) {
+        const root = this.findRootMemory(memories);
+        return root ? root.id : 'root';
+    },
+
+    isRootMemory: function(mem, rootId) {
+        return !!(mem && rootId && mem.id === rootId);
+    },
+
+    // HTTP status extractor
+    getHttpStatus: function(error) {
+        return Number(error?.status || error?.statusCode || error?.response?.status || 0);
+    },
+
+    // Toast fallback
+    createInlineShowToastFallback: function() {
+        return (message, type = 'info') => {
+            if (window.LoveBudUI?.showToast) {
+                window.LoveBudUI.showToast(message, type, 3000);
+            } else {
+                if (!window.__editorToastWarningShown) {
+                    console.warn('[editor] LoveBudUI not loaded, toast degraded to console');
+                    window.__editorToastWarningShown = true;
+                }
+                console.log(`[Toast ${type}] ${message}`);
+            }
+        };
+    },
+
+    // Editor base path utilities
+    getEditorBasePath: function() {
+        return window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+    },
+
+    buildEditorRedirectTarget: function() {
+        return this.getEditorBasePath() + 'editor.html' + (window.location.search || '');
+    },
+
+    // Login redirect fallback
+    createInlineRedirectToEditorLoginFallback: function(options) {
+        const opts = options || {};
+        const getEditorBasePath = opts.getEditorBasePath || (() => '');
+        const buildEditorRedirectTarget = opts.buildEditorRedirectTarget || (() => 'editor.html');
+
+        return (delayMs = 0) => {
+            const loginUrl = getEditorBasePath() + 'login.html?redirect=' + encodeURIComponent(buildEditorRedirectTarget());
+
+            if (delayMs > 0) {
+                setTimeout(() => {
+                    window.location.href = loginUrl;
+                }, delayMs);
+                return;
+            }
+
+            window.location.href = loginUrl;
+        };
+    },
+
+    // i18n utility
+    getI18n: function() {
+        return window.t || ((k) => k);
+    },
+
+    // HTML escaping
+    escapeHtml: function(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    },
+
+    // YouTube validation
+    getYouTubeInputErrorMessage: function(rawUrl, i18n) {
+        const value = String(rawUrl || '').trim();
+        if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
+        const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);
+        const hasYouTubeHint = /(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(value);
+        const idLikeMatch = value.match(/(?:v=|\/|youtu\.be\/|shorts\/)([0-9A-Za-z_-]+)/i);
+        const candidateId = idLikeMatch ? idLikeMatch[1] : '';
+        if (!looksLikeUrl) return i18n('invalid_youtube_format') || '전체 YouTube 링크를 붙여 넣어 주세요.';
+        if (!hasYouTubeHint) return i18n('invalid_youtube_unsupported') || 'YouTube 링크만 지원합니다. youtube.com 또는 youtu.be 링크를 사용해 주세요.';
+        if (candidateId && candidateId.length !== 11) return i18n('invalid_youtube_id_length') || '링크가 중간에 잘린 것 같아요. 전체 YouTube 링크를 다시 복사해 주세요.';
+        return i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.';
+    },
+
+    // Time formatting fallback
+    createInlineFormatTimeAgoFallback: function() {
+        return (date) => {
+            if (!date) return '';
+            const diff = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+            if (diff < 60) return '방금';
+            if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+            if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+            return `${Math.floor(diff / 86400)}일 전`;
+        };
+    },
+
+    // Shell copy application
+    applyEditorShellCopy: function(safeI18nText, i18n) {
+        const setText = (id, key, fallback) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.textContent = safeI18nText(i18n, key, fallback);
+        };
+        const setPlaceholder = (id, key, fallback) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.setAttribute('placeholder', safeI18nText(i18n, key, fallback));
+        };
+
+        setText('backToMyTreesLabel', 'editor_back_to_my_trees', '내 러브트리로 돌아가기');
+        setText('editorFlowHeading', 'sidebar_flow_heading', '트리 정보');
+        setText('editorFlowLead', 'sidebar_flow_lead', '트리 이름과 공개 상태를 여기서 정리하고, 가운데 캔버스에서는 흐름만 살펴보세요.');
+        setText('sidebarVisibilityToggleBtnLabel', 'editor_make_public', '이 트리 공개하기');
+        setText('recenterCanvasBtnLabel', 'sidebar_recenter_tree', '트리 한눈에 보기');
+        setText('addMemoryEyebrow', 'editor_add_memory_eyebrow', '다음 순간 심기');
+        setText('addMemoryIntro', 'editor_add_memory_intro', '지금 마음이 머문 다음 장면을 이어 심어 보세요. 첫 순간이라면 여기서 러브트리가 시작됩니다.');
+        setText('saveStatusText', 'save_saved', '저장됨');
+        setText('detailMoreBtn', 'editor_open_detail', '상세로 보기');
+        setText('detailEmptyStartBtn', 'editor_add_first_memory', '첫 순간 심기');
+        setText('canvasEmptyGuideEyebrow', 'editor_canvas_empty_eyebrow', '첫 순간 준비');
+        setText('canvasEmptyGuideTitle', 'editor_canvas_empty_title', '이 장면에서 러브트리가 시작돼요');
+        setText('canvasEmptyGuideDesc', 'editor_canvas_empty_desc', '첫 순간을 심으면 이 공간에 감정의 흐름이 천천히 뻗어나갑니다.');
+        setText('canvasEmptyStartBtn', 'editor_add_first_memory', '첫 순간 심기');
+        setText('addMemoryFormEyebrow', 'editor_add_first_memory', '첫 순간 심기');
+        setText('addMemoryFormTitle', 'editor_new_memory', '어떤 순간이 이어졌나요?');
+        setText('addMemoryFormIntro', 'editor_add_memory_intro', '지금 마음이 머문 다음 장면을 이어 심어 보세요. 첫 순간이라면 여기서 러브트리가 시작됩니다.');
+        setText('memoryUrlLabel', 'editor_youtube_link', 'YouTube 장면 링크');
+        setText('memoryTitleLabel', 'editor_memory_title', '순간 제목');
+        setText('memoryMemoLabel', 'editor_memory_memo_optional', '감정 메모');
+        setText('cancelAddMemory', 'editor_cancel', '취소');
+        setText('confirmAddMemory', 'editor_confirm_add', '이 순간 심기');
+        setPlaceholder('memoryTitleInput', 'editor_memory_title_placeholder', '이 순간을 어떻게 기억하고 싶은지 적어보세요');
+        setPlaceholder('memoryMemoInput', 'editor_memory_memo_placeholder', '왜 이 장면이 이어졌는지, 지금 마음을 남겨보세요...');
+        setText('detailEmptyTitle', 'detail_empty_title', '첫 순간이 트리를 깨워요');
+        setText('detailEmptyDesc', 'detail_empty_desc', '첫 순간을 심으면 이 패널이 현재 순간 허브로 바뀝니다.');
+        setText('detailCurrentMomentBadge', 'editor_current_moment_badge', '현재 순간');
+        setText('detailCurrentMomentTitle', 'editor_current_moment_title', '지금 마음이 머문 장면');
+        setText('detailCurrentMomentHint', 'editor_current_moment_hint', '선택한 순간을 중심으로 감정 메모와 다음 행동이 정리됩니다.');
+        setText('detailMomentInfoLabel', 'editor_moment_info_label', '순간 정보');
+        setText('detailTreeStatusLabel', 'current_tree', '현재 트리');
+        setText('detailDateLabel', 'editor_date_label', '기억한 날');
+        setText('detailTagsLabel', 'editor_tag_label', '감정 태그');
+        setText('detailMemoLabel', 'editor_note_label', '감정 메모');
+        setText('editMemoryBtn', 'editor_edit', '순간 수정');
+        setText('deleteMemoryBtn', 'editor_delete', '순간 삭제');
+        setText('editTitleLabel', 'editor_memory_title', '제목');
+        setText('editMemoLabel', 'editor_note_label', '감정 메모');
+        setText('editTagsLabel', 'editor_edit_tag_label', '감정 태그 (쉼표로 구분)');
+        setPlaceholder('editTitleInput', 'editor_edit_title_placeholder', '순간의 제목을 입력하세요');
+        setPlaceholder('editMemoInput', 'editor_memory_memo_placeholder', '이 순간의 감정을 남겨보세요...');
+        setPlaceholder('editTagsInput', 'editor_edit_tag_placeholder', '#감동, #행복, #그리움');
+        setText('cancelEditBtn', 'editor_cancel', '취소');
+        setText('saveEditBtn', 'editor_save', '저장하기');
+        setText('detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기');
+    }
+};

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -2,44 +2,18 @@
 // Provides fallbacks and utilities for editor initialization without affecting runtime behavior
 
 window.LoveBudEditorShellHelpers = {
-    // Root memory utilities
-    findRootMemory: function(memories) {
-        if (!Array.isArray(memories)) return null;
-
-        const parentNullNodes = memories.filter(m => m.parentId === null || m.parentId === undefined);
-        if (parentNullNodes.length === 1) {
-            return parentNullNodes[0];
-        }
-        if (parentNullNodes.length > 1) {
-            const oldest = parentNullNodes.sort((a, b) => {
-                const aTime = a.createdAt || a.timestamp || '9999';
-                const bTime = b.createdAt || b.timestamp || '9999';
-                return new Date(aTime) - new Date(bTime);
-            })[0];
-            console.log('[editor] Multiple parentId=null nodes found, using oldest as root:', oldest.id);
-            return oldest;
-        }
-
-        return memories.find(m => m.id === 'root') || null;
+    // i18n utility
+    getI18n: function() {
+        return window.t || ((k) => k);
     },
 
-    getRootId: function(memories) {
-        const root = this.findRootMemory(memories);
-        return root ? root.id : 'root';
+    // Editor base path utilities
+    getEditorBasePath: function() {
+        return window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
     },
 
-    getCanonicalRootId: function(memories) {
-        const root = this.findRootMemory(memories);
-        return root ? root.id : 'root';
-    },
-
-    isRootMemory: function(mem, rootId) {
-        return !!(mem && rootId && mem.id === rootId);
-    },
-
-    // HTTP status extractor
-    getHttpStatus: function(error) {
-        return Number(error?.status || error?.statusCode || error?.response?.status || 0);
+    buildEditorRedirectTarget: function() {
+        return this.getEditorBasePath() + 'editor.html' + (window.location.search || '');
     },
 
     // Toast fallback
@@ -54,76 +28,6 @@ window.LoveBudEditorShellHelpers = {
                 }
                 console.log(`[Toast ${type}] ${message}`);
             }
-        };
-    },
-
-    // Editor base path utilities
-    getEditorBasePath: function() {
-        return window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
-    },
-
-    buildEditorRedirectTarget: function() {
-        return this.getEditorBasePath() + 'editor.html' + (window.location.search || '');
-    },
-
-    // Login redirect fallback
-    createInlineRedirectToEditorLoginFallback: function(options) {
-        const opts = options || {};
-        const getEditorBasePath = opts.getEditorBasePath || (() => '');
-        const buildEditorRedirectTarget = opts.buildEditorRedirectTarget || (() => 'editor.html');
-
-        return (delayMs = 0) => {
-            const loginUrl = getEditorBasePath() + 'login.html?redirect=' + encodeURIComponent(buildEditorRedirectTarget());
-
-            if (delayMs > 0) {
-                setTimeout(() => {
-                    window.location.href = loginUrl;
-                }, delayMs);
-                return;
-            }
-
-            window.location.href = loginUrl;
-        };
-    },
-
-    // i18n utility
-    getI18n: function() {
-        return window.t || ((k) => k);
-    },
-
-    // HTML escaping
-    escapeHtml: function(value) {
-        return String(value ?? '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    },
-
-    // YouTube validation
-    getYouTubeInputErrorMessage: function(rawUrl, i18n) {
-        const value = String(rawUrl || '').trim();
-        if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
-        const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);
-        const hasYouTubeHint = /(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(value);
-        const idLikeMatch = value.match(/(?:v=|\/|youtu\.be\/|shorts\/)([0-9A-Za-z_-]+)/i);
-        const candidateId = idLikeMatch ? idLikeMatch[1] : '';
-        if (!looksLikeUrl) return i18n('invalid_youtube_format') || '전체 YouTube 링크를 붙여 넣어 주세요.';
-        if (!hasYouTubeHint) return i18n('invalid_youtube_unsupported') || 'YouTube 링크만 지원합니다. youtube.com 또는 youtu.be 링크를 사용해 주세요.';
-        if (candidateId && candidateId.length !== 11) return i18n('invalid_youtube_id_length') || '링크가 중간에 잘린 것 같아요. 전체 YouTube 링크를 다시 복사해 주세요.';
-        return i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.';
-    },
-
-    // Time formatting fallback
-    createInlineFormatTimeAgoFallback: function() {
-        return (date) => {
-            if (!date) return '';
-            const diff = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
-            if (diff < 60) return '방금';
-            if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
-            if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
-            return `${Math.floor(diff / 86400)}일 전`;
         };
     },
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -265,6 +265,7 @@
     <script src="../js/editor/editor-data-loader.js?v=20260422-1"></script>
     <script src="../js/editor/editor-data-loader-fallbacks.js?v=20260422-1"></script>
     <script src="../js/editor/editor-entry-fallbacks.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-shell-helpers.js?v=20260422-1"></script>
 
     <script src="../js/editor.js?v=20260422-4"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -77,6 +77,12 @@ test('entry fallback boundary is explicitly mounted before editor entry', () => 
   assertLoadedBefore(sources, 'js/editor/editor-entry-fallbacks.js', 'js/editor.js');
 });
 
+test('shell helpers are explicitly mounted before editor entry', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(sources, 'js/editor/editor-shell-helpers.js', 'js/editor.js');
+});
+
 test('resolver fallback module remains explicit audit gap', () => {
   const sources = scriptSources(editorHtml());
 


### PR DESCRIPTION
## Summary
- Extract editor entry shell helper logic from \js/editor.js\.
- Add \js/editor/editor-shell-helpers.js\ for entry-only shell helpers.
- Keep editor runtime behavior unchanged.

## Scope
- Entry shell/helper extraction only.
- No auth flow changes.
- No API/data loading changes.
- No canvas/detail UI changes.
- No memory form/action changes.
- No CSS/UI changes.
- No Search changes.
- PR #7/prototype/reference/demo/variant paths untouched.

## Validation
- \
ode --check js/editor.js\
- \
ode --check js/editor/editor-shell-helpers.js\
- \
ode --test tests/contracts/editor-script-order-contract.test.js\
- \
ode --test tests/contracts/editor-api-surface.test.js\
- \
pm test\
- \
pm run lint\
- \git diff --check\
- Browser smoke, if available

## Browser Smoke Note
- Record whether authenticated browser smoke was completed.
- If not completed, state: authenticated browser smoke not completed.