### PR TITLE
refactor(search): extract shared renderer utilities

### DIFF
--- a/js/search-card-renderer.js
+++ b/js/search-card-renderer.js
@@ -1,42 +1,58 @@
 /**
  * LoveBud Search Card Renderer
- * v20260422-4
+ * v20260428-1
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
  * 
- * Dependencies: LoveBudPath (for navigation)
+ * Dependencies: LoveBudPath (for navigation), LoveBudSearchSharedUtils (for shared utilities)
  */
 
- (function() {
-     'use strict';
+(function() {
+    'use strict';
 
-     function escapeHtml(value) {
-         return String(value == null ? '' : value)
-             .replace(/&/g, '&amp;')
-             .replace(/</g, '&lt;')
-             .replace(/>/g, '&gt;')
-             .replace(/\"/g, '&quot;')
-             .replace(/'/g, '&#39;');
-     }
+    function getSharedUtils() {
+        return window.LoveBudSearchSharedUtils || null;
+    }
 
-     function sanitizeUrl(value) {
-         if (!value) return '';
-         const raw = String(value).trim();
-         if (!raw) return '';
-         try {
-             const parsed = new URL(raw, window.location.origin);
-             const protocol = parsed.protocol;
-             if (protocol === 'http:' || protocol === 'https:') {
-                 return parsed.href;
-             }
-             return '';
-         } catch (e) {
-             return '';
-         }
-     }
+    function escapeHtml(value) {
+        const utils = getSharedUtils();
+        if (utils?.escapeHtml) {
+            return utils.escapeHtml(value);
+        }
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function sanitizeUrl(value) {
+        const utils = getSharedUtils();
+        if (utils?.sanitizeUrl) {
+            return utils.sanitizeUrl(value);
+        }
+        if (!value) return '';
+        const raw = String(value).trim();
+        if (!raw) return '';
+        try {
+            const parsed = new URL(raw, window.location.origin);
+            const protocol = parsed.protocol;
+            if (protocol === 'http:' || protocol === 'https:') {
+                return parsed.href;
+            }
+            return '';
+        } catch (e) {
+            return '';
+        }
+    }
 
     function isSuspiciousYouTubeThumbnailImage(img) {
+        const utils = getSharedUtils();
+        if (utils?.isSuspiciousYouTubeThumbnailImage) {
+            return utils.isSuspiciousYouTubeThumbnailImage(img);
+        }
         if (!img || !img.currentSrc) return false;
         const src = String(img.currentSrc || img.src || '');
         const isYouTubeThumb = src.includes('ytimg.com/vi/') || src.includes('img.youtube.com/vi/');
@@ -65,6 +81,10 @@
     }
 
     function getBasePath() {
+        const utils = getSharedUtils();
+        if (utils?.getBasePath) {
+            return utils.getBasePath();
+        }
         if (window.LoveBudPath?.getBasePath) {
             return window.LoveBudPath.getBasePath();
         }
@@ -355,5 +375,5 @@
         }
     };
 
-     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260422-4');
+     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260428-1');
  })();

--- a/js/search-preview-renderer.js
+++ b/js/search-preview-renderer.js
@@ -1,17 +1,25 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260422-4
+ * v20260428-1
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
  * 
- * Dependencies: LoveBudPath (for navigation)
+ * Dependencies: LoveBudPath (for navigation), LoveBudSearchSharedUtils (for shared utilities)
  */
 
 (function() {
     'use strict';
 
+    function getSharedUtils() {
+        return window.LoveBudSearchSharedUtils || null;
+    }
+
     function escapeHtml(value) {
+        const utils = getSharedUtils();
+        if (utils?.escapeHtml) {
+            return utils.escapeHtml(value);
+        }
         return String(value == null ? '' : value)
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
@@ -21,6 +29,10 @@
     }
 
     function sanitizeUrl(value) {
+        const utils = getSharedUtils();
+        if (utils?.sanitizeUrl) {
+            return utils.sanitizeUrl(value);
+        }
         if (!value) return '';
         const raw = String(value).trim();
         if (!raw) return '';
@@ -37,6 +49,10 @@
     }
 
     function isSuspiciousYouTubeThumbnailImage(img) {
+        const utils = getSharedUtils();
+        if (utils?.isSuspiciousYouTubeThumbnailImage) {
+            return utils.isSuspiciousYouTubeThumbnailImage(img);
+        }
         if (!img || !img.currentSrc) return false;
         const src = String(img.currentSrc || img.src || '');
         const isYouTubeThumb = src.includes('ytimg.com/vi/') || src.includes('img.youtube.com/vi/');
@@ -75,6 +91,10 @@
     }
 
     function getBasePath() {
+        const utils = getSharedUtils();
+        if (utils?.getBasePath) {
+            return utils.getBasePath();
+        }
         if (window.LoveBudPath?.getBasePath) {
             return window.LoveBudPath.getBasePath();
         }
@@ -599,5 +619,5 @@
         }
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260422-4');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260428-1');
 })();

--- a/js/search-shared-utils.js
+++ b/js/search-shared-utils.js
@@ -1,0 +1,64 @@
+/**
+ * LoveBud Search Shared Renderer Utilities
+ * v20260428-1
+ * 
+ * Pure utility functions shared by search card and preview renderers.
+ * DOM-agnostic, stateless helpers.
+ */
+
+(function() {
+    'use strict';
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function sanitizeUrl(value) {
+        if (!value) return '';
+        const raw = String(value).trim();
+        if (!raw) return '';
+        try {
+            const parsed = new URL(raw, window.location.origin);
+            const protocol = parsed.protocol;
+            if (protocol === 'http:' || protocol === 'https:') {
+                return parsed.href;
+            }
+            return '';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    function getBasePath() {
+        if (window.LoveBudPath?.getBasePath) {
+            return window.LoveBudPath.getBasePath();
+        }
+        const path = window.location.pathname;
+        return path.indexOf('/pages/') !== -1 ? '' : 'pages/';
+    }
+
+    function isSuspiciousYouTubeThumbnailImage(img) {
+        if (!img || !img.currentSrc) return false;
+        const src = String(img.currentSrc || img.src || '');
+        const isYouTubeThumb = src.includes('ytimg.com/vi/') || src.includes('img.youtube.com/vi/');
+        if (!isYouTubeThumb) return false;
+
+        const width = Number(img.naturalWidth || 0);
+        const height = Number(img.naturalHeight || 0);
+        return width > 0 && height > 0 && width <= 120 && height <= 90;
+    }
+
+    window.LoveBudSearchSharedUtils = {
+        escapeHtml: escapeHtml,
+        sanitizeUrl: sanitizeUrl,
+        getBasePath: getBasePath,
+        isSuspiciousYouTubeThumbnailImage: isSuspiciousYouTubeThumbnailImage
+    };
+
+    console.log('[LoveBudSearchSharedUtils] Search shared renderer utilities loaded v20260428-1');
+})();

--- a/pages/search.html
+++ b/pages/search.html
@@ -143,8 +143,9 @@
     <!-- Search modules -->
     <script src="../js/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
-    <script src="../js/search-card-renderer.js?v=20260422-1"></script>
-    <script src="../js/search-preview-renderer.js?v=20260422-4"></script>
+    <script src="../js/search-shared-utils.js?v=20260428-1"></script>
+    <script src="../js/search-card-renderer.js?v=20260428-1"></script>
+    <script src="../js/search-preview-renderer.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>
     <script src="../js/search/search-url-state.js?v=20260427-1"></script>


### PR DESCRIPTION
## Summary
Extract duplicated pure renderer utilities shared by search card and preview renderers.
Preserve Search/Browse rendering behavior.
Keep Search grouping paused.

## Scope
- js/search-shared-utils.js - new file with shared utilities (escapeHtml, sanitizeUrl, getBasePath, isSuspiciousYouTubeThumbnailImage)
- js/search-preview-renderer.js - updated to use shared utilities with fallback
- js/search-card-renderer.js - updated to use shared utilities with fallback
- pages/search.html - added search-shared-utils.js script before card/preview renderers
- No API adapter changes
- No Search orchestrator changes
- No CSS/visual changes

## Validation
- node --check js/search-shared-utils.js: PASS
- node --check js/search-preview-renderer.js: PASS
- node --check js/search-card-renderer.js: PASS
- npm test: PASS (97/97)
- npm run lint: PASS
- git diff --check: PASS

## Browser smoke
- Test URL: https://test1.lovebud.pages.dev/pages/search.html
- Head SHA verified: 4f4af96
- Desktop 1280x720: PASS
- Mobile 375x812: PASS
- Script load: PASS (search-shared-utils.js, search-card-renderer.js, search-preview-renderer.js)
- Window namespaces: PASS (LoveBudSearchSharedUtils, LoveBudSearchCardRenderer, LoveBudSearchPreviewRenderer)
- Card list rendering: PASS (10 cards rendered)
- Preview rendering: PASS (title, description, emotion tags displayed)
- Search controls: PASS (query input, filtering works)
- API status: PASS (/api/community/trees 200, /api/community/growing-trees 200)
- Console errors: expected YouTube thumbnail 404 only (fallback behavior normal)
- Blocking issues: none

## Runtime impact
- Intended behavior unchanged
- Refactor only
- Thumbnail fallback policy unchanged

## Related
- Refs #72
- Related: #65