### PR TITLE
feat(api): add public LoveTree copy fork endpoint

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -89,6 +89,14 @@ function buildModalUrl(request, env) {
     return target;
   }
 
+  // POST /api/trees/:id/fork → /modal/private/trees/:id/fork
+  const treeForkMatch = path.match(/^\/api\/trees\/([^/]+)\/fork$/);
+  if (treeForkMatch && method === 'POST') {
+    const treeId = encodeURIComponent(decodeURIComponent(treeForkMatch[1]));
+    target.pathname = `/modal/private/trees/${treeId}/fork`;
+    return target;
+  }
+
   const treeMatch = path.match(/^\/api\/trees\/([^/]+)$/);
   if (treeMatch) {
     const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
@@ -126,6 +134,11 @@ function isModalOwnedWriteRoute(request, env) {
 
   const url = new URL(request.url);
   const path = url.pathname.replace(/\/+$/, '');
+
+  // POST /api/trees/:id/fork
+  if (method === 'POST' && path.match(/^\/api\/trees\/[^/]+\/fork$/)) {
+    return buildModalUrl(request, env || {}) !== null;
+  }
 
   // POST is for collection paths
   if (method === 'POST' && ['/api/trees', '/api/memories'].includes(path)) {
@@ -295,9 +308,10 @@ export async function onRequest(context) {
   if (modalUrl) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/\/+$/, '');
+    const isForkPath = path.match(/^\/api\/trees\/[^/]+\/fork$/);
     const isCollection = ['/api/trees', '/api/memories'].includes(path);
     const isDetail = path.match(/^\/api\/(trees|memories)\/[^/]+$/);
-    const allow = isCollection ? 'GET, POST' : (isDetail ? 'GET, PUT, DELETE' : 'GET');
+    const allow = isForkPath ? 'POST' : (isCollection ? 'GET, POST' : (isDetail ? 'GET, PUT, DELETE' : 'GET'));
     return buildMethodNotAllowedResponse(allow);
   }
 

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime
 from typing import Any
@@ -577,6 +578,122 @@ def delete_owner_memory(owner_id: str, memory_id: str) -> dict[str, Any]:
     return {"deleted": True, "id": str(row["id"])}
 
 
+def fork_public_tree(owner_id: str, source_tree_id: str) -> dict[str, Any]:
+    """Copy a public LoveTree and its public memories into a new tree owned by owner_id."""
+    safe_source_id = validate_required_uuid(source_tree_id, "sourceTreeId")
+
+    # Fetch source tree — must exist and be public
+    source_tree = fetch_tree_for_owner_check(safe_source_id)
+    if not source_tree:
+        raise HTTPException(status_code=404, detail="Source tree not found")
+    if str(source_tree.get("visibility") or "") != "public":
+        raise HTTPException(
+            status_code=403,
+            detail="Only public trees can be forked",
+        )
+
+    # Idempotency guard: if authenticated user already forked this tree, return existing copy
+    existing_fork_query = """
+        SELECT id FROM trees
+        WHERE owner_id = %s
+          AND forked_from_tree_id = %s
+        ORDER BY created_at DESC
+        LIMIT 1;
+    """
+
+    def check_existing():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(existing_fork_query, (owner_id, safe_source_id))
+                return cur.fetchone()
+
+    existing = run_db_with_retry(check_existing)
+    if existing:
+        existing_id = str(existing["id"])
+        forked_tree = fetch_owner_tree(existing_id, owner_id)
+        if forked_tree:
+            return {**forked_tree, "forked": False, "duplicate": True}
+
+    # Build new tree title with suffix
+    source_title = str(source_tree.get("title") or "LoveTree")
+    new_title_raw = f"{source_title} (복사본)"
+    new_title = new_title_raw[:200]
+
+    new_tree_id = str(uuid.uuid4())
+
+    insert_tree_query = """
+        INSERT INTO trees (id, owner_id, title, visibility, forked_from_tree_id, created_at, updated_at)
+        VALUES (%s, %s, %s, 'public', %s, NOW(), NOW())
+        RETURNING id, owner_id, title, visibility, forked_from_tree_id, created_at, updated_at;
+    """
+
+    # Fetch public memories from source tree
+    fetch_source_memories_query = """
+        SELECT id, parent_id, title, memo, artist, source, source_url, source_type,
+               thumbnail, emotion_tags, timestamp
+        FROM memories
+        WHERE tree_id = %s
+          AND visibility = 'public'
+        ORDER BY created_at ASC
+        LIMIT 200;
+    """
+
+    insert_memory_query = """
+        INSERT INTO memories (
+            id, tree_id, parent_id, title, memo, artist, source, source_url,
+            source_type, thumbnail, emotion_tags, timestamp, visibility,
+            created_at, updated_at
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'public', NOW(), NOW());
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            # Insert new tree
+            cur.execute(insert_tree_query, (new_tree_id, owner_id, new_title, safe_source_id))
+            new_tree_row = cur.fetchone()
+
+            # Fetch source memories
+            cur.execute(fetch_source_memories_query, (safe_source_id,))
+            source_memories = cur.fetchall()
+
+            # Build old->new memory id map for parent_id rewriting
+            id_map: dict[str, str] = {}
+            for mem in source_memories:
+                id_map[str(mem["id"])] = str(uuid.uuid4())
+
+            # Insert copied memories with rewritten tree_id and parent_id
+            for mem in source_memories:
+                new_mem_id = id_map[str(mem["id"])]
+                old_parent_id = str(mem["parent_id"]) if mem["parent_id"] else None
+                new_parent_id = id_map.get(old_parent_id) if old_parent_id else None
+                cur.execute(
+                    insert_memory_query,
+                    (
+                        new_mem_id,
+                        new_tree_id,
+                        new_parent_id,
+                        mem["title"],
+                        mem["memo"],
+                        mem["artist"],
+                        mem["source"],
+                        mem["source_url"],
+                        mem["source_type"],
+                        mem["thumbnail"],
+                        mem["emotion_tags"],
+                        mem["timestamp"],
+                    ),
+                )
+        conn.commit()
+
+    memory_count = len(source_memories)
+    new_tree = normalize_tree_row(new_tree_row, memory_count)
+    new_tree["forkedFromTreeId"] = safe_source_id
+    new_tree["forked"] = True
+    new_tree["duplicate"] = False
+    return new_tree
+
+
 def _allowed_origins() -> list[str]:
     return _config_allowed_origins()
 
@@ -703,6 +820,15 @@ def get_private_tree_detail(
     if not tree:
         raise HTTPException(status_code=404, detail="Tree not found")
     return tree
+
+
+@web_app.post("/modal/private/trees/{tree_id}/fork")
+def post_fork_tree(
+    tree_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return fork_public_tree(user["uid"], tree_id)
 
 
 @web_app.put("/modal/private/trees/{tree_id}")

--- a/tests/contracts/test_fork_tree.py
+++ b/tests/contracts/test_fork_tree.py
@@ -1,0 +1,254 @@
+"""Contract tests for POST /api/trees/:id/fork
+
+Tests verify:
+- Unauthenticated request returns 401
+- Missing source tree returns 404
+- Non-public (private) source tree returns 403
+- Public source copy returns 201/200 with correct ownership and lineage
+- Original source tree is unchanged after fork
+- Duplicate fork guard returns existing copy with duplicate=true
+
+These are contract-level tests. They mock db and auth layers.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from modal_compute.app import web_app
+
+client = TestClient(web_app)
+
+PUBLIC_TREE_ID = str(uuid.uuid4())
+PRIVATE_TREE_ID = str(uuid.uuid4())
+MISSING_TREE_ID = str(uuid.uuid4())
+AUTH_USER_ID = "test-user-uid-fork"
+
+MOCK_PUBLIC_TREE_ROW = {
+    "id": PUBLIC_TREE_ID,
+    "owner_id": "original-owner-uid",
+    "title": "My Public LoveTree",
+    "visibility": "public",
+    "created_at": "2026-01-01T00:00:00",
+    "updated_at": "2026-01-01T00:00:00",
+}
+
+MOCK_PRIVATE_TREE_ROW = {
+    "id": PRIVATE_TREE_ID,
+    "owner_id": "original-owner-uid",
+    "title": "My Private LoveTree",
+    "visibility": "private",
+    "created_at": "2026-01-01T00:00:00",
+    "updated_at": "2026-01-01T00:00:00",
+}
+
+MOCK_SOURCE_MEMORIES = [
+    {
+        "id": str(uuid.uuid4()),
+        "parent_id": None,
+        "title": "Memory 1",
+        "memo": "memo text",
+        "artist": "Artist A",
+        "source": "YouTube",
+        "source_url": "https://youtube.com/watch?v=test1",
+        "source_type": "youtube",
+        "thumbnail": "https://img.example.com/1.jpg",
+        "emotion_tags": json.dumps(["joy"]),
+        "timestamp": "1:23",
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "parent_id": None,
+        "title": "Memory 2",
+        "memo": None,
+        "artist": None,
+        "source": None,
+        "source_url": None,
+        "source_type": "youtube",
+        "thumbnail": None,
+        "emotion_tags": json.dumps([]),
+        "timestamp": None,
+    },
+]
+
+
+def _make_new_tree_row(new_id: str, owner_id: str, title: str, source_id: str) -> dict:
+    return {
+        "id": new_id,
+        "owner_id": owner_id,
+        "title": title,
+        "visibility": "public",
+        "forked_from_tree_id": source_id,
+        "created_at": "2026-04-29T00:00:00",
+        "updated_at": "2026-04-29T00:00:00",
+    }
+
+
+# --- Auth Required ---
+
+def test_fork_tree_requires_auth():
+    """POST /api/trees/:id/fork without Authorization must return 401."""
+    response = client.post(f"/modal/private/trees/{PUBLIC_TREE_ID}/fork")
+    assert response.status_code == 401, f"Expected 401, got {response.status_code}"
+
+
+# --- Missing Source ---
+
+@patch("modal_compute.app.require_firebase_user", return_value={"uid": AUTH_USER_ID})
+@patch("modal_compute.app.fetch_tree_for_owner_check", return_value=None)
+def test_fork_tree_missing_source(mock_fetch, mock_auth):
+    """POST /api/trees/:id/fork with non-existent source tree must return 404."""
+    response = client.post(
+        f"/modal/private/trees/{MISSING_TREE_ID}/fork",
+        headers={"authorization": "Bearer fake-token"},
+    )
+    assert response.status_code == 404
+    body = response.json()
+    assert "not found" in body.get("detail", "").lower()
+
+
+# --- Private Source Rejection ---
+
+@patch("modal_compute.app.require_firebase_user", return_value={"uid": AUTH_USER_ID})
+@patch("modal_compute.app.fetch_tree_for_owner_check", return_value=MOCK_PRIVATE_TREE_ROW)
+def test_fork_tree_private_source_denied(mock_fetch, mock_auth):
+    """POST /api/trees/:id/fork with private source tree must return 403."""
+    response = client.post(
+        f"/modal/private/trees/{PRIVATE_TREE_ID}/fork",
+        headers={"authorization": "Bearer fake-token"},
+    )
+    assert response.status_code == 403
+    body = response.json()
+    assert "public" in body.get("detail", "").lower() or "fork" in body.get("detail", "").lower()
+
+
+# --- Public Source Copy Success ---
+
+@patch("modal_compute.app.require_firebase_user", return_value={"uid": AUTH_USER_ID})
+@patch("modal_compute.app.run_db_with_retry")
+@patch("modal_compute.app.get_db_connection")
+def test_fork_tree_public_source_success(mock_conn_ctx, mock_retry, mock_auth):
+    """POST /api/trees/:id/fork with public source must create new tree owned by authed user."""
+    new_tree_id = str(uuid.uuid4())
+    new_tree_row = _make_new_tree_row(
+        new_tree_id, AUTH_USER_ID, "My Public LoveTree (복사본)", PUBLIC_TREE_ID
+    )
+
+    # run_db_with_retry: first call = no existing fork, subsequent = used in fork_public_tree
+    call_count = 0
+
+    def retry_side_effect(fn):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # check_existing → no prior fork
+            return None
+        return fn()
+
+    mock_retry.side_effect = retry_side_effect
+
+    # Mock DB connection for insert operations
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = [new_tree_row, *[None] * 10]
+    mock_cursor.fetchall.return_value = MOCK_SOURCE_MEMORIES
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn_ctx.return_value.__enter__ = lambda s: mock_conn
+    mock_conn_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("modal_compute.app.fetch_tree_for_owner_check", return_value=MOCK_PUBLIC_TREE_ROW):
+        response = client.post(
+            f"/modal/private/trees/{PUBLIC_TREE_ID}/fork",
+            headers={"authorization": "Bearer fake-token"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("forked") is True
+    assert body.get("duplicate") is False
+    assert body.get("forkedFromTreeId") == PUBLIC_TREE_ID
+    # New tree title must contain source title
+    assert "My Public LoveTree" in body.get("title", "")
+    assert "복사본" in body.get("title", "")
+
+
+# --- Original Tree Unchanged ---
+
+@patch("modal_compute.app.require_firebase_user", return_value={"uid": AUTH_USER_ID})
+@patch("modal_compute.app.run_db_with_retry")
+@patch("modal_compute.app.get_db_connection")
+def test_fork_tree_original_unchanged(mock_conn_ctx, mock_retry, mock_auth):
+    """After fork, source tree must not be modified."""
+    new_tree_id = str(uuid.uuid4())
+    new_tree_row = _make_new_tree_row(
+        new_tree_id, AUTH_USER_ID, "My Public LoveTree (복사본)", PUBLIC_TREE_ID
+    )
+
+    call_count = 0
+
+    def retry_side_effect(fn):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return None
+        return fn()
+
+    mock_retry.side_effect = retry_side_effect
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = [new_tree_row, *[None] * 10]
+    mock_cursor.fetchall.return_value = MOCK_SOURCE_MEMORIES
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn_ctx.return_value.__enter__ = lambda s: mock_conn
+    mock_conn_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("modal_compute.app.fetch_tree_for_owner_check", return_value=MOCK_PUBLIC_TREE_ROW):
+        client.post(
+            f"/modal/private/trees/{PUBLIC_TREE_ID}/fork",
+            headers={"authorization": "Bearer fake-token"},
+        )
+
+    # Verify no UPDATE or DELETE was issued against the source tree
+    all_execute_calls = [
+        str(call) for call in mock_cursor.execute.call_args_list
+    ]
+    source_mutations = [
+        c for c in all_execute_calls
+        if ("UPDATE trees" in c or "DELETE FROM trees" in c) and PUBLIC_TREE_ID in c
+    ]
+    assert len(source_mutations) == 0, f"Source tree was mutated: {source_mutations}"
+
+
+# --- Duplicate Fork Guard ---
+
+@patch("modal_compute.app.require_firebase_user", return_value={"uid": AUTH_USER_ID})
+@patch("modal_compute.app.fetch_tree_for_owner_check", return_value=MOCK_PUBLIC_TREE_ROW)
+@patch("modal_compute.app.fetch_owner_tree")
+@patch("modal_compute.app.run_db_with_retry")
+def test_fork_tree_duplicate_guard(mock_retry, mock_owner_tree, mock_fetch, mock_auth):
+    """If user already forked this tree, return existing copy with duplicate=true."""
+    existing_id = str(uuid.uuid4())
+    mock_retry.return_value = {"id": existing_id}  # existing fork found
+    mock_owner_tree.return_value = {
+        "id": existing_id,
+        "owner_id": AUTH_USER_ID,
+        "title": "My Public LoveTree (복사본)",
+        "visibility": "public",
+        "forkedFromTreeId": PUBLIC_TREE_ID,
+    }
+
+    response = client.post(
+        f"/modal/private/trees/{PUBLIC_TREE_ID}/fork",
+        headers={"authorization": "Bearer fake-token"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("duplicate") is True
+    assert body.get("forked") is False


### PR DESCRIPTION
## Summary
- Add backend/API endpoint for copying/forking a public LoveTree into the authenticated user's editable trees.
- Preserve source tree and record copy lineage.
- Keep Search Preview/Public Detail UI integration for a follow-up PR.

## Scope
- Backend/API contract implementation only.
- No Search Preview UI.
- No public detail UI.
- No CSS/page changes.
- No Search JS changes.
- No docs changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #84

## Verification
- [x] Head SHA verified: `967d580e8fbdb8be45ff99a059057812bef56cf0`
- [x] Rebased onto latest verified main base: `c4df76fe084f0beb62a5342b7c7495dadcf60915`
- [x] Changed files limited to `functions/api/[[path]].js`, `modal_compute/app.py`, `tests/contracts/test_fork_tree.py`
- [x] git diff --check clean
- [x] Contract tests cover auth required
- [x] Contract tests cover public source copy success
- [x] Contract tests cover private/non-copyable source rejection
- [x] Original source tree remains unchanged
- [x] Duplicate fork guard covered
- [x] `pytest tests/contracts/test_fork_tree.py` passed: 6/6
- [x] `npm test` passed: 97/97
- [x] `npm run verify` passed: 126/126
- [x] Cloudflare Pages deploy successful for head `967d580`
- [x] No UI/CSS/page/Search/docs changes
- [x] No close keywords for #84