### PR TITLE
refactor(my-trees): clean up dropdown binding

### DIFF
--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -313,35 +313,33 @@
     ].join('');
 
     // Set up menu events
-    setTimeout(function() {
-      var menuBtn = document.getElementById(menuBtnId);
-      var dropdown = document.getElementById(dropdownId);
-      if (!menuBtn || !dropdown) return;
+    var menuBtn = card.querySelector('.tree-card-menu');
+    var dropdown = card.querySelector('.tree-card-dropdown');
+    if (!menuBtn || !dropdown) return;
 
-      menuBtn.addEventListener('click', function(e) {
+    menuBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var wasShown = dropdown.classList.contains('show');
+      closeAllDropdowns();
+      if (!wasShown) dropdown.classList.add('show');
+    });
+
+    dropdown.querySelectorAll('.dropdown-item').forEach(function(item) {
+      item.addEventListener('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
-        var wasShown = dropdown.classList.contains('show');
+        var action = this.getAttribute('data-action');
+        if (action === 'visibility') {
+          toggleTreeVisibility(normalizedTree.id, normalizedTree.visibility);
+        } else if (action === 'rename') {
+          renameTree(normalizedTree.id, normalizedTree.title);
+        } else if (action === 'delete') {
+          deleteTree(normalizedTree.id, normalizedTree.title);
+        }
         closeAllDropdowns();
-        if (!wasShown) dropdown.classList.add('show');
       });
-
-      dropdown.querySelectorAll('.dropdown-item').forEach(function(item) {
-        item.addEventListener('click', function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          var action = this.getAttribute('data-action');
-          if (action === 'visibility') {
-            toggleTreeVisibility(normalizedTree.id, normalizedTree.visibility);
-          } else if (action === 'rename') {
-            renameTree(normalizedTree.id, normalizedTree.title);
-          } else if (action === 'delete') {
-            deleteTree(normalizedTree.id, normalizedTree.title);
-          }
-          closeAllDropdowns();
-        });
-      });
-    }, 0);
+    });
 
     return card;
   }


### PR DESCRIPTION
## Summary
- Remove `setTimeout(fn, 0)` from My Trees card dropdown binding.
- Replace global `document.getElementById()` menu/dropdown re-query with card-local `querySelector()`.
- Preserve existing card navigation and dropdown action behavior.

## Scope
- My Trees dropdown binding cleanup only.
- No action behavior changes.
- No module fail-safe changes.
- No HTML/CSS changes.
- No Search/Auth/Editor/API/Modal changes.
- PR #7/prototype/reference/demo/variant paths untouched.

## Related
- Refs #125

## Validation
- [x] `node --check js/my-trees.js`
- [x] `npm test`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Browser smoke, if available

## Browser Smoke Note
- Record whether authenticated My Trees browser smoke was completed.
- If not completed, state: `authenticated browser smoke not completed`.