### PR TITLE
refactor(search): extract controls css module

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,5 +1,6 @@
 @import url("./search/base.css");
 @import url("./search/hero-controls.css");
+@import url("./search/controls.css");
 @import url("./search/results-skeleton.css");
 @import url("./search/empty-state.css");
 @import url("./search/growing-trees.css");

--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -1,0 +1,78 @@
+/* Search Controls Module
+ * Extracted from hero-controls.css
+ * Contains: search input, filter chips, utility row
+ * Refs #65
+ */
+
+.search-input-wrapper {
+    position: relative;
+    margin-bottom: 0;
+    max-width: 420px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.search-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 15px 18px 15px 48px;
+    border-radius: 999px;
+    border: 1px solid rgba(144, 73, 81, 0.09);
+    background: rgba(255,255,255,0.82);
+    box-shadow: 0 10px 22px rgba(0,0,0,0.022);
+    font-size: 0.96rem;
+    font-family: var(--font-body);
+    outline: none;
+    transition: all 0.3s;
+}
+
+.search-input:focus {
+    border-color: rgba(144,73,81,0.18);
+    box-shadow: 0 12px 28px rgba(141, 71, 79, 0.06);
+}
+
+.search-icon {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--primary);
+    font-size: 20px;
+    opacity: 0.72;
+}
+
+.tag-chip {
+    padding: 8px 14px;
+    border-radius: 99px;
+    background: rgba(255,255,255,0.76);
+    color: var(--on-surface-variant);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+}
+
+.tag-chip.active {
+    background: rgba(144, 73, 81, 0.12);
+    color: var(--primary);
+    border-color: rgba(144, 73, 81, 0.16);
+}
+
+.filter-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    min-width: 0;
+}
+
+.browse-utility-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 18px;
+    min-width: 0;
+}

--- a/css/search/hero-controls.css
+++ b/css/search/hero-controls.css
@@ -1,3 +1,8 @@
+/* Search Hero / Header / Curation / Results-Head Module
+ * Controls selectors extracted to css/search/controls.css
+ * Refs #65
+ */
+
 .browse-curation-shell {
     margin-bottom: 20px;
     padding: 0;
@@ -40,61 +45,6 @@
     margin: 0;
 }
 
-.search-input-wrapper {
-    position: relative;
-    margin-bottom: 0;
-    max-width: 420px;
-    flex: 1 1 auto;
-    min-width: 0;
-}
-
-.search-input {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 15px 18px 15px 48px;
-    border-radius: 999px;
-    border: 1px solid rgba(144, 73, 81, 0.09);
-    background: rgba(255,255,255,0.82);
-    box-shadow: 0 10px 22px rgba(0,0,0,0.022);
-    font-size: 0.96rem;
-    font-family: var(--font-body);
-    outline: none;
-    transition: all 0.3s;
-}
-
-.search-input:focus {
-    border-color: rgba(144,73,81,0.18);
-    box-shadow: 0 12px 28px rgba(141, 71, 79, 0.06);
-}
-
-.search-icon {
-    position: absolute;
-    left: 16px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--primary);
-    font-size: 20px;
-    opacity: 0.72;
-}
-
-.tag-chip {
-    padding: 8px 14px;
-    border-radius: 99px;
-    background: rgba(255,255,255,0.76);
-    color: var(--on-surface-variant);
-    font-size: 12px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: all 0.2s;
-    border: 1px solid rgba(144, 73, 81, 0.08);
-}
-
-.tag-chip.active {
-    background: rgba(144, 73, 81, 0.12);
-    color: var(--primary);
-    border-color: rgba(144, 73, 81, 0.16);
-}
-
 .search-intent-note {
     display: flex;
     align-items: center;
@@ -104,24 +54,6 @@
     font-size: 0.92rem;
     font-weight: 700;
     line-height: 1.55;
-}
-
-.filter-row {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 0;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    min-width: 0;
-}
-
-.browse-utility-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    margin-top: 18px;
-    min-width: 0;
 }
 
 .browse-guidance-strip {


### PR DESCRIPTION
## Summary
• Extract Search input, filter chip, and utility row styles into css/search/controls.css.
• Keep Search page markup, JavaScript, data loading, and runtime behavior unchanged.
• Continue the #65 Search CSS extraction backlog after the empty-state CSS extraction.

## Scope
• CSS-only extraction.
• No page markup changes.
• No JavaScript changes.
• No API/Auth/runtime/data loading changes.
• No prototype/reference/demo/variant changes.

## Related
Refs #65

## Verification
[✓] git diff --check
[✓] Changed files limited to css/search.css, css/search/hero-controls.css, and css/search/controls.css
[✓] CSS extraction verified, no duplicated moved selectors
[✓] Search controls visual smoke checked on localhost:8081 (desktop + mobile viewport)
[✓] No new console blocker (only expected 404s for local server missing /api routes)
[✓] No horizontal overflow (desktop: 1920px, mobile: 360px)
[✓] Search input, icon, filter chips, and utility row layout render correctly
[✓] Cloudflare Preview available: https://refactor-search-controls-css.lovebud.pages.dev

## Notes
CSS extraction verified via LOCAL_ONLY browser smoke test. Cloudflare Preview deployed successfully for additional verification.