### PR TITLE
refactor(auth): deduplicate token cache key constant

### DIFF
--- a/js/api/base-api-fetch.js
+++ b/js/api/base-api-fetch.js
@@ -1,5 +1,6 @@
 (function () {
-  const AUTH_TOKEN_KEY = 'lovebud_auth_token';
+  // auth-state.js의 AUTH_TOKEN_KEY 상수를 재사용, fallback으로 기존 문자열 유지
+  const AUTH_TOKEN_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_TOKEN_KEY) || 'lovebud_auth_token';
 
   function getCachedTokenRecord() {
     try {


### PR DESCRIPTION
## Summary
- Reuse the shared auth token cache key constant for API token cache access.
- Preserve the existing lovebud_auth_token storage key.
- Do not change token cache policy or API retry behavior.

## Changed files
- js/api/base-api-fetch.js (reads AUTH_TOKEN_KEY from window.LoveBudAuthState with fallback)

## Scope
- No Auth flow changes.
- No token expiry/timeout changes.
- No protected-route changes.
- Storage key unchanged: lovebud_auth_token

## Validation
- node --check js/auth/auth-state.js: PASS
- node --check js/api/base-api-fetch.js: PASS
- npm test: PASS
- npm run lint: PASS
- git diff --check: PASS

## Runtime impact
- Intended behavior unchanged.
- Constant deduplication only.

## Related
- Refs #78