### PR TITLE
refactor(search): complete CSS inline style cleanup pass

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,3 +1,13 @@
+/**
+ * Search page CSS owner entry
+ * v20260429-2
+ *
+ * Closure audit (2026-04-29):
+ * - pages/search.html contains no <style> blocks
+ * - pages/search.html contains no style= attributes
+ * - All Search presentation styles are in css/search/* sub-modules below
+ * - Inline style closure pass for Issue #65 is COMPLETE
+ */
 @import url("./search/base.css");
 @import url("./search/hero-controls.css");
 @import url("./search/controls.css");


### PR DESCRIPTION
## Summary
- Audit `pages/search.html` for remaining inline styles (`<style>` blocks, `style=` attributes).
- **Result: none found.** All Search presentation styles are already in `css/search/*` sub-modules.
- Add closure audit comment to `css/search.css` to record the confirmed clean state.
- Preserve Search JS, URL state, data loading, and preview behavior.

## Audit Result
| Check | Result |
|---|---|
| `<style>` blocks in `pages/search.html` | ✅ None |
| `style=` attributes in `pages/search.html` | ✅ None |
| Search CSS sub-modules present | ✅ 9 sub-modules in `css/search/` |
| Any style migration needed | ✅ No migration needed |

## Scope
- `css/search.css` audit comment only (no style rule changes).
- No JS changes.
- No API/Auth/runtime changes.
- No Search behavior changes.
- No `pages/search.html` markup changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #65
Refs #72

## Verification
- [x] git diff --check
- [x] Changed files limited to `css/search.css` (comment-only)
- [x] No JS/API/Auth/runtime changes
- [x] Desktop/mobile Search visual smoke not required for comment-only CSS entry change
- [x] No horizontal overflow risk from comment-only CSS entry change
- [x] No close keywords for #65 or #72

## Notes
- Issue #65 and #72 remain open.
- This PR records completion evidence for the inline style audit item in Issue #65.
- CSS sub-module structure (`css/search/base.css`, `hero-controls.css`, `controls.css`, `results-skeleton.css`, `empty-state.css`, `growing-trees.css`, `tree-card.css`, `preview-sidebar.css`, `responsive.css`) is already complete.