### PR TITLE
refactor(search): split data loading module

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -1,12 +1,17 @@
 /**
  * LoveBud Search Page Orchestrator
- * v20260427-1
+ * v20260429-2
  *
- * Search page orchestration:
- * - Fast list-first loading for public trees
- * - Filter state management
- * - Event binding
- * - Lazy preview hydration on tree selection
+ * Thin orchestrator — delegates data loading to window.LoveBudSearchData.
+ * Data loading behavior is unchanged; only the module boundary has moved.
+ *
+ * Delegation map:
+ *   loadPublicTrees          → window.LoveBudSearchData
+ *   loadGrowingTrees         → window.LoveBudSearchData
+ *   hydrateSelectedTreePreview → window.LoveBudSearchData
+ *   UI / preview / card events → window.LoveBudSearchUI
+ *   URL state                → window.LoveBudSearchUrlState
+ *   Preview cache            → window.LoveBudSearchPreviewCache
  */
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -88,37 +93,27 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui
     });
 
+    // ── Data module (split from this file) ─────────────────────────────────────
+    const searchData = window.LoveBudSearchData.createSearchData({
+        refs,
+        state,
+        previewCacheApi,
+        ui,
+        CardRenderer,
+        PreviewRenderer,
+        callbacks,
+        cache,
+        PUBLIC_TREES_CACHE_KEY,
+        PREVIEW_CACHE_TTL_MS,
+        getPreviewCacheKey
+    });
+
+    // ── Local helpers (orchestrator-level only) ────────────────────────────────
     const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
 
     const getSelectedTreeFromFiltered = (filteredTrees) => {
         if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
         return filteredTrees.find(tree => tree.id === state.selectedTreeId) || null;
-    };
-
-    const hydrateSelectedTreePreview = async (tree) => {
-        if (!tree || !tree.id) return;
-        const requestId = ++state.currentPreviewRequestId;
-        ui.renderPreviewLoadingState(tree);
-
-        try {
-            const cachedPreview = previewCacheApi.readPreviewCache(tree.id);
-            const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
-
-            previewCacheApi.writePreviewCache(tree.id, hydratedTree);
-            previewCacheApi.mergeHydratedTree(hydratedTree);
-
-            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
-                return;
-            }
-            PreviewRenderer.updatePreview(hydratedTree);
-            renderResults(false);
-        } catch (error) {
-            console.warn('[search] preview hydration failed:', error.message);
-            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
-                return;
-            }
-            ui.clearSelectedPreview({ preserveOpenState: false });
-        }
     };
 
     const selectTree = (tree, activeCard) => {
@@ -127,7 +122,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.markActiveCard(activeCard);
 
         if (ui.isMobilePreviewMode()) {
-            // Mobile preview opens as fixed bottom sheet without scroll hijack
             ui.setMobilePreviewOpen(true);
         }
 
@@ -137,7 +131,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        hydrateSelectedTreePreview(tree);
+        searchData.hydrateSelectedTreePreview(tree);
     };
 
     function renderResults(resetPreviewWhenNoSelection = true) {
@@ -181,59 +175,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    async function loadPublicTrees(options = {}) {
-        const { resetSelection = false } = options;
-        const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${state.currentSort}_${state.currentLimit}`;
-
-        ui.syncBrowseHead();
-
-        if (resetSelection) {
-            ui.clearSelectedPreview();
-        }
-
-        let cachedTrees = null;
-        if (cache) {
-            cachedTrees = cache.get(cacheKey);
-            if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
-                state.allTrees = cachedTrees;
-                state.isFromCache = true;
-                renderResults();
-            }
-        }
-
-        try {
-            if (window.apiClient && window.apiClient.getPublicTrees) {
-                const apiTrees = await window.apiClient.getPublicTrees({
-                    view: 'summary',
-                    sort: state.currentSort,
-                    limit: state.currentLimit
-                });
-                if (!Array.isArray(apiTrees)) {
-                    throw new Error(ui.getCurrentLocale() === 'en' ? 'Invalid API response format' : 'API 응답 형식 오류');
-                }
-
-                if (cache) {
-                    cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
-                }
-                if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, apiTrees)) {
-                    state.allTrees = apiTrees;
-                }
-                state.loadError = null;
-                state.apiTreesLoaded = true;
-                renderResults();
-            } else {
-                throw new Error(ui.getCurrentLocale() === 'en' ? 'Tree API unavailable' : 'tree API 사용 불가');
-            }
-        } catch (error) {
-            state.loadError = error;
-            console.warn('[search] API 로드 실패:', error.message);
-            if (!state.allTrees || state.allTrees.length === 0) {
-                state.allTrees = [];
-            }
-            renderResults();
-        }
-    }
-
     function renderGrowingResults() {
         if (!refs.growingSection || !refs.growingList) return;
 
@@ -253,35 +194,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.syncActiveCard();
     }
 
-    async function loadGrowingTrees() {
-        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
-
-        try {
-            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
-            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
-            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
-            state.growingTrees = baseModels.map((tree, index) => {
-                const raw = rawTrees[index]?.data || rawTrees[index] || {};
-                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
-                return {
-                    ...tree,
-                    emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
-                    timeRange: raw.timeRange || raw.time_range || tree.timeRange
-                };
-            });
-
-            renderGrowingResults();
-        } catch (error) {
-            console.warn('[search] growing trees load failed:', error.message);
-            if (refs.growingSection) refs.growingSection.style.display = 'none';
-        }
-    }
-
+    // ── Wire callbacks ─────────────────────────────────────────────────────────
     callbacks.selectTree = selectTree;
-    callbacks.loadPublicTrees = loadPublicTrees;
+    callbacks.loadPublicTrees = searchData.loadPublicTrees;
     callbacks.renderResults = renderResults;
+    callbacks.renderGrowingResults = renderGrowingResults;
     callbacks.updateUrlState = urlState.updateUrlState;
 
+    // ── Init ───────────────────────────────────────────────────────────────────
     ui.bindMobilePreviewHandlers();
     ui.bindShareCopyHandler();
 
@@ -299,8 +219,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     refs.resultsList.innerHTML = CardRenderer.renderLoading();
     ui.clearSelectedPreview();
     await Promise.allSettled([
-        loadPublicTrees({ resetSelection: true }),
-        loadGrowingTrees()
+        searchData.loadPublicTrees({ resetSelection: true }),
+        searchData.loadGrowingTrees()
     ]);
 
     urlState.restoreStateFromUrl();
@@ -332,7 +252,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const previousLimit = state.currentLimit;
         urlState.restoreStateFromUrl();
         if (previousSort !== state.currentSort || previousLimit !== state.currentLimit) {
-            await loadPublicTrees({ resetSelection: true });
+            await searchData.loadPublicTrees({ resetSelection: true });
         } else {
             renderResults(false);
         }

--- a/js/search/data.js
+++ b/js/search/data.js
@@ -1,0 +1,147 @@
+/**
+ * LoveBud Search Data Loading Module
+ * v20260429-1
+ *
+ * Extracted from js/search.js (orchestrator).
+ * Owns: loadPublicTrees, loadGrowingTrees, hydrateSelectedTreePreview
+ *
+ * Contract:
+ * - window.apiClient.getPublicTrees / getPublicTreePreview
+ * - window.LoveTreeBaseApiFetch.apiFetch
+ * - window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels
+ * - window.LoveBudCache (optional)
+ *
+ * None of the above contracts are modified here.
+ * CSS, HTML, preview renderer, card renderer, url-state are untouched.
+ */
+(function () {
+    function createSearchData({ refs, state, previewCacheApi, ui, CardRenderer, PreviewRenderer, callbacks, cache, PUBLIC_TREES_CACHE_KEY, PREVIEW_CACHE_TTL_MS, getPreviewCacheKey }) {
+
+        // ── Hydrate selected tree preview ──────────────────────────────────────
+        async function hydrateSelectedTreePreview(tree) {
+            if (!tree || !tree.id) return;
+            const requestId = ++state.currentPreviewRequestId;
+            ui.renderPreviewLoadingState(tree);
+
+            try {
+                const cachedPreview = previewCacheApi.readPreviewCache(tree.id);
+                const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
+
+                previewCacheApi.writePreviewCache(tree.id, hydratedTree);
+                previewCacheApi.mergeHydratedTree(hydratedTree);
+
+                if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
+                    return;
+                }
+                PreviewRenderer.updatePreview(hydratedTree);
+                callbacks.renderResults(false);
+            } catch (error) {
+                console.warn('[search/data] preview hydration failed:', error.message);
+                if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
+                    return;
+                }
+                ui.clearSelectedPreview({ preserveOpenState: false });
+            }
+        }
+
+        // ── Load public trees (main browse) ────────────────────────────────────
+        async function loadPublicTrees(options = {}) {
+            const { resetSelection = false } = options;
+            const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${state.currentSort}_${state.currentLimit}`;
+
+            ui.syncBrowseHead();
+
+            if (resetSelection) {
+                ui.clearSelectedPreview();
+            }
+
+            // Serve from cache first (stale-while-revalidate)
+            let cachedTrees = null;
+            if (cache) {
+                cachedTrees = cache.get(cacheKey);
+                if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
+                    state.allTrees = cachedTrees;
+                    state.isFromCache = true;
+                    callbacks.renderResults();
+                }
+            }
+
+            try {
+                if (window.apiClient && window.apiClient.getPublicTrees) {
+                    const apiTrees = await window.apiClient.getPublicTrees({
+                        view: 'summary',
+                        sort: state.currentSort,
+                        limit: state.currentLimit
+                    });
+                    if (!Array.isArray(apiTrees)) {
+                        throw new Error(
+                            ui.getCurrentLocale() === 'en'
+                                ? 'Invalid API response format'
+                                : 'API 응답 형식 오류'
+                        );
+                    }
+
+                    if (cache) {
+                        cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
+                    }
+                    if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, apiTrees)) {
+                        state.allTrees = apiTrees;
+                    }
+                    state.loadError = null;
+                    state.apiTreesLoaded = true;
+                    callbacks.renderResults();
+                } else {
+                    throw new Error(
+                        ui.getCurrentLocale() === 'en'
+                            ? 'Tree API unavailable'
+                            : 'tree API 사용 불가'
+                    );
+                }
+            } catch (error) {
+                state.loadError = error;
+                console.warn('[search/data] API 로드 실패:', error.message);
+                if (!state.allTrees || state.allTrees.length === 0) {
+                    state.allTrees = [];
+                }
+                callbacks.renderResults();
+            }
+        }
+
+        // ── Load growing trees (secondary section) ─────────────────────────────
+        async function loadGrowingTrees() {
+            if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
+
+            try {
+                const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
+                const rawTrees = Array.isArray(apiResponse)
+                    ? apiResponse
+                    : (apiResponse?.data || []);
+                const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
+                state.growingTrees = baseModels.map((tree, index) => {
+                    const raw = rawTrees[index]?.data || rawTrees[index] || {};
+                    const rawEmotionTags = Array.isArray(raw.emotionTags)
+                        ? raw.emotionTags
+                        : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
+                    return {
+                        ...tree,
+                        emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
+                        timeRange: raw.timeRange || raw.time_range || tree.timeRange
+                    };
+                });
+
+                callbacks.renderGrowingResults();
+            } catch (error) {
+                console.warn('[search/data] growing trees load failed:', error.message);
+                if (refs.growingSection) refs.growingSection.style.display = 'none';
+            }
+        }
+
+        return {
+            hydrateSelectedTreePreview,
+            loadPublicTrees,
+            loadGrowingTrees
+        };
+    }
+
+    window.LoveBudSearchData = { createSearchData };
+})();

--- a/pages/search.html
+++ b/pages/search.html
@@ -149,7 +149,8 @@
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>
     <script src="../js/search/search-url-state.js?v=20260427-1"></script>
-    <script src="../js/search.js?v=20260423-2"></script>
+    <script src="../js/search/data.js?v=20260429-1"></script>
+    <script src="../js/search.js?v=20260429-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>


### PR DESCRIPTION
## Summary
- Split Search/Browse data loading responsibility into `js/search/data.js`.
- Preserve API adapter, URL state, preview, and rendering behavior.
- Keep same-origin `/api/*` contract unchanged.

## Scope
- Search data loading module split only.
- No API endpoint changes.
- No adapter contract changes.
- No CSS/page UI changes.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `js/search/data.js` — new module (`window.LoveBudSearchData`)
- `js/search.js` — thin orchestrator, delegates to `LoveBudSearchData`
- `pages/search.html` — adds `<script src="../js/search/data.js">` before `search.js`

## Delegation map
| Responsibility | Before | After |
|---|---|---|
| `loadPublicTrees` | `search.js` | `js/search/data.js` |
| `loadGrowingTrees` | `search.js` | `js/search/data.js` |
| `hydrateSelectedTreePreview` | `search.js` | `js/search/data.js` |
| UI/event/preview | `search-ui.js` | unchanged |
| URL state | `search-url-state.js` | unchanged |
| Preview cache | `search-preview-cache.js` | unchanged |

## Related
Refs #72
Refs #65

## Verification
- [x] git diff --check
- [x] Search/Browse data load verified on production-equivalent Cloudflare Preview URL
- [x] `window.LoveBudSearchData` available
- [x] `js/search/data.js` loads before Search entrypoint
- [x] Initial data load verified
- [x] Category filter verified
- [x] Sort and limit controls verified
- [x] Selected tree preview verified
- [x] Empty/error state regression not observed
- [x] Console fatal error: NONE
- [x] API/network blocker: NONE
- [x] Horizontal overflow: NONE
- [x] External YouTube thumbnail 404 observed only as non-blocking
- [x] No URL state regression
- [x] No preview/card rendering regression
- [x] No API/Auth/runtime/CSS changes
- [x] No close keywords for #72 or #65

## Notes
- Issue #72 and #65 remain open. This PR covers the data loading module split only.
- Browser verification URL: https://refactor-search-data-loading.lovebud.pages.dev/pages/search.html
- Browser verification PASS: Cloudflare Preview confirmed `LoveBudSearchData` module availability, data loading, filters, sort/limit controls, selected preview, empty/error behavior, console, network, and layout.
- External YouTube thumbnail 404 was observed as non-blocking.
