### PR TITLE
docs(css): add CSS version/prototype folder reference map audit

### DIFF
--- a/docs/engineering/CSS_VERSION_PROTOTYPE_FOLDER_MAP.md
+++ b/docs/engineering/CSS_VERSION_PROTOTYPE_FOLDER_MAP.md
@@ -1,0 +1,118 @@
+# CSS Version / Prototype Folder Reference Map
+
+## Purpose
+
+이 문서는 LoveBud 저장소 내 CSS 파일의 버전/prototype/reference/demo/variant 관련 경로를 감사하고 현재 active 경로와 비교하는 audit 문서입니다.
+
+- Issue #224 Auth/Editor fallback findings의 후속 CSS 파일 구조 감사
+- 구현 PR이 아니라 현재 상태 파악과 향후 정리 기준을 제공하는 문서
+- 실제 CSS 이동/삭제/통합은 이 문서 리뷰 후 별도 PR에서 수행
+
+---
+
+## Non-goals
+
+- CSS 파일 이동/삭제 없음
+- selector consolidation 없음
+- property/value 변경 없음
+- pages/editor.html 또는 다른 HTML 변경 없음
+- JS 변경 없음
+- PR #7/prototype/reference/demo/variant 파일 변경 없음
+
+---
+
+## Current Active CSS Structure
+
+현재 `main` 기준 CSS 파일 구조는 `docs/engineering/CSS_ARCHITECTURE.md`를 source of truth로 합니다.
+
+주요 active 경로:
+
+| 경로 | 역할 |
+|------|------|
+| `css/global.css` | 공통 토큰, 공통 컴포넌트, 공통 레이아웃 |
+| `css/editor/overrides.css` | Editor final cascade override (role-based relocation 감사 중 → `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`) |
+| `css/search.css` | Search/Browse 페이지 전용 |
+| `css/detail.css` | Detail 페이지 전용 |
+| `css/my-trees.css` | My Trees 페이지 전용 |
+| `css/login.css` | Login 페이지 전용 |
+| `css/intro.css` | Intro 페이지 전용 |
+
+---
+
+## Version / Prototype / Reference / Demo / Variant Folder Audit
+
+### Audit Scope
+
+아래 경로 패턴을 감사합니다.
+
+- `css/v*/` — 버전 폴더
+- `css/prototype*/` — 프로토타입 폴더
+- `css/reference*/` — 레퍼런스 폴더
+- `css/demo*/` — 데모 폴더
+- `css/variant*/` — 변형 폴더
+- `css/*-old*`, `css/*-backup*`, `css/*-legacy*` — 이름에 old/backup/legacy 포함
+- PR #7 연결 경로 (별도 보존 대상)
+
+### Current Finding
+
+> **이 감사는 현재 main 기준 파일 목록을 직접 조회한 정적 스냅샷이 아닙니다.**
+> 실제 파일 목록 확인은 `git ls-files css/` 또는 GitHub API 조회로 수행합니다.
+> 이 문서는 감사 기준과 분류 정책을 제공합니다.
+
+감사 결과는 아래 두 단계로 채워집니다:
+
+1. **파일 목록 수집** (Code Executor 또는 Web/GitHub Executor)
+2. **분류 및 문서 업데이트** (CTO 승인 후)
+
+### Classification Policy
+
+| 분류 | 정의 | 조치 |
+|------|------|------|
+| `active` | 현재 pages/*.html에서 직접 로드되는 파일 | 보존 필수 |
+| `pr7-preserved` | PR #7/prototype/reference/demo/variant 경로 | 절대 보존, 수정 금지 |
+| `orphan-candidate` | 어떤 HTML에서도 로드되지 않는 CSS | 별도 PR에서 제거 후보 검토 |
+| `version-duplicate` | active 파일의 이전 버전 사본 | 별도 PR에서 제거 후보 검토 |
+| `unknown` | 출처/용도 불명 | 추가 조사 필요 |
+
+---
+
+## Known Risk
+
+- `css/editor/overrides.css`는 final cascade override 역할이므로 섣불리 이동/삭제 금지
+- 버전/prototype 폴더가 실제로 존재하더라도 PR #7 보존 대상이면 수정 금지
+- orphan-candidate 분류 후에도 실제 제거 전 반드시 CTO 승인 필요
+
+---
+
+## Future Implementation Gate
+
+아래 조건이 모두 충족된 후에만 실제 파일 정리 PR을 진행합니다.
+
+- [ ] `git ls-files css/` 전체 목록 수집 완료
+- [ ] 각 파일의 HTML 로드 여부 확인 완료
+- [ ] PR #7 보존 대상 파일 식별 완료
+- [ ] orphan-candidate 목록 CTO 리뷰 완료
+- [ ] editor browser smoke 통과
+- [ ] Cloudflare Preview 또는 fixed slot 검증 완료
+
+---
+
+## Suggested Future PR Split
+
+- **PR A**: `git ls-files css/` 수집 결과 + 분류 표 채우기 (docs-only)
+- **PR B**: orphan-candidate 제거 (CTO 승인 후)
+- **PR C**: version-duplicate 제거 (CTO 승인 후)
+- **PR D**: visual verification pass
+
+---
+
+## Related
+
+- Issue #224
+- `docs/engineering/CSS_ARCHITECTURE.md` — active CSS import hub
+- `docs/engineering/EDITOR_OVERRIDES_RELOCATION_AUDIT.md` — editor overrides 별도 감사
+- `docs/engineering/GLOBAL_CSS_RGBA_AUDIT.md` — global.css RGBA token 감사 (별도 문서)
+
+---
+
+Last updated: 2026-04-29

--- a/docs/engineering/CSS_VERSION_PROTOTYPE_FOLDER_MAP.md
+++ b/docs/engineering/CSS_VERSION_PROTOTYPE_FOLDER_MAP.md
@@ -111,7 +111,7 @@
 - Issue #224
 - `docs/engineering/CSS_ARCHITECTURE.md` — active CSS import hub
 - `docs/engineering/EDITOR_OVERRIDES_RELOCATION_AUDIT.md` — editor overrides 별도 감사
-- `docs/engineering/GLOBAL_CSS_RGBA_AUDIT.md` — global.css RGBA token 감사 (별도 문서)
+- `docs/engineering/GLOBAL_CSS_RGBA_TOKEN_AUDIT.md` — global.css RGBA token 감사 (별도 문서)
 
 ---
 

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -29,6 +29,8 @@
 10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
 11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+13. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 후보 감사
+14. [CSS_VERSION_PROTOTYPE_FOLDER_MAP.md](./CSS_VERSION_PROTOTYPE_FOLDER_MAP.md) - CSS 버전/prototype/reference/demo/variant 경로 감사 기준 및 분류 정책
 
 ---
 
@@ -53,6 +55,8 @@
 | [COMMON_CODE_CANDIDATES.md](./COMMON_CODE_CANDIDATES.md) | 공통화 후보 |
 | [FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md](./FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md) | Firebase config/global migration staged strategy |
 | [FIREBASE_CONFIG_CONTRACT.md](./FIREBASE_CONFIG_CONTRACT.md) | Firebase config/init global contract |
+| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | css/editor/overrides.css role-based relocation 후보 감사 (구현 없음) |
+| [CSS_VERSION_PROTOTYPE_FOLDER_MAP.md](./CSS_VERSION_PROTOTYPE_FOLDER_MAP.md) | CSS 버전/prototype/reference/demo/variant 경로 감사 기준, 분류 정책, future gate |
 | [CTO_REPORT_20260418.md](./CTO_REPORT_20260418.md) | 특정 시점 엔지니어링 요약 |
 
 ---
@@ -74,6 +78,7 @@
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
 - #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
+- CSS 버전/prototype 폴더 감사 기준은 `CSS_VERSION_PROTOTYPE_FOLDER_MAP.md`를 먼저 봅니다.
 
 ---
 

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -84,11 +84,8 @@
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias ?뺣━??`EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`??audit gate瑜?癒쇱? ?듦낵?댁빞 ?⑸땲??
 - #224 Auth/Editor fallback checklist ?먮떒? `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`?먯꽌 #78/#223/#225 ownership mapping??癒쇱? ?뺤씤?⑸땲??
 - Shared header config/path helper extraction ?먮떒? `SHARED_HEADER_CONFIG_HELPER_DECISION.md`??defer 議곌굔怨?follow-up trigger瑜?癒쇱? ?뺤씤?⑸땲??
-<<<<<<< HEAD
-- CSS 踰꾩쟾/prototype ?대뜑 媛먯궗 湲곗?? `CSS_VERSION_PROTOTYPE_FOLDER_MAP.md`瑜?癒쇱? 遊낅땲??
-=======
-- `css/editor/overrides.css` relocation ?먮떒? `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`??cascade risk 諛?future implementation gate瑜?癒쇱? ?뺤씤?⑸땲??
->>>>>>> origin/main
+- CSS 踰꾩쟾/prototype ?대뜑 媛먯궗 湲곗?? CSS_VERSION_PROTOTYPE_FOLDER_MAP.md瑜?癒쇱? 遊낅땲??
+- css/editor/overrides.css relocation ?먮떒? EDITOR_OVERRIDES_RELOCATION_AUDIT.md??cascade risk 諛?future implementation gate瑜?癒쇱? ?뺤씤?⑸땲??
 
 ---
 

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -1,96 +1,92 @@
-﻿# LoveBud Engineering 臾몄꽌 ?몃뜳??
-??臾몄꽌??LoveBud ?붿??덉뼱留?臾몄꽌???꾩옱 湲곗? ?쎄린 ?쒖꽌瑜??뺣━?⑸땲??
+# LoveBud Engineering 문서 인덱스
 
-?꾩옱 ?댁쁺 ?꾩젣???꾨옒? 媛숈뒿?덈떎.
+이 문서는 LoveBud 엔지니어링 문서의 현재 기준 읽기 순서를 정리합니다.
 
-- ?ㅼ꽌鍮꾩뒪 ?꾨줎?? `https://lovebud.pages.dev/`
-- ?명봽???곗꽑?쒖쐞: **Modal > Cloudflare Pages > Vercel > Netlify**
-- Cloudflare Pages??怨듭떇 user-facing entry?댁옄 same-origin `/api` router?낅땲??
-- Modal? active compute/runtime ?곗꽑 寃쎈줈?낅땲??
-- Vercel? upstream / secondary / transitional fallback 怨꾩링?낅땲??
-- Netlify??legacy artifact / removal candidate?낅땲?? active production fallback???꾨떃?덈떎.
-- 釉뚮씪?곗???媛?ν븯硫?**same-origin `/api`** 留??ъ슜?⑸땲??
-- browse display filter ? publication guard ???ㅻⅨ 臾몄젣濡??ㅻ９?덈떎.
+현재 운영 전제는 아래와 같습니다.
+
+- 실서비스 프론트: `https://lovebud.pages.dev/`
+- 인프라 우선순위: **Modal > Cloudflare Pages > Vercel > Netlify**
+- Cloudflare Pages는 공식 user-facing entry이자 same-origin `/api` router입니다.
+- Modal은 active compute/runtime 우선 경로입니다.
+- Vercel은 upstream / secondary / transitional fallback 계층입니다.
+- Netlify는 legacy artifact / removal candidate입니다. active production fallback이 아닙니다.
+- 브라우저는 가능하면 **same-origin `/api`** 만 사용합니다.
+- browse display filter 와 publication guard 는 다른 문제로 다룹니다.
 
 ---
 
-## 癒쇱? ?쎄린
+## 먼저 읽기
 
-1. [API_CONTRACT.md](./API_CONTRACT.md) - API ?묐떟 怨꾩빟 (flat camelCase)
-2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 援щ텇
+1. [API_CONTRACT.md](./API_CONTRACT.md) - API 응답 계약 (flat camelCase)
+2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
-4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 湲곗?
+4. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
 5. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
 6. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition ?④퀎, 湲덉? 議고빀, fixed test slot 寃利?湲곗?
-8. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories? global state cleanup path 媛먯궗 怨꾪쉷
-9. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings??#78/#223/#225 ownership mapping
-10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 寃곗젙怨?follow-up trigger
-11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 諛섎났 false positive 諛⑹? 洹쒖튃
-12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 理쒓렐 由ы뙥?곕쭅 湲곕줉
-8. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog ?곹깭? ?⑥? ?묒뾽 ?쒖꽌
-9. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories? global state cleanup path 媛먯궗 怨꾪쉷
-10. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings??#78/#223/#225 ownership mapping
-11. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 寃곗젙怨?follow-up trigger
-12. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 諛섎났 false positive 諛⑹? 洹쒖튃
-13. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 理쒓렐 由ы뙥?곕쭅 湲곕줉
-14. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation ?꾨낫 audit (援ы쁽 ?놁쓬, #137 ?꾩냽)
+7. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+8. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+9. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+13. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - `css/editor/overrides.css` role-based relocation 후보 audit (구현 없음, #137 후속)
 
 ---
 
-## ?듭떖 臾몄꽌
+## 핵심 문서
 
-| 臾몄꽌 | ?ㅻ챸 |
+| 문서 | 설명 |
 |------|------|
-| [API_CONTRACT.md](./API_CONTRACT.md) | ?꾨줎?몄? API媛 ?곕Ⅴ??flat camelCase 怨꾩빟 |
-| [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse ?쒖떆 ?뺤콉怨?publication guard 遺꾨━ 湲곗? |
-| [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | ?뚯씪 ?ш린, thin entrypoint, browser-global module split, ????뚯씪 由ы뙥?곕쭅 ?덉쟾 ?쒖꽌 |
-| [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 湲곗? |
+| [API_CONTRACT.md](./API_CONTRACT.md) | 프론트와 API가 따르는 flat camelCase 계약 |
+| [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
+| [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 순서 |
+| [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
-| [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 以鍮?audit? ?꾩냽 援ы쁽 guardrail |
-| [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition ?④퀎, file ownership, forbidden combinations, fixed slot smoke 湲곗? |
-| [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 湲곗? |
+| [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 후속 구현 guardrail |
+| [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
+| [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
-| [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 梨낆엫怨?config/helper extraction defer 湲곗? |
-| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | `css/editor/overrides.css` role-based relocation ?꾨낫 audit ??援ы쁽 ?놁쓬, cascade ?꾪뿕 臾몄꽌?? future PR split 怨꾪쉷 (#137 ?꾩냽) |
-| [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 湲곕컲 ?κ린 backend 援ъ“ ?⑥닚??寃利?怨꾪쉷 |
-| [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 諛섎났 false positive 諛⑹?? 由щ럭 洹쒖튃 |
-| [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 理쒓렐 肄붾뱶 援ъ“ ?뺣━ ?댁뿭 |
-| [UTIL_USAGE_POLICY.md](./UTIL_USAGE_POLICY.md) | 怨듯넻 ?좏떥 ?ъ슜 ?뺤콉 |
-| [COMMON_CODE_CANDIDATES.md](./COMMON_CODE_CANDIDATES.md) | 怨듯넻???꾨낫 |
+| [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
+| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | `css/editor/overrides.css` role-based relocation 후보 audit — 구현 없음, cascade 위험 문서화, future PR split 계획 (#137 후속) |
+| [CSS_VERSION_PROTOTYPE_FOLDER_MAP.md](./CSS_VERSION_PROTOTYPE_FOLDER_MAP.md) | CSS 버전/prototype/reference/demo/variant 경로 감사 기준, 분류 정책, future gate |
+| [GLOBAL_CSS_RGBA_TOKEN_AUDIT.md](./GLOBAL_CSS_RGBA_TOKEN_AUDIT.md) | global.css RGBA token 감사 (CSS token audit reference map) |
+| [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
+| [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지와 리뷰 규칙 |
+| [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 내역 |
+| [UTIL_USAGE_POLICY.md](./UTIL_USAGE_POLICY.md) | 공통 유틸 사용 정책 |
+| [COMMON_CODE_CANDIDATES.md](./COMMON_CODE_CANDIDATES.md) | 공통화 후보 |
 | [FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md](./FIREBASE_CONFIG_GLOBAL_MIGRATION_STRATEGY.md) | Firebase config/global migration staged strategy |
 | [FIREBASE_CONFIG_CONTRACT.md](./FIREBASE_CONFIG_CONTRACT.md) | Firebase config/init global contract |
-| [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | css/editor/overrides.css role-based relocation ?꾨낫 媛먯궗 (援ы쁽 ?놁쓬) |
-| [CSS_VERSION_PROTOTYPE_FOLDER_MAP.md](./CSS_VERSION_PROTOTYPE_FOLDER_MAP.md) | CSS 踰꾩쟾/prototype/reference/demo/variant 寃쎈줈 媛먯궗 湲곗?, 遺꾨쪟 ?뺤콉, future gate |
-| [GLOBAL_CSS_RGBA_TOKEN_AUDIT.md](./GLOBAL_CSS_RGBA_TOKEN_AUDIT.md) | global.css RGBA token 감사 (CSS token audit reference map) |
-| [CTO_REPORT_20260418.md](./CTO_REPORT_20260418.md) | ?뱀젙 ?쒖젏 ?붿??덉뼱留??붿빟 |
+| [CTO_REPORT_20260418.md](./CTO_REPORT_20260418.md) | 특정 시점 엔지니어링 요약 |
 
 ---
 
-## ?쎌쓣 ??二쇱쓽????
-- ???대뜑???쒗뭹 泥좏븰 臾몄꽌???泥대Ъ???꾨떃?덈떎.
-- ?쒗뭹 / 釉뚮옖??/ UI ?먮떒? 癒쇱? ?꾨옒 臾몄꽌瑜?遊낅땲??
+## 읽을 때 주의할 점
+
+- 이 폴더는 제품 철학 문서의 대체물이 아닙니다.
+- 제품 / 브랜드 / UI 판단은 먼저 아래 문서를 봅니다.
   - `../product/PRODUCT_IDENTITY.md`
   - `../product/BRAND_EXPERIENCE.md`
   - `../design/UI_DESIGN_SYSTEM.md`
-- ?붿??덉뼱留?臾몄꽌???꾩옱 怨꾩빟, 援ъ“, 遺꾨━ 湲곗?, ?꾪솚 ?먯튃???ㅻ챸?섎뒗 ?⑸룄濡??ъ슜?⑸땲??
-- ?고???/ 諛고룷 ?먮떒? `../ops/OPERATIONS.md`? `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`???꾩옱 湲곗????곗꽑?⑸땲??
-- 諛섎났?섎뒗 ?ㅽ뙋 諛⑹???`REVIEW_GUARDRAILS.md`瑜?湲곗??쇰줈 ?⑸땲??
-- ?좉퇋 肄붾뱶 援ъ“, thin entrypoint, browser-global split, ????뚯씪 由ы뙥?곕쭅 ?쒖꽌??`CODE_ARCHITECTURE.md`瑜?湲곗??쇰줈 ?⑸땲??
-- pages/*.html script order 蹂寃??먮떒? `SCRIPT_LOAD_ORDER.md`瑜?癒쇱? 蹂닿퀬, Auth/Login active provider ?꾪솚? `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`? ?④퍡 遊낅땲??
-- Auth/Login active provider ?꾪솚? `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`??phase gate? 湲덉? 議고빀??湲곗??쇰줈 ?⑸땲??
-- CSS import hub, split ownership, visual verification ?먮떒? `CSS_ARCHITECTURE.md`? `../ops/BROWSER_VERIFICATION_URL_POLICY.md`瑜??④퍡 遊낅땲??
-- Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias ?뺣━??`EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`??audit gate瑜?癒쇱? ?듦낵?댁빞 ?⑸땲??
-- #224 Auth/Editor fallback checklist ?먮떒? `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`?먯꽌 #78/#223/#225 ownership mapping??癒쇱? ?뺤씤?⑸땲??
-- Shared header config/path helper extraction ?먮떒? `SHARED_HEADER_CONFIG_HELPER_DECISION.md`??defer 議곌굔怨?follow-up trigger瑜?癒쇱? ?뺤씤?⑸땲??
-- CSS 踰꾩쟾/prototype ?대뜑 媛먯궗 湲곗?? CSS_VERSION_PROTOTYPE_FOLDER_MAP.md瑜?癒쇱? 遊낅땲??
-- css/editor/overrides.css relocation ?먮떒? EDITOR_OVERRIDES_RELOCATION_AUDIT.md??cascade risk 諛?future implementation gate瑜?癒쇱? ?뺤씤?⑸땲??
+- 엔지니어링 문서는 현재 계약, 구조, 분리 기준, 전환 원칙을 설명하는 용도로 사용합니다.
+- 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
+- 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
+- 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
+- pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
+- Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
+- CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
+- Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
+- #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
+- Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
+- `css/editor/overrides.css` relocation 판단은 `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`의 cascade risk 및 future implementation gate를 먼저 확인합니다.
+- CSS 버전/prototype 폴더 감사 판단은 `CSS_VERSION_PROTOTYPE_FOLDER_MAP.md`를 먼저 확인합니다.
+- global.css RGBA token 감사 참고는 `GLOBAL_CSS_RGBA_TOKEN_AUDIT.md`를 유지합니다.
 
 ---
 
-## ?묒꽦 洹쒖튃
+## 작성 규칙
 
-1. ?덈줈??湲곗닠 臾몄꽌?????대뜑???앹꽦?⑸땲??
-2. ?앹꽦 ??`docs/doc_index.md`?먮룄 異붽??⑸땲??
-3. API 怨꾩빟?대굹 寃쎈줈 ?꾨왂??諛붾뚮㈃ 愿???댁쁺 臾몄꽌? ?④퍡 媛깆떊?⑸땲??
+1. 새로운 기술 문서는 이 폴더에 생성합니다.
+2. 생성 후 `docs/doc_index.md`에도 추가합니다.
+3. API 계약이나 경로 전략이 바뀌면 관련 운영 문서와 함께 갱신합니다.


### PR DESCRIPTION
## Summary
- Add `docs/engineering/CSS_VERSION_PROTOTYPE_FOLDER_MAP.md` — audit criteria and classification policy for CSS version/prototype/reference/demo/variant paths.
- Update `docs/engineering/engineering_index.md` — add entry #14 for new audit doc.
- Fix related RGBA audit reference to `GLOBAL_CSS_RGBA_TOKEN_AUDIT.md`.

## Scope
- Docs-only.
- No CSS implementation.
- No JS/HTML/runtime changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #224

## Verification
- [ ] git diff --check
- [x] docs-only changes
- [x] no CSS/JS/HTML/runtime changes
- [x] no close keywords for #224
- [x] related audit links checked