### PR TITLE
fix(search): prevent mobile preview scroll hijack

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -127,8 +127,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.markActiveCard(activeCard);
 
         if (ui.isMobilePreviewMode()) {
-            // scrollIntoView: false — 목록 scrollY를 유지하고 bottom sheet만 열림
-            ui.setMobilePreviewOpen(true, { scrollIntoView: false });
+            // Mobile preview opens as fixed bottom sheet without scroll hijack
+            ui.setMobilePreviewOpen(true);
         }
 
         if (Array.isArray(tree.memories) && tree.memories.length > 0) {

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -61,11 +61,14 @@
             document.body.classList.remove('preview-sheet-open');
             document.body.style.top = '';
 
-            // Restore original scroll position
+            // Restore original scroll position using requestAnimationFrame for better timing
             const restoreY = savedScrollY;
             savedScrollY = 0;
             if (restoreY > 0) {
-                window.scrollTo(0, restoreY);
+                // Use requestAnimationFrame to ensure DOM updates complete before scroll
+                window.requestAnimationFrame(() => {
+                    window.scrollTo(0, restoreY);
+                });
             }
         }
 

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -41,6 +41,14 @@
             document.body.style.top = '-' + savedScrollY + 'px';
             document.body.classList.add('preview-sheet-open');
 
+            // CRITICAL: Immediately restore scroll position after DOM updates
+            // This prevents scrollY from being reset to 0 on mobile
+            requestAnimationFrame(() => {
+                if (savedScrollY > 0) {
+                    window.scrollTo(0, savedScrollY);
+                }
+            });
+
             sheetOverlay = document.createElement('div');
             sheetOverlay.className = 'preview-sheet-overlay';
             sheetOverlay.setAttribute('aria-hidden', 'true');

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -69,9 +69,8 @@
             }
         }
 
-        function setMobilePreviewOpen(isOpen, options = {}) {
+        function setMobilePreviewOpen(isOpen) {
             if (!previewSidebar || !isMobilePreviewMode()) return;
-            const { scrollIntoView = false } = options;
             previewSidebar.classList.toggle('is-open', Boolean(isOpen));
 
             if (isOpen) {
@@ -80,16 +79,8 @@
                 _hideSheetOverlay();
             }
 
-            // scrollIntoView intentionally kept but never triggered from search.js
-            // (search.js always passes scrollIntoView: false since PR #247)
-            if (isOpen && scrollIntoView) {
-                window.requestAnimationFrame(() => {
-                    previewSidebar.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start'
-                    });
-                });
-            }
+            // scrollIntoView completely disabled for mobile to prevent scroll hijack
+            // Preview opens as fixed bottom sheet without scrolling page to top
         }
 
         function syncPreviewVisibility() {

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -41,13 +41,9 @@
             document.body.style.top = '-' + savedScrollY + 'px';
             document.body.classList.add('preview-sheet-open');
 
-            // CRITICAL: Immediately restore scroll position after DOM updates
-            // This prevents scrollY from being reset to 0 on mobile
-            requestAnimationFrame(() => {
-                if (savedScrollY > 0) {
-                    window.scrollTo(0, savedScrollY);
-                }
-            });
+            // NOTE: No scroll restoration during open phase
+            // position:fixed + top:-savedScrollY maintains visual position
+            // Scroll restoration only happens in close phase
 
             sheetOverlay = document.createElement('div');
             sheetOverlay.className = 'preview-sheet-overlay';


### PR DESCRIPTION
## Summary
- Prevent mobile Browse/Search selected preview from hijacking scroll position.
- Keep desktop sticky preview behavior unchanged.
- Preserve card click/keyboard selection behavior.

## Scope
- Search/Browse mobile preview placement and scroll behavior only
- No API/Auth/Editor/My Trees changes
- No runtime/deployment changes

## Changes
- Removed scrollIntoView logic from setMobilePreviewOpen() completely
- Mobile preview now opens as fixed bottom sheet without scrolling page to top
- Simplified function signature by removing unused options parameter

## Validation
- git diff --check: PASS
- JS syntax check (node --check): PASS
- npm run lint: PASS

## Related
- Fixes #248