### PR TITLE
refactor(header): extract cached avatar inline styles

### DIFF
--- a/css/global/header.css
+++ b/css/global/header.css
@@ -232,6 +232,38 @@
     line-height: 1;
 }
 
+/* Cached Avatar Styles (shared-header) */
+.cached-avatar-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+}
+
+.cached-avatar-initial {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.cached-avatar-name {
+    font-size: 14px;
+    color: var(--on-surface);
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .nav-links a.active {
     color: var(--primary);
     font-weight: 700;

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -179,11 +179,11 @@
         var avatarLabel = currentPage === 'settings.html' ? '내 러브트리로 돌아가기' : '설정 열기';
 
         return [
-            '<a href="' + avatarHref + '" title="' + avatarLabel + '" style="display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;cursor:pointer;">',
-                '<div style="width:32px;height:32px;border-radius:50%;background:var(--primary);display:flex;align-items:center;justify-content:center;color:white;font-size:14px;font-weight:500;">',
+            '<a href="' + avatarHref + '" title="' + avatarLabel + '" class="cached-avatar-link">',
+                '<div class="cached-avatar-initial">',
                     initial,
                 '</div>',
-                '<span style="font-size:14px;color:var(--on-surface);max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + displayName + '</span>',
+                '<span class="cached-avatar-name">' + displayName + '</span>',
             '</a>'
         ].join('');
     }


### PR DESCRIPTION
## Summary
- Move shared-header cached avatar inline styles into `css/global/header.css`.
- Add cached avatar CSS classes for the link, initial badge, and display name.
- Preserve existing avatar link target and auth/header behavior.

## Scope
- Cached avatar style extraction only.
- No auth logic changes.
- No settings returnTo changes.
- No language toggle changes.
- No logo/headline changes.
- No page HTML changes.
- No Search/MyTrees/Editor/API/Modal changes.
- PR #7/prototype/reference/demo/variant paths untouched.

## Related
- Refs #126

## Validation
- [x] `node --check js/shared-header.js`
- [x] `npm test`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Browser smoke, if available

## Browser Smoke Note
- Record whether logged-in cached-avatar browser smoke was completed.
- If not completed, state: `authenticated cached-avatar smoke not completed`.