### PR TITLE
docs(search): audit preview controller split path

### DIFF
--- a/docs/engineering/SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md
+++ b/docs/engineering/SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md
@@ -1,0 +1,179 @@
+# Search Preview Controller Split Audit
+
+> Status: audit / planning only  
+> Scope: Search/Browse preview controller split preparation  
+> Related: #65, #72  
+> Runtime impact: none
+
+## 1. Purpose
+
+This document records the safe path for a future Search/Browse preview controller split.
+
+The goal is to prepare the next implementation slice for Issue #72 and Issue #65 without modifying runtime code in this PR.
+
+This audit is needed because Search/Browse currently has several adjacent responsibilities:
+
+- data loading
+- URL state
+- controls binding
+- card rendering
+- preview rendering
+- selected tree hydration
+- desktop/mobile preview behavior
+- preview cache interaction
+
+PR #336 covers data loading split. PR #337 covers URL state and controls split. This document defines the guardrails for the later preview controller split only.
+
+## 2. Non-goals
+
+This PR does not implement the preview controller split.
+
+Do not do the following in this audit PR:
+
+- create `js/search/preview-controller.js`
+- modify `js/search.js`
+- modify `js/search/data.js`
+- modify `js/search-ui.js`
+- modify `search-preview-cache.js`
+- modify `pages/search.html`
+- change Search/Browse CSS
+- change API calls or adapter contracts
+- change selected tree deep link behavior
+- close Issue #65 or Issue #72
+
+## 3. Current dependency sequence
+
+The implementation order should remain:
+
+1. PR #336 — Search/Browse data loading split
+2. PR #337 — Search URL state and controls split
+3. Preview controller split — future implementation PR after #336/#337 are stable on `main`
+
+The preview controller split must not be merged before the preceding Search split PRs are resolved.
+
+## 4. Candidate future file
+
+Future implementation candidate:
+
+```text
+js/search/preview-controller.js
+```
+
+Expected browser-global namespace candidate:
+
+```text
+window.LoveBudSearchPreviewController
+```
+
+The exact exported API should be finalized in the implementation PR, but it should be small and focused.
+
+## 5. Candidate responsibility boundary
+
+The future preview controller module may own orchestration around:
+
+- selected tree preview activation
+- preview sidebar open/close coordination
+- selected tree hydration handoff
+- preview cache read/write handoff
+- desktop/mobile preview state coordination
+- preview loading/error state coordination
+
+It should not own:
+
+- API adapter implementation
+- raw public tree response normalization
+- card markup rendering
+- preview markup rendering internals
+- global URL state parsing
+- category/sort/limit controls binding
+- CSS definitions
+
+## 6. Compatibility rules
+
+A future implementation must preserve existing user-visible behavior:
+
+- direct selected tree deep link must keep working
+- desktop preview sidebar behavior must remain stable
+- mobile preview behavior must remain stable
+- back/forward behavior must not regress
+- category/sort/limit controls must not reset selected tree unexpectedly
+- preview cache behavior must remain compatible
+- YouTube embed/thumbnail fallback behavior must not change
+- no API endpoint or response contract changes
+
+## 7. Script loading guardrails
+
+If a future PR adds `js/search/preview-controller.js`, then `pages/search.html` must load it in a safe order.
+
+Candidate order should be verified against the current Search runtime contract:
+
+1. shared dependencies and API/client scripts
+2. Search adapter/cache/rendering helpers
+3. preview controller module
+4. `js/search.js` or future thin entrypoint
+
+The implementation PR must confirm that any new namespace is available before the entrypoint uses it.
+
+## 8. Browser verification required for future implementation
+
+A future implementation PR requires Cloudflare Preview or fixed test slot browser verification.
+
+Local static server alone is not final PASS because Search/Browse is API/data-loaded.
+
+Minimum checks:
+
+- `/pages/search.html` loads on assigned Cloudflare Preview or fixed test slot
+- initial public tree data load works
+- category filter works
+- sort/limit controls work
+- selected tree preview opens
+- selected tree deep link works
+- desktop preview behavior is stable
+- mobile preview behavior is stable
+- empty state renders correctly
+- API/network has no new blocker
+- console has no fatal error
+- horizontal overflow does not appear
+
+## 9. Suggested future PR body skeleton
+
+```markdown
+## Summary
+- Split Search/Browse preview controller orchestration into `js/search/preview-controller.js`.
+- Preserve selected tree deep link, desktop/mobile preview behavior, and preview cache behavior.
+- Keep API, adapter, renderer, CSS, and URL state contracts unchanged.
+
+## Scope
+- Preview controller orchestration split only.
+- No API endpoint changes.
+- No adapter contract changes.
+- No renderer markup changes.
+- No CSS/page layout changes.
+- No PR #7/prototype/reference/demo/variant changes.
+
+## Related
+Refs #72
+Refs #65
+
+## Verification
+- [ ] git diff --check
+- [ ] Search/Browse initial data load verified on Cloudflare Preview or fixed test slot
+- [ ] selected tree preview works
+- [ ] selected tree deep link works
+- [ ] desktop/mobile preview behavior preserved
+- [ ] category/sort/limit controls do not regress
+- [ ] no API/Auth/runtime/CSS changes
+- [ ] no close keywords for #72 or #65
+```
+
+## 10. Final audit decision
+
+Proceed with a future preview controller implementation only after:
+
+- PR #336 is merged or otherwise resolved
+- PR #337 is merged or otherwise resolved
+- latest `main` contains the expected Search split baseline
+- a valid Cloudflare Preview or fixed test slot is assigned
+- the future PR has a Browser verification entrypoint comment
+
+Until then, this remains a planning/audit document only.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -42,6 +42,7 @@
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
+| [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 후속 구현 guardrail |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
 | [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |


### PR DESCRIPTION
## Summary
- Add a docs-only audit for a future Search/Browse preview controller split.
- Define preview controller ownership boundaries and non-goals.
- Document dependency ordering after PR #336 and PR #337.
- Preserve Search/Browse runtime behavior by deferring implementation to a later PR.

## Scope
- Docs-only.
- No JS/CSS/page/runtime changes.
- No preview controller implementation.
- No Search script loading changes.
- No API or adapter contract changes.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `docs/engineering/SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md`
- `docs/engineering/engineering_index.md`

## Related
Refs #65
Refs #72

## Verification
- [ ] git diff --check — not run in GitHub Web/API-only verification
- [x] Docs-only audit added
- [x] Changed files limited to engineering docs/index link
- [x] No JS/CSS/page/runtime changes
- [x] No implementation files added
- [x] Future dependency order documented: #336 → #337 → preview controller split
- [x] No close keywords for #65 or #72

## Notes
Issue #65 and Issue #72 remain open. This PR does not complete either tracker; it prepares the next safe follow-up slice after PR #336 and PR #337 are resolved.