### PR TITLE
docs(runtime): map auth editor fallback checklist status

### DIFF
--- a/docs/engineering/AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md
+++ b/docs/engineering/AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md
@@ -1,0 +1,190 @@
+# Auth / Editor Fallback Checklist Mapping
+
+**Status:** CHECKLIST_MAPPING  
+**Primary issue:** #224  
+**Related issues:** #223, #225, #78, #220  
+**Scope:** Docs-only mapping of existing Auth and Editor transitional fallback findings to owner trackers and audit plans.
+
+---
+
+## 1. Purpose
+
+This document maps the `auth.js` / `editor.js` transitional fallback patterns and `window.currentTreeMemories` / `window.currentTreeData` findings referenced by Issue #224 to the existing LoveBud owner trackers and audit plans.
+
+This PR does not remove fallbacks, introduce an EditorStore, change Auth handoff, change Editor runtime behavior, or modify any JavaScript. It only records the current checklist status and ownership boundaries so future work is split into the correct PRs.
+
+---
+
+## 2. Ownership Summary
+
+| Finding area | Primary owner / tracker | #224 status | Notes |
+|---|---|---|---|
+| `auth.js` transitional fallback cleanup | #78 | Deferred to primary tracker | #224 should not own broad Auth fallback removal. |
+| Auth runtime boundary / same-origin contract context | #223 | Related only | API/Cloudflare/Modal boundary work remains separate from Auth fallback cleanup. |
+| `editor.js` fallback factory audit | #225 and #322 audit path | Already planned / mapped | Implementation remains blocked until audit gate is complete. |
+| `window.currentTreeMemories` global state audit | #225 and #322 audit path | Already planned / mapped | Do not implement store migration from #224. |
+| `window.currentTreeData` global state audit | #225 and #322 audit path | Already planned / mapped | Same ownership as `currentTreeMemories`. |
+| EditorStore or equivalent migration | #225 follow-up after audit | Deferred | Requires compatibility and browser smoke plan first. |
+| Legacy runtime/fallback discovery notes | #220 where applicable | Related only | Use #220 only for broader runtime cleanup context, not direct implementation here. |
+
+---
+
+## 3. #224 Checklist Classification
+
+### 3.1 Completed in #224 Context
+
+The following can be considered completed for #224 as mapping work, not implementation work:
+
+- Auth fallback cleanup is identified as **not owned by #224** and remains under #78.
+- Editor fallback/global state cleanup is identified as **not directly implemented from #224** and remains under #225 / #322 audit planning.
+- `window.currentTreeMemories` and `window.currentTreeData` are mapped to the Editor fallback/global state audit path.
+- Runtime/API boundary work remains separate under #223.
+
+### 3.2 Deferred
+
+The following are deferred to their primary owner trackers:
+
+- Removal or rewrite of Auth transitional fallback logic.
+- Removal or rewrite of Editor inline fallback factories.
+- Migration of `window.currentTreeMemories` to EditorStore or equivalent.
+- Migration of `window.currentTreeData` to EditorStore or equivalent.
+- Any compatibility alias cleanup.
+- Any runtime behavior change that requires fixed-slot or production-equivalent smoke.
+
+### 3.3 Not Applicable to #224 Implementation
+
+The following are not implementation work for #224:
+
+- Editing `js/auth.js` or `js/auth/**`.
+- Editing `js/editor.js` or `js/editor/**`.
+- Changing `pages/editor.html` script order.
+- Changing Auth redirect/session behavior.
+- Changing Editor data load/save behavior.
+- Changing Cloudflare Functions, Modal, or database behavior.
+
+---
+
+## 4. Auth Fallback Cleanup Boundary
+
+Auth fallback cleanup remains under #78 as the primary tracker.
+
+#224 may reference Auth fallback patterns as a strategy or audit dependency, but it should not drive direct Auth implementation. Auth changes are high-risk because they can affect:
+
+- protected route access;
+- confirmed auth cache reconciliation;
+- logout behavior;
+- login redirect behavior;
+- shared header Auth handoff;
+- Firebase/Auth provider initialization timing.
+
+Any future Auth fallback cleanup PR must define its own browser smoke matrix and must not be mixed with Editor fallback cleanup, API route mapping, CSS changes, or docs-only closure work.
+
+---
+
+## 5. Editor Fallback and Global State Boundary
+
+Editor fallback and global state cleanup remains under #225 and the #322 audit path.
+
+The mapped surfaces include:
+
+- `createInlineLoadInitialTreeFallback`;
+- `createInlineNormalizeMemoryFallback`;
+- `createInlineLoadEditorMemoriesFallback`;
+- `createInlineRefreshMemoriesFallback`;
+- `window.currentTreeMemories` read/write inventory;
+- `window.currentTreeData` read/write inventory;
+- future EditorStore or equivalent migration criteria;
+- compatibility alias cleanup criteria.
+
+#224 should not remove these fallbacks or introduce a store. The correct sequence is:
+
+1. Complete the fallback/global state audit.
+2. Identify exact read/write ownership.
+3. Preserve compatibility aliases where runtime code still expects globals.
+4. Add or confirm browser smoke for editor load, memory add/edit/delete, title rename, and save flows.
+5. Only then propose implementation PRs.
+
+---
+
+## 6. Relationship to #223, #225, #78, and #220
+
+### #223
+
+#223 owns runtime boundary and contract work where applicable, including Cloudflare/API/Modal route mapping and related contract protection. It does not directly own Auth or Editor fallback implementation unless a specific runtime contract requires clarification.
+
+### #225
+
+#225 owns Editor fallback/global state cleanup planning and implementation staging. It is the correct owner for `window.currentTreeMemories`, `window.currentTreeData`, and EditorStore migration criteria.
+
+### #78
+
+#78 remains the primary Auth cleanup tracker. Auth transitional fallback cleanup and Auth smoke requirements should be kept there.
+
+### #220
+
+#220 may provide broader runtime cleanup context. It should not be used to bypass the narrower ownership boundaries above.
+
+---
+
+## 7. Implementation Guardrails
+
+Future implementation PRs must follow these guardrails:
+
+- Do not combine Auth fallback cleanup with Editor fallback cleanup.
+- Do not combine docs-only mapping with JS implementation.
+- Do not remove compatibility globals without a consumer inventory.
+- Do not change `window.initAuth()` handoff or protected route semantics from an Editor cleanup PR.
+- Do not change Editor load/save behavior from an Auth cleanup PR.
+- Do not mix Cloudflare/API route mapping with Auth or Editor fallback removal.
+- Do not use local-only browser smoke as final PASS for Auth or Editor runtime changes.
+- Do not touch PR #7 or prototype/reference/demo/variant paths.
+
+---
+
+## 8. Smoke Requirements for Future Implementation
+
+Any future implementation PR must include a scoped smoke plan.
+
+### 8.1 Auth Cleanup Smoke
+
+Required when Auth fallback behavior changes:
+
+- logged-out protected page redirect;
+- confirmed auth cache reconciliation;
+- login redirect target preservation;
+- logout clears protected access;
+- shared header Auth container handoff;
+- no fatal console errors;
+- fixed test slot or production-equivalent URL when Auth/API/runtime behavior is involved.
+
+### 8.2 Editor Cleanup Smoke
+
+Required when Editor fallback/global state behavior changes:
+
+- editor load with existing tree;
+- editor load with missing/invalid tree id;
+- memory list render;
+- memory add/edit/delete where applicable;
+- title rename where applicable;
+- save/refresh behavior;
+- compatibility global reads/writes if not yet removed;
+- no fatal console errors;
+- fixed test slot or production-equivalent URL when API/Auth/runtime behavior is involved.
+
+---
+
+## 9. Final Recommendation for #224
+
+For #224, the Auth/Editor fallback checklist should be treated as **mapped and deferred**, not as direct implementation backlog.
+
+Recommended classification:
+
+| #224 item | Recommendation |
+|---|---|
+| Auth fallback cleanup | Keep open under #78; do not implement here. |
+| Editor fallback factories | Track under #225 / #322 audit; do not implement here. |
+| `window.currentTreeMemories` | Track under #225 / #322 audit; do not implement here. |
+| `window.currentTreeData` | Track under #225 / #322 audit; do not implement here. |
+| API/runtime contract concerns | Keep under #223 where route/runtime boundary related. |
+
+This lets #224 record the strategy decision without increasing runtime risk or duplicating ownership across trackers.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -25,9 +25,10 @@
 6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
 7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
 8. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-9. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-10. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-11. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+9. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -43,6 +44,7 @@
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
 | [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
+| [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
 | [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지와 리뷰 규칙 |
@@ -70,6 +72,7 @@
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
+- #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
 
 ---


### PR DESCRIPTION
## Summary
- Map #224 auth/editor fallback findings to existing tracker/audit work.
- Record what is completed, deferred, or owned by #78/#223/#225.
- Keep Auth and Editor runtime unchanged.

## Scope
- Docs-only.
- No Auth/Editor runtime changes.
- No fallback removal.
- No EditorStore implementation.
- No PR #7 changes.

## Related
Refs #224
Refs #223
Refs #225
Refs #78
Refs #220

## Verification
- [ ] git diff --check — not run (web/API only)
- [x] Changed files limited to fallback mapping docs/index links — VERIFIED: docs/engineering/AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md (added, 190 lines) + docs/engineering/engineering_index.md (minimal index link only, +6/-3). No JS/page/CSS/runtime files.
- [x] No JS/page/CSS/runtime changes — VERIFIED: 0 js/pages/css/functions/modal_compute/package.json changes
- [x] No close keywords for #224 — VERIFIED: PR body and diff contain only `Refs #224`, `Refs #223`, `Refs #225`, `Refs #78`, `Refs #220`. No closes/fixes/resolves.
- [x] PR #7/prototype/reference/demo/variant untouched — VERIFIED
- [x] Auth/Editor fallback runtime unchanged — VERIFIED: no js/auth/** or js/editor/** changes
- [x] No EditorStore implementation — VERIFIED: doc classifies EditorStore as deferred
- [x] Issue #224/#223/#225/#78/#220 remain open — VERIFIED: no close keywords

## Notes
Issue #224 remains open. Auth fallback cleanup ownership mapped to #78. Editor fallback/global state ownership mapped to #225/#322 audit path. API/runtime boundary remains under #223.