### PR TITLE
docs(ops): add browser verification agent entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ UI 검증 프롬프트를 작성하기 전 반드시 아래를 먼저 판단하�
 - 이미 확보한 테스트/프리뷰 URL이 있는가?
 - Cloudflare PR Preview URL이 있는가?
 
-브라우저/로컬 검증 작업자는 추가로 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`를 먼저 읽고, URL 출처·fixed slot·evidence 규칙은 `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`와 `docs/ops/TEST_PREVIEW_SLOTS.md`를 따릅니다.
+브라우저/Auth/API/data-loaded 검증 작업자는 `docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`를 먼저 읽고, 그 다음 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`, `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`, `docs/ops/TEST_PREVIEW_SLOTS.md` 및 PR별 `Browser verification entrypoint` comment를 따릅니다.
 
 ---
 
@@ -213,18 +213,16 @@ LoveBud / LoveTree는 다음과 같은 서비스가 아닙니다.
    - `docs/design/UI_DESIGN_SYSTEM.md`
 5. 운영 판단이 필요하면:
    - `docs/ops/OPERATIONS.md`
+   - `docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`
    - `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
    - `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`
    - `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`
    - `docs/ops/TEST_PREVIEW_SLOTS.md`
    - `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`
-6. 구현 판단이 필요하면:
-   - `docs/engineering/API_CONTRACT.md`
-   - 관련 페이지/ops/engineering 문서
 
 GitHub CLI, browser login, connector-backed GitHub access, or token-backed local access를 사용하는 작업자는 `docs/ops/GITHUB_AUTH_TOKEN_USAGE.md`를 함께 따릅니다.
 
-브라우저/로컬 검증 작업자는 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`를 먼저 따릅니다.
+브라우저/Auth/API/data-loaded 검증 작업자는 `docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`를 먼저 읽고, 그 다음 `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`를 먼저 따릅니다.
 
 대화 복원이 필요하면 아래를 추가로 읽습니다.
 

--- a/docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md
+++ b/docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md
@@ -1,0 +1,325 @@
+# Browser Verification Agent Entrypoint
+
+> **Status:** operational entrypoint  
+> **Scope:** browser/Auth/data-loaded verification only  
+> **Primary reader:** new agent/new session assigned to browser verification
+
+This document is the browser verification entrypoint that should be linked from `AGENTS.md`.
+
+A new browser verification agent should be able to read this document, the target PR, and the PR-specific browser verification entrypoint comment, then run the verification without reconstructing context from prior chat.
+
+---
+
+## 1. Core rule
+
+Browser verification is not a guessing task.
+
+The verifier must not invent or infer:
+
+- test slot URL
+- Cloudflare Preview URL
+- production URL applicability
+- credential location
+- account values
+- ready/merge authority
+
+If a required value is missing, the result is `BLOCKED`, not guessed.
+
+---
+
+## 2. Required starting order
+
+For browser/Auth/data-loaded verification, read in this order:
+
+1. `AGENTS.md`
+2. This document: `docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`
+3. The target PR body
+4. The PR comment titled or clearly marked `Browser verification entrypoint`
+5. Relevant URL policy docs only if the entrypoint references them:
+   - `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`
+   - `docs/ops/TEST_PREVIEW_SLOTS.md`
+   - `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+6. Credential policy docs only if the page is Auth-gated:
+   - `docs/ops/QA_CREDENTIALS.md`
+
+Do not scan unrelated docs unless a blocker requires it.
+
+---
+
+## 3. PR-specific entrypoint comment is required
+
+Every Auth/API/data-loaded browser verification PR should have a PR comment with this information:
+
+```text
+Browser verification entrypoint
+
+PR: #<number>
+Assigned URL: <Cloudflare PR Preview or fixed test slot>
+URL provenance: <who assigned it and why it is valid>
+Page(s): <page paths>
+Credential source state: <not needed | .local/test-accounts.json exists | restored from temporary handoff | restored from persistent bundle>
+Account type: <Internal QA User | Internal QA Admin | not needed>
+Final PASS allowed from local server: NO for Auth/API/data-loaded pages
+Ready transition allowed: <YES/NO>
+Merge allowed: NO unless explicitly CTO-approved
+```
+
+If this comment is missing for an Auth/API/data-loaded page, report:
+
+```text
+Final status: BLOCKED — missing Browser verification entrypoint comment
+```
+
+---
+
+## 4. URL rules
+
+### Valid final PASS URLs
+
+Use only one of these for final browser PASS:
+
+1. CTO-assigned Cloudflare Pages PR Preview URL
+2. CTO-assigned fixed test slot, for example:
+   - `https://test1.lovebud.pages.dev`
+   - `https://test2.lovebud.pages.dev`
+   - `https://test3.lovebud.pages.dev`
+   - `https://test4.lovebud.pages.dev`
+   - `https://test5.lovebud.pages.dev`
+   - `https://test6.lovebud.pages.dev`
+3. Production URL only after the PR is merged and deployed
+
+### Invalid final PASS URLs
+
+Do not use these as final PASS for Auth/API/data-loaded pages:
+
+- local static server
+- guessed Cloudflare URL
+- production URL before merge
+- stale test slot with unknown branch/SHA
+- any URL whose provenance is not documented
+
+Local server may be recorded as partial smoke only.
+
+---
+
+## 5. Credential prerequisite for Auth-gated pages
+
+For Auth-gated pages, the verifier must confirm the credential source state before testing.
+
+Allowed credential source states:
+
+- `not needed`
+- `pre-existing local .local/test-accounts.json`
+- `restored from temporary handoff`
+- `restored from persistent encrypted bundle`
+
+For `.local/test-accounts.json`, verify:
+
+```text
+file exists: YES
+JSON valid: YES
+account slots count: 10
+git tracked: NO
+secret values exposed: NO
+```
+
+Never print or report:
+
+- password values
+- token values
+- cookie/session values
+- credential file contents
+- ZIP password
+- account secrets
+
+Report only the credential source state and account type used.
+
+---
+
+## 6. Standard verification checks
+
+For any Auth/API/data-loaded page, include these checks:
+
+1. Assigned URL loads
+2. URL provenance recorded
+3. Login succeeds if required
+4. Target page loads after login
+5. Loading state behaves normally
+6. Expected empty/content/error state appears
+7. Main changed UI behavior works
+8. Console has no fatal error
+9. Network has no new API blocker
+10. No obvious horizontal overflow
+11. Credential values were not exposed
+
+For My Trees verification, also check:
+
+- `/pages/my-trees.html` loads after login
+- loading/empty/content/error state renders
+- manage summary visible/hidden behavior works
+- classList/CSS-state display behavior is stable
+
+---
+
+## 7. Automatic vs manual browser verification
+
+Automation is preferred only when it is stable.
+
+If automation fails because of tool/session/driver issues, the verifier may switch to manual browser verification on the assigned Cloudflare/test-slot URL.
+
+Manual verification must still report:
+
+- URL
+- URL provenance
+- account type used
+- exact checked states
+- console fatal error status
+- network blocker status
+- horizontal overflow status
+
+Do not mark an automation-tool failure as app failure unless the app behavior itself is confirmed broken.
+
+---
+
+## 8. Report format
+
+Use this report format for browser verification:
+
+```text
+1. computer/model
+2. PR number
+3. branch
+4. verification URL
+5. URL provenance
+6. credential source state
+7. account type used
+8. local server used: YES/NO
+9. final PASS environment: Cloudflare PR Preview / fixed test slot / production-after-merge
+10. target page initial load result
+11. loading/empty/content/error state result
+12. changed UI behavior result
+13. console fatal error: YES/NO
+14. network/API blocker: YES/NO
+15. horizontal overflow: YES/NO
+16. secret values exposed: NO
+17. PR body checklist updated: YES/NO
+18. ready transition: YES/NO
+19. merge performed: NO unless explicitly CTO-approved
+20. issue close status: NO unless explicitly CTO-approved
+21. Final status: PASS / PARTIAL / BLOCKED / FAIL
+```
+
+---
+
+## 9. Ready and merge authority
+
+Browser verifiers do not infer ready or merge authority.
+
+- Ready transition requires explicit task instruction.
+- Merge requires explicit CTO merge approval.
+- Issues remain open unless explicit close approval is given.
+- PR #7 and prototype/reference/demo/variant paths are never modified or closed during verification.
+
+---
+
+## 10. Blocker taxonomy
+
+Use these final statuses consistently:
+
+### PASS
+All required checks passed on valid final PASS environment.
+
+### PARTIAL
+Some checks passed, but at least one required final PASS condition is missing.
+
+Examples:
+- local-only smoke passed but test slot not checked
+- login worked but content state was not verified
+
+### BLOCKED
+Verification cannot proceed because prerequisite information or access is missing.
+
+Examples:
+- no assigned URL
+- missing Browser verification entrypoint comment
+- missing credential source
+- credential file absent
+- test slot branch/SHA provenance unknown
+
+### FAIL
+The app behavior itself failed on a valid final PASS environment.
+
+Examples:
+- login fails with valid QA credential
+- page fatal blank
+- target JS fatal error
+- required UI state no longer renders
+
+---
+
+## 11. PR-specific entrypoint template
+
+Use this template as a PR comment before assigning a new browser verifier:
+
+```markdown
+## Browser verification entrypoint
+
+PR: #<number>  
+Branch: `<branch>`  
+Assigned URL: `<url>`  
+URL provenance: `<Cloudflare PR Preview / fixed test slot assignment / production after merge>`  
+Target pages:
+- `<path>`
+
+Credential source state:
+- `<not needed | pre-existing local .local/test-accounts.json | restored from temporary handoff | restored from persistent encrypted bundle>`
+
+Account type:
+- `<Internal QA User | Internal QA Admin | not needed>`
+
+Final PASS rules:
+- Local static server final PASS: NO for Auth/API/data-loaded pages.
+- Use only the assigned URL above.
+
+Checks:
+- [ ] login succeeds if required
+- [ ] target page loads
+- [ ] loading/empty/content/error state renders
+- [ ] changed UI behavior works
+- [ ] no fatal console error
+- [ ] no network/API blocker
+- [ ] no horizontal overflow
+- [ ] secret values exposed: NO
+
+Restrictions:
+- Do not modify files.
+- Do not mark ready unless explicitly instructed.
+- Do not merge.
+- Do not close issues.
+- Do not touch PR #7 or prototype/reference/demo/variant paths.
+```
+
+---
+
+## 12. Minimal My Trees example
+
+For a My Trees PR such as PR #350, the entrypoint should specify:
+
+```text
+Page: /pages/my-trees.html
+Credential source state: pre-existing local .local/test-accounts.json or restored from handoff/bundle
+Account type: Internal QA User
+Final PASS URL: assigned fixed test slot or Cloudflare PR Preview
+Local server final PASS: NO
+```
+
+Checks:
+
+- login succeeds
+- My Trees page loads after login
+- loading/empty/content/error state appears
+- manage summary visible/hidden behavior works
+- classList display state behavior is stable
+- console fatal error is absent
+- network/API blocker is absent
+- horizontal overflow is absent

--- a/docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md
+++ b/docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md
@@ -57,8 +57,9 @@ PR: #<number>
 Assigned URL: <Cloudflare PR Preview or fixed test slot>
 URL provenance: <who assigned it and why it is valid>
 Page(s): <page paths>
-Credential source state: <not needed | .local/test-accounts.json exists | restored from temporary handoff | restored from persistent bundle>
+Credential source state: <not needed | pre-existing local .local/test-accounts.json | restored from temporary handoff | restored from persistent encrypted bundle>
 Account type: <Internal QA User | Internal QA Admin | not needed>
+Account selection: <first active matching account type | specific local slot label | not needed>
 Final PASS allowed from local server: NO for Auth/API/data-loaded pages
 Ready transition allowed: <YES/NO>
 Merge allowed: NO unless explicitly CTO-approved
@@ -123,20 +124,45 @@ git tracked: NO
 secret values exposed: NO
 ```
 
-Never print or report:
+Report only the credential source state, account type, and account selection rule used.
 
-- password values
-- token values
-- cookie/session values
-- credential file contents
-- ZIP password
-- account secrets
-
-Report only the credential source state and account type used.
+If the required credential source or account type is not available, stop and report `BLOCKED`.
 
 ---
 
-## 6. Standard verification checks
+## 6. Auth auto-login procedure
+
+For Auth-gated pages, the verifier should use browser automation to log in when all of these are true:
+
+- The PR-specific entrypoint comment provides an assigned URL.
+- The assigned URL has documented provenance.
+- The credential source state is available locally.
+- The PR-specific entrypoint comment provides an account type.
+- The account selection rule is clear.
+
+Standard account selection:
+
+1. Read the required `Account type` from the PR-specific entrypoint comment.
+2. Read the `Account selection` rule from the PR-specific entrypoint comment.
+3. If the rule is `first active matching account type`, select the first active local account matching the required account type.
+4. If the rule names a local slot label, select only that local slot.
+5. If no matching active account exists, report `BLOCKED`.
+
+Standard browser automation steps:
+
+1. Open the assigned Cloudflare Preview or fixed test slot URL.
+2. If redirected to login, use the selected local account for the login form.
+3. Submit the login form.
+4. Confirm either redirect to the target page or successful target page access after login.
+5. Continue with the standard verification checks below.
+
+Do not guess selectors if the login form cannot be identified. Report `BLOCKED` or switch to manual verification if the browser tool is unstable.
+
+Manual login fallback is allowed only on the assigned URL and must still use the same credential source state, account type, and account selection rule.
+
+---
+
+## 7. Standard verification checks
 
 For any Auth/API/data-loaded page, include these checks:
 
@@ -161,7 +187,7 @@ For My Trees verification, also check:
 
 ---
 
-## 7. Automatic vs manual browser verification
+## 8. Automatic vs manual browser verification
 
 Automation is preferred only when it is stable.
 
@@ -171,7 +197,9 @@ Manual verification must still report:
 
 - URL
 - URL provenance
+- credential source state
 - account type used
+- account selection rule used
 - exact checked states
 - console fatal error status
 - network blocker status
@@ -181,7 +209,7 @@ Do not mark an automation-tool failure as app failure unless the app behavior it
 
 ---
 
-## 8. Report format
+## 9. Report format
 
 Use this report format for browser verification:
 
@@ -193,25 +221,26 @@ Use this report format for browser verification:
 5. URL provenance
 6. credential source state
 7. account type used
-8. local server used: YES/NO
-9. final PASS environment: Cloudflare PR Preview / fixed test slot / production-after-merge
-10. target page initial load result
-11. loading/empty/content/error state result
-12. changed UI behavior result
-13. console fatal error: YES/NO
-14. network/API blocker: YES/NO
-15. horizontal overflow: YES/NO
-16. secret values exposed: NO
-17. PR body checklist updated: YES/NO
-18. ready transition: YES/NO
-19. merge performed: NO unless explicitly CTO-approved
-20. issue close status: NO unless explicitly CTO-approved
-21. Final status: PASS / PARTIAL / BLOCKED / FAIL
+8. account selection rule used
+9. local server used: YES/NO
+10. final PASS environment: Cloudflare PR Preview / fixed test slot / production-after-merge
+11. target page initial load result
+12. loading/empty/content/error state result
+13. changed UI behavior result
+14. console fatal error: YES/NO
+15. network/API blocker: YES/NO
+16. horizontal overflow: YES/NO
+17. secret values exposed: NO
+18. PR body checklist updated: YES/NO
+19. ready transition: YES/NO
+20. merge performed: NO unless explicitly CTO-approved
+21. issue close status: NO unless explicitly CTO-approved
+22. Final status: PASS / PARTIAL / BLOCKED / FAIL
 ```
 
 ---
 
-## 9. Ready and merge authority
+## 10. Ready and merge authority
 
 Browser verifiers do not infer ready or merge authority.
 
@@ -222,7 +251,7 @@ Browser verifiers do not infer ready or merge authority.
 
 ---
 
-## 10. Blocker taxonomy
+## 11. Blocker taxonomy
 
 Use these final statuses consistently:
 
@@ -244,6 +273,8 @@ Examples:
 - missing Browser verification entrypoint comment
 - missing credential source
 - credential file absent
+- required account type unavailable
+- account selection rule missing or ambiguous
 - test slot branch/SHA provenance unknown
 
 ### FAIL
@@ -257,7 +288,7 @@ Examples:
 
 ---
 
-## 11. PR-specific entrypoint template
+## 12. PR-specific entrypoint template
 
 Use this template as a PR comment before assigning a new browser verifier:
 
@@ -276,6 +307,9 @@ Credential source state:
 
 Account type:
 - `<Internal QA User | Internal QA Admin | not needed>`
+
+Account selection:
+- `<first active matching account type | specific local slot label | not needed>`
 
 Final PASS rules:
 - Local static server final PASS: NO for Auth/API/data-loaded pages.
@@ -301,7 +335,7 @@ Restrictions:
 
 ---
 
-## 12. Minimal My Trees example
+## 13. Minimal My Trees example
 
 For a My Trees PR such as PR #350, the entrypoint should specify:
 
@@ -309,6 +343,7 @@ For a My Trees PR such as PR #350, the entrypoint should specify:
 Page: /pages/my-trees.html
 Credential source state: pre-existing local .local/test-accounts.json or restored from handoff/bundle
 Account type: Internal QA User
+Account selection: first active matching account type
 Final PASS URL: assigned fixed test slot or Cloudflare PR Preview
 Local server final PASS: NO
 ```


### PR DESCRIPTION
## Summary
- Add a dedicated browser verification agent entrypoint document under `docs/ops/`.
- Standardize PR-specific Browser verification entrypoint comments, URL provenance, credential source state, account selection, and final PASS reporting.
- Document the Auth auto-login procedure for browser verification agents.
- Link the new entrypoint document from `AGENTS.md`.

## Scope
- Docs-only.
- No runtime/code changes.
- No credentials or secret values added.
- No PR #7/prototype/reference/demo/variant changes.

## Notes
- `AGENTS.md` now links to `docs/ops/AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`.
- This PR remains docs-only and does not include runtime/code changes.
- Browser agents still require a PR-specific `Browser verification entrypoint` comment with assigned URL, URL provenance, credential source state, account type, and account selection rule.
- Issue #137, #350, #351, and #352 remain open.

## Related
Refs #137
Refs #350
Refs #351
Refs #352

## Verification
- [x] Browser verification entrypoint document added
- [x] PR-specific verification comment template included
- [x] URL provenance and fixed test slot rules documented
- [x] `.local/test-accounts.json` credential prerequisite documented without values
- [x] Account selection rule documented
- [x] Auth auto-login procedure documented
- [x] Local static server final PASS prohibition documented
- [x] Automatic vs manual verification fallback documented
- [x] No secret values added
- [x] No JS/CSS/page/runtime changes
- [x] No close keywords