### PR TITLE
refactor(search): split URL state and controls modules

### DIFF
--- a/js/search/controls.js
+++ b/js/search/controls.js
@@ -1,0 +1,68 @@
+(function () {
+    function createSearchControls({ refs, state, callbacks, ui }) {
+        const { searchInput, tagChips } = refs;
+        let searchInputTimer = null;
+
+        function bindSearchInput() {
+            if (!searchInput) return;
+
+            searchInput.addEventListener('input', (event) => {
+                state.currentQuery = event.target.value.trim();
+                if (searchInputTimer) clearTimeout(searchInputTimer);
+                searchInputTimer = setTimeout(() => {
+                    callbacks.renderResults(false);
+                    callbacks.updateUrlState();
+                }, 180);
+            });
+        }
+
+        function bindCategoryChips() {
+            if (!tagChips) return;
+
+            tagChips.forEach(chip => {
+                chip.addEventListener('click', () => {
+                    tagChips.forEach(c => c.classList.remove('active'));
+                    chip.classList.add('active');
+                    state.currentCategory = chip.dataset.category || chip.textContent.trim();
+                    callbacks.renderResults(false);
+                    callbacks.updateUrlState();
+                });
+            });
+        }
+
+        function bindSortAndLimitControls() {
+            if (typeof ui?.ensureBrowseControls === 'function') {
+                ui.ensureBrowseControls();
+            }
+        }
+
+        function syncControlsFromState() {
+            if (searchInput) searchInput.value = state.currentQuery || '';
+
+            if (tagChips) {
+                tagChips.forEach(chip => {
+                    const chipCategory = chip.dataset.category || chip.textContent.trim();
+                    chip.classList.toggle('active', chipCategory === state.currentCategory);
+                });
+            }
+
+            if (typeof ui?.syncControlsFromState === 'function') {
+                ui.syncControlsFromState();
+            }
+        }
+
+        function bind() {
+            bindSortAndLimitControls();
+            bindSearchInput();
+            bindCategoryChips();
+            syncControlsFromState();
+        }
+
+        return {
+            bind,
+            syncControlsFromState
+        };
+    }
+
+    window.LoveBudSearchControls = { createSearchControls };
+})();

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -87,6 +87,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui
     });
 
+    const dataApi = window.LoveBudSearchData.createSearchData({
+        refs,
+        state,
+        previewCacheApi,
+        ui,
+        CardRenderer,
+        PreviewRenderer,
+        callbacks,
+        cache,
+        PUBLIC_TREES_CACHE_KEY,
+        PREVIEW_CACHE_TTL_MS,
+        getPreviewCacheKey
+    });
+
     const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
 
     const getSelectedTreeFromFiltered = (filteredTrees) => {
@@ -128,32 +142,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         state.initialTreeDeepLinkApplied = true;
     };
 
-    const hydrateSelectedTreePreview = async (tree) => {
-        if (!tree || !tree.id) return;
-        const requestId = ++state.currentPreviewRequestId;
-        ui.renderPreviewLoadingState(tree);
-
-        try {
-            const cachedPreview = previewCacheApi.readPreviewCache(tree.id);
-            const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
-
-            previewCacheApi.writePreviewCache(tree.id, hydratedTree);
-            previewCacheApi.mergeHydratedTree(hydratedTree);
-
-            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
-                return;
-            }
-            PreviewRenderer.updatePreview(hydratedTree);
-            renderResults(false);
-        } catch (error) {
-            console.warn('[search] preview hydration failed:', error.message);
-            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
-                return;
-            }
-            ui.clearSelectedPreview({ preserveOpenState: false });
-        }
-    };
-
     const selectTree = (tree, activeCard) => {
         if (!tree) return;
         state.selectedTreeId = tree.id;
@@ -169,7 +157,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
-        hydrateSelectedTreePreview(tree);
+        dataApi.hydrateSelectedTreePreview(tree);
     };
 
     function renderResults(resetPreviewWhenNoSelection = true) {
@@ -213,58 +201,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    async function loadPublicTrees(options = {}) {
-        const { resetSelection = false } = options;
-        const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${state.currentSort}_${state.currentLimit}`;
-
-        ui.syncBrowseHead();
-
-        if (resetSelection) {
-            ui.clearSelectedPreview();
-        }
-
-        let cachedTrees = null;
-        if (cache) {
-            cachedTrees = cache.get(cacheKey);
-            if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
-                state.allTrees = cachedTrees;
-                state.isFromCache = true;
-                renderResults();
-            }
-        }
-
-        try {
-            if (window.apiClient && window.apiClient.getPublicTrees) {
-                const apiTrees = await window.apiClient.getPublicTrees({
-                    view: 'summary',
-                    sort: state.currentSort,
-                    limit: state.currentLimit
-                });
-                if (!Array.isArray(apiTrees)) {
-                    throw new Error(ui.getCurrentLocale() === 'en' ? 'Invalid API response format' : 'API 응답 형식 오류');
-                }
-
-                if (cache) {
-                    cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
-                }
-                if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, apiTrees)) {
-                    state.allTrees = apiTrees;
-                }
-                state.loadError = null;
-                state.apiTreesLoaded = true;
-                renderResults();
-            } else {
-                throw new Error(ui.getCurrentLocale() === 'en' ? 'Tree API unavailable' : 'tree API 사용 불가');
-            }
-        } catch (error) {
-            state.loadError = error;
-            console.warn('[search] API 로드 실패:', error.message);
-            if (!state.allTrees || state.allTrees.length === 0) {
-                state.allTrees = [];
-            }
-            renderResults();
-        }
-    }
 
     function renderGrowingResults() {
         if (!refs.growingSection || !refs.growingList) return;
@@ -285,33 +221,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.syncActiveCard();
     }
 
-    async function loadGrowingTrees() {
-        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
-
-        try {
-            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
-            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
-            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
-            state.growingTrees = baseModels.map((tree, index) => {
-                const raw = rawTrees[index]?.data || rawTrees[index] || {};
-                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
-                return {
-                    ...tree,
-                    emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
-                    timeRange: raw.timeRange || raw.time_range || tree.timeRange
-                };
-            });
-
-            renderGrowingResults();
-        } catch (error) {
-            console.warn('[search] growing trees load failed:', error.message);
-            if (refs.growingSection) refs.growingSection.style.display = 'none';
-        }
-    }
-
     callbacks.selectTree = selectTree;
-    callbacks.loadPublicTrees = loadPublicTrees;
+    callbacks.loadPublicTrees = dataApi.loadPublicTrees;
     callbacks.renderResults = renderResults;
+    callbacks.renderGrowingResults = renderGrowingResults;
     callbacks.updateUrlState = urlState.updateUrlState;
 
     const controls = window.LoveBudSearchControls.createSearchControls({
@@ -338,8 +251,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     refs.resultsList.innerHTML = CardRenderer.renderLoading();
     ui.clearSelectedPreview();
     await Promise.allSettled([
-        loadPublicTrees({ resetSelection: true }),
-        loadGrowingTrees()
+        dataApi.loadPublicTrees({ resetSelection: true }),
+        dataApi.loadGrowingTrees()
     ]);
 
     urlState.restoreStateFromUrl();
@@ -351,7 +264,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const previousLimit = state.currentLimit;
         urlState.restoreStateFromUrl();
         if (previousSort !== state.currentSort || previousLimit !== state.currentLimit) {
-            await loadPublicTrees({ resetSelection: true });
+            await dataApi.loadPublicTrees({ resetSelection: true });
         } else {
             renderResults(false);
         }

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -250,12 +250,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     refs.resultsList.innerHTML = CardRenderer.renderLoading();
     ui.clearSelectedPreview();
+    
+    urlState.restoreStateFromUrl();
+    
     await Promise.allSettled([
         dataApi.loadPublicTrees({ resetSelection: true }),
         dataApi.loadGrowingTrees()
     ]);
 
-    urlState.restoreStateFromUrl();
     applySelectedTreeFromUrl();
     state.urlStateReady = true;
 

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -1,0 +1,360 @@
+/**
+ * LoveBud Search Page Orchestrator
+ * v20260429-1
+ *
+ * Search page orchestration:
+ * - Fast list-first loading for public trees
+ * - Delegates q/category/sort/limit URL state to js/search/url-state.js
+ * - Delegates search/filter/sort/limit controls binding to js/search/controls.js
+ * - Lazy preview hydration on tree selection
+ */
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const refs = {
+        resultsList: document.getElementById('resultsList'),
+        previewSidebar: document.getElementById('previewSidebar'),
+        previewMobileClose: document.getElementById('previewMobileClose'),
+        previewContainer: document.getElementById('previewVideoContainer'),
+        previewTitle: document.getElementById('previewTitle'),
+        previewDesc: document.getElementById('previewDesc'),
+        previewMemoriesCount: document.getElementById('previewMemoriesCount'),
+        previewTreeDuration: document.getElementById('previewTreeDuration'),
+        previewEmotionTags: document.getElementById('previewEmotionTags'),
+        searchInput: document.getElementById('searchInput'),
+        tagChips: document.querySelectorAll('.tag-chip'),
+        resultsHead: document.querySelector('.browse-results-head'),
+        growingSection: document.getElementById('growingTreesSection'),
+        growingList: document.getElementById('growingTreesList'),
+        mobilePreviewMediaQuery: window.matchMedia('(max-width: 768px)')
+    };
+    refs.resultsTitle = refs.resultsHead?.querySelector('h3');
+    refs.resultsBadge = refs.resultsHead?.querySelector('.browse-results-badge');
+
+    const CardRenderer = window.LoveBudSearchCardRenderer;
+    CardRenderer.init(refs.resultsList);
+
+    const PreviewRenderer = window.LoveBudSearchPreviewRenderer;
+    PreviewRenderer.init({
+        previewContainer: refs.previewContainer,
+        previewTitle: refs.previewTitle,
+        previewDesc: refs.previewDesc,
+        previewMemoriesCount: refs.previewMemoriesCount,
+        previewTreeDuration: refs.previewTreeDuration,
+        previewEmotionTags: refs.previewEmotionTags
+    });
+
+    const Adapter = window.LoveBudSearchAdapter;
+    const cache = window.LoveBudCache;
+    const PUBLIC_TREES_CACHE_KEY = 'public_trees_summary_latest_10';
+    const PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
+    const getPreviewCacheKey = (treeId) => `public_tree_preview_${treeId}`;
+
+    const state = {
+        allTrees: [],
+        growingTrees: [],
+        loadError: null,
+        isFromCache: false,
+        apiTreesLoaded: false,
+        selectedTreeId: null,
+        currentPreviewRequestId: 0,
+        currentQuery: '',
+        currentSort: 'latest',
+        currentLimit: 10,
+        currentCategory: '전체',
+        isRestoringUrlState: false,
+        urlStateReady: false,
+        initialTreeDeepLinkApplied: false
+    };
+    const previewCache = new Map();
+    const callbacks = {};
+
+    const ui = window.LoveBudSearchUI.createSearchUI({
+        refs,
+        state,
+        renderers: { PreviewRenderer },
+        callbacks
+    });
+    const previewCacheApi = window.LoveBudSearchPreviewCache.createPreviewCache({
+        cache,
+        previewCache,
+        previewCacheTtlMs: PREVIEW_CACHE_TTL_MS,
+        getPreviewCacheKey,
+        state
+    });
+    const urlState = window.LoveBudSearchUrlState.createSearchUrlState({
+        refs,
+        state,
+        ui
+    });
+
+    const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
+
+    const getSelectedTreeFromFiltered = (filteredTrees) => {
+        if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
+        return filteredTrees.find(tree => tree.id === state.selectedTreeId) || null;
+    };
+
+    const readSelectedTreeFromUrl = () => {
+        try {
+            return new URLSearchParams(window.location.search).get('tree') || '';
+        } catch {
+            return '';
+        }
+    };
+
+    const applySelectedTreeFromUrl = () => {
+        if (state.initialTreeDeepLinkApplied) return;
+        const treeId = readSelectedTreeFromUrl();
+        if (!treeId) return;
+
+        const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
+        if (!targetTree) return;
+
+        let activeCard = null;
+        let selector = '';
+        try {
+            selector = `.tree-card[data-tree-id="${CSS.escape(treeId)}"]`;
+        } catch (e) {
+            selector = `.tree-card[data-tree-id="${treeId.replace(/"/g, '\\"')}"]`;
+        }
+
+        const allCardContainers = [refs.resultsList, refs.growingList].filter(Boolean);
+        for (const container of allCardContainers) {
+            activeCard = container.querySelector(selector);
+            if (activeCard) break;
+        }
+
+        callbacks.selectTree(targetTree, activeCard);
+        state.initialTreeDeepLinkApplied = true;
+    };
+
+    const hydrateSelectedTreePreview = async (tree) => {
+        if (!tree || !tree.id) return;
+        const requestId = ++state.currentPreviewRequestId;
+        ui.renderPreviewLoadingState(tree);
+
+        try {
+            const cachedPreview = previewCacheApi.readPreviewCache(tree.id);
+            const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
+
+            previewCacheApi.writePreviewCache(tree.id, hydratedTree);
+            previewCacheApi.mergeHydratedTree(hydratedTree);
+
+            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
+                return;
+            }
+            PreviewRenderer.updatePreview(hydratedTree);
+            renderResults(false);
+        } catch (error) {
+            console.warn('[search] preview hydration failed:', error.message);
+            if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
+                return;
+            }
+            ui.clearSelectedPreview({ preserveOpenState: false });
+        }
+    };
+
+    const selectTree = (tree, activeCard) => {
+        if (!tree) return;
+        state.selectedTreeId = tree.id;
+        ui.markActiveCard(activeCard);
+
+        if (ui.isMobilePreviewMode()) {
+            ui.setMobilePreviewOpen(true);
+        }
+
+        if (Array.isArray(tree.memories) && tree.memories.length > 0) {
+            previewCacheApi.writePreviewCache(tree.id, tree);
+            PreviewRenderer.updatePreview(tree);
+            return;
+        }
+
+        hydrateSelectedTreePreview(tree);
+    };
+
+    function renderResults(resetPreviewWhenNoSelection = true) {
+        const filtered = getFilteredTrees();
+
+        if (filtered.length === 0) {
+            const hasNoData = state.loadError === null && state.allTrees.length === 0;
+            const isApiFailure = state.loadError !== null && !state.isFromCache && state.allTrees.length === 0;
+
+            if (isApiFailure) {
+                ui.renderLoadErrorState();
+            } else if (hasNoData) {
+                refs.resultsList.innerHTML = CardRenderer.renderNoTreesState();
+                ui.clearSelectedPreview();
+            } else {
+                refs.resultsList.innerHTML = CardRenderer.renderEmptySearchState();
+                ui.clearSelectedPreview();
+            }
+            return;
+        }
+
+        const html = CardRenderer.renderResults(filtered, {
+            isDemo: !state.apiTreesLoaded && !state.loadError
+        });
+        refs.resultsList.innerHTML = html;
+        ui.attachCardEvents(refs.resultsList, filtered);
+        ui.syncActiveCard();
+
+        const selectedTree = getSelectedTreeFromFiltered(filtered);
+        if (!state.selectedTreeId && resetPreviewWhenNoSelection) {
+            ui.clearSelectedPreview();
+            return;
+        }
+
+        if (selectedTree && Array.isArray(selectedTree.memories) && selectedTree.memories.length > 0) {
+            previewCacheApi.writePreviewCache(selectedTree.id, selectedTree);
+            PreviewRenderer.updatePreview(selectedTree);
+            ui.syncPreviewVisibility();
+        } else if (!selectedTree && resetPreviewWhenNoSelection) {
+            ui.clearSelectedPreview();
+        }
+    }
+
+    async function loadPublicTrees(options = {}) {
+        const { resetSelection = false } = options;
+        const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${state.currentSort}_${state.currentLimit}`;
+
+        ui.syncBrowseHead();
+
+        if (resetSelection) {
+            ui.clearSelectedPreview();
+        }
+
+        let cachedTrees = null;
+        if (cache) {
+            cachedTrees = cache.get(cacheKey);
+            if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
+                state.allTrees = cachedTrees;
+                state.isFromCache = true;
+                renderResults();
+            }
+        }
+
+        try {
+            if (window.apiClient && window.apiClient.getPublicTrees) {
+                const apiTrees = await window.apiClient.getPublicTrees({
+                    view: 'summary',
+                    sort: state.currentSort,
+                    limit: state.currentLimit
+                });
+                if (!Array.isArray(apiTrees)) {
+                    throw new Error(ui.getCurrentLocale() === 'en' ? 'Invalid API response format' : 'API 응답 형식 오류');
+                }
+
+                if (cache) {
+                    cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
+                }
+                if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, apiTrees)) {
+                    state.allTrees = apiTrees;
+                }
+                state.loadError = null;
+                state.apiTreesLoaded = true;
+                renderResults();
+            } else {
+                throw new Error(ui.getCurrentLocale() === 'en' ? 'Tree API unavailable' : 'tree API 사용 불가');
+            }
+        } catch (error) {
+            state.loadError = error;
+            console.warn('[search] API 로드 실패:', error.message);
+            if (!state.allTrees || state.allTrees.length === 0) {
+                state.allTrees = [];
+            }
+            renderResults();
+        }
+    }
+
+    function renderGrowingResults() {
+        if (!refs.growingSection || !refs.growingList) return;
+
+        if (!state.growingTrees || state.growingTrees.length === 0) {
+            refs.growingSection.hidden = true;
+            refs.growingList.innerHTML = '';
+            return;
+        }
+
+        refs.growingSection.hidden = false;
+        refs.growingList.innerHTML = state.growingTrees
+            .slice(0, 3)
+            .map((tree, index) => CardRenderer.renderTreeCard(tree, index + 1))
+            .join('');
+
+        ui.attachCardEvents(refs.growingList, state.growingTrees);
+        ui.syncActiveCard();
+    }
+
+    async function loadGrowingTrees() {
+        if (!window.LoveTreeBaseApiFetch || typeof window.LoveTreeBaseApiFetch.apiFetch !== 'function') return;
+
+        try {
+            const apiResponse = await window.LoveTreeBaseApiFetch.apiFetch('/community/growing-trees?limit=3');
+            const rawTrees = Array.isArray(apiResponse) ? apiResponse : (apiResponse?.data || []);
+            const baseModels = window.LoveTreePublicTreeAdapter.buildPublicTreeSummaryModels(rawTrees);
+            state.growingTrees = baseModels.map((tree, index) => {
+                const raw = rawTrees[index]?.data || rawTrees[index] || {};
+                const rawEmotionTags = Array.isArray(raw.emotionTags) ? raw.emotionTags : (Array.isArray(raw.emotion_tags) ? raw.emotion_tags : []);
+                return {
+                    ...tree,
+                    emotionTags: rawEmotionTags.filter(Boolean).slice(0, 3),
+                    timeRange: raw.timeRange || raw.time_range || tree.timeRange
+                };
+            });
+
+            renderGrowingResults();
+        } catch (error) {
+            console.warn('[search] growing trees load failed:', error.message);
+            if (refs.growingSection) refs.growingSection.style.display = 'none';
+        }
+    }
+
+    callbacks.selectTree = selectTree;
+    callbacks.loadPublicTrees = loadPublicTrees;
+    callbacks.renderResults = renderResults;
+    callbacks.updateUrlState = urlState.updateUrlState;
+
+    const controls = window.LoveBudSearchControls.createSearchControls({
+        refs,
+        state,
+        callbacks,
+        ui
+    });
+
+    ui.bindMobilePreviewHandlers();
+    ui.bindShareCopyHandler();
+
+    controls.bind();
+    ui.syncStaticBrowseCopy();
+    ui.syncPreviewVisibility();
+    if (typeof window.onLangChange === 'function') {
+        window.onLangChange(() => {
+            ui.syncStaticBrowseCopy();
+            ui.syncBrowseHead();
+            controls.syncControlsFromState();
+        });
+    }
+
+    refs.resultsList.innerHTML = CardRenderer.renderLoading();
+    ui.clearSelectedPreview();
+    await Promise.allSettled([
+        loadPublicTrees({ resetSelection: true }),
+        loadGrowingTrees()
+    ]);
+
+    urlState.restoreStateFromUrl();
+    applySelectedTreeFromUrl();
+    state.urlStateReady = true;
+
+    window.addEventListener('popstate', async () => {
+        const previousSort = state.currentSort;
+        const previousLimit = state.currentLimit;
+        urlState.restoreStateFromUrl();
+        if (previousSort !== state.currentSort || previousLimit !== state.currentLimit) {
+            await loadPublicTrees({ resetSelection: true });
+        } else {
+            renderResults(false);
+        }
+        ui.syncBrowseHead();
+    });
+});

--- a/js/search/url-state.js
+++ b/js/search/url-state.js
@@ -1,0 +1,119 @@
+(function () {
+    const DEFAULT_CATEGORY = '전체';
+    const DEFAULT_SORT = 'latest';
+    const DEFAULT_LIMIT = 10;
+    const MAX_LIMIT = 60;
+
+    function createSearchUrlState({ refs, state, ui }) {
+        const { searchInput, tagChips } = refs;
+
+        function readUrlState() {
+            try {
+                const params = new URLSearchParams(window.location.search);
+                return {
+                    query: params.get('q') || '',
+                    category: params.get('category') || '',
+                    sort: params.get('sort') || '',
+                    limit: params.get('limit') || ''
+                };
+            } catch {
+                return { query: '', category: '', sort: '', limit: '' };
+            }
+        }
+
+        function writeUrlState() {
+            if (state.isRestoringUrlState || !state.urlStateReady) return;
+
+            try {
+                const params = new URLSearchParams(window.location.search);
+
+                if (state.currentQuery) params.set('q', state.currentQuery);
+                else params.delete('q');
+
+                if (state.currentCategory && state.currentCategory !== DEFAULT_CATEGORY) {
+                    params.set('category', state.currentCategory);
+                } else {
+                    params.delete('category');
+                }
+
+                if (state.currentSort && state.currentSort !== DEFAULT_SORT) {
+                    params.set('sort', state.currentSort);
+                } else {
+                    params.delete('sort');
+                }
+
+                if (state.currentLimit && state.currentLimit !== DEFAULT_LIMIT) {
+                    params.set('limit', String(state.currentLimit));
+                } else {
+                    params.delete('limit');
+                }
+
+                // Preserve the existing selected-tree deep link contract while this
+                // module owns only q/category/sort/limit state transitions.
+                if (state.selectedTreeId) params.set('tree', state.selectedTreeId);
+
+                const newSearch = params.toString();
+                const newUrl = newSearch
+                    ? `${window.location.pathname}?${newSearch}`
+                    : window.location.pathname;
+
+                if (newUrl !== (window.location.pathname + window.location.search)) {
+                    history.pushState(null, '', newUrl);
+                }
+            } catch { /* ignore URL sync failures */ }
+        }
+
+        function restoreStateFromUrl() {
+            window.readUrlState = readUrlState;
+            window.updateUrlState = writeUrlState;
+            window.restoreStateFromUrl = restoreStateFromUrl;
+
+            const { query, category, sort, limit } = readUrlState();
+            state.isRestoringUrlState = true;
+
+            state.currentQuery = query || '';
+            if (category) state.currentCategory = category;
+            else state.currentCategory = DEFAULT_CATEGORY;
+
+            if (sort === 'latest' || sort === 'popular') {
+                state.currentSort = sort;
+            } else {
+                state.currentSort = DEFAULT_SORT;
+            }
+
+            if (limit) {
+                const parsedLimit = parseInt(limit, 10);
+                if (!Number.isNaN(parsedLimit) && parsedLimit >= 1 && parsedLimit <= MAX_LIMIT) {
+                    state.currentLimit = parsedLimit;
+                } else {
+                    state.currentLimit = DEFAULT_LIMIT;
+                }
+            } else {
+                state.currentLimit = DEFAULT_LIMIT;
+            }
+
+            if (searchInput) searchInput.value = state.currentQuery;
+
+            if (tagChips) {
+                tagChips.forEach(chip => {
+                    const chipCategory = chip.dataset.category || chip.textContent.trim();
+                    chip.classList.toggle('active', chipCategory === state.currentCategory);
+                });
+            }
+
+            if (typeof ui?.syncControlsFromState === 'function') {
+                ui.syncControlsFromState();
+            }
+
+            state.isRestoringUrlState = false;
+        }
+
+        return {
+            readUrlState,
+            updateUrlState: writeUrlState,
+            restoreStateFromUrl
+        };
+    }
+
+    window.LoveBudSearchUrlState = { createSearchUrlState };
+})();

--- a/pages/search.html
+++ b/pages/search.html
@@ -148,8 +148,9 @@
     <script src="../js/search-preview-renderer.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>
-    <script src="../js/search/search-url-state.js?v=20260427-1"></script>
-    <script src="../js/search.js?v=20260423-2"></script>
+    <script src="../js/search/url-state.js?v=20260429-1"></script>
+    <script src="../js/search/controls.js?v=20260429-1"></script>
+    <script src="../js/search/index.js?v=20260429-1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>


### PR DESCRIPTION
## Summary
- Split Search URL state helpers and controls binding into dedicated modules.
- Preserve existing `q`, `category`, `sort`, and `limit` URL behavior.
- Keep preview, selected tree deep link, adapter, API, and CSS behavior unchanged.

## Scope
- Search URL state/control responsibility split only.
- No data loading split.
- No preview controller split.
- No API/Auth/runtime/CSS changes.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `js/search/url-state.js` — new module (`window.LoveBudSearchUrlState`)
- `js/search/controls.js` — new module (`window.LoveBudSearchControls`)
- `js/search/index.js` — updated orchestrator delegating URL state and controls
- `pages/search.html` — replaces `search-url-state.js` + `search.js` with `url-state.js`, `controls.js`, `index.js`

## Delegation map
| Responsibility | Before | After |
|---|---|---|
| `q`/`category`/`sort`/`limit` URL state | `search-url-state.js` | `js/search/url-state.js` |
| search input / category chip binding | `search.js` inline | `js/search/controls.js` |
| sort/limit control binding | `search.js` inline | `js/search/controls.js` |
| data loading | `search.js` | unchanged (delegated to `js/search/data.js` in PR #336) |
| UI / preview | `search-ui.js` | unchanged |
| Preview cache | `search-preview-cache.js` | unchanged |

## Related
Refs #72
Refs #65

## Pre-conditions
> ✅ PR #336 prerequisite satisfied; branch reconciled with latest main.

## Verification
- [x] git diff --check — PASS
- [x] node --check — PASS
- [x] `js/search/index.js` exists on latest `main` before merge
- [x] Search URL state preserved for q/category/sort/limit — PASS
- [x] Refresh after filter → state restored from URL — PASS (refresh restore limit fix applied)
- [x] back/forward navigation behavior preserved — PASS
- [x] No selected tree deep link regression — PASS
- [x] No data loading regression — PASS
- [x] No preview/card rendering regression — PASS
- [x] No API/Auth/runtime/CSS changes — confirmed
- [x] No close keywords for #72 or #65 — confirmed
- [x] Cloudflare fixed slot test2 verified — PASS (SHA: 8dfc8a5)

## Notes
- Issue #72 and #65 remain open. This PR covers URL state and controls split only.
- Browser verification completed on fixed slot test2 (reflected SHA: 8dfc8a5).
- q/category/sort/limit URL smoke: PASS. Refresh restore: PASS. back/forward: PASS. preview/card/data: PASS. No fatal console errors. No network blockers. No horizontal overflow.