### PR TITLE
docs(audit): map primary RGBA token usage in global.css

### DIFF
--- a/docs/engineering/GLOBAL_CSS_RGBA_TOKEN_AUDIT.md
+++ b/docs/engineering/GLOBAL_CSS_RGBA_TOKEN_AUDIT.md
@@ -1,0 +1,142 @@
+# Global CSS RGBA Token Audit
+
+## Purpose
+
+This document audits repeated direct uses of the primary color RGBA literal in `css/global.css` before any token replacement work.
+
+- Related issue: #224 checklist item #2
+- Scope: audit-only documentation
+- Target pattern: `rgba(144, 73, 81, X)`
+- Implementation status: no CSS changes in this PR
+
+---
+
+## Scope
+
+This audit covers only `css/global.css` on current `main`.
+
+It does not modify:
+
+- `css/global.css`
+- generated CSS
+- prototype/reference/demo/variant CSS
+- runtime HTML/JS/API/Auth/Editor files
+
+---
+
+## Findings
+
+`css/global.css` currently contains **18** direct primary RGBA uses matching `rgba(144, 73, 81, X)`.
+
+| Area / selector | Literal | Current purpose | Replacement candidate |
+|---|---:|---|---|
+| `.btn-primary` | `rgba(144, 73, 81, 0.2)` | primary button shadow | `rgba(var(--primary-rgb), 0.2)` |
+| `.btn-primary:hover` | `rgba(144, 73, 81, 0.3)` | primary button hover shadow | `rgba(var(--primary-rgb), 0.3)` |
+| `.cta-appreciation:hover` | `rgba(144, 73, 81, 0.25)` | appreciation CTA hover shadow | `rgba(var(--primary-rgb), 0.25)` |
+| `.card-appreciation:hover` | `rgba(144, 73, 81, 0.12)` | appreciation card hover shadow | `rgba(var(--primary-rgb), 0.12)` |
+| `.save-status-indicator.saving` | `rgba(144, 73, 81, 0.08)` | saving state background | `rgba(var(--primary-rgb), 0.08)` |
+| `body .btn-primary`, `body .cta-appreciation` | `rgba(144, 73, 81, 0.2)` | PR3 primary CTA shadow | `rgba(var(--primary-rgb), 0.2)` |
+| `body .btn-primary:hover`, `body .cta-appreciation:hover` | `rgba(144, 73, 81, 0.28)` | PR3 primary CTA hover shadow | `rgba(var(--primary-rgb), 0.28)` |
+| `body .btn-outline:hover` | `rgba(144, 73, 81, 0.22)` | outline hover border | `rgba(var(--primary-rgb), 0.22)` |
+| `body .intro-cta-primary` | `rgba(144, 73, 81, 0.2)` | intro CTA shadow | `rgba(var(--primary-rgb), 0.2)` |
+| `body .intro-cta-primary:hover` | `rgba(144, 73, 81, 0.28)` | intro CTA hover shadow | `rgba(var(--primary-rgb), 0.28)` |
+| `body .intro-cta-secondary` | `rgba(144, 73, 81, 0.16)` | intro secondary border | `rgba(var(--primary-rgb), 0.16)` |
+| `body .intro-cta-secondary:hover` | `rgba(144, 73, 81, 0.28)` | intro secondary hover border | `rgba(var(--primary-rgb), 0.28)` |
+| `body .tag-chip:hover` | `rgba(144, 73, 81, 0.06)` | tag chip hover background | `rgba(var(--primary-rgb), 0.06)` |
+| `body .tag-chip:hover` | `rgba(144, 73, 81, 0.18)` | tag chip hover border | `rgba(var(--primary-rgb), 0.18)` |
+| `body .preview-badge`, `body .growing-trees-badge`, `body .browse-results-badge`, `body .how-to-badge` | `rgba(144, 73, 81, 0.06)` | badge background | `rgba(var(--primary-rgb), 0.06)` |
+| same badge group | `rgba(144, 73, 81, 0.1)` | badge border | `rgba(var(--primary-rgb), 0.1)` |
+| `body .emotion-tag-refined` | `rgba(144, 73, 81, 0.08)` | emotion tag background | `rgba(var(--primary-rgb), 0.08)` |
+| `body .emotion-tag-refined` | `rgba(144, 73, 81, 0.12)` | emotion tag border | `rgba(var(--primary-rgb), 0.12)` |
+
+---
+
+## Existing token candidate
+
+`css/global.css` already uses `rgba(var(--primary-rgb), X)` for some control tokens:
+
+- `--control-chip-border: rgba(var(--primary-rgb), 0.08)`
+- `--control-chip-active-bg: rgba(var(--primary-rgb), 0.12)`
+- `--control-chip-active-border: rgba(var(--primary-rgb), 0.16)`
+- `--control-focus-ring: rgba(var(--primary-rgb), 0.42)`
+
+Therefore, most direct `rgba(144, 73, 81, X)` values can likely be replaced with `rgba(var(--primary-rgb), X)` without adding a new token.
+
+---
+
+## Replacement strategy candidates
+
+### Candidate A — Literal-to-token syntax replacement
+
+Replace only direct literals with equivalent `rgba(var(--primary-rgb), X)` values.
+
+Pros:
+- smallest CSS diff
+- no new semantic token naming required
+- preserves opacity values exactly
+
+Risks:
+- still leaves visual semantics spread across selectors
+- requires browser visual smoke because shadows/borders can be sensitive
+
+### Candidate B — Semantic shadow/border tokens
+
+Introduce specific tokens for common repeated roles, for example:
+
+- `--primary-shadow-soft`
+- `--primary-shadow-hover`
+- `--primary-border-subtle`
+- `--primary-bg-subtle`
+
+Pros:
+- clearer design intent
+- easier future tuning
+
+Risks:
+- larger token design decision
+- higher chance of overfitting one page/state
+- should be planned in design token docs before implementation
+
+---
+
+## Recommendation
+
+Use Candidate A first in a later CSS-only PR:
+
+- replace the 18 direct literal instances in `css/global.css`
+- preserve every alpha value exactly
+- do not change selector grouping or visual behavior
+- do not touch generated/prototype/reference CSS
+- verify Home, Intro, Search/Browse, Detail, My Trees, Login, and Settings visual smoke where applicable
+
+Do not introduce new semantic tokens unless the design system explicitly needs shared shadow/border vocabulary beyond the existing `--primary-rgb` token.
+
+---
+
+## Future implementation gate
+
+Before a CSS implementation PR:
+
+- [ ] confirm `--primary-rgb` is defined in active tokens
+- [ ] confirm all 18 literal instances still exist on latest `main`
+- [ ] keep alpha values unchanged
+- [ ] run `git diff --check`
+- [ ] verify no generated/prototype/reference/demo/variant files changed
+- [ ] browser smoke active public pages for obvious visual regression
+
+---
+
+## Non-goals
+
+- No CSS changes in this PR
+- No broad token redesign
+- No global search/replace outside `css/global.css`
+- No generated/prototype/reference/demo/variant CSS changes
+- No runtime/API/Auth/Editor JS changes
+- No Issue #224 closure
+
+---
+
+## Related
+
+Refs #224

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -29,6 +29,7 @@
 10. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
 11. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 12. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+13. [GLOBAL_CSS_RGBA_TOKEN_AUDIT.md](./GLOBAL_CSS_RGBA_TOKEN_AUDIT.md) - `css/global.css` primary RGBA literal usage audit
 
 ---
 
@@ -46,6 +47,7 @@
 | [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) | Editor fallback factories, `window.currentTreeMemories`, `window.currentTreeData`, compatibility aliases, future store migration 기준 |
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
 | [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
+| [GLOBAL_CSS_RGBA_TOKEN_AUDIT.md](./GLOBAL_CSS_RGBA_TOKEN_AUDIT.md) | `css/global.css` 내 direct primary RGBA literal 반복 사용 위치와 token replacement 후보 audit |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지와 리뷰 규칙 |
 | [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 내역 |
@@ -74,6 +76,7 @@
 - Editor fallback factory, `window.currentTreeMemories`, `window.currentTreeData`, compatibility alias 정리는 `EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md`의 audit gate를 먼저 통과해야 합니다.
 - #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
+- `css/global.css` direct primary RGBA literal replacement 판단은 `GLOBAL_CSS_RGBA_TOKEN_AUDIT.md`를 먼저 확인합니다.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `docs/engineering/GLOBAL_CSS_RGBA_TOKEN_AUDIT.md` to document direct `rgba(144, 73, 81, X)` usage in `css/global.css`.
- Record replacement candidates using the existing `rgba(var(--primary-rgb), X)` pattern.
- Update the engineering docs index.

## Scope
- Docs-only audit.
- No CSS changes.
- No generated/prototype/reference/demo/variant CSS changes.
- No UI/runtime/API/Auth/Editor JS changes.

## Related
Refs #224

## Verification
- [ ] git diff --check
- [x] docs-only changes
- [x] no CSS/JS/HTML/runtime changes
- [x] no generated/prototype/reference/demo/variant changes
- [x] no close keywords for #224