### PR TITLE
docs(runtime): add ownership markers for active and legacy runtime paths

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -4,6 +4,8 @@
 
 `functions/api/[[path]].js` is the **active same-origin `/api/*` entry point** for this project, served via Cloudflare Pages Functions.
 
+> **Runtime Ownership Marker** - This folder contains the active production API entry point.
+
 ## Request Flow
 
 ```


### PR DESCRIPTION
## Summary
- Add docs-only runtime ownership markers near active and legacy runtime folders.
- Clarify Cloudflare Pages Functions and Modal as the active runtime path.
- Clarify Netlify and legacy SQL as artifacts, not active production targets.

## Scope
- Docs-only.
- No runtime code changes.
- No route mapping changes.
- No Modal/Netlify/Vercel behavior changes.
- No deletion/move/reactivation of legacy folders.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #79

## Verification
- [ ] git diff --check
- [ ] Changed files limited to runtime ownership README/marker docs/index links
- [ ] No JS/Python/runtime/config changes
- [ ] No close keywords for #79