### PR TITLE
docs(agents): link browser verification and GitHub auth guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ UI 검증 프롬프트를 작성하기 전 반드시 아래를 먼저 판단하�
 - 이미 확보한 테스트/프리뷰 URL이 있는가?
 - Cloudflare PR Preview URL이 있는가?
 
+브라우저/로컬 검증 작업자는 추가로 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`를 먼저 읽고, URL 출처·fixed slot·evidence 규칙은 `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`와 `docs/ops/TEST_PREVIEW_SLOTS.md`를 따릅니다.
+
 ---
 
 ## 4. 제품 / 용어 해석 가드레일
@@ -211,10 +213,18 @@ LoveBud / LoveTree는 다음과 같은 서비스가 아닙니다.
    - `docs/design/UI_DESIGN_SYSTEM.md`
 5. 운영 판단이 필요하면:
    - `docs/ops/OPERATIONS.md`
+   - `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+   - `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`
+   - `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`
+   - `docs/ops/TEST_PREVIEW_SLOTS.md`
    - `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
 6. 구현 판단이 필요하면:
    - `docs/engineering/API_CONTRACT.md`
    - 관련 페이지/ops/engineering 문서
+
+GitHub CLI, browser login, connector-backed GitHub access, or token-backed local access를 사용하는 작업자는 `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`를 함께 따릅니다.
+
+브라우저/로컬 검증 작업자는 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`를 먼저 따릅니다.
 
 대화 복원이 필요하면 아래를 추가로 읽습니다.
 
@@ -319,6 +329,8 @@ LoveBud 작업에는 배포, API 접근, 테스트 계정, 외부 서비스 연�
 - provider access tokens
 - 마지막 8자리 등 token 식별 정보
 
+GitHub CLI, browser login, connector-backed GitHub access, or token-backed local access를 사용하는 경우 `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`를 함께 따릅니다.
+
 작업에 secret이 필요하면 에이전트는 값을 요구하거나 출력하지 말고, 필요한 secret name만 말합니다. 실제 값 주입은 사용자가 로컬 환경, provider dashboard, GitHub Actions Secrets, Cloudflare/Vercel/Netlify dashboard 등 적절한 secret store를 통해 처리합니다.
 
 **금지 예시:**
@@ -416,6 +428,10 @@ UI 검증 환경은 `## 3. 현재 서비스 / 인프라 기준`의 **UI 검증 �
 
 ### 운영 / 배포
 - `docs/ops/OPERATIONS.md`
+- `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+- `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`
+- `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`
+- `docs/ops/TEST_PREVIEW_SLOTS.md`
 - `docs/ops/DEPLOY_CHECKLIST.md`
 - `docs/ops/RUNBOOK.md`
 - `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
@@ -465,6 +481,7 @@ LoveBud 작업은 항상 **현재 `main` 확인 → source of truth 확인 → �
 
 ### 보안
 - 자격 증명, 토큰, 쿠키, 세션, Firebase/Cloudflare/Modal/Neon secret 값을 절대 기록하거나 노출하지 않습니다.
+- GitHub CLI/browser login/connector/token-backed local access는 `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`를 함께 따릅니다.
 - 필요한 secret은 이름과 위치 정책만 언급하며, 실제 값은 절대 포함하지 않습니다.
 
 ### Local Artifact Hygiene

--- a/docs/ops/GITHUB_AUTH_TOKEN_USAGE.md
+++ b/docs/ops/GITHUB_AUTH_TOKEN_USAGE.md
@@ -1,0 +1,201 @@
+# GitHub Auth Token Usage
+
+**Status:** Active ops guidance
+**Owner:** CTO / Ops Lead
+**Scope:** GitHub CLI login, browser login sessions, connector-backed GitHub access, and local verification agents
+
+---
+
+## 1. Purpose
+
+Some LoveBud agents work through GitHub connectors, while other local/browser agents must authenticate with GitHub directly through GitHub CLI or a browser session.
+
+This document defines safe operating rules for GitHub authentication and credential handling.
+
+It does not authorize broad repository writes, direct `main` pushes, merges, issue closes, branch deletion, or secret disclosure. Task-specific authority must still come from the CTO prompt.
+
+---
+
+## 2. Allowed authentication surfaces
+
+Allowed GitHub access surfaces:
+
+- GitHub connector access provided by the execution environment.
+- GitHub CLI authenticated through the local credential manager.
+- Browser login to GitHub for viewing PRs, issues, checks, deployments, and comments.
+- Local environment variables for GitHub authentication only when values are already provisioned securely by the user or CI environment.
+
+Agents may verify authentication state with commands such as:
+
+```bash
+gh auth status
+```
+
+Do not print credential values or copy credential-store contents into reports.
+
+---
+
+## 3. Secret handling rules
+
+Never output, paste, summarize, screenshot, or log:
+
+- raw GitHub credential values;
+- partial credential values;
+- credential prefixes or suffixes;
+- Authorization headers;
+- cookies;
+- browser session values;
+- credential store contents;
+- one-time login codes;
+- password manager entries.
+
+Allowed reporting examples:
+
+```text
+GitHub CLI auth: authenticated as <account>
+GitHub CLI auth: not authenticated
+Required secret name: GH_TOKEN
+Required secret name: GITHUB_TOKEN
+```
+
+Forbidden reporting examples:
+
+```text
+<environment variable name>=<credential value>
+Authorization header with credential value
+Cookie header with session value
+```
+
+If a credential or session value appears in terminal output, screenshots, logs, or browser developer tools, redact it before reporting. If redaction is not possible, do not share the artifact.
+
+---
+
+## 4. Credential storage and local files
+
+GitHub login material must stay outside committed repository content.
+
+Local-only paths that may contain secrets are:
+
+- `.secrets/`
+- `.env`
+- `.env.*`
+
+These paths must not be committed, copied into docs, pasted into PR comments, or included in screenshots.
+
+If any `.secrets/` or `.env*` file appears in `git status --short` as tracked or staged content, stop and report `BLOCKED`.
+
+Do not create new credential files inside the repository unless the CTO explicitly assigns a local-only file path and confirms it is ignored.
+
+---
+
+## 5. GitHub CLI usage rules
+
+Before write operations, verify repository and account context:
+
+```bash
+gh auth status
+gh repo view --json nameWithOwner
+```
+
+For PR-specific work, verify the target PR:
+
+```bash
+gh pr view <PR_NUMBER> --json number,state,isDraft,headRefName,headRefOid,baseRefName,changedFiles,url
+```
+
+For merge operations, use expected head SHA protection when available:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --match-head-commit <EXPECTED_HEAD_SHA>
+```
+
+Merge is forbidden unless the CTO explicitly approves that merge in the current task.
+
+---
+
+## 6. Browser login rules
+
+Browser login may be used to inspect GitHub PRs, issues, checks, deployments, and deployment bot comments.
+
+Rules:
+
+- Do not show password manager UI in screenshots.
+- Do not reveal account email, credentials, cookies, or browser session information.
+- Do not copy private deployment logs that contain secrets.
+- Do not approve OAuth scopes or third-party app permissions unless CTO explicitly instructs it.
+- Do not use a personal browser session to mutate repository state unless the task explicitly authorizes that action.
+
+When a browser session is needed only for inspection, keep the action read-only.
+
+---
+
+## 7. Connector vs local GitHub access
+
+Connector-based access and local GitHub access are separate trust surfaces.
+
+Connector access may be used for:
+
+- reading PRs, issues, commits, changed files, and diffs;
+- creating issues or PRs when explicitly assigned;
+- updating PR body/checklist when explicitly assigned;
+- adding comments when explicitly assigned.
+
+Local `gh` access should be preferred for:
+
+- `git diff --check` verification;
+- local branch and working-tree checks;
+- mergeability checks involving `merge-tree`;
+- ready/merge actions when connector mutation fails;
+- expected head SHA protected merges.
+
+Do not assume connector state and local branch state are equivalent. Verify both when the task requires it.
+
+---
+
+## 8. Write permission guardrails
+
+Authentication does not imply authorization.
+
+Even when authenticated, do not perform these actions unless explicitly assigned:
+
+- direct push to `main`;
+- merge PR;
+- close issue;
+- delete branch;
+- force push;
+- rebase shared branch;
+- reset/stash/clean dirty worktree;
+- modify secrets or provider dashboard configuration;
+- approve new OAuth/application scopes.
+
+Use task-specific permission, not account capability, as the source of authority.
+
+---
+
+## 9. Reporting template
+
+Use this compact report when GitHub authentication is relevant:
+
+```text
+GitHub Auth Context Report
+1. Computer/model:
+2. Access surface: connector / gh CLI / browser login / CI-provided credential
+3. Repository verified:
+4. Auth account verified: yes/no
+5. Credential value exposed: NO
+6. Cookie/session exposed: NO
+7. Write operation performed: NO / specify authorized operation
+8. Issue/PR close performed: NO
+9. Merge performed: NO / specify approved merge
+10. Final status:
+```
+
+---
+
+## 10. Related documents
+
+- [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md)
+- [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md)
+- [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)
+- [PR_CHECKLIST.md](PR_CHECKLIST.md)
+- [RUNBOOK.md](RUNBOOK.md)

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -19,15 +19,16 @@
 1. [OPERATIONS.md](OPERATIONS.md) - 현재 운영 전략과 계층 정의
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
-4. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-5. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-6. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-7. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-8. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-9. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-10. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-11. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-12. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+4. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+5. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+6. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+7. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+8. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+9. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+10. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+11. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+12. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+13. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -49,6 +50,7 @@
 | [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) | 배포 전/후 검증 체크리스트 |
 | [RUNBOOK.md](RUNBOOK.md) | 운영 및 장애 대응 런북 |
 | [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) | 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준 |
+| [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |
 | [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) | 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
 | [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) | browse summary의 Modal 우선 경로와 Modal security contract 기준 |


### PR DESCRIPTION
## Summary
- Add GitHub auth/token usage guidance for local/browser agents using GitHub CLI, browser login, connector-backed access, or CI-provided credentials.
- Link browser/local verification startup guidance and GitHub auth guidance from `AGENTS.md`.
- Link the new GitHub auth guidance from the ops index.

## Scope
- Docs-only.
- No runtime, CSS, JS, page, Auth, API, Modal, or test changes.
- No secret values or credentials added.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #136
Refs #65

## Verification
- [x] `git diff --check`
- [x] Changed files limited to `AGENTS.md`, `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`, and `docs/ops/ops_index.md`
- [x] No runtime/CSS/JS/page/test changes
- [x] No token/secret values added

## Notes
The branch was created from the latest `main` at the time of creation, but `main` moved during editing. Local verification confirmed no merge-tree conflicts.