### PR TITLE
docs(runtime): add runtime ownership folder markers

### DIFF
--- a/docs/ops/ENV_DEPENDENCY.md
+++ b/docs/ops/ENV_DEPENDENCY.md
@@ -107,7 +107,7 @@ Vercel은 deprecated transitional fallback / upstream under audit입니다.
 
 ### Netlify
 
-Netlify는 legacy / fallback / artifact 성격으로 남아 있습니다.
+Netlify는 **legacy artifact**입니다. 현재 active production runtime이 아니며, local 또는 CI harness에서만 참고용으로 사용됩니다. CTO 승인 없이 삭제/이동/재활성화 금지.
 
 ### DATABASE_URL / NETLIFY_DATABASE_URL / POSTGRES_URL
 
@@ -197,4 +197,4 @@ Netlify는 legacy / fallback / artifact 성격으로 남아 있습니다.
 - **Cloudflare Pages**: 공식 사용자-facing production / preview entry + same-origin API entry
 - **Modal**: active compute/runtime 우선 경로
 - **Vercel**: deprecated transitional fallback / upstream under audit
-- **Netlify**: legacy / fallback / artifact. `netlify/functions/*`는 현재 active production backend가 아님
+- **Netlify**: legacy artifact. `netlify/functions/*`는 현재 active production backend가 아니며, local/CI harness only unless explicitly reactivated by CTO.

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,19 @@
+# Cloudflare Pages Functions
+
+## 역할
+
+이 폴더는 Cloudflare Pages의 same-origin `/api/*` 진입점입니다.
+
+## 핵심 구조
+
+- `api/[[path]].js`: Cloudflare Pages Functions의 catch-all route handler
+  - 사용자 브라우저는 `https://lovebud.pages.dev/api/*`로만 접근
+  - approved routes만 Modal 또는 fallback으로 연결
+  - route 추가 시 `functions/api/README.md`의 contract test 기준을 따라야 함
+  - approved route mapping 없이 새 production route 추가 금지
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/engineering/API_CONTRACT.md`
+- `functions/api/README.md`

--- a/netlify/README.md
+++ b/netlify/README.md
@@ -1,0 +1,29 @@
+# Netlify (Legacy Artifact)
+
+## 역할
+
+이 폴더는 lovebud.pages.dev의 active production backend가 아닙니다.
+
+## 상태
+
+- **Legacy artifact**
+- 현재 Cloudflare Pages + Modal 구조로 migration 완료
+- CTO 승인 없이 삭제/이동/재활성화 금지
+- `netlify/functions/*`는 active production fallback이 아님
+- local 또는 CI harness에서만 참고용으로 사용
+
+## 기존 구조
+
+- `functions/`: Netlify Functions (legacy)
+- `sql/`: Netlify SQL schema/seed (legacy)
+
+## Migration 상태
+
+모든 routes는 현재 Cloudflare Pages Functions → Modal로 연결됩니다.
+
+## 관련 문서
+
+- `docs/ops/OPERATIONS.md`
+- `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
+- `netlify/functions/README.md`
+- `netlify/sql/README.md`

--- a/netlify/functions/README.md
+++ b/netlify/functions/README.md
@@ -6,7 +6,7 @@
 
 ## 상태
 
-- **Legacy/fallback/artifact**
+- **Legacy artifact; not active production fallback unless explicitly reactivated by CTO**
 - 현재 Cloudflare Pages + Modal 구조로 migration 완료
 - CTO 승인 없이 삭제/이동/재활성화 금지
 


### PR DESCRIPTION
**Type:** docs-only

**Scope:** Runtime ownership folder markers for unctions/ and 
etlify/

This PR adds top-level README ownership markers to clarify runtime responsibility:

- unctions/README.md: Marks Cloudflare Pages Functions as the active same-origin /api/* entry point. Route additions must follow unctions/api/README.md contract; new production routes require approval.
- 
etlify/functions/README.md: Clarifies that Netlify is legacy artifact and NOT an active production fallback unless explicitly reactivated by CTO.
- docs/ops/ENV_DEPENDENCY.md: Removes ambiguous 'fallback' wording; explicitly states Netlify as legacy artifact for local/CI harness only.

No runtime behavior changes. No code modifications. No route mapping changes. No deploy/config changes.

Refs #79