### PR TITLE
docs(product): define YouTube segment player PoC scope

### DIFF
--- a/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md
+++ b/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md
@@ -1,0 +1,183 @@
+# YouTube Segment Player PoC Scope
+
+## Purpose
+
+Define the proof-of-concept scope for cue-based YouTube segment playback before any production integration.
+
+This document supports Moment Timeline by clarifying what must be proven with the YouTube IFrame Player API.
+
+Related issues:
+
+- Parent: #362
+- PoC: #366
+- Planning PR: #363
+
+---
+
+## Scope
+
+The PoC should validate whether LoveBud can reliably:
+
+- parse a YouTube video ID from common URL formats
+- load a video with the YouTube IFrame Player API
+- seek to `startSeconds`
+- detect current playback time
+- stop at `endSeconds`
+- advance to the next Moment segment
+- loop a selected segment by seeking back to `startSeconds`
+- sequence-play multiple segments
+- report console, network, and player errors
+- document browser behavior and limitations
+
+---
+
+## Non-goals
+
+- No production UI
+- No database persistence
+- No API implementation
+- No video download
+- No video export
+- No server-side encoding
+- No Search/Auth/Editor cleanup work
+- No PR #7/prototype/reference/demo/variant changes
+
+---
+
+## Candidate PoC path
+
+The PoC should be isolated from active production pages.
+
+Recommended path options for CTO approval:
+
+| Option | Path | Notes |
+|---|---|---|
+| A | `pages/dev/youtube-segment-poc.html` | Static dev page, not linked from navigation |
+| B | `pages/internal/youtube-segment-poc.html` | Internal naming, still static-only |
+| C | local-only verifier page | No repository page, harder to review |
+
+Recommended choice: **Option A**, if implementation is approved later.
+
+The PoC page should not be linked from Home, Intro, Search, Detail, My Trees, Editor, Settings, or shared navigation.
+
+---
+
+## Required behaviors
+
+| Behavior | Expected proof |
+|---|---|
+| Load video by `videoId` | Player enters ready state |
+| Seek to `startSeconds` | playback begins near requested time |
+| Detect current time | current time polling or player event strategy documented |
+| Stop at `endSeconds` | playback pauses/stops within acceptable drift |
+| Advance to next Moment | next cue loads after current cue end |
+| Loop current segment | player seeks back to `startSeconds` repeatedly |
+| Invalid/unavailable video | visible error state and console/player error capture |
+| Invalid range | `endSeconds <= startSeconds` blocks playback |
+
+---
+
+## YouTube keyframe drift tolerance
+
+The PoC must assume YouTube playback may not start at the exact requested frame.
+
+Acceptance should be based on segment behavior, not frame-accurate editing:
+
+- `seekTo(startSeconds)` may land slightly before or after the requested time.
+- The player should still enforce the segment end using current time checks.
+- Drift should be recorded as observed behavior.
+- LoveBud should not promise frame-accurate clipping.
+
+---
+
+## Candidate test cases
+
+1. Play one segment from `00:10` to `00:20`.
+2. Loop one segment.
+3. Play two Moments from two different YouTube videos.
+4. Switch from one segment to the next.
+5. Handle invalid or unavailable video.
+6. Handle `endSeconds` earlier than `startSeconds`.
+7. Mobile browser smoke.
+
+---
+
+## PoC controls
+
+The PoC implementation may include simple controls only:
+
+- video ID / URL input
+- start seconds input
+- end seconds input
+- load button
+- play segment button
+- loop toggle
+- play sequence button
+- error/status log panel
+
+No final LoveBud visual design is required for the PoC.
+
+---
+
+## Verification evidence to collect
+
+The implementation PR should record:
+
+- browser and viewport
+- tested video IDs or safe public sample URLs
+- observed start drift
+- observed end behavior
+- loop behavior result
+- sequence playback result
+- console errors
+- network/player errors
+- mobile smoke result
+
+Do not record private user data or credentials.
+
+---
+
+## Go / No-Go criteria
+
+### Go
+
+Proceed toward production integration if:
+
+- segment start/end playback is reliable enough for cue-based memories
+- loop behavior works without fatal player errors
+- sequence playback can advance between cues
+- mobile smoke is acceptable
+- limitations are clearly documented
+
+### No-Go / Blocked
+
+Block or redesign if:
+
+- YouTube API restrictions prevent reliable cue loading
+- end detection is too unstable for acceptable UX
+- mobile autoplay/player constraints break the core flow
+- unavailable video handling cannot be surfaced cleanly
+
+---
+
+## Future PR split
+
+1. PoC implementation page with static sample controls.
+2. Browser verification report documenting feasibility.
+3. Capture UI shell implementation after PoC passes.
+4. Timeline sequence playback integration after capture/timeline data model is approved.
+
+---
+
+## Acceptance criteria for this docs stage
+
+- PoC path options are documented.
+- Required behaviors are listed.
+- Test cases are documented.
+- Keyframe drift tolerance is defined.
+- Production integration remains blocked until PoC evidence exists.
+
+---
+
+Refs #366
+Refs #362

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -18,6 +18,7 @@
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
+| [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC 범위와 Go/No-Go 기준 |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
@@ -59,11 +60,12 @@
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
 4. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-5. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-6. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
-7. **USER_FLOW.md** — 사용자 여정과 핵심 플로우
-8. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-9. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+5. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC 범위와 검증 기준
+6. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+7. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
+8. **USER_FLOW.md** — 사용자 여정과 핵심 플로우
+9. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+10. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -19,7 +19,6 @@
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC 범위와 Go/No-Go 기준 |
-| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -19,6 +19,7 @@
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC 범위와 Go/No-Go 기준 |
+| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
@@ -62,8 +63,8 @@
 4. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
 5. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC 범위와 검증 기준
 6. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-7. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
-8. **USER_FLOW.md** — 사용자 여정과 핵심 플로우
+7. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+8. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
 9. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
 10. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 


### PR DESCRIPTION
## Summary
- Add a docs-only scope document for the YouTube segment player PoC.
- Define required behaviors, candidate PoC path options, keyframe drift tolerance, test cases, and Go/No-Go criteria.
- Link the PoC scope document from the product docs index.
- Keep implementation and browser verification for a later approved PR.

## Scope
- Docs-only.
- No production UI implementation.
- No YouTube player implementation.
- No API/database changes.
- No Search/Auth/Editor cleanup work.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- docs/product/YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md
- docs/product/product_index.md

## Related
Refs #366
Refs #362

## Verification
- [ ] CTO review
- [x] docs-only scope confirmed
- [ ] PoC path option approved before coding
- [x] required behaviors reviewed
- [x] product index link added
- [x] no close keywords for #366 or #362
- [x] product_index duplicate row fixed
