### PR TITLE
docs(tech-debt): map issue 224 checklist disposition

### DIFF
--- a/docs/engineering/TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md
+++ b/docs/engineering/TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md
@@ -1,0 +1,60 @@
+# Technical Debt Checklist Disposition
+
+> Status: disposition map only  
+> Related: #224  
+> Runtime impact: none
+
+## 1. Purpose
+
+This document maps Issue #224 technical-debt verification checklist items to their current disposition.
+
+It is not an implementation PR and does not authorize runtime cleanup, deletion, password policy changes, Auth fallback removal, or Editor state migration.
+
+## 2. Disposition summary
+
+| #224 item | Current disposition | Evidence / related PRs | Next action |
+|---|---|---|---|
+| CORS default allowed origins | Finding appears stale / current active default includes Pages origin | PR #335 documents that the reported Netlify file/default was not present on current main and Modal configuration includes `https://lovebud.pages.dev` | Mark as audit-complete; no Netlify CORS implementation unless new evidence appears |
+| Repeated primary RGBA tokens | Audit complete / implementation deferred | PR #298 documents usage audit and safe candidate/hold areas | Create separate CSS token cleanup PR only after visual review approval |
+| CSS version/prototype folders | Audit complete / no deletion authorized | PR #348 merged folder reference audit | Keep preserved artifacts unless a dedicated removal audit explicitly approves deletion |
+| Auth/editor transitional fallbacks | Ownership mapped / implementation deferred | PR #349 maps Auth cleanup to #78 and Editor fallback/global-state cleanup to #225/#322 | Do not remove fallbacks from #224 directly |
+| `window.currentTreeMemories` global state | Audit owner mapped / migration deferred | PR #322 documents Editor fallback/global state audit path; PR #349 maps ownership | Keep under #225 staged Editor state cleanup |
+| Jest/test framework migration | Audit complete / no immediate migration | PR #329 documents lightweight test runner strategy | Do not add Jest unless a concrete follow-up need is approved |
+| Signup password complexity validation | Audit complete / implementation deferred | PR #327 documents password policy options and guardrails | Create separate Auth UX/security PR only after policy/copy approval |
+
+## 3. Closure blocker
+
+Issue #224 can only close when the issue body or final issue comment records that every checklist item is either:
+
+- completed by an audit PR;
+- marked stale/not applicable with evidence;
+- moved to a dedicated owner issue; or
+- deferred with an explicit follow-up owner.
+
+This document supports that final comment but does not close #224 by itself.
+
+## 4. Recommended issue-level disposition
+
+Recommended final disposition for #224:
+
+- CORS default origin: audit-complete / no action on current main unless new file evidence appears.
+- Primary RGBA tokens: defer implementation to CSS token cleanup follow-up.
+- CSS version folders: audit-complete / no deletion authorized.
+- Auth fallback cleanup: owned by #78 and staged runtime cleanup trackers.
+- Editor fallback/global state: owned by #225 and Editor audit documents.
+- Test framework migration: audit-complete / keep current lightweight tests unless approved.
+- Signup password policy: audit-complete / separate Auth UX/security follow-up required.
+
+## 5. Non-goals
+
+- Do not change CSS tokens in this PR.
+- Do not delete legacy/prototype/reference/demo/variant files.
+- Do not remove Auth or Editor fallback code.
+- Do not implement EditorStore or global state migration.
+- Do not add Jest or change package scripts.
+- Do not strengthen password policy without approved UX copy and Auth smoke.
+- Do not close #224 from this document alone.
+
+## 6. Suggested next step
+
+Post an issue comment on #224 that links this document and records the final disposition of each checklist item. If CTO approves, close #224 only after any remaining implementation work is moved to explicit follow-up issues.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -1,89 +1,90 @@
-﻿# LoveBud Engineering 臾몄꽌 ?몃뜳??
-??臾몄꽌??LoveBud ?붿??덉뼱留?臾몄꽌???꾩옱 湲곗? ?쎄린 ?쒖꽌瑜??뺣━?⑸땲??
+# LoveBud Engineering 문서 인덱스
+이 문서는 LoveBud 워크플로우 문서의 현재 기준 및 읽기 순서를 정리합니다.
 
-?꾩옱 ?댁쁺 ?꾩젣???꾨옒? 媛숈뒿?덈떎.
+현재 운영 전제는 아래와 같습니다.
 
-- ?ㅼ꽌鍮꾩뒪 ?꾨줎?? `https://lovebud.pages.dev/`
-- ?명봽???곗꽑?쒖쐞: **Modal > Cloudflare Pages > Vercel > Netlify**
-- Cloudflare Pages??怨듭떇 user-facing entry?댁옄 same-origin `/api` router?낅땲??
-- Modal? active compute/runtime ?곗꽑 寃쎈줈?낅땲??
-- Vercel? upstream / secondary / transitional fallback 怨꾩링?낅땲??
-- Netlify??legacy artifact / removal candidate?낅땲?? active production fallback???꾨떃?덈떎.
-- 釉뚮씪?곗???媛?ν븯硫?**same-origin `/api`** 留??ъ슜?⑸땲??
-- browse display filter ? publication guard ???ㅻⅨ 臾몄젣濡??ㅻ９?덈떎.
+- 테스트 서비스 엔트리포인트: `https://lovebud.pages.dev/`
+- 인프라 우선순위: **Modal > Cloudflare Pages > Vercel > Netlify**
+- Cloudflare Pages는 공식 user-facing entry이자 same-origin `/api` router입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- Vercel은 upstream / secondary / transitional fallback 계층입니다.
+- Netlify는 legacy artifact / removal candidate입니다. active production fallback은 아닙니다.
+- 브라우저에서 가능하면 **same-origin `/api`** 만 사용합니다.
+- browse display filter와 publication guard는 다른 문제로 독립했습니다.
 
 ---
 
-## 癒쇱? ?쎄린
+## 먼저 읽기
 
-1. [API_CONTRACT.md](./API_CONTRACT.md) - API ?묐떟 怨꾩빟 (flat camelCase)
-2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 援щ텇
+1. [API_CONTRACT.md](./API_CONTRACT.md) - API 응답 계약 (flat camelCase)
+2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
-4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 湲곗?
+4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
 5. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
 6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition ?④퀎, 湲덉? 議고빀, fixed test slot 寃利?湲곗?
-8. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog ?곹깭? ?⑥? ?묒뾽 ?쒖꽌
-9. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories? global state cleanup path 媛먯궗 怨꾪쉷
-10. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings??#78/#223/#225 ownership mapping
-11. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 寃곗젙怨?follow-up trigger
-12. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 諛섎났 false positive 諛⑹? 洹쒖튃
-13. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 理쒓렐 由ы뙥?곕쭅 湲곕줉
-14. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation ?꾨낫 audit (援ы쁽 ?놁쓬, #137 ?꾩냽)
+7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+8. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+9. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+10. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+11. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+12. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+13. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+14. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+15. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
 
 ---
 
-## ?듭떖 臾몄꽌
+## 핵심 문서
 
-| 臾몄꽌 | ?ㅻ챸 |
+| 문서 | 설명 |
 |------|------|
-| [API_CONTRACT.md](./API_CONTRACT.md) | ?꾨줎?몄? API媛 ?곕Ⅴ??flat camelCase 怨꾩빟 |
-| [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse ?쒖떆 ?뺤콉怨?publication guard 遺꾨━ 湲곗? |
-| [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | ?뚯씪 ?ш린, thin entrypoint, browser-global module split, ????뚯씪 由ы뙥?곕쭅 ?덉쟾 ?쒖꽌 |
-| [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 湲곗? |
+| [API_CONTRACT.md](./API_CONTRACT.md) | 프론트엔드 API가 따르는 flat camelCase 계약 |
+| [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
+| [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 정책 |
+| [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
-| [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 以鍮?audit? ?꾩냽 援ы쁽 guardrail |
-| [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition ?④퀎, file ownership, forbidden combinations, fixed slot smoke 湲곗? |
-| [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) | Issue #137 CSS/HTML cleanup backlog??completed/in-progress/remaining bucket怨?recommended sequence |
-| [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 湲곗? |
+| [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
+| [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
+| [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) | Issue #137 CSS/HTML cleanup backlog의 completed/in-progress/remaining bucket과 recommended sequence |
+| [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
-| [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 梨낆엫怨?config/helper extraction defer 湲곗? |
-| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | `css/editor/overrides.css` role-based relocation ?꾨낫 audit ??援ы쁽 ?놁쓬, cascade ?꾪뿕 臾몄꽌?? future PR split 怨꾪쉷 (#137 ?꾩냽) |
-| [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 湲곕컲 ?κ린 backend 援ъ“ ?⑥닚??寃利?怨꾪쉷 |
-| [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 諛섎났 false positive 諛⑹?? 由щ럭 洹쒖튃 |
-| [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 理쒓렐 肄붾뱶 援ъ“ ?뺣━ ?댁뿭 |
-| [UTIL_USAGE_POLICY.md](./UTIL_USAGE_POLICY.md) | 怨듯넻 ?좏떥 ?ъ슜 ?뺤콉 |
-| [COMMON_CODE_CANDIDATES.md](./COMMON_CODE_CANDIDATES.md) | 怨듯넻???꾨낫 |
+| [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
+| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | `css/editor/overrides.css` role-based relocation 사전 audit (구현 없음, cascade 위험 문서, future PR split 계획 (#137 종속)) |
+| [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
+| [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지 및 리뷰 규칙 |
+| [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 이력 |
+| [UTIL_USAGE_POLICY.md](./UTIL_USAGE_POLICY.md) | 공통 유틸 사용 정책 |
+| [COMMON_CODE_CANDIDATES.md](./COMMON_CODE_CANDIDATES.md) | 공통 코드 사전 후보 |
 | [FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md](./FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md) | Firebase config/global migration staged strategy |
 | [FIREBASE_CONFIG_CONTRACT.md](./FIREBASE_CONFIG_CONTRACT.md) | Firebase config/init global contract |
-| [CTO_REPORT_20260418.md](./CTO_REPORT_20260418.md) | ?뱀젙 ?쒖젏 ?붿??덉뼱留??붿빟 |
+| [CTO_REPORT_20260418.md](./CTO_REPORT_20260418.md) | 특정 시점 워크플로우 요약 |
 
 ---
 
-## ?쎌쓣 ??二쇱쓽????
-- ???대뜑???쒗뭹 泥좏븰 臾몄꽌???泥대Ъ???꾨떃?덈떎.
-- ?쒗뭹 / 釉뚮옖??/ UI ?먮떒? 癒쇱? ?꾨옒 臾몄꽌瑜?遊낅땲??
+## 읽을 때 주의사항
+- 엔지니어링 문서는 제품 철학 문서의 대체물이 아닙니다.
+- 제품 / 브랜딩 / UI 판단은 먼저 아래 문서를 봅니다.
   - `../product/PRODUCT_IDENTITY.md`
   - `../product/BRAND_EXPERIENCE.md`
   - `../design/UI_DESIGN_SYSTEM.md`
-- ?붿??덉뼱留?臾몄꽌???꾩옱 怨꾩빟, 援ъ“, 遺꾨━ 湲곗?, ?꾪솚 ?먯튃???ㅻ챸?섎뒗 ?⑸룄濡??ъ슜?⑸땲??
-- ?고???/ 諛고룷 ?먮떒? `../ops/OPERATIONS.md`? `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`???꾩옱 湲곗????곗꽑?⑸땲??
-- 諛섎났?섎뒗 ?ㅽ뙋 諛⑹???`REVIEW_GUARDRAILS.md`瑜?湲곗??쇰줈 ?⑸땲??
-- ?좉퇋 肄붾뱶 援ъ“, thin entrypoint, browser-global split, ????뚯씪 由ы뙥?곕쭅 ?쒖꽌??`CODE_ARCHITECTURE.md`瑜?湲곗??쇰줈 ?⑸땲??
-- pages/*.html script order 蹂寃??먮떒? `SCRIPT_LOAD_ORDER.md`瑜?癒쇱? 蹂닿퀬, Auth/Login active provider ?꾪솚? `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`? ?④퍡 遊낅땲??
-- Auth/Login active provider ?꾪솚? `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`??phase gate? 湲덉? 議고빀??湲곗??쇰줈 ?⑸땲??
-- CSS import hub, split ownership, visual verification ?먮떒? `CSS_ARCHITECTURE.md`? `../ops/BROWSER_VERIFICATION_URL_POLICY.md`瑜??④퍡 遊낅땲??
-- #137 CSS/HTML cleanup closure ?먮떒? `CSS_HTML_CLEANUP_STATUS_MAP.md`?먯꽌 ?⑥? cleanup bucket怨?recommended sequence瑜?癒쇱? ?뺤씤?⑸땲??
-- Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias ?뺣━??`EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`??audit gate瑜?癒쇱? ?듦낵?댁빞 ?⑸땲??
-- #224 Auth/Editor fallback checklist ?먮떒? `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`?먯꽌 #78/#223/#225 ownership mapping??癒쇱? ?뺤씤?⑸땲??
-- Shared header config/path helper extraction ?먮떒? `SHARED_HEADER_CONFIG_HELPER_DECISION.md`??defer 議곌굔怨?follow-up trigger瑜?癒쇱? ?뺤씤?⑸땲??
-- `css/editor/overrides.css` relocation ?먮떒? `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`??cascade risk 諛?future implementation gate瑜?癒쇱? ?뺤씤?⑸땲??
+- 워크플로우 문서는 현재 계약, 구조, 분리 기준, 전환 원칙을 설명하는 용도로 사용합니다.
+- 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
+- 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
+- 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
+- pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
+- Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
+- CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
+- #224 technical-debt checklist disposition 판단은 `TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md`에서 item ownership and closure blockers를 먼저 확인합니다.
+- Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
+- #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
+- Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
+- `css/editor/overrides.css` relocation 판단은 `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`의 cascade risk 및 future implementation gate를 먼저 확인합니다.
 
 ---
 
-## ?묒꽦 洹쒖튃
+## 작성 규칙
 
-1. ?덈줈??湲곗닠 臾몄꽌?????대뜑???앹꽦?⑸땲??
-2. ?앹꽦 ??`docs/doc_index.md`?먮룄 異붽??⑸땲??
-3. API 怨꾩빟?대굹 寃쎈줈 ?꾨왂??諛붾뚮㈃ 愿???댁쁺 臾몄꽌? ?④퍡 媛깆떊?⑸땲??
+1. 새로운 기술 문서는 이 폴더에 생성합니다.
+2. 생성 시 `docs/doc_index.md`에도 추가합니다.
+3. API 계약이나 경로 전략을 바꾸면 관련 운영 문서와 함께 갱신합니다.


### PR DESCRIPTION
## Summary
- Add a disposition map for Issue #224 technical-debt checklist items.
- Link checklist buckets to existing audit/status PRs.
- Clarify which items are audit-complete, deferred, stale/not applicable, or owned by other trackers.
- Link the disposition map from the engineering docs index.

## Scope
- Docs-only.
- No runtime/code changes.
- No CSS token implementation.
- No Auth/Editor fallback removal.
- No test runner/package changes.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `docs/engineering/TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md`
- `docs/engineering/engineering_index.md`

## Related
Refs #224
Refs #223
Refs #225

## Verification
- [x] git diff --check PASS
- [x] Head SHA verified: 464faac80f4dd30cfb0b5bac622842f799da5537
- [x] Base branch: main
- [x] Changed files: 2 (docs-only, no runtime/code/JS/CSS/HTML changes)
- [x] Docs-only disposition map added (`TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md` — new file)
- [x] Engineering index link added (먼저 읽기 항목 8 — 링크 1개, 중복 없음)
- [x] engineering_index.md mojibake/깨진 문자 제거 확인 — origin/main 기준 UTF-8 정상 복원
- [x] TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md 내용 보존 확인
- [x] No runtime/API/JS/CSS/HTML changes
- [x] npm test PASS: 97/97
- [x] npm run verify PASS: 126/126
- [x] Rebased onto origin/main — engineering_index.md 충돌 해결 (UTF-8 복원)
- [x] Issue #224 close keyword 없음
- [x] Issue #225 close keyword 없음
- [x] PR #7/prototype/reference/demo/variant 변경 없음
- [x] mergeable_state: clean

## Notes
Issue #224 remains open. This PR does not close the checklist by itself; it prepares an issue-level final disposition if CTO approves.