### PR TITLE
chore(repo): ignore local verification artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ coverage/
 # Local agent docs / notes (ignored from public repo)
 AGENT.md
 LOCAL_AGENT.md
-AGENTS.md
 
 # App pages and project reports are real repo assets and must stay trackable.
 # Do not ignore `pages/` or `docs/reports/`.
@@ -121,3 +120,15 @@ firebase-debug*.log
 # Git Sync Conflicts & Backups
 .git (1)/
 .git-backup-*/
+
+# Local verification artifacts and work folders
+local-backup/
+work/
+ops/inbox/
+ops/reports/
+ops/screenshots/
+ops/slots/
+
+# Root-level screenshots (desktop/mobile verification)
+*.png
+!*.svg

--- a/.kilocode/rules/00-lovebud-global.md
+++ b/.kilocode/rules/00-lovebud-global.md
@@ -28,3 +28,11 @@ These rules apply to all agents working on the LoveBud project, especially code-
 ## Security
 - Never log, record, or expose credentials, tokens, cookies, sessions, or secrets (Firebase, Cloudflare, Modal, Neon, etc.).
 - Only reference secret names/locations; never include values.
+
+## Local Artifact Hygiene
+- Do not create `local-backup/`, `work/`, screenshots, or report JSON files inside the repo.
+- Move local verification artifacts (screenshots, reports, backup files) outside the repo to `local-backup/`.
+- Before creating a PR, always check `git status --short` and `git diff --name-only origin/main...HEAD`.
+- If unexpected files are included, stop immediately and clean up the scope.
+- Do not run git clean, git reset --hard, or git stash without explicit approval.
+- Stop work in a dirty worktree and prepare a clean environment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,3 +466,11 @@ LoveBud 작업은 항상 **현재 `main` 확인 → source of truth 확인 → �
 ### 보안
 - 자격 증명, 토큰, 쿠키, 세션, Firebase/Cloudflare/Modal/Neon secret 값을 절대 기록하거나 노출하지 않습니다.
 - 필요한 secret은 이름과 위치 정책만 언급하며, 실제 값은 절대 포함하지 않습니다.
+
+### Local Artifact Hygiene
+- repo 내부에 `local-backup/`, `work/`, screenshots, report JSON 파일을 만들지 않습니다.
+- 로컬 검증 산출물(screenshots, reports, backup files)은 repo 밖 `local-backup/`로 이동합니다.
+- PR 생성 전 반드시 `git status --short`와 `git diff --name-only origin/main...HEAD`를 확인합니다.
+- 예상 외 파일이 포함되어 있으면 즉시 중단하고 scope를 정리합니다.
+- git clean, git reset --hard, git stash는 명시 승인 없이 실행하지 않습니다.
+- dirty worktree 상태에서는 작업을 중단하고 clean 환경을 준비합니다.


### PR DESCRIPTION
## Summary
- Add ignore rules for local verification artifacts and backup/work folders.
- Document stop rules for dirty worktrees and local artifact hygiene.
- Prevent screenshots, reports, and nested work folders from contaminating PR diffs.

## Scope
- .gitignore
- AGENTS.md
- .kilocode/rules/00-lovebud-global.md
- No app/runtime/code changes.

## Validation
- git diff --check: PASS
- changed files limited to repo hygiene files: PASS
- npm run lint: SKIPPED (repo hygiene/docs-only, not applicable)

## Related
- Refs #277