### PR TITLE
docs(runtime): document page shell and header boundary

### DIFF
--- a/js/page-shell.js
+++ b/js/page-shell.js
@@ -1,3 +1,39 @@
+/**
+ * LoveBud - Page Shell (Shared Page Initializer)
+ * v20260428
+ *
+ * 책임 경계:
+ * - page-shell은 공통 페이지 초기화 순서를 조정합니다.
+ * - page-shell은 header markup을 직접 생성하지 않습니다.
+ * - page-shell은 optional hook 실행을 조정합니다:
+ *   * renderSharedHeader(): shared-header.js가 제공하는 헤더 렌더링
+ *   * applyI18n(): 국제화 적용 (제공: i18n module)
+ *   * afterInit(): page-specific 후처리
+ *
+ * 소유하지 않는 것:
+ * - Header markup/behavior (→ shared-header.js 소유)
+ * - Page-specific business logic
+ * - Auth logic (→ auth.js)
+ * - Navigation rendering (→ shared-header.js)
+ * - Search/Editor/My Trees page logic
+ *
+ * 사용법:
+ *   LoveTreePageShell.initSharedPage({
+ *     renderHeader: true,   // shared-header 렌더링
+ *     applyI18n: true,      // i18n 적용
+ *     afterInit: fn         // page-specific 초기화 함수 (optional)
+ *   });
+ *
+ * 호출 순서:
+ *   1. renderSharedHeader() - header markup + 헤더 동작 바인딩
+ *   2. applyI18n()        - 국제화 적용
+ *   3. afterInit()        - 페이지별 초기화 (있을 경우)
+ *
+ * 노트:
+ * - renderHeader가 true여야 window.renderSharedHeader()가 호출됩니다.
+ * - shared-header.js는 별도 script로 로드되어야 합니다.
+ * - page-shell은 orchestrator 역할만 수행합니다.
+ */
 (function () {
   function onReady(fn) {
     if (document.readyState === 'loading') {
@@ -25,10 +61,10 @@
     });
   }
 
-// Canonical namespace
-window.LoveTreePageShell = {
+  // Canonical namespace
+  window.LoveTreePageShell = {
     initSharedPage: initSharedPage,
-};
-// Legacy alias retained for compatibility
-window.LovetreePageShell = window.LoveTreePageShell;
+  };
+  // Legacy alias retained for compatibility
+  window.LovetreePageShell = window.LoveTreePageShell;
 })();

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -2,15 +2,29 @@
  * LoveBud - Shared Header Component
  * v20260421-2
  *
- * 모든 페이지에 공통 헤더를 렌더링합니다.
+ * 책임 경계:
+ * - shared-header는 실제 header markup과 header-specific behavior를 소유합니다.
+ * - page-shell과의 협업:
+ *   * page-shell은 renderSharedHeader() 호출을 조정합니다.
+ *   * shared-header은 markup 생성과 헤더 동작을 구현합니다.
+ *
+ * 소유하는 header behavior:
  * - 현재 페이지에 맞는 active 메뉴 자동 표시
  * - 상대경로 차이 자동 처리 (root vs pages)
  * - auth.js가 붙을 #auth-nav 또는 #auth-nav-container 계약 유지
+ * - 언어 토글
+ * - 모바일 네비게이션
+ * - 헤더 rerender hooks
  *
  * 사용법:
  * <script src="js/shared-header.js"></script>
  * <div id="shared-header"></div>
  * <script>renderSharedHeader();</script>
+ *
+ * 노트:
+ * - shared-header은 header markup과 header-specific behavior만 소유합니다.
+ * - page-shell과의 협업으로 전체 페이지 초기화를 완성합니다.
+ * - general page boot orchestrator가 아닙니다.
  */
 
 (function() {


### PR DESCRIPTION
## Summary
- Document the responsibility boundary between `js/page-shell.js` and `js/shared-header.js`.
- Clarify that page-shell coordinates shared initialization hooks.
- Clarify that shared-header owns header markup and header-specific behavior.

## Scope
- Comment/JSDoc-only.
- No runtime behavior changes.
- No script order changes.
- No Auth/Login changes.
- No CSS/page changes.
- No tests changes.
- PR #7/prototype/reference/demo/variant paths untouched.

## Related
- Refs #222

## Validation
- [x] `node --check js/page-shell.js`
- [x] `node --check js/shared-header.js`
- [x] `npm test`
- [x] `npm run lint`
- [x] `git diff --check`