### PR TITLE
docs(ops): document persistent encrypted QA credential bundle workflow

### DIFF
--- a/docs/ops/QA_CREDENTIALS.md
+++ b/docs/ops/QA_CREDENTIALS.md
@@ -1,0 +1,182 @@
+# QA Credentials - Persistent Encrypted Bundle Workflow
+
+## Overview
+
+This document describes the workflow for managing QA test credentials using a persistent encrypted bundle. This approach allows local verifiers to restore credentials across multiple clones/worktrees without storing plaintext credentials in the repository.
+
+## Architecture
+
+### Components
+
+1. **Encrypted Bundle**: Stored in repository (password-protected ZIP)
+2. **Local Restore Target**: `.local/test-accounts.json` (gitignored)
+3. **QA Account Slots**: 10 total slots
+   - `qa-user-01` ~ `qa-user-08` (8 user slots)
+   - `qa-admin-01` ~ `qa-admin-02` (2 admin slots)
+
+### Security Model
+
+- **Repository**: Contains only encrypted bundle
+- **Local Runtime**: Uses decrypted `.local/test-accounts.json`
+- **No Plaintext**: Credentials never committed in plain text
+- **Bundle Password**: Never documented in repository
+
+## Workflow
+
+### For Computer 2 (Local Verifier)
+
+#### Initial Setup
+
+1. Obtain encrypted bundle from Computer 1
+2. Extract bundle locally using provided password
+3. Copy extracted credentials to `.local/test-accounts.json`
+4. Verify file format matches `.local/test-accounts.example.json`
+
+#### Multi-Clone/Worktree Setup
+
+For each new clone or worktree:
+
+```bash
+# In each repository clone/worktree
+mkdir -p .local
+# Copy restored credentials from your master location
+cp /path/to/your/restored/test-accounts.json .local/
+```
+
+#### Usage Pattern
+
+- Single restore operation per machine
+- Multiple repositories can share same credentials
+- Credentials persist across worktree operations
+- No repeated bundle extraction needed
+
+### For Computer 1 (Bundle Custodian)
+
+#### Bundle Creation
+
+1. Prepare credentials file with all 10 slots
+2. Create password-protected ZIP bundle
+3. Store bundle in repository (committed)
+4. Distribute bundle password through secure channel
+
+#### Bundle Structure
+
+```
+qa-credential-bundle.zip
+  test-accounts.json
+    qa-user-01: {email, password, displayName}
+    qa-user-02: {email, password, displayName}
+    ...
+    qa-user-08: {email, password, displayName}
+    qa-admin-01: {email, password, displayName}
+    qa-admin-02: {email, password, displayName}
+```
+
+#### Update Procedure
+
+When credentials need rotation:
+
+1. Update local credentials file
+2. Create new encrypted bundle
+3. Commit new bundle to repository
+4. Notify Computer 2 of new bundle availability
+5. Distribute new password securely
+
+## File Locations
+
+### Repository Structure
+
+```
+docs/ops/QA_CREDENTIALS.md          # This documentation
+.local/test-accounts.json          # Runtime credentials (gitignored)
+.local/test-accounts.example.json  # Example format (committed)
+[qa-credential-bundle.zip]         # Encrypted bundle (location TBD)
+```
+
+### Git Configuration
+
+`.gitignore` ensures runtime credentials are never committed:
+
+```
+.local/test-accounts.json
+```
+
+## Verification Checklist
+
+### Bundle Integrity
+
+- [ ] Bundle contains all 10 QA slots
+- [ ] Bundle is password-protected
+- [ ] Bundle file is committed to repository
+- [ ] No plaintext credentials in repository
+
+### Local Setup
+
+- [ ] `.local/test-accounts.json` exists
+- [ ] File format matches example structure
+- [ ] All QA slots are populated
+- [ ] Credentials are valid for testing
+
+### Multi-Repository Usage
+
+- [ ] Credentials copied to all required clones/worktrees
+- [ ] Each repository can read credentials independently
+- [ ] No repeated bundle extraction needed
+
+## Security Guidelines
+
+### Do's
+
+- Use strong passwords for bundle encryption
+- Distribute bundle passwords through secure channels
+- Rotate credentials regularly
+- Verify bundle integrity after extraction
+
+### Don'ts
+
+- Never commit plaintext `.local/test-accounts.json`
+- Never document bundle passwords in repository
+- Never share bundle passwords in plaintext channels
+- Never store bundle passwords in scripts
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing `.local/test-accounts.json`**
+   - Extract bundle again
+   - Verify bundle password
+   - Check file permissions
+
+2. **Invalid credential format**
+   - Compare with `.local/test-accounts.example.json`
+   - Verify JSON structure
+   - Check for missing required fields
+
+3. **Bundle extraction fails**
+   - Verify bundle file integrity
+   - Check bundle password
+   - Re-download bundle if corrupted
+
+### Recovery Procedures
+
+If credentials are lost or corrupted:
+
+1. Contact Computer 1 (bundle custodian)
+2. Request fresh bundle extraction
+3. Follow initial setup procedure
+4. Verify all QA slots work correctly
+
+## Reporting
+
+When using this workflow in reports:
+
+- **credential source**: encrypted bundle restored to `.local/test-accounts.json`
+- **account slots count**: 10
+- **secret values exposed**: NO
+
+## Related Documents
+
+- [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md)
+- [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md)
+- [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)

--- a/docs/ops/QA_CREDENTIALS.md
+++ b/docs/ops/QA_CREDENTIALS.md
@@ -1,114 +1,186 @@
-# QA Credentials - Persistent Encrypted Bundle Workflow
+# QA Credentials — Persistent Encrypted Bundle Workflow
+
+> **⚠️ PROCEDURE STATUS (as of 2026-04-29)**
+>
+> **Persistent encrypted bundle: NOT YET COMMITTED TO REPOSITORY**
+>
+> The bundle file (`docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`) does not yet exist in the repository.
+> A new verifier **cannot restore credentials from docs alone** until the bundle is committed.
+>
+> **Current working method: Temporary handoff via Issue #351**
+> See [Temporary Handoff Workflow](#temporary-handoff-workflow-issue-351) below.
+
+---
 
 ## Overview
 
-This document describes the workflow for managing QA test credentials using a persistent encrypted bundle. This approach allows local verifiers to restore credentials across multiple clones/worktrees without storing plaintext credentials in the repository.
+This document describes two distinct workflows for managing QA test credentials:
+
+| Workflow | Status | Source of truth |
+|---|---|---|
+| **Persistent encrypted bundle** | ⛔ Bundle not yet committed | This document (future) |
+| **Temporary handoff** | ✅ Currently active | Issue #351 comment |
+
+Do not conflate these two workflows. The temporary handoff branch (`ops/temp-qa-credential-handoff`) is a transitional mechanism and will be cleaned up. It is **not** the persistent source of truth.
+
+---
 
 ## Architecture
 
-### Components
+### QA Account Slots
 
-1. **Encrypted Bundle**: Stored in repository (password-protected ZIP)
-2. **Local Restore Target**: `.local/test-accounts.json` (gitignored)
-3. **QA Account Slots**: 10 total slots
-   - `qa-user-01` ~ `qa-user-08` (8 user slots)
-   - `qa-admin-01` ~ `qa-admin-02` (2 admin slots)
+- `qa-user-01` ~ `qa-user-08` (8 user slots)
+- `qa-admin-01` ~ `qa-admin-02` (2 admin slots)
+- **Total: 10 slots**
 
 ### Security Model
 
-- **Repository**: Contains only encrypted bundle
-- **Local Runtime**: Uses decrypted `.local/test-accounts.json`
+- **Repository**: Will contain only encrypted bundle (password-protected ZIP or `.age` file)
+- **Local Runtime**: Uses decrypted `.local/test-accounts.json` (gitignored)
 - **No Plaintext**: Credentials never committed in plain text
 - **Bundle Password**: Never documented in repository
 
-## Workflow
+---
 
-### For Computer 2 (Local Verifier)
+## Persistent Encrypted Bundle Workflow (TARGET STATE)
 
-#### Initial Setup
+> **⛔ NOT ACTIVE: Bundle not yet committed.**
+> This section describes the intended persistent workflow once the bundle is added.
 
-1. Obtain encrypted bundle from Computer 1
-2. Extract bundle locally using provided password
-3. Copy extracted credentials to `.local/test-accounts.json`
-4. Verify file format matches `.local/test-accounts.example.json`
+### Bundle Location (Once Committed)
 
-#### Multi-Clone/Worktree Setup
+```
+docs/ops/qa-credential-bundle/test-accounts-encrypted.zip
+```
+
+Alternative (age-encrypted):
+```
+docs/ops/qa-credential-bundle/test-accounts.json.age
+```
+
+See [`docs/ops/qa-credential-bundle/README.md`](qa-credential-bundle/README.md) for bundle commit status.
+
+### Repository Structure (Target)
+
+```
+docs/ops/QA_CREDENTIALS.md                              # This documentation
+docs/ops/qa-credential-bundle/README.md                 # Bundle status and path
+docs/ops/qa-credential-bundle/test-accounts-encrypted.zip  # ← NOT YET ADDED
+.local/test-accounts.json                               # Runtime credentials (gitignored)
+.local/test-accounts.example.json                       # Example format (committed)
+```
+
+### For Computer 2 (Local Verifier) — Persistent Restore
+
+**Decision tree before starting:**
+
+```
+Step 1: Does docs/ops/qa-credential-bundle/test-accounts-encrypted.zip exist in repo?
+  ├─ YES → Follow persistent restore procedure below
+  └─ NO  → Bundle not yet committed. Use Temporary Handoff (Issue #351) instead.
+
+Step 2: Does .local/test-accounts.json already exist on your machine?
+  ├─ YES → You have a pre-existing local credential file.
+  │        This is NOT a docs-based restore success.
+  │        Report: credential source = pre-existing local file
+  └─ NO  → Proceed with bundle restore.
+```
+
+**Persistent restore procedure (only when bundle exists in repo):**
+
+1. Pull latest branch containing the bundle
+2. Locate bundle: `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`
+3. Extract using the bundle password (obtained via secure channel from bundle custodian)
+4. Copy extracted `test-accounts.json` to `.local/test-accounts.json`
+5. Verify format matches `.local/test-accounts.example.json`
+
+#### Multi-Clone / Worktree Setup
 
 For each new clone or worktree:
 
 ```bash
 # In each repository clone/worktree
 mkdir -p .local
-# Copy restored credentials from your master location
+# Copy restored credentials from your master restore location
 cp /path/to/your/restored/test-accounts.json .local/
 ```
 
-#### Usage Pattern
+---
 
-- Single restore operation per machine
-- Multiple repositories can share same credentials
-- Credentials persist across worktree operations
-- No repeated bundle extraction needed
+## Temporary Handoff Workflow (Issue #351)
 
-### For Computer 1 (Bundle Custodian)
+> **✅ CURRENTLY ACTIVE — use this until persistent bundle is committed.**
 
-#### Bundle Creation
+### Source
+
+- **Issue**: [#351](https://github.com/skerishKang/LoveBud/issues/351)
+- **Temporary branch**: `ops/temp-qa-credential-handoff`
+- **File in branch**: `test-accounts-encrypted-v2.zip` (or as documented in Issue #351)
+
+### ⚠️ Temporary Handoff Limitations
+
+- This branch **may be deleted** after cleanup. Do not treat it as a permanent source.
+- The file in this branch is a one-time transfer artifact, not a versioned credential store.
+- A new verifier cannot bootstrap solely from this branch without the Issue #351 context and the bundle password.
+- **This is not the source of truth for the persistent workflow.**
+
+### Procedure
+
+1. Read Issue #351 for the current handoff file location and instructions
+2. Obtain bundle password via secure channel
+3. Extract bundle and copy to `.local/test-accounts.json`
+4. Verify credentials are valid
+5. Report: `credential source: temporary handoff (Issue #351)`
+
+---
+
+## For Computer 1 (Bundle Custodian)
+
+### Bundle Creation (Persistent)
 
 1. Prepare credentials file with all 10 slots
 2. Create password-protected ZIP bundle
-3. Store bundle in repository (committed)
-4. Distribute bundle password through secure channel
+3. Commit bundle to `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`
+4. Update `docs/ops/qa-credential-bundle/README.md` with commit SHA and date
+5. Distribute bundle password through secure channel
+6. Once persistent bundle is committed, mark Issue #351 temporary handoff as superseded
 
-#### Bundle Structure
-
-```
-qa-credential-bundle.zip
-  test-accounts.json
-    qa-user-01: {email, password, displayName}
-    qa-user-02: {email, password, displayName}
-    ...
-    qa-user-08: {email, password, displayName}
-    qa-admin-01: {email, password, displayName}
-    qa-admin-02: {email, password, displayName}
-```
-
-#### Update Procedure
+### Bundle Update Procedure
 
 When credentials need rotation:
 
 1. Update local credentials file
 2. Create new encrypted bundle
-3. Commit new bundle to repository
-4. Notify Computer 2 of new bundle availability
-5. Distribute new password securely
+3. Replace `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip` in repo
+4. Update README with new SHA and date
+5. Notify Computer 2 of new bundle availability
+6. Distribute new password securely
 
-## File Locations
+---
 
-### Repository Structure
+## PR #350 Verification Standard
 
-```
-docs/ops/QA_CREDENTIALS.md          # This documentation
-.local/test-accounts.json          # Runtime credentials (gitignored)
-.local/test-accounts.example.json  # Example format (committed)
-[qa-credential-bundle.zip]         # Encrypted bundle (location TBD)
-```
+> **⚠️ Local static server is NOT a final PASS for PR #350 verification.**
 
-### Git Configuration
+| Method | Verdict |
+|---|---|
+| `python -m http.server` or equivalent local static server | ❌ Not final PASS |
+| Cloudflare PR Preview URL | ✅ Valid |
+| Fixed test slot (see `TEST_PREVIEW_SLOTS.md`) | ✅ Valid |
 
-`.gitignore` ensures runtime credentials are never committed:
+Final verification for PR #350 must be performed against a **fixed test slot** or **Cloudflare PR Preview** URL. Local server results are preliminary only and must not be reported as final PASS.
 
-```
-.local/test-accounts.json
-```
+---
 
 ## Verification Checklist
 
-### Bundle Integrity
+### Bundle Integrity (when bundle exists)
 
 - [ ] Bundle contains all 10 QA slots
 - [ ] Bundle is password-protected
-- [ ] Bundle file is committed to repository
+- [ ] Bundle file is committed to `docs/ops/qa-credential-bundle/`
 - [ ] No plaintext credentials in repository
+- [ ] `docs/ops/qa-credential-bundle/README.md` reflects current bundle SHA
 
 ### Local Setup
 
@@ -122,6 +194,8 @@ docs/ops/QA_CREDENTIALS.md          # This documentation
 - [ ] Credentials copied to all required clones/worktrees
 - [ ] Each repository can read credentials independently
 - [ ] No repeated bundle extraction needed
+
+---
 
 ## Security Guidelines
 
@@ -138,45 +212,75 @@ docs/ops/QA_CREDENTIALS.md          # This documentation
 - Never document bundle passwords in repository
 - Never share bundle passwords in plaintext channels
 - Never store bundle passwords in scripts
+- Never treat `ops/temp-qa-credential-handoff` branch as a permanent source
+
+---
 
 ## Troubleshooting
 
 ### Common Issues
 
 1. **Missing `.local/test-accounts.json`**
-   - Extract bundle again
+   - Check if persistent bundle exists in `docs/ops/qa-credential-bundle/`
+   - If not: use temporary handoff (Issue #351)
+   - If yes: extract bundle and restore
    - Verify bundle password
    - Check file permissions
 
-2. **Invalid credential format**
+2. **Procedure appears to work but bundle was not used**
+   - If `.local/test-accounts.json` already existed before restore attempt, that is a **pre-existing local credential**, not a docs-based restore
+   - Always confirm whether the file existed before starting the procedure
+
+3. **Invalid credential format**
    - Compare with `.local/test-accounts.example.json`
    - Verify JSON structure
    - Check for missing required fields
 
-3. **Bundle extraction fails**
+4. **Bundle extraction fails**
    - Verify bundle file integrity
    - Check bundle password
-   - Re-download bundle if corrupted
+   - Re-download bundle from repository if corrupted
 
 ### Recovery Procedures
 
 If credentials are lost or corrupted:
 
-1. Contact Computer 1 (bundle custodian)
-2. Request fresh bundle extraction
-3. Follow initial setup procedure
+1. Check if persistent bundle exists in `docs/ops/qa-credential-bundle/`
+2. If yes: extract from persistent bundle (contact custodian for password)
+3. If no: use temporary handoff via Issue #351
 4. Verify all QA slots work correctly
 
-## Reporting
+---
 
-When using this workflow in reports:
+## Reporting Template
 
-- **credential source**: encrypted bundle restored to `.local/test-accounts.json`
-- **account slots count**: 10
-- **secret values exposed**: NO
+When reporting credential workflow results:
+
+```
+procedure validation result: PROCEDURE WORKS | PARTIALLY WORKS | BLOCKED
+credential source:           persistent bundle | temporary handoff (Issue #351) | pre-existing local file
+secret values exposed:       NO
+bundle committed to repo:    YES | NO
+verification environment:    Cloudflare PR Preview | fixed test slot | [other]
+```
+
+**Example (current state — bundle not yet committed):**
+```
+procedure validation result: BLOCKED
+credential source:           temporary handoff (Issue #351)
+secret values exposed:       NO
+bundle committed to repo:    NO
+verification environment:    fixed test slot
+```
+
+---
 
 ## Related Documents
 
+- [qa-credential-bundle/README.md](qa-credential-bundle/README.md) — persistent bundle commit status
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md)
 - [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md)
 - [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)
+- [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md)
+- Issue [#351](https://github.com/skerishKang/LoveBud/issues/351) — temporary handoff
+- Issue [#137](https://github.com/skerishKang/LoveBud/issues/137)

--- a/docs/ops/QA_CREDENTIALS.txt
+++ b/docs/ops/QA_CREDENTIALS.txt
@@ -1,8 +1,22 @@
-# Lovetree QA 테스트 계정 안내
+# LoveBud QA 테스트 계정 안내
 
-## ⚠️ 중요: 실제 계정 정보는 저장소에 없음
+## ⚠️ 현재 상태 (2026-04-29 기준)
 
-실제 QA 테스트 계정 정보는 **로컬 파일**에 저장됩니다.
+**Persistent encrypted bundle: 아직 저장소에 없음**
+
+새 작업자가 이 문서만 보고 credential을 복원하려 할 경우 절차가 막힙니다 (PROCEDURE BLOCKED).
+현재 working 방법: **Issue #351 임시 handoff** 를 사용하세요.
+
+---
+
+## 워크플로우 구분
+
+| 방식 | 상태 | 출처 |
+|------|------|------|
+| **Persistent encrypted bundle** | ⛔ 아직 커밋되지 않음 | 문서 기반 (미래) |
+| **Temporary handoff (Issue #351)** | ✅ 현재 사용 가능 | Issue #351 코멘트 |
+
+---
 
 ## 계정 정보 위치
 
@@ -10,18 +24,58 @@
 |------|-----------|------|
 | **실제 값** | `.local/test-accounts.json` | 로컬에만 존재 (Git 무시) |
 | **예시 형식** | `.local/test-accounts.example.json` | 저장소에 포함된 예시 |
+| **Persistent bundle (예정)** | `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip` | ⛔ 아직 없음 |
+| **Temporary bundle** | Issue #351 참고 | branch: `ops/temp-qa-credential-handoff` (임시, 정리 예정) |
 
-## 사용 방법
+---
 
-1. `.local/test-accounts.example.json`을 참고하여
-2. `.local/test-accounts.json` 파일 생성
-3. 실제 계정 정보를 해당 파일에 기록
+## 현재 복원 절차
+
+### 1. Persistent bundle이 repo에 있는 경우
+- `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip` 존재 확인
+- 번들 custodian에게 비밀번호 수령 (안전한 채널)
+- 압축 해제 후 `.local/test-accounts.json`에 저장
+
+### 2. Persistent bundle이 없는 경우 (현재 상태)
+- Issue #351 코멘트에서 임시 handoff 위치 확인
+- 비밀번호 수령 후 압축 해제
+- credential source = `temporary handoff (Issue #351)` 로 보고
+
+### 3. `.local/test-accounts.json`이 이미 존재하는 경우
+- 이는 **문서 기반 복원 성공이 아닙니다**
+- `credential source: pre-existing local file` 로 보고
+
+---
+
+## PR #350 검증 기준
+
+⚠️ **local static server (`python -m http.server` 등)는 final PASS가 아닙니다.**
+
+- ✅ Cloudflare PR Preview URL 기준
+- ✅ fixed test slot 기준 (TEST_PREVIEW_SLOTS.md 참고)
+- ❌ 로컬 정적 서버는 예비 확인용만 가능
+
+---
 
 ## 운영 원칙
 
 - 저장소에는 **실제 비밀번호를 남기지 않음**
 - 문서에는 **경로/사용법/주의사항**만 기록
 - 실제 값은 **로컬 환경**에서만 관리
+- `ops/temp-qa-credential-handoff` branch는 임시 경로이므로 cleanup 후 사라질 수 있음
 
 ---
-Last updated: 2026-04-18
+
+## 보고 양식
+
+```
+procedure validation result: PROCEDURE WORKS | PARTIALLY WORKS | BLOCKED
+credential source:           persistent bundle | temporary handoff (Issue #351) | pre-existing local file
+secret values exposed:       NO
+bundle committed to repo:    YES | NO
+```
+
+---
+
+관련 문서: QA_CREDENTIALS.md, qa-credential-bundle/README.md, TEST_PREVIEW_SLOTS.md
+Last updated: 2026-04-29

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -60,7 +60,7 @@
 | [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) | PR #49~#58 이후 merged/stale branch cleanup 후보와 보존 branch 분류 기준 |
 | [FLOW_A_QA_CHECKLIST.md](FLOW_A_QA_CHECKLIST.md) | QA 체크리스트 |
 | [PR_CHECKLIST.md](PR_CHECKLIST.md) | PR 점검 기준 |
-| [QA_CREDENTIALS.md](QA_CREDENTIALS.md) | QA credentials — persistent bundle workflow (⛔ bundle not yet committed; use Issue #351 temporary handoff) |
+| [QA_CREDENTIALS.md](QA_CREDENTIALS.md) | QA credentials — persistent encrypted bundle workflow (⛔ bundle not yet committed; use Issue #351 temporary handoff) |
 | [QA_CREDENTIALS.txt](QA_CREDENTIALS.txt) | QA credentials 한국어 요약 및 현재 상태 |
 | [qa-credential-bundle/README.md](qa-credential-bundle/README.md) | Persistent encrypted bundle commit status and path |
 | [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) | Cloudflare Pages / Modal 전환 문서 |

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -60,7 +60,7 @@
 | [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) | PR #49~#58 이후 merged/stale branch cleanup 후보와 보존 branch 분류 기준 |
 | [FLOW_A_QA_CHECKLIST.md](FLOW_A_QA_CHECKLIST.md) | QA 체크리스트 |
 | [PR_CHECKLIST.md](PR_CHECKLIST.md) | PR 점검 기준 |
-| [QA_CREDENTIALS.md](QA_CREDENTIALS.md) | QA credentials — persistent encrypted bundle workflow (⛔ bundle not yet committed; use Issue #351 temporary handoff) |
+| [QA_CREDENTIALS.md](QA_CREDENTIALS.md) | QA credentials — persistent bundle workflow (⛔ bundle not yet committed; use Issue #351 temporary handoff) |
 | [QA_CREDENTIALS.txt](QA_CREDENTIALS.txt) | QA credentials 한국어 요약 및 현재 상태 |
 | [qa-credential-bundle/README.md](qa-credential-bundle/README.md) | Persistent encrypted bundle commit status and path |
 | [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) | Cloudflare Pages / Modal 전환 문서 |

--- a/docs/ops/qa-credential-bundle/README.md
+++ b/docs/ops/qa-credential-bundle/README.md
@@ -1,0 +1,74 @@
+# QA Credential Bundle — Status
+
+## Current Status
+
+> **⛔ BUNDLE NOT YET COMMITTED**
+
+The persistent encrypted bundle has not been added to this directory.
+
+A new verifier **cannot restore QA credentials from this path** until the bundle is committed here.
+
+---
+
+## Expected Bundle Path
+
+```
+docs/ops/qa-credential-bundle/test-accounts-encrypted.zip
+```
+
+Alternative (age-encrypted):
+```
+docs/ops/qa-credential-bundle/test-accounts.json.age
+```
+
+---
+
+## Bundle Commit Record
+
+| Version | Status | Committed by | Date | Commit SHA |
+|---------|--------|--------------|------|------------|
+| v1 | ⛔ Not committed | — | — | — |
+
+Update this table when the bundle is first committed.
+
+---
+
+## Current Workaround
+
+Until the persistent bundle is committed here, use the **temporary handoff** method:
+
+- See Issue [#351](https://github.com/skerishKang/LoveBud/issues/351) for current handoff file location
+- Temporary branch: `ops/temp-qa-credential-handoff`
+- Temporary file: `test-accounts-encrypted-v2.zip` (or as documented in Issue #351)
+
+⚠️ **The temporary handoff branch may be deleted after cleanup. Do not treat it as a permanent source.**
+
+---
+
+## Procedure Validation Result
+
+When reporting credential restore attempts, use this format:
+
+```
+procedure validation result: PROCEDURE WORKS | PARTIALLY WORKS | BLOCKED
+credential source:           persistent bundle | temporary handoff (Issue #351) | pre-existing local file
+secret values exposed:       NO
+bundle committed to repo:    YES | NO
+```
+
+**Current expected result for new verifiers:**
+```
+procedure validation result: BLOCKED
+credential source:           temporary handoff (Issue #351)
+secret values exposed:       NO
+bundle committed to repo:    NO
+```
+
+---
+
+## Related
+
+- [../QA_CREDENTIALS.md](../QA_CREDENTIALS.md) — full workflow documentation
+- [../QA_CREDENTIALS.txt](../QA_CREDENTIALS.txt) — 한국어 요약
+- Issue [#351](https://github.com/skerishKang/LoveBud/issues/351) — temporary handoff
+- Issue [#137](https://github.com/skerishKang/LoveBud/issues/137)


### PR DESCRIPTION
## Summary

Fix procedure validation blocker: encrypted QA credential bundle location was ambiguous (`location TBD`), causing PROCEDURE BLOCKED for a new verifier following only the docs.

- Remove `location TBD` from all workflow docs
- Clarify that the persistent encrypted bundle is **not yet committed** to the repository
- Split persistent workflow vs. temporary handoff (Issue #351) into separate documented sections
- Add multi-clone/worktree decision tree with a branch for pre-existing local credential (not a docs restore success)
- Add PR #350 verification standard: local static server is NOT final PASS
- Add procedure validation result reporting template
- Add `docs/ops/qa-credential-bundle/README.md` as persistent bundle placeholder with commit status table

## Scope

- Docs-only.
- No JS/CSS/page/runtime changes.
- No prototype/reference/demo/variant changes.

## Changed Files

- `docs/ops/QA_CREDENTIALS.md` — core workflow doc updated
- `docs/ops/QA_CREDENTIALS.txt` — Korean summary updated to reflect current status
- `docs/ops/qa-credential-bundle/README.md` — new file: persistent bundle placeholder and status

## Related

Refs #351
Refs #350
Refs #137

## Verification

- [x] `git diff --check`
- [x] `location TBD` removed
- [x] Persistent bundle path documented (`docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`)
- [x] Persistent bundle missing state explicitly noted: &#34;Persistent encrypted bundle is not committed yet&#34;
- [x] Persistent workflow and temporary handoff (Issue #351) split into separate sections
- [x] Pre-existing local credential distinguished from docs-based restore
- [x] PR #350: local static server NOT final PASS — Cloudflare PR Preview / fixed test slot required
- [x] Procedure validation result reporting template added
- [x] No plaintext `.local/test-accounts.json` added
- [x] No ZIP password documented
- [x] No JS/CSS/page/runtime changes
- [x] No close keywords for any issue
- [x] Procedure blocker from 컴2 validation addressed

## Notes

- Issues #351, #350, #137 remain open.
- Persistent bundle commit is a follow-up action by the bundle custodian (Computer 1). When the bundle is committed, update `docs/ops/qa-credential-bundle/README.md` commit record and remove the &#34;not yet committed&#34; notices.
- `docs/ops/ops_index.md` was touched during rebase conflict resolution but net diff vs. main is zero — not included in final changed files.