### PR TITLE
fix(my-trees): recover state display transitions

### DIFF
--- a/css/my-trees/states.css
+++ b/css/my-trees/states.css
@@ -15,3 +15,8 @@
 #state-error { display: none; }
 #state-empty { display: none; }
 #state-loaded { display: none; }
+
+/* Runtime display state classes. Keep selectors ID-scoped so they override initial state IDs. */
+#treesContainer .state-hidden { display: none; }
+#treesContainer .state-visible { display: flex; }
+#treesContainer .state-visible-block { display: block; }

--- a/js/my-trees/my-trees-page.js
+++ b/js/my-trees/my-trees-page.js
@@ -17,6 +17,13 @@
     ERROR: 'error'
   };
 
+  var STATE_DISPLAY_CLASS = {
+    loading: 'state-visible',
+    error: 'state-visible',
+    empty: 'state-visible',
+    loaded: 'state-visible-block'
+  };
+
   function showToast(message, type) {
     if (window.LoveBudUI?.showToast) {
       window.LoveBudUI.showToast(message, type, 3000);
@@ -24,6 +31,23 @@
       console.warn('[my-trees] LoveBudUI not loaded, toast degraded to console');
       console.log('[Toast ' + type + '] ' + message);
     }
+  }
+
+  function hideStateSection(el) {
+    if (!el) return;
+    el.style.display = '';
+    el.classList.remove('state-visible', 'state-visible-block');
+    el.classList.add('state-hidden');
+    el.setAttribute('aria-hidden', 'true');
+  }
+
+  function showStateSection(el, stateName) {
+    var displayClass = STATE_DISPLAY_CLASS[stateName];
+    if (!el || !displayClass) return;
+    el.style.display = '';
+    el.classList.remove('state-hidden', 'state-visible', 'state-visible-block');
+    el.classList.add(displayClass);
+    el.removeAttribute('aria-hidden');
   }
 
   function setState(newState) {
@@ -37,22 +61,24 @@
       loaded: document.getElementById('state-loaded')
     };
 
-    Object.values(sections).forEach(function(el) {
-      if (el) el.style.display = 'none';
-    });
+    Object.values(sections).forEach(hideStateSection);
 
     switch (newState) {
       case STATE.LOADING:
-        if (sections.loading) sections.loading.style.display = 'flex';
+        showStateSection(sections.loading, 'loading');
         break;
       case STATE.ERROR:
-        if (sections.error) sections.error.style.display = 'flex';
+        showStateSection(sections.error, 'error');
         break;
       case STATE.EMPTY:
-        if (sections.empty) sections.empty.style.display = 'flex';
+        showStateSection(sections.empty, 'empty');
         break;
       case STATE.LOADED:
-        if (sections.loaded) sections.loaded.style.display = 'block';
+        showStateSection(sections.loaded, 'loaded');
+        break;
+      default:
+        console.warn('[my-trees] Unknown state requested:', newState);
+        showStateSection(sections.error, 'error');
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Ensure my-trees exits loading state for empty, auth error, and load error outcomes.
- Make state display transitions apply consistently across loading/error/empty/loaded sections.
- Keep API/Auth/server behavior unchanged.

## Scope
- Frontend state-display resilience only.
- No API/Auth/backend/config changes.
- No tree create/delete/publish/update behavior changes.
- No PR #350 branch changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #137
Refs #377

## Verification
- [ ] git diff --check
- [ ] 200 with empty tree list shows empty state
- [ ] 401/403 exits loading and shows auth/re-login error state
- [ ] 5xx/network failure does not leave loading stuck
- [ ] normal loaded state remains unchanged
- [ ] no credential/token/session/cookie/header values exposed
- [ ] no close keywords for #137/#377