### PR TITLE
docs(vercel): annotate vercel.json as deprecated transitional fallback

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "x-lovebud-runtime-note": "Deprecated transitional fallback only. Active user-facing runtime is Cloudflare Pages with same-origin /api/* to Cloudflare Pages Functions and Modal. This config is not active for production.",
+  "x-lovebud-runtime-docs": [
+    "docs/ops/OPERATIONS.md",
+    "docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md"
+  ],
   "framework": null,
   "buildCommand": null,
   "installCommand": null,


### PR DESCRIPTION
## Summary
Annotate `vercel.json` as deprecated transitional fallback artifact. Clarify that active user-facing runtime is Cloudflare Pages + Modal, and this Vercel config is not active for production.

## Scope
- Documentation/annotation only.
- No routing rule changes.
- No behavior changes.
- No other files modified.

## Changes
- Add `x-lovebud-runtime-note`: describes deprecated status and active runtime
- Add `x-lovebud-runtime-docs`: references to `docs/ops/OPERATIONS.md` and `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
- JSON validity preserved; Vercel unknown-field safe (non-breaking)

## Related
- Refs #221
- Follows PR #256 and PR #259

## Validation
- [x] JSON syntax valid (`node -e "require('./vercel.json')"`)
- [x] `git diff --check` clean
- [ ] Optional: verify Vercel deployment unaffected (not required for annotation PR)
