### PR TITLE
test: fix modal contract function body extraction (CRLF + blank line tolerance)

### DIFF
--- a/tests/contracts/growing-trees-api-contract.test.js
+++ b/tests/contracts/growing-trees-api-contract.test.js
@@ -98,7 +98,7 @@ test('modal growing snapshot query keeps public memory count and growing stage c
 
   const normalizedSource = source.replace(/\r\n/g, '\n');
   const functionMatch = normalizedSource.match(
-    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\ndef\s+)/
+    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\n+def\s+)/
   );
   assert.ok(functionMatch, 'missing fetch_growing_public_tree_snapshots function body');
 

--- a/tests/contracts/growing-trees-api-contract.test.js
+++ b/tests/contracts/growing-trees-api-contract.test.js
@@ -97,7 +97,7 @@ test('modal growing snapshot query keeps public memory count and growing stage c
   const source = readModalApp();
 
   const functionMatch = source.match(
-    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\ndef\s+)/
+    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\n+def\s+)/
   );
   assert.ok(functionMatch, 'missing fetch_growing_public_tree_snapshots function body');
 

--- a/tests/contracts/growing-trees-api-contract.test.js
+++ b/tests/contracts/growing-trees-api-contract.test.js
@@ -96,8 +96,9 @@ test('modal app exposes growing browse endpoint backed by growing snapshot fetch
 test('modal growing snapshot query keeps public memory count and growing stage contract', () => {
   const source = readModalApp();
 
-  const functionMatch = source.match(
-    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\n+def\s+)/
+  const normalizedSource = source.replace(/\r\n/g, '\n');
+  const functionMatch = normalizedSource.match(
+    /def\s+fetch_growing_public_tree_snapshots\s*\(\s*limit:\s*int\s*=\s*6\s*\)[\s\S]*?(?=\n\ndef\s+)/
   );
   assert.ok(functionMatch, 'missing fetch_growing_public_tree_snapshots function body');
 

--- a/tests/contracts/modal-private-ownership-policy.test.js
+++ b/tests/contracts/modal-private-ownership-policy.test.js
@@ -15,7 +15,8 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
+  const normalizedSource = source.replace(/\r\n/g, '\n');
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-private-ownership-policy.test.js
+++ b/tests/contracts/modal-private-ownership-policy.test.js
@@ -15,7 +15,7 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-private-ownership-policy.test.js
+++ b/tests/contracts/modal-private-ownership-policy.test.js
@@ -16,7 +16,7 @@ function compact(value) {
 
 function getFunctionBody(source, functionName) {
   const normalizedSource = source.replace(/\r\n/g, '\n');
-  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-memory-parent-visibility.test.js
+++ b/tests/contracts/modal-public-memory-parent-visibility.test.js
@@ -15,7 +15,8 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
+  const normalizedSource = source.replace(/\r\n/g, '\n');
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-memory-parent-visibility.test.js
+++ b/tests/contracts/modal-public-memory-parent-visibility.test.js
@@ -15,7 +15,7 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-memory-parent-visibility.test.js
+++ b/tests/contracts/modal-public-memory-parent-visibility.test.js
@@ -16,7 +16,7 @@ function compact(value) {
 
 function getFunctionBody(source, functionName) {
   const normalizedSource = source.replace(/\r\n/g, '\n');
-  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-read-retry-policy.test.js
+++ b/tests/contracts/modal-public-read-retry-policy.test.js
@@ -15,7 +15,8 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
+  const normalizedSource = source.replace(/\r\n/g, '\n');
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-read-retry-policy.test.js
+++ b/tests/contracts/modal-public-read-retry-policy.test.js
@@ -15,7 +15,7 @@ function compact(value) {
 }
 
 function getFunctionBody(source, functionName) {
-  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = source.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }

--- a/tests/contracts/modal-public-read-retry-policy.test.js
+++ b/tests/contracts/modal-public-read-retry-policy.test.js
@@ -16,7 +16,7 @@ function compact(value) {
 
 function getFunctionBody(source, functionName) {
   const normalizedSource = source.replace(/\r\n/g, '\n');
-  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\ndef\\s+)`));
+  const match = normalizedSource.match(new RegExp(`def\\s+${functionName}\\s*\\([\\s\\S]*?(?=\\n\\n+def\\s+)`));
   assert.ok(match, `missing ${functionName}`);
   return match[0];
 }


### PR DESCRIPTION
## Summary
Fix baseline npm test failures in modal contract tests caused by brittle regex for Python function body extraction.

### Root Cause
- Tests previously expected Python top-level functions separated by exactly one blank line (`\n\ndef`).
- `modal_compute/app.py` follows PEP-8 style spacing and may use CRLF line endings in local environments.
- Regex matching needed to tolerate CRLF and one-or-more blank lines before the next top-level `def`.

### Changes
- Normalize line endings (`\r\n` → `\n`) before regex matching.
- Update lookahead from exact `\n\ndef` to blank-line tolerant `\n\n+def`.
- Files updated:
  - `tests/contracts/modal-private-ownership-policy.test.js`
  - `tests/contracts/modal-public-memory-parent-visibility.test.js`
  - `tests/contracts/modal-public-read-retry-policy.test.js`
  - `tests/contracts/growing-trees-api-contract.test.js`

### Scope
- Test infrastructure only.
- `modal_compute/app.py` unchanged.
- `functions/api/**` unchanged.
- Search/UI/docs/runtime files unchanged.
- No implementation behavior changes.
- No PR #7/prototype/reference/demo/variant changes.

### Verification
- Local `git diff --check`: PASS
- Local targeted modal ownership contract test: PASS
- Local targeted contract tests for all 4 updated files: PASS
- Local `npm test`: PASS
- Local `npm run verify`: PASS
- GitHub `verify-static`: SUCCESS
- GitHub `Cloudflare Pages`: SUCCESS
- GitHub `GitGuardian Security Checks`: SUCCESS
- GitHub merge state: CLEAN / MERGEABLE

## Related
Refs baseline CI recovery for modal contract tests.
