### PR TITLE
refactor(editor): clarify tree load error fallback boundary

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -167,7 +167,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.';
     });
 
-    const createInlineRenderTreeLoadErrorFallback = () => ({
+    // Tree load error renderer: primary = editorPageHelpers.renderTreeLoadError, fallback = inline minimal UI
+    const createRenderTreeLoadErrorFallback = () => ({
         canvas,
         addBtn,
         errorTitle,
@@ -203,7 +204,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (addBtn) addBtn.disabled = true;
     };
 
-    const renderTreeLoadError = editorPageHelpers.renderTreeLoadError || createInlineRenderTreeLoadErrorFallback();
+    const renderTreeLoadError = editorPageHelpers.renderTreeLoadError || createRenderTreeLoadErrorFallback();
     const createInlineNormalizeMemoryFallback = dataLoaderFallbacks.createInlineNormalizeMemoryFallback || (() => (mem) => mem);
     const createInlineLoadInitialTreeFallback = dataLoaderFallbacks.createInlineLoadInitialTreeFallback || (() => async () => ({}));
     const createInlineLoadEditorMemoriesFallback = dataLoaderFallbacks.createInlineLoadEditorMemoriesFallback || (() => async () => ({}));


### PR DESCRIPTION
## Summary
- Clarify the tree load error fallback boundary after editor shell helper extraction.
- Keep editor-page-helpers.js as the primary owner for tree load error rendering.
- Preserve existing error UI fallback behavior.

## Scope
- Editor tree-load-error fallback boundary only.
- No auth redirect changes.
- No data loader changes.
- No canvas/detail/memory behavior changes.
- No API changes.
- No CSS/UI redesign.
- PR #7/prototype/reference/demo/variant paths untouched.

## Related
- Refs #225
- Refs #224
- Refs #223

## Validation
- \
ode --check js/editor.js\
- \
ode --check js/editor/editor-page-helpers.js\
- \
ode --test tests/contracts/editor-script-order-contract.test.js\
- \
ode --test tests/contracts/editor-api-surface.test.js\
- \
pm test\
- \
pm run lint\
- \git diff --check\
- Browser smoke, if available

## Browser Smoke Note
- Record whether authenticated editor smoke was completed.
- Record whether tree load error path was verified.