### PR TITLE
fix(settings): stabilize auth pending state and return navigation

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -70,8 +70,9 @@
       return;
     }
 
+    // history.back()은 최후의 수단으로만 사용
     try {
-      if (window.history.length > 1 && document.referrer) {
+      if (window.history.length > 1 && document.referrer && !document.referrer.includes('settings.html')) {
         window.history.back();
         return;
       }
@@ -222,7 +223,17 @@
   var settingsBootedFromCache = false;
 
   function getSettingsLoginHref() {
-    var redirect = 'settings.html' + (window.location.search || '');
+    var returnTo = '';
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      returnTo = params.get('returnTo') || '';
+    } catch (e) {}
+    var redirect = 'settings.html';
+    if (returnTo) {
+      redirect += '?returnTo=' + encodeURIComponent(returnTo);
+    } else if (window.location.search) {
+      redirect += window.location.search;
+    }
     return 'login.html?redirect=' + encodeURIComponent(redirect);
   }
 
@@ -247,6 +258,55 @@
     }, 0);
 
     console.log('[settings] Initialized with browse introduction guidance:', settings);
+  }
+
+  function getConfirmedSessionUser() {
+    try {
+      if (window.getConfirmedAuthUser) {
+        return window.getConfirmedAuthUser();
+      }
+      if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
+        var raw = localStorage.getItem('lovebud_auth_cache');
+        if (raw && raw !== 'null') {
+          return JSON.parse(raw);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function clearConfirmedSessionUser() {
+    try {
+      localStorage.removeItem('lovebud_auth_cache');
+      localStorage.removeItem('lovebud_auth_confirmed');
+      localStorage.removeItem('lovebud_auth_token');
+    } catch (e) {}
+  }
+
+  function bootSettings(user, options) {
+    if (settingsInitialized) return;
+    settingsInitialized = true;
+    settingsBootedFromCache = !!(options && options.fromCache);
+    handleSettingsAuthUser(user);
+  }
+
+  function reconcileSettingsUser(user) {
+    if (user && user.uid) {
+      if (!settingsInitialized) {
+        bootSettings(user, { fromCache: false });
+      }
+      return;
+    }
+
+    if (settingsBootedFromCache) {
+      clearConfirmedSessionUser();
+      redirectToLogin();
+      return;
+    }
+
+    if (!settingsInitialized) {
+      bootSettings(null, { fromCache: false });
+    }
   }
 
   function getConfirmedSessionUser() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -219,6 +219,7 @@
   }
 
   var settingsInitialized = false;
+  var settingsBootedFromCache = false;
 
   function getSettingsLoginHref() {
     var redirect = 'settings.html' + (window.location.search || '');
@@ -248,36 +249,98 @@
     console.log('[settings] Initialized with browse introduction guidance:', settings);
   }
 
+  function getConfirmedSessionUser() {
+    try {
+      if (window.getConfirmedAuthUser) {
+        return window.getConfirmedAuthUser();
+      }
+      if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
+        var raw = localStorage.getItem('lovebud_auth_cache');
+        if (raw && raw !== 'null') {
+          return JSON.parse(raw);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function clearConfirmedSessionUser() {
+    try {
+      localStorage.removeItem('lovebud_auth_cache');
+      localStorage.removeItem('lovebud_auth_confirmed');
+      localStorage.removeItem('lovebud_auth_token');
+    } catch (e) {}
+  }
+
+  function bootSettings(user, options) {
+    if (settingsInitialized) return;
+    settingsInitialized = true;
+    settingsBootedFromCache = !!(options && options.fromCache);
+    handleSettingsAuthUser(user);
+  }
+
+  function reconcileSettingsUser(user) {
+    if (user && user.uid) {
+      if (!settingsInitialized) {
+        bootSettings(user, { fromCache: false });
+      }
+      return;
+    }
+
+    if (settingsBootedFromCache) {
+      clearConfirmedSessionUser();
+      redirectToLogin();
+      return;
+    }
+
+    if (!settingsInitialized) {
+      bootSettings(null, { fromCache: false });
+    }
+  }
+
   function handleSettingsAuthUser(user) {
     if (!user || !user.uid) {
       redirectToLogin();
       return;
     }
+    document.body.classList.remove('settings-auth-pending');
     startSettings();
   }
 
   // UI 초기화 (auth gate)
   function initSettings() {
+    var cachedUser = getConfirmedSessionUser();
+
+    if (cachedUser && cachedUser.uid && !settingsInitialized) {
+      bootSettings(cachedUser, { fromCache: true });
+    }
+
     if (
       window.LoveBudAuthBootstrap &&
       typeof window.LoveBudAuthBootstrap.whenReady === 'function'
     ) {
-      window.LoveBudAuthBootstrap.whenReady()
-        .then(handleSettingsAuthUser)
-        .catch(function() {
-          redirectToLogin();
-        });
+      try {
+        window.LoveBudAuthBootstrap.whenReady()
+          .then(reconcileSettingsUser)
+          .catch(function() {
+            reconcileSettingsUser(null);
+          });
+      } catch (e) {
+        reconcileSettingsUser(null);
+      }
       return;
     }
 
     if (typeof window.registerOnAuthReady === 'function') {
       window.registerOnAuthReady(function(user) {
-        handleSettingsAuthUser(user || null);
+        reconcileSettingsUser(user || null);
       });
       return;
     }
 
-    redirectToLogin();
+    if (!settingsInitialized) {
+      bootSettings(cachedUser || null, { fromCache: !!(cachedUser && cachedUser.uid) });
+    }
   }
 
   function redirectAfterLogout() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - Settings Module
- * v20260425-1
+ * v20260428-1
  * 
  * localStorage 기반 설정 관리
  * - 설정 화면 닫기 / 로그아웃
@@ -70,7 +70,6 @@
       return;
     }
 
-    // history.back()은 최후의 수단으로만 사용
     try {
       if (window.history.length > 1 && document.referrer && !document.referrer.includes('settings.html')) {
         window.history.back();
@@ -83,7 +82,6 @@
     window.location.href = '../index.html';
   }
 
-  // 설정 불러오기
   function loadSettings() {
     try {
       var stored = localStorage.getItem(SETTINGS_KEY);
@@ -119,7 +117,6 @@
     });
   }
 
-  // i18n 텍스트 적용
   function applyI18nText() {
     var t = window.t || function(key) { return key; };
 
@@ -219,8 +216,8 @@
     }, true);
   }
 
-  var settingsInitialized = false;
-  var settingsBootedFromCache = false;
+  var settingsStarted = false;
+  var settingsRedirected = false;
 
   function getSettingsLoginHref() {
     var returnTo = '';
@@ -238,12 +235,15 @@
   }
 
   function redirectToLogin() {
+    if (settingsRedirected) return;
+    settingsRedirected = true;
     window.location.replace(getSettingsLoginHref());
   }
 
   function startSettings() {
-    if (settingsInitialized) return;
-    settingsInitialized = true;
+    if (settingsStarted) return;
+    settingsStarted = true;
+    document.body.classList.remove('settings-auth-pending');
 
     var settings = loadSettings();
 
@@ -268,111 +268,41 @@
       if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
         var raw = localStorage.getItem('lovebud_auth_cache');
         if (raw && raw !== 'null') {
-          return JSON.parse(raw);
+          var parsed = JSON.parse(raw);
+          return parsed && parsed.uid ? parsed : null;
         }
       }
     } catch (e) {}
     return null;
   }
 
-  function clearConfirmedSessionUser() {
-    try {
-      localStorage.removeItem('lovebud_auth_cache');
-      localStorage.removeItem('lovebud_auth_confirmed');
-      localStorage.removeItem('lovebud_auth_token');
-    } catch (e) {}
-  }
-
-  function bootSettings(user, options) {
-    if (settingsInitialized) return;
-    settingsInitialized = true;
-    settingsBootedFromCache = !!(options && options.fromCache);
-    handleSettingsAuthUser(user);
-  }
-
-  function reconcileSettingsUser(user) {
-    if (user && user.uid) {
-      if (!settingsInitialized) {
-        bootSettings(user, { fromCache: false });
-      }
-      return;
-    }
-
-    if (settingsBootedFromCache) {
-      clearConfirmedSessionUser();
-      redirectToLogin();
-      return;
-    }
-
-    if (!settingsInitialized) {
-      bootSettings(null, { fromCache: false });
-    }
-  }
-
-  function getConfirmedSessionUser() {
-    try {
-      if (window.getConfirmedAuthUser) {
-        return window.getConfirmedAuthUser();
-      }
-      if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
-        var raw = localStorage.getItem('lovebud_auth_cache');
-        if (raw && raw !== 'null') {
-          return JSON.parse(raw);
-        }
-      }
-    } catch (e) {}
+  function normalizeAuthUser(result) {
+    if (result && result.uid) return result;
+    if (result && result.user && result.user.uid) return result.user;
     return null;
   }
 
-  function clearConfirmedSessionUser() {
-    try {
-      localStorage.removeItem('lovebud_auth_cache');
-      localStorage.removeItem('lovebud_auth_confirmed');
-      localStorage.removeItem('lovebud_auth_token');
-    } catch (e) {}
-  }
+  function handleSettingsAuthUser(result) {
+    var user = normalizeAuthUser(result);
 
-  function bootSettings(user, options) {
-    if (settingsInitialized) return;
-    settingsInitialized = true;
-    settingsBootedFromCache = !!(options && options.fromCache);
-    handleSettingsAuthUser(user);
-  }
-
-  function reconcileSettingsUser(user) {
-    if (user && user.uid) {
-      if (!settingsInitialized) {
-        bootSettings(user, { fromCache: false });
-      }
+    if (user) {
+      startSettings();
       return;
     }
 
-    if (settingsBootedFromCache) {
-      clearConfirmedSessionUser();
+    if (!getConfirmedSessionUser()) {
       redirectToLogin();
       return;
     }
 
-    if (!settingsInitialized) {
-      bootSettings(null, { fromCache: false });
-    }
-  }
-
-  function handleSettingsAuthUser(user) {
-    if (!user || !user.uid) {
-      redirectToLogin();
-      return;
-    }
-    document.body.classList.remove('settings-auth-pending');
     startSettings();
   }
 
-  // UI 초기화 (auth gate)
   function initSettings() {
     var cachedUser = getConfirmedSessionUser();
 
-    if (cachedUser && cachedUser.uid && !settingsInitialized) {
-      bootSettings(cachedUser, { fromCache: true });
+    if (cachedUser) {
+      startSettings();
     }
 
     if (
@@ -381,26 +311,31 @@
     ) {
       try {
         window.LoveBudAuthBootstrap.whenReady()
-          .then(reconcileSettingsUser)
+          .then(handleSettingsAuthUser)
           .catch(function() {
-            reconcileSettingsUser(null);
+            if (!cachedUser) {
+              redirectToLogin();
+            }
           });
       } catch (e) {
-        reconcileSettingsUser(null);
+        if (!cachedUser) {
+          redirectToLogin();
+        }
       }
       return;
     }
 
     if (typeof window.registerOnAuthReady === 'function') {
-      window.registerOnAuthReady(function(user) {
-        reconcileSettingsUser(user || null);
-      });
+      window.registerOnAuthReady(handleSettingsAuthUser);
       return;
     }
 
-    if (!settingsInitialized) {
-      bootSettings(cachedUser || null, { fromCache: !!(cachedUser && cachedUser.uid) });
+    if (cachedUser) {
+      startSettings();
+      return;
     }
+
+    redirectToLogin();
   }
 
   function redirectAfterLogout() {
@@ -422,7 +357,6 @@
     };
   }
 
-  // 로그아웃 처리
   function handleLogout() {
     if (window.LoveBudAuthFirebase && typeof window.LoveBudAuthFirebase.signOut === 'function') {
       Promise.resolve(window.LoveBudAuthFirebase.signOut(getCanonicalLogoutOptions()))

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -67,7 +67,7 @@
      <script src="../js/auth/auth-session.js?v=20260417-31"></script>
      <script src="../js/auth/auth-firebase.js?v=20260427-3"></script>
      <script src="../js/auth.js?v=20260417-31"></script>
-    <script src="../js/settings.js?v=20260427-3"></script>
+    <script src="../js/settings.js?v=20260428-1"></script>
   <script>
     renderSharedHeader();
     initSettings();


### PR DESCRIPTION
## Summary
- Hide Settings protected UI while auth state is pending to prevent flicker.
- Prefer explicit Settings return targets over unstable history/referrer fallback.
- Preserve existing shared-header returnTo behavior without changing auth.js.

## Scope
- pages/settings.html
- css/settings.css
- js/settings.js
- No auth.js changes.
- No backend/API/Auth provider/Firebase config changes.
- No Search/Browse/Intro/docs/runtime changes.

## Validation
- git diff --check: PASS
- node --check js/settings.js: PASS
- node --check js/shared-header.js: SKIPPED (unchanged)
- npm run lint: PASS (Static lint passed)
- Browser verification: PENDING Cloudflare Preview or assigned fixed test slot

## Related
- Refs #243