### PR TITLE
refactor(search): extract empty state css module

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,80 +1,8 @@
 @import url("./search/base.css");
 @import url("./search/hero-controls.css");
 @import url("./search/results-skeleton.css");
+@import url("./search/empty-state.css");
 @import url("./search/growing-trees.css");
 @import url("./search/tree-card.css");
 @import url("./search/preview-sidebar.css");
 @import url("./search/responsive.css");
-
-.search-empty-state {
-    grid-column: 1 / -1;
-    padding: clamp(44px, 6vw, 64px) 24px;
-    text-align: center;
-    color: var(--on-surface-variant);
-}
-
-.search-empty-icon,
-.search-error-icon {
-    display: block;
-    margin: 0 auto 16px;
-    font-size: 48px;
-    line-height: 1;
-    opacity: 0.42;
-}
-
-.search-empty-icon {
-    color: var(--primary);
-}
-
-.search-error-icon {
-    color: var(--on-surface-variant);
-}
-
-.search-empty-heading {
-    margin: 0 0 8px;
-    color: var(--on-surface);
-    font-size: 1.08rem;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-}
-
-.search-empty-body {
-    max-width: 420px;
-    margin: 0 auto;
-    color: var(--on-surface-variant);
-    font-size: 0.94rem;
-    line-height: 1.6;
-}
-
-.search-empty-actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 22px;
-}
-
-@media (max-width: 420px) {
-    .search-empty-state {
-        padding: 36px 18px;
-    }
-
-    .search-empty-icon,
-    .search-error-icon {
-        margin-bottom: 14px;
-        font-size: 40px;
-    }
-
-    .search-empty-heading {
-        font-size: 1rem;
-    }
-
-    .search-empty-body {
-        font-size: 0.9rem;
-    }
-
-    .search-empty-actions {
-        gap: 8px;
-        margin-top: 18px;
-    }
-}

--- a/css/search/empty-state.css
+++ b/css/search/empty-state.css
@@ -1,0 +1,72 @@
+.search-empty-state {
+    grid-column: 1 / -1;
+    padding: clamp(44px, 6vw, 64px) 24px;
+    text-align: center;
+    color: var(--on-surface-variant);
+}
+
+.search-empty-icon,
+.search-error-icon {
+    display: block;
+    margin: 0 auto 16px;
+    font-size: 48px;
+    line-height: 1;
+    opacity: 0.42;
+}
+
+.search-empty-icon {
+    color: var(--primary);
+}
+
+.search-error-icon {
+    color: var(--on-surface-variant);
+}
+
+.search-empty-heading {
+    margin: 0 0 8px;
+    color: var(--on-surface);
+    font-size: 1.08rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.search-empty-body {
+    max-width: 420px;
+    margin: 0 auto;
+    color: var(--on-surface-variant);
+    font-size: 0.94rem;
+    line-height: 1.6;
+}
+
+.search-empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 22px;
+}
+
+@media (max-width: 420px) {
+    .search-empty-state {
+        padding: 36px 18px;
+    }
+
+    .search-empty-icon,
+    .search-error-icon {
+        margin-bottom: 14px;
+        font-size: 40px;
+    }
+
+    .search-empty-heading {
+        font-size: 1rem;
+    }
+
+    .search-empty-body {
+        font-size: 0.9rem;
+    }
+
+    .search-empty-actions {
+        gap: 8px;
+        margin-top: 18px;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract search empty/error state styles from css/search.css into css/search/empty-state.css.
- Keep search page markup, JavaScript, data loading, and runtime behavior unchanged.
- Continue the #65 Search CSS extraction backlog with a narrow CSS-only change.

## Scope
- CSS-only extraction.
- No page markup changes.
- No JavaScript changes.
- No API/Auth/runtime/data loading changes.
- No prototype/reference/demo/variant changes.

## Related
Refs #65

## Verification
- [x] git diff --check passed (no whitespace issues)
- [x] Changed files limited to css/search.css and css/search/empty-state.css
- [x] CSS extraction verified (import added in search.css, all .search-empty-*/.search-error-* rules moved to empty-state.css)
- [x] Search page visual smoke checked on localhost:8080 (desktop + mobile viewport)
- [x] No new console blocker (only expected 404s for local server missing /api routes)
- [x] No horizontal overflow (desktop: 973px, mobile: 360px)
- [x] Empty state and error state both render correctly with proper CSS applied
- [x] Error icon color verified: rgb(108, 89, 83) (var(--on-surface-variant))

## Notes
Static CSS extraction. No runtime changes.