### PR TITLE
docs(cleanup): map remaining CSS HTML cleanup backlog

### DIFF
--- a/docs/engineering/CSS_HTML_CLEANUP_STATUS_MAP.md
+++ b/docs/engineering/CSS_HTML_CLEANUP_STATUS_MAP.md
@@ -1,0 +1,160 @@
+# CSS/HTML Cleanup Status Map
+
+**Status:** tracking map only  
+**Related:** Issue #137  
+**Base main SHA:** `ac08f6468e988357518b6cd3f1a3164662522428`
+
+---
+
+## 1. Purpose
+
+This document maps the remaining CSS/HTML cleanup backlog tracked under Issue #137.
+
+It is not an implementation plan with merge authority. It does not close Issue #137, approve broad CSS rewrites, or modify runtime behavior. It exists to separate completed, in-progress, and remaining cleanup work so that later PRs can stay small and reviewable.
+
+This PR is docs-only.
+
+---
+
+## 2. Completed or in-progress references
+
+| Reference | Status | Role in #137 cleanup |
+|---|---|---|
+| PR #302 — global CSS hardening strategy v1 | Merged | Added the initial `GLOBAL_CSS_HARDENING_STRATEGY.md` strategy document. |
+| PR #347 — global CSS hardening strategy v2 | Open / draft at time of mapping | Expands the global CSS strategy with token, ready-class, icon hiding, transition, and PR split decisions. |
+| PR #328 — editor overrides formatting-only cleanup | Completed/in progress reference | Formatting-only cleanup around editor overrides. It is not a role-based relocation implementation. |
+| PR #285 — my-trees inline display cleanup history | Historical reference | Prior My Trees display-state cleanup context; use only as history when deciding remaining My Trees cleanup. |
+| PR #350 — my-trees class display state cleanup | In progress | Expected to complete the My Trees inline style/display state cleanup bucket before #137 closure. |
+| PR #353 — browser verification entrypoint docs | Merged / ops docs | Supports verification workflow only. Not a CSS/HTML cleanup implementation. |
+| PR #354 — local auto browser verification runbook | Open / draft at time of mapping | Supports browser verification workflow only. Not a CSS/HTML cleanup implementation. |
+
+Notes:
+
+- PR #353 and PR #354 improve verification readiness. They should not be counted as direct CSS/HTML cleanup implementation for #137.
+- PR #302 and PR #347 are strategy/decision documents. They are prerequisites for safe implementation, not implementation completion.
+
+---
+
+## 3. Remaining cleanup buckets
+
+### 3.1 `global.css` hardening implementation PRs
+
+Remaining work:
+
+- Inventory and consolidate duplicate `:root` token blocks only after strategy review.
+- Audit `--control-*` token declarations and usage before any removal or relocation.
+- Evaluate Material Symbols ready-class split between `.ms-fonts-loaded` and `html.material-symbols-ready`.
+- Treat global `.material-symbols-outlined` hiding rule as high-risk and avoid behavior changes without browser smoke.
+- Keep `transition: none` changes out of structural hardening PRs; route them to UX polish only.
+
+Rules:
+
+- One risk area per PR.
+- No broad CSS split.
+- No selector/property/value behavior change mixed with docs or audit-only PRs.
+- Desktop and mobile smoke required for any CSS behavior change.
+
+### 3.2 Editor overrides role-based relocation audit/implementation
+
+Remaining work:
+
+- Audit which editor override rules are truly editor-owned versus global/shared.
+- Decide whether any override belongs in a page owner CSS file or should remain in its current owner file.
+- Move rules only after ownership is explicit.
+
+Rules:
+
+- Do not combine override relocation with editor JS refactors.
+- Do not combine override relocation with global token cleanup.
+- If visual behavior changes, browser smoke is required on editor page.
+
+### 3.3 Editor inline event handler cleanup
+
+Remaining work:
+
+- Identify remaining inline event handlers in editor-related HTML or generated markup.
+- Move behavior to JS modules only after current ownership and script order are understood.
+- Preserve editor runtime and fallback behavior.
+
+Rules:
+
+- This is JS/HTML behavior cleanup, not CSS cleanup.
+- Do not mix with Editor fallback/global-state migration.
+- Do not mix with CSS override relocation.
+
+### 3.4 My Trees inline style cleanup completion via PR #350
+
+Remaining work:
+
+- Complete PR #350 or equivalent My Trees class/display state cleanup.
+- Confirm no JS/CSS/page runtime regression.
+- Verify visual state behavior if any display-state behavior changed.
+
+Rules:
+
+- Do not duplicate PR #350 work in a separate branch unless PR #350 is abandoned or explicitly superseded.
+- Keep My Trees cleanup separate from Search/Browse and Editor cleanup.
+
+---
+
+## 4. Recommended sequence
+
+Recommended sequence before considering Issue #137 closure:
+
+1. Finish PR #350 or explicitly supersede it with a scoped My Trees cleanup PR.
+2. Complete editor inline event handler cleanup as a separate scoped PR.
+3. Land global CSS minimal hardening PRs one at a time, following PR #302/#347 strategy constraints.
+4. Perform editor overrides relocation audit.
+5. Implement editor overrides relocation only if the audit identifies safe ownership moves.
+6. Re-evaluate Issue #137.
+7. If remaining work is still broad, split the leftovers into new specific issues rather than closing #137 prematurely.
+
+---
+
+## 5. Closure criteria for Issue #137
+
+Do not close Issue #137 until at least one of these is true:
+
+- all remaining cleanup buckets in this document are complete and verified; or
+- the remaining buckets are explicitly split into new issues with clear ownership and acceptance criteria; or
+- CTO approves reducing #137 to a tracking-only issue and records that decision separately.
+
+Close keywords must not be used by this document.
+
+---
+
+## 6. Non-goals
+
+This status map does not:
+
+- change CSS;
+- change JS;
+- change HTML;
+- change runtime behavior;
+- close Issue #137;
+- approve broad CSS splitting;
+- approve token replacement implementation;
+- approve editor fallback migration;
+- modify PR #7;
+- modify prototype/reference/demo/variant paths.
+
+---
+
+## 7. Guardrails
+
+Future cleanup PRs must preserve these guardrails:
+
+- No broad `global.css` split.
+- No unrelated JS/CSS/HTML changes bundled into one PR.
+- No runtime/Auth/API behavior changes in CSS cleanup PRs.
+- No prototype/reference/demo/variant path changes unless explicitly approved.
+- PR #7 remains untouched unless a future CTO-approved task explicitly says otherwise.
+- Verification must distinguish docs-only, visual-only, and behavior-changing PRs.
+
+---
+
+## 8. Final status
+
+Issue #137 remains open.
+
+Current recommended next operational step: finish PR #350 or determine whether it should be superseded, then proceed to editor inline event handler cleanup and global CSS hardening implementation in separate, narrow PRs.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -24,11 +24,12 @@
 5. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
 6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
 7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-8. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-9. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+8. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 남은 작업 순서
+9. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+10. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+11. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+12. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+13. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -43,6 +44,7 @@
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
+| [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) | Issue #137 CSS/HTML cleanup backlog의 completed/in-progress/remaining bucket과 recommended sequence |
 | [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
 | [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
@@ -71,6 +73,7 @@
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
+- #137 CSS/HTML cleanup closure 판단은 `CSS_HTML_CLEANUP_STATUS_MAP.md`에서 남은 cleanup bucket과 recommended sequence를 먼저 확인합니다.
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
 - #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.


### PR DESCRIPTION
## Summary
- Add a status map for remaining Issue #137 CSS/HTML cleanup work.
- Separate completed, in-progress, and remaining cleanup buckets.
- Clarify that #350 and future editor/global CSS PRs are still required before #137 closure.

## Scope
- Docs-only.
- No CSS/JS/HTML/runtime changes.
- No issue close.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #137

## Verification
- [ ] git diff --check
- [x] docs-only changes
- [x] changed files limited to cleanup status map docs/index links
- [x] no CSS/JS/HTML/runtime changes
- [x] #350 remains in-progress and is mapped as required before #137 closure
- [x] PR #7/prototype/reference/demo/variant paths untouched
- [x] no close keywords for #137

## Notes
- Changed files are limited to `docs/engineering/CSS_HTML_CLEANUP_STATUS_MAP.md` and `docs/engineering/engineering_index.md`.
- This PR does not implement cleanup, close #137, or touch PR #7/prototype/reference/demo/variant paths.
- Current branch is diverged from latest `main`; index reconcile is required before merge readiness.