### PR TITLE
docs(runtime): add ownership markers for functions and netlify

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,38 @@
+# LoveBud Cloudflare Pages Functions
+
+> **Runtime Ownership**: Cloudflare Pages Functions  
+> **Status**: Active same-origin API gateway
+
+## Overview
+
+This directory contains Cloudflare Pages Functions that serve as the **active same-origin API gateway** for LoveBud.
+
+## API Flow
+
+```
+browser → /api/* → functions/api/** → Modal → Neon
+```
+
+- Browser makes requests to same-origin `/api/*` paths
+- Cloudflare Pages Functions handle routing and proxying
+- Modal compute layer handles business logic
+- Neon PostgreSQL for data persistence
+
+## Structure
+
+- `functions/api/` - API route handlers and proxy logic
+- `functions/api/memories/` - Memory-related endpoints
+- `functions/api/trees/` - Tree-related endpoints
+
+## Important Notes
+
+- **Do not replace** this Cloudflare Pages Functions setup with Netlify or Vercel fallback behavior
+- This is the primary production API gateway
+- All new backend policy implementations should target this layer
+- See `docs/ops/OPERATIONS.md` for detailed infrastructure documentation
+
+## Related
+
+- `docs/ops/OPERATIONS.md` - Infrastructure and deployment details
+- `modal_compute/` - Modal compute layer (upstream)
+- `netlify/` - Legacy artifact (see netlify/README.md)

--- a/netlify/README.md
+++ b/netlify/README.md
@@ -1,0 +1,39 @@
+# LoveBud Netlify (Legacy)
+
+> **Runtime Ownership**: Legacy artifact only  
+> **Status**: Removal candidate pending CTO approval/audit
+
+## Overview
+
+This directory contains Netlify-related configurations and functions that are **legacy artifacts**.
+
+## Status
+
+- **Not an active fallback** - Do not rely on Netlify for production traffic
+- **Not a target for new backend policy implementation** - Do not add new runtime logic here
+- **Removal candidate** - Pending explicit CTO approval before removal
+
+## Current Contents
+
+- `netlify/functions/` - Legacy serverless functions (kept for reference)
+- `netlify.toml` - Legacy configuration (kept for reference)
+
+## Important Notes
+
+- **Do not add new runtime logic** to this directory without explicit CTO approval
+- This is kept as a **reference/audit trail** only
+- Active runtime is Cloudflare Pages + Modal (see `functions/README.md`)
+- Any Netlify-specific functionality should be migrated to Cloudflare Pages Functions
+
+## Migration Path
+
+If you encounter Netlify-specific code that appears active:
+1. Check `functions/README.md` for the current active gateway
+2. Consult `docs/ops/OPERATIONS.md` for infrastructure details
+3. Do not modify Netlify code without CTO approval
+
+## Related
+
+- `functions/README.md` - Active Cloudflare Pages Functions gateway
+- `docs/ops/OPERATIONS.md` - Infrastructure documentation
+- `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md` - Migration history


### PR DESCRIPTION
## Summary
- Add runtime ownership marker for Cloudflare Pages Functions.
- Mark Netlify as legacy artifact / removal candidate.
- Keep runtime behavior unchanged.

## Scope
- functions/README.md
- netlify/README.md
- No routing changes
- No API implementation changes
- No deletion/move

## Validation
- git diff --check: PASS
- changed files limited to README markers

## Related
- Refs #79