### PR TITLE
feat(transition): add shared page transition assets

### DIFF
--- a/css/page-transitions.css
+++ b/css/page-transitions.css
@@ -1,0 +1,87 @@
+/*
+ * LoveBud shared page transition and reveal assets.
+ *
+ * Asset-only: this file is inert until a page explicitly opts in by adding
+ * the classes below. Do not attach these classes globally.
+ */
+
+.page-transition-ready,
+.page-transition-enter,
+.reveal-up,
+.reveal-fade,
+.reveal-scale {
+    pointer-events: auto;
+}
+
+.page-transition-ready {
+    opacity: 1;
+}
+
+.page-transition-enter {
+    opacity: 0;
+    transform: translateY(10px);
+}
+
+.page-transition-enter.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 260ms ease, transform 260ms ease;
+}
+
+.reveal-up {
+    opacity: 0;
+    transform: translateY(14px);
+}
+
+.reveal-up.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 280ms ease, transform 280ms ease;
+}
+
+.reveal-fade {
+    opacity: 0;
+}
+
+.reveal-fade.is-visible {
+    opacity: 1;
+    transition: opacity 240ms ease;
+}
+
+.reveal-scale {
+    opacity: 0;
+    transform: scale(0.98);
+}
+
+.reveal-scale.is-visible {
+    opacity: 1;
+    transform: scale(1);
+    transition: opacity 260ms ease, transform 260ms ease;
+}
+
+.page-transition-stagger > .reveal-up,
+.page-transition-stagger > .reveal-fade,
+.page-transition-stagger > .reveal-scale {
+    transition-delay: calc(var(--reveal-index, 0) * 45ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .page-transition-enter,
+    .page-transition-enter.is-visible,
+    .reveal-up,
+    .reveal-up.is-visible,
+    .reveal-fade,
+    .reveal-fade.is-visible,
+    .reveal-scale,
+    .reveal-scale.is-visible {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+
+    .page-transition-stagger > .reveal-up,
+    .page-transition-stagger > .reveal-fade,
+    .page-transition-stagger > .reveal-scale {
+        transition-delay: 0ms;
+    }
+}

--- a/js/page-transitions.js
+++ b/js/page-transitions.js
@@ -1,0 +1,101 @@
+/*
+ * LoveBud shared page transition and reveal behavior.
+ *
+ * Asset-only: pages must explicitly include this script and opt in with
+ * transition/reveal classes. If no opt-in nodes exist, this script is a no-op.
+ */
+
+(function () {
+    'use strict';
+
+    var VISIBLE_CLASS = 'is-visible';
+    var REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+    var ROOT_SELECTOR = '.page-transition-enter';
+    var REVEAL_SELECTOR = '.reveal-up, .reveal-fade, .reveal-scale';
+
+    function safely(fn) {
+        try {
+            fn();
+        } catch (error) {
+            if (window.console && typeof window.console.warn === 'function') {
+                window.console.warn('[page-transitions] skipped:', error);
+            }
+        }
+    }
+
+    function prefersReducedMotion() {
+        return Boolean(
+            window.matchMedia &&
+            window.matchMedia(REDUCED_MOTION_QUERY).matches
+        );
+    }
+
+    function markVisible(node) {
+        if (!node || !node.classList) return;
+        node.classList.add(VISIBLE_CLASS);
+    }
+
+    function collectOptInNodes(root) {
+        var scope = root || document;
+        var nodes = [];
+
+        if (scope.querySelectorAll) {
+            nodes = Array.prototype.slice.call(
+                scope.querySelectorAll(ROOT_SELECTOR + ', ' + REVEAL_SELECTOR)
+            );
+        }
+
+        if (scope.matches && scope.matches(ROOT_SELECTOR + ', ' + REVEAL_SELECTOR)) {
+            nodes.unshift(scope);
+        }
+
+        return nodes;
+    }
+
+    function setRevealIndexes(nodes) {
+        var index = 0;
+
+        nodes.forEach(function (node) {
+            if (!node || !node.classList) return;
+            if (!node.matches || !node.matches(REVEAL_SELECTOR)) return;
+            if (node.style && !node.style.getPropertyValue('--reveal-index')) {
+                node.style.setProperty('--reveal-index', String(index));
+            }
+            index += 1;
+        });
+    }
+
+    function revealNodes(nodes) {
+        if (!nodes || nodes.length === 0) return;
+
+        setRevealIndexes(nodes);
+
+        if (prefersReducedMotion()) {
+            nodes.forEach(markVisible);
+            return;
+        }
+
+        window.requestAnimationFrame(function () {
+            nodes.forEach(markVisible);
+        });
+    }
+
+    function init(root) {
+        safely(function () {
+            var nodes = collectOptInNodes(root);
+            revealNodes(nodes);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            init(document);
+        }, { once: true });
+    } else {
+        init(document);
+    }
+
+    window.LoveBudPageTransitions = {
+        init: init
+    };
+})();


### PR DESCRIPTION
## Summary
- Add shared page transition and reveal assets for future opt-in page adoption.
- Keep the assets inert unless pages explicitly opt in.
- Respect `prefers-reduced-motion`.

## Scope
- Add `css/page-transitions.css`.
- Add `js/page-transitions.js`.
- No page opt-in changes.
- No global CSS changes.
- No Search/Auth/Editor/API/runtime behavior changes.

## Related
Refs #242

## Verification
- [x] `git diff --check`
- [x] Changed files limited to `css/page-transitions.css` and `js/page-transitions.js`
- [x] No `pages/*.html` changes
- [x] No `css/global.css` changes
- [x] No Search/Auth/Editor/API/Modal changes
- [x] Asset-only inert/no-op behavior verified

## Notes
Issue #242 remains open because page opt-in phases are still pending.
PR #294 only completes the shared transition asset-only step.