### PR TITLE
docs(runtime): sync Netlify removal wording

### DIFF
--- a/docs/ops/OPERATIONS.md
+++ b/docs/ops/OPERATIONS.md
@@ -4,21 +4,21 @@
 
 LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 
-> **Hierarchy: Cloudflare Pages Entry + Modal Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact**
+> **Hierarchy: Cloudflare Pages Entry + Modal Runtime > Vercel Transitional Fallback > Netlify Removed Legacy Artifacts**
 
 | 계층 | 역할 | 현재 책임 범위 | 상태 |
 | :--- | :--- | :--- | :--- |
 | **Cloudflare Pages** | **Primary Entry / API Router** | 실서비스 진입점, 정적 프런트 서빙, same-origin `/api/*` 라우팅, `functions/api/*` 실행 | 1순위 |
 | **Modal** | **Active API / Backend Target** | `/api/trees`, `/api/memories`, browse/community/private read/write target, 대표 카드 계산 | 1순위 |
 | **Vercel** | **Deprecated Transitional Fallback** | 일부 fallback / 전이기 보조 계층 | audit 중 |
-| **Netlify** | **Legacy Artifact Only / Removal Candidate** | `netlify/functions/*`, `netlify.toml` historical/reference purpose. 현재 `lovebud.pages.dev` production/test slot active backend 또는 active fallback 아님 | 신규 구현 금지 |
+| **Netlify** | **Removed Legacy Artifact Layer** | PR #291로 repository residual artifacts 제거 완료. 현재 `lovebud.pages.dev` production/test slot active backend 또는 active fallback 아님 | 신규 구현 금지 |
 
 핵심 원칙:
 - 실서비스 주소는 **반드시 `https://lovebud.pages.dev/`** 기준으로 본다.
 - browser-facing API entry는 **Cloudflare Pages same-origin `/api/*`** 기준으로 본다.
 - active backend target은 **Cloudflare Pages Functions → Modal** 경로 기준으로 본다.
-- `netlify/functions/*`는 현재 active production backend가 아니며, Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend 정책 구현 대상이 아니다.
-- Netlify route gap은 즉시 blocker가 아니며, Issue #119 runtime routing audit에서 제거/보존 여부를 판단한다.
+- Netlify residual repository artifacts는 PR #291로 제거되었으며, Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend 정책 구현 대상이 아니다.
+- Netlify route gap은 즉시 blocker가 아니며, Issue #119 runtime routing audit에서 외부 deploy target 보존 여부를 판단한다.
 
 ---
 
@@ -28,12 +28,12 @@ LoveBud의 현재 운영 우선순위는 아래와 같습니다.
 - **Cloudflare Pages 프로젝트(운영 기준)**: `lovebud.pages.dev`
 - **Modal 앱**: `lovebud-browse-snapshot`
 - **Vercel 주소(Deprecated transitional fallback)**: `https://lovebud.vercel.app/`
-- **Netlify 주소 / Functions(Legacy artifact only / Removal Candidate)**: `https://lovebud.netlify.app/`, `netlify/functions/*`
+- **Netlify 주소(removed legacy external reference)**: `https://lovebud.netlify.app/`
 
 주의:
 - Vercel과 Netlify 주소는 현재 공식 사용자-facing 대표 주소가 아닙니다.
 - 운영 문서에서 `lovebud.vercel.app`, `lovebud.netlify.app`를 주서비스처럼 설명하지 않습니다.
-- Netlify Functions를 현재 `lovebud.pages.dev` production/test slot backend나 active fallback처럼 설명하지 않습니다.
+- Netlify residual repository artifacts were removed by PR #291; Netlify를 현재 `lovebud.pages.dev` production/test slot backend나 active fallback처럼 설명하지 않습니다.
 
 ---
 
@@ -112,10 +112,10 @@ Modal runtime 핵심 변수:
 ### 4.3 Vercel / Netlify
 
 Vercel은 deprecated transitional fallback입니다.
-Netlify Functions는 Legacy Artifact Only / Removal Candidate입니다.
+Netlify residual repository artifacts were removed by PR #291.
 
 운영 설명에서는 두 계층 모두 **주경로**로 표현하지 않습니다.
-Netlify는 active fallback 구현 대상이 아니며, removal audit 완료 전까지 historical/reference purpose로만 남습니다.
+Netlify는 active fallback 구현 대상이 아니며, repo artifact 재도입이나 external deploy target 재활성화는 별도 CTO 승인 없이는 수행하지 않습니다.
 
 ---
 
@@ -123,10 +123,10 @@ Netlify는 active fallback 구현 대상이 아니며, removal audit 완료 전�
 
 - Modal browse summary가 실패해도 browse 전체가 멈추면 안 된다.
 - fallback이라는 표현은 Vercel deprecated transitional fallback 또는 Modal 실패 시 degraded response에 한정한다.
-- Netlify Functions는 active fallback이 아니다.
-- Netlify artifacts는 removal audit 완료 전까지 historical/reference purpose로만 남는다.
-- CTO가 Netlify runtime 재활성화를 명시 승인하지 않는 한, `netlify.toml` 또는 `netlify/functions/*`에 신규 route parity, backend policy, feature parity를 추가하지 않는다.
-- Netlify route gap은 고쳐서 유지할 문제가 아니라 Issue #119 runtime routing audit에서 제거/보존 여부를 판단한다.
+- Netlify is not an active fallback.
+- Netlify residual repository artifacts were removed by PR #291.
+- CTO가 Netlify runtime 재활성화를 명시 승인하지 않는 한, Netlify artifacts를 재생성하거나 신규 route parity, backend policy, feature parity를 추가하지 않는다.
+- Netlify route gap은 고쳐서 유지할 문제가 아니라 Issue #119 runtime routing audit에서 외부 deploy target 보존 여부를 판단한다.
 
 ---
 
@@ -140,8 +140,8 @@ Netlify는 active fallback 구현 대상이 아니며, removal audit 완료 전�
 3. `/api/trees`, `/api/memories`는 Cloudflare Pages Functions → Modal로 고정
 4. browse summary는 Modal 우선으로 고정
 5. Vercel은 deprecated transitional fallback으로 축소
-6. Netlify Functions는 Legacy Artifact Only / Removal Candidate로 축소
-7. tests/docs reference transition 완료 후 Issue #119 audit에서 Netlify archive 여부를 별도 승인한다
+6. Netlify residual repository artifacts were removed by PR #291
+7. tests/docs reference transition 완료 후 Issue #119 audit에서 Netlify external deploy target archive 여부를 별도 승인한다
 
 ---
 
@@ -152,9 +152,9 @@ PR #38은 active runtime이 아닌 `netlify/functions/*`에 backend 정책을 �
 해당 판단은 다음 기준을 따른다.
 
 - active production/test slot runtime: Cloudflare Pages Functions → Modal
-- legacy artifact / removal candidate: `netlify/functions/*`
+- removed legacy artifact layer: Netlify residual repository artifacts were removed by PR #291
 - archive: 이번 문서 정리 PR에서 수행하지 않음
-- Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend policy를 `netlify/functions/*`에 구현하지 않음
+- Netlify runtime 재활성화가 명시 승인되지 않는 한 신규 backend policy를 Netlify artifacts로 재도입하지 않음
 
 ---
 
@@ -167,7 +167,7 @@ PR #38은 active runtime이 아닌 `netlify/functions/*`에 backend 정책을 �
 - 응답 server가 Cloudflare인지 확인했는가
 - Cloudflare Pages env에 `MODAL_BASE_URL`이 설정되어 있는가
 - Modal `/modal/health`가 정상 응답하는가
-- `netlify/functions/*`를 새 backend 구현 대상이나 active fallback 구현 대상으로 오해하지 않았는가
+- Netlify를 새 backend 구현 대상이나 active fallback 구현 대상으로 오해하지 않았는가
 - Netlify route gap을 Issue #119 audit 대상으로 분리했는가
 
 ---

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -3,11 +3,11 @@
 ## 1. 프로젝트 주요 정보
 
 - 공식 서비스 URL: `https://lovebud.pages.dev/`
-- 운영 기준: `Cloudflare Pages Entry + Modal Active Runtime > Vercel Transitional Fallback > Netlify Legacy Artifact`
+- 운영 기준: `Cloudflare Pages Entry + Modal Active Runtime > Vercel Transitional Fallback > Netlify Removed Legacy Artifacts`
 - Cloudflare Pages 역할: 공식 사용자-facing production / preview entry, 정적 프런트, same-origin `/api/*` entry
 - Modal 역할: active compute/runtime 우선 경로, browse summary 및 private/community read/write target
 - Vercel 역할: deprecated transitional fallback / upstream under audit
-- Netlify 역할: legacy artifact / removal candidate. `netlify/functions/*`는 현재 `lovebud.pages.dev` production backend 또는 active production fallback이 아님
+- Netlify 역할: PR #291로 repository residual artifacts가 제거된 legacy layer. 현재 `lovebud.pages.dev` production backend 또는 active production fallback이 아님
 
 ## 2. 현재 운영 구조
 
@@ -28,9 +28,9 @@
 ### Fallback / Legacy
 - Modal read 실패 시 Cloudflare Pages가 Vercel upstream으로 fallback 할 수 있습니다.
 - catch-all `/api/*`의 기본 fallback upstream origin은 현재 Vercel입니다.
-- Netlify 관련 파일과 `netlify/functions/*`는 legacy artifact / removal candidate로 남아 있습니다.
+- Netlify residual repository artifacts were removed by PR #291.
 - Netlify는 active production fallback이 아니며, 새 backend feature/policy work의 대상이 아닙니다.
-- Netlify 코드는 tests/docs transition 전까지 삭제 대상이라고 단정하지 않습니다. 별도 승인 없이 이동, archive, 삭제하지 않습니다.
+- Netlify 관련 재도입, external deploy target 재활성화, 또는 historical reference 복원은 별도 CTO 승인 없이는 수행하지 않습니다.
 
 ## 3. 배포 절차
 
@@ -60,12 +60,12 @@
 - 공식 사용자-facing 주소가 아니라 보조 계층으로 취급
 
 ### Netlify
-- 역할: legacy artifact / removal candidate
+- 역할: removed legacy artifact layer after PR #291
 - 주서비스 주소, active runtime, active production fallback으로 취급하지 않습니다.
-- `netlify.toml`, `netlify/functions/**`, `tests/functions/**`는 tests/docs transition 전까지 남아 있을 수 있습니다.
-- `netlify/functions/*`는 현재 active runtime 구현 위치로 보지 않습니다.
-- Netlify runtime 재활성화, 코드 이동, 삭제, archive는 별도 CTO 승인 전 수행하지 않습니다.
-- 자세한 기준은 [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](NETLIFY_LEGACY_ARTIFACT_AUDIT.md)를 따릅니다.
+- `netlify.toml`, `netlify/functions/**`, `netlify/sql/**` residual repository artifacts는 PR #291로 제거되었습니다.
+- Netlify는 현재 active runtime 구현 위치가 아닙니다.
+- Netlify runtime 재활성화, artifact 재생성, archive 복원은 별도 CTO 승인 전 수행하지 않습니다.
+- 과거 기준은 [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](NETLIFY_LEGACY_ARTIFACT_AUDIT.md)를 따르되, 현재 repository residual artifact 상태는 PR #291 이후 기준으로 봅니다.
 
 ## 4. 장애 대응
 
@@ -104,7 +104,7 @@
 1. CI/E2E smoke workflow가 `netlify dev`를 사용할 수 있습니다.
 2. 이 경로는 CI 로컬 실행 harness이며, production active runtime 또는 active production fallback이 Netlify라는 뜻이 아닙니다.
 3. Netlify dev의 `DATABASE_URL` / `NETLIFY_DATABASE_URL` 누락으로 발생하는 503은 production Cloudflare/Modal runtime truth와 분리해서 봅니다.
-4. CI/E2E blocker를 이유로 `netlify/functions/*`를 active runtime처럼 수정하지 않습니다.
+4. CI/E2E blocker를 이유로 Netlify runtime artifact를 재생성하거나 active runtime처럼 수정하지 않습니다.
 5. Netlify-targeting tests는 Cloudflare/Modal parity 확인 후 별도 migration/delete 승인 대상입니다.
 
 ### Fixed test slot access failure
@@ -156,6 +156,6 @@
 - browse summary와 API compute의 1순위는 Modal
 - Cloudflare Pages가 same-origin `/api/*` entry
 - Vercel은 deprecated transitional fallback / upstream under audit
-- Netlify는 legacy artifact / removal candidate이며, active production fallback이 아니고 `netlify/functions/*`는 현재 active production backend가 아님
-- Netlify 제거는 Cloudflare/Modal route parity, Netlify-targeting test migration/deletion, CI import 제거, production/test slot route matrix 확인, active Netlify deploy target 미사용 확인 후 별도 승인으로만 진행합니다.
+- Netlify residual repository artifacts were removed by PR #291; Netlify is not an active production fallback or new backend implementation target.
+- Netlify-related reintroduction or external deploy target reactivation requires separate CTO approval after Cloudflare/Modal route parity, Netlify-targeting test migration/deletion, CI import review, production/test slot route matrix confirmation, and active Netlify deploy target review.
 - fixed test slot 검증의 역할/판정/evidence 기준은 `docs/ops/TEST_PREVIEW_SLOTS.md`가 canonical입니다

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lovebud-mvp",
   "version": "1.0.0",
   "private": true,
-  "description": "LoveBud — Cloudflare Pages frontend + same-origin API entry with Modal runtime and Vercel transitional fallback",
+  "description": "LoveBud — Cloudflare Pages frontend + same-origin API entry with Modal/Vercel/Netlify transitional layers",
   "scripts": {
     "lint": "node scripts/lint-static.js",
     "build": "node scripts/build-static.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lovebud-mvp",
   "version": "1.0.0",
   "private": true,
-  "description": "LoveBud — Cloudflare Pages frontend + same-origin API entry with Modal/Vercel/Netlify transitional layers",
+  "description": "LoveBud — Cloudflare Pages frontend + same-origin API entry with Modal runtime and Vercel transitional fallback",
   "scripts": {
     "lint": "node scripts/lint-static.js",
     "build": "node scripts/build-static.js",


### PR DESCRIPTION
## Summary
- Update runtime docs wording after Netlify residual artifacts were removed.
- Clarify that Cloudflare Pages + Modal remains the active runtime.
- Keep Vercel as deprecated transitional fallback while avoiding stale Netlify runtime wording.

## Scope
- docs/ops/RUNBOOK.md
- docs/ops/OPERATIONS.md
- Docs only.
- No runtime code changes.
- No package metadata changes.

## Validation
- git diff --check: PASS
- Changed files limited to docs/ops/RUNBOOK.md and docs/ops/OPERATIONS.md.

## Related
- Refs #223
- Refs #225