### PR TITLE
refactor(header): extract logo and language inline styles

### DIFF
--- a/css/global/header.css
+++ b/css/global/header.css
@@ -20,6 +20,7 @@
     letter-spacing: -0.04em;
     cursor: pointer;
     margin: 0;
+    text-decoration: none;
 }
 
 .nav-links {
@@ -102,15 +103,20 @@
 .lang-menu-trigger {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    min-height: 40px;
-    padding: 0 16px !important;
+    gap: 4px;
+    padding: 6px 12px;
+    height: 36px;
+    font-size: 14px;
+    font-weight: 500;
     border-radius: 999px !important;
     border: 1px solid var(--outline-variant) !important;
     background: linear-gradient(180deg, rgba(255,255,255,0.94), rgba(248,245,240,0.92)) !important;
     color: var(--on-surface-variant);
     box-shadow: 0 8px 18px rgba(75, 64, 57, 0.06);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+    text-decoration: none;
+    min-height: auto;
+    justify-content: flex-start;
 }
 
 .lang-menu-trigger:hover {

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -203,8 +203,8 @@
         var hiddenStyle = isHidden ? ' style="display:none !important;"' : '';
         return [
             '<div class="lang-toggle header-lang-toggle"' + hiddenAttr + hiddenStyle + '>',
-                '<button type="button" class="btn-round btn-outline lang-menu-trigger" style="text-decoration:none;display:flex;align-items:center;gap:4px;padding:6px 12px;height:36px;font-size:14px;font-weight:500;">',
-                    '<span class="material-symbols-outlined" style="font-size:18px;">language</span>',
+                '<button type="button" class="btn-round btn-outline lang-menu-trigger">',
+                    '<span class="material-symbols-outlined">language</span>',
                     '<span>언어</span>',
                 '</button>',
                 '<div class="lang-dropdown">',
@@ -278,7 +278,7 @@
 
         return [
             '<header class="nav-bar">',
-                '<a href="' + logoHref + '" class="headline" aria-label="LoveTree 홈으로 이동" style="font-size: 1.5rem; font-weight: 900; color: var(--on-surface); letter-spacing: -0.04em; cursor: pointer; text-decoration:none;">LoveTree</a>',
+                '<a href="' + logoHref + '" class="headline header-logo" aria-label="LoveTree 홈으로 이동">LoveTree</a>',
                 '<button class="mobile-nav-toggle" id="mobileNavToggle" type="button" aria-label="메뉴 열기" aria-expanded="false">',
                     '<span class="material-symbols-outlined">menu</span>',
                 '</button>',


### PR DESCRIPTION
## Summary
- Move shared header logo/language presentation-only inline styles into css/global/header.css.
- Preserve existing header behavior and event binding.
- Leave auth placeholder/avatar style extraction for a separate follow-up.

## Scope
- js/shared-header.js
- css/global/header.css
- No Auth/API/DB changes.
- No page-specific changes.
- No Editor/Search changes.
- No Netlify/Vercel/_redirects changes.

## Validation
- node --check js/shared-header.js: PASS
- npm test: PASS (97/97)
- npm run lint: PASS
- git diff --check: PASS

## Browser smoke
- Not performed (no local server available)

## Runtime impact
- Presentation-only style extraction.
- Header behavior intended unchanged.

## Changed files
- js/shared-header.js: Removed inline styles from logo anchor and language trigger button
- css/global/header.css: Added text-decoration: none to .nav-bar .headline, updated .lang-menu-trigger to match previous inline values

## Notes
- Auth placeholder/avatar/spinner inline styles intentionally left untouched
- All existing tests pass
- No functional changes