### PR TITLE
docs(runtime): map staged cleanup disposition

### DIFF
--- a/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
+++ b/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
@@ -1,0 +1,63 @@
+# Staged Runtime Cleanup Disposition
+
+> Status: disposition map only  
+> Related: #225  
+> Runtime impact: none
+
+## 1. Purpose
+
+This document maps Issue #225 staged runtime cleanup items to their current owners and next steps.
+
+Issue #225 intentionally does not authorize immediate implementation. It tracks valid cleanup directions that must wait until Auth/Login, Editor, script-load-order, and Cloudflare Pages runtime contracts are stable.
+
+## 2. Current disposition summary
+
+| #225 stage | Current disposition | Evidence / related PRs | Next action |
+|---|---|---|---|
+| Stage 1 — Auth/Login legacy fallback reduction | Deferred / owned by #78 | PR #349 maps Auth fallback cleanup ownership to #78 and keeps runtime unchanged | Do not remove Auth fallbacks under #225; continue under #78 after module contracts stabilize |
+| Stage 1 — Editor fallback removal | Audited / implementation deferred | PR #322 documents Editor fallback/global state audit; PR #349 maps ownership | Future implementation only after module coverage and editor browser smoke matrix are ready |
+| Stage 2 — Editor global state encapsulation | Audited / migration deferred | PR #322 covers `window.currentTreeMemories` and `window.currentTreeData` audit plan | Create a dedicated EditorStore/call-site inventory implementation tracker before code changes |
+| Stage 3 — optional bundler feasibility | Audit complete / no immediate build-tool adoption | PR #324 documents static multipage bundler feasibility | Do not introduce Vite/Rollup unless a later implementation proposal is approved |
+| Stage 4 — password policy strengthening | Audit complete / separate Auth UX/security follow-up needed | PR #327 documents signup password policy options and guardrails | Create separate policy/copy/i18n/validation PRs only after product/security approval |
+
+## 3. Recommended tracker decision
+
+Issue #225 should usually remain open while staged runtime cleanup is still active.
+
+If CTO wants to close #225, first split remaining work into dedicated owner issues:
+
+1. Auth fallback reduction — owned by #78 or a dedicated Auth fallback implementation issue.
+2. Editor fallback removal — dedicated Editor fallback implementation tracker after #322.
+3. Editor global state encapsulation — dedicated EditorStore/call-site inventory tracker.
+4. Bundler adoption — no implementation unless a new build-tool proposal is approved.
+5. Password policy strengthening — dedicated Auth UX/security implementation tracker after copy/policy approval.
+
+## 4. Non-goals
+
+This disposition does not authorize:
+
+- modifying `js/auth.js`;
+- modifying `js/editor.js`;
+- removing fallback code;
+- adding EditorStore;
+- changing memory persistence semantics;
+- converting scripts to `type="module"`;
+- adding Vite/Rollup;
+- changing Cloudflare Pages routing or `/api/*` behavior;
+- strengthening signup validation without UX copy and Auth smoke;
+- touching PR #7 or prototype/reference/demo/variant paths;
+- closing #225 from this document alone.
+
+## 5. Closure conditions
+
+#225 can be considered for closure only after:
+
+- Auth/Login fallback reduction is fully owned by #78 or a dedicated issue;
+- Editor fallback removal and Editor global state migration have separate implementation trackers;
+- bundler feasibility is either explicitly deferred or moved to a future build-tool tracker;
+- password policy strengthening is moved to a dedicated Auth UX/security issue;
+- a final issue comment records the disposition of every stage.
+
+## 6. Recommended immediate next step
+
+Post a #225 issue comment linking this disposition map and stating whether CTO wants to keep #225 open as the umbrella tracker or split-and-close it after follow-up issues are created.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -24,11 +24,12 @@
 5. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
 6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
 7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-8. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-9. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+8. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup disposition map
+9. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+10. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+11. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+12. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+13. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 
 ---
 
@@ -43,6 +44,7 @@
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
+| [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) | Issue #225 staged runtime cleanup owners, deferred implementation gates, and closure conditions |
 | [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
 | [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
@@ -71,6 +73,7 @@
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
+- #225 staged runtime cleanup 판단은 `STAGED_RUNTIME_CLEANUP_DISPOSITION.md`에서 owner split and deferred implementation gates를 먼저 확인합니다.
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
 - #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.


### PR DESCRIPTION
## Summary
- Add a disposition map for Issue #225 staged runtime cleanup work.
- Record current owners for Auth fallback, Editor fallback/global state, bundler feasibility, and password policy items.
- Clarify that implementation remains deferred until dedicated owner issues or PRs are approved.
- Link the disposition map from the engineering docs index.

## Scope
- Docs-only.
- No runtime/code changes.
- No Auth/Editor fallback removal.
- No EditorStore implementation.
- No build-tool/package changes.
- No password policy implementation.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md`
- `docs/engineering/engineering_index.md`

## Related
Refs #225
Refs #224
Refs #223
Refs #78

## Verification
- [ ] git diff --check
- [x] Docs-only disposition map added
- [x] Engineering index link added
- [x] No runtime/code changes
- [x] No close keywords for #225

## Notes
Issue #225 remains open. This PR does not close the staged cleanup tracker by itself; it documents owner split and closure conditions.

Current branch is diverged from latest `main`; index reconcile is required before merge readiness.