### PR TITLE
docs: _redirects ownership marker (Issue #79 follow-up)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,8 @@
+# LoveBud runtime marker:
+# Cloudflare Pages static rewrite aliases — KEEP FOR NOW.
+# This file does not define /api/* routing.
+# Do not remove during Netlify legacy cleanup without explicit CTO approval.
+
 /intro.html /pages/intro.html 200
 /login.html /pages/login.html 200
 /search.html /pages/search.html 200


### PR DESCRIPTION
**Issue:** #79 Audit: Runtime ownership and legacy folder guardrails

**Scope:** Smallest docs-only marker PR following the audit

**Change:**
- Add ownership comment marker to \_redirects\ file
- Mark as Cloudflare Pages static rewrite aliases
- Add KEEP FOR NOW notice
- Clarify not an /api/* routing file
- Require explicit CTO approval before removal during Netlify legacy cleanup

**Files changed:**
- \_redirects\ (comment only, rewrite rules unchanged)

**Runtime context:**
- Active runtime: Cloudflare Pages → Modal
- Legacy: Netlify functions/sql (artifact), Vercel (deprecated fallback)
- \_redirects\ is Cloudflare Pages static rewrites, unrelated to /api routing

**CTO approval required before merge:** Yes