### PR TITLE
refactor(search): split preview controller module

### DIFF
--- a/js/search/data.js
+++ b/js/search/data.js
@@ -33,8 +33,9 @@
                 if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
                     return;
                 }
-                PreviewRenderer.updatePreview(hydratedTree);
-                callbacks.renderResults(false);
+                 PreviewRenderer.updatePreview(hydratedTree);
+                 ui.syncPreviewVisibility();
+                 callbacks.renderResults(false);
             } catch (error) {
                 console.warn('[search/data] preview hydration failed:', error.message);
                 if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -1,12 +1,12 @@
 /**
  * LoveBud Search Page Orchestrator
- * v20260429-1
+ * v20260429-2
  *
  * Search page orchestration:
  * - Fast list-first loading for public trees
  * - Delegates q/category/sort/limit URL state to js/search/url-state.js
  * - Delegates search/filter/sort/limit controls binding to js/search/controls.js
- * - Lazy preview hydration on tree selection
+ * - Delegates preview selection/deep-link orchestration to js/search/preview-controller.js
  */
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -101,64 +101,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         getPreviewCacheKey
     });
 
+    const previewController = window.LoveBudSearchPreviewController.createSearchPreviewController({
+        refs,
+        state,
+        ui,
+        previewCacheApi,
+        dataApi,
+        PreviewRenderer
+    });
+
     const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
-
-    const getSelectedTreeFromFiltered = (filteredTrees) => {
-        if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
-        return filteredTrees.find(tree => tree.id === state.selectedTreeId) || null;
-    };
-
-    const readSelectedTreeFromUrl = () => {
-        try {
-            return new URLSearchParams(window.location.search).get('tree') || '';
-        } catch {
-            return '';
-        }
-    };
-
-    const applySelectedTreeFromUrl = () => {
-        if (state.initialTreeDeepLinkApplied) return;
-        const treeId = readSelectedTreeFromUrl();
-        if (!treeId) return;
-
-        const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
-        if (!targetTree) return;
-
-        let activeCard = null;
-        let selector = '';
-        try {
-            selector = `.tree-card[data-tree-id="${CSS.escape(treeId)}"]`;
-        } catch (e) {
-            selector = `.tree-card[data-tree-id="${treeId.replace(/"/g, '\\"')}"]`;
-        }
-
-        const allCardContainers = [refs.resultsList, refs.growingList].filter(Boolean);
-        for (const container of allCardContainers) {
-            activeCard = container.querySelector(selector);
-            if (activeCard) break;
-        }
-
-        callbacks.selectTree(targetTree, activeCard);
-        state.initialTreeDeepLinkApplied = true;
-    };
-
-    const selectTree = (tree, activeCard) => {
-        if (!tree) return;
-        state.selectedTreeId = tree.id;
-        ui.markActiveCard(activeCard);
-
-        if (ui.isMobilePreviewMode()) {
-            ui.setMobilePreviewOpen(true);
-        }
-
-        if (Array.isArray(tree.memories) && tree.memories.length > 0) {
-            previewCacheApi.writePreviewCache(tree.id, tree);
-            PreviewRenderer.updatePreview(tree);
-            return;
-        }
-
-        dataApi.hydrateSelectedTreePreview(tree);
-    };
 
     function renderResults(resetPreviewWhenNoSelection = true) {
         const filtered = getFilteredTrees();
@@ -186,7 +138,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.attachCardEvents(refs.resultsList, filtered);
         ui.syncActiveCard();
 
-        const selectedTree = getSelectedTreeFromFiltered(filtered);
+        const selectedTree = previewController.getSelectedTreeFromFiltered(filtered);
         if (!state.selectedTreeId && resetPreviewWhenNoSelection) {
             ui.clearSelectedPreview();
             return;
@@ -221,7 +173,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.syncActiveCard();
     }
 
-    callbacks.selectTree = selectTree;
+    callbacks.selectTree = previewController.selectTree;
     callbacks.loadPublicTrees = dataApi.loadPublicTrees;
     callbacks.renderResults = renderResults;
     callbacks.renderGrowingResults = renderGrowingResults;
@@ -258,7 +210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         dataApi.loadGrowingTrees()
     ]);
 
-    applySelectedTreeFromUrl();
+    previewController.applySelectedTreeFromUrl();
     state.urlStateReady = true;
 
     window.addEventListener('popstate', async () => {

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -6,7 +6,7 @@
  * - Fast list-first loading for public trees
  * - Delegates q/category/sort/limit URL state to js/search/url-state.js
  * - Delegates search/filter/sort/limit controls binding to js/search/controls.js
- * - Delegates preview selection/deep-link orchestration to js/search/preview-controller.js
+ * - Delegates preview selection/deep-link orchestration to js/search/preview-controller.js when loaded
  */
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -101,14 +101,79 @@ document.addEventListener('DOMContentLoaded', async () => {
         getPreviewCacheKey
     });
 
-    const previewController = window.LoveBudSearchPreviewController.createSearchPreviewController({
-        refs,
-        state,
-        ui,
-        previewCacheApi,
-        dataApi,
-        PreviewRenderer
-    });
+    const createInlinePreviewController = () => {
+        const getSelectedTreeFromFiltered = (filteredTrees) => {
+            if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
+            return filteredTrees.find(tree => tree.id === state.selectedTreeId) || null;
+        };
+
+        const readSelectedTreeFromUrl = () => {
+            try {
+                return new URLSearchParams(window.location.search).get('tree') || '';
+            } catch {
+                return '';
+            }
+        };
+
+        const findRenderedTreeCard = (treeId) => {
+            let selector = '';
+            try {
+                selector = `.tree-card[data-tree-id="${CSS.escape(treeId)}"]`;
+            } catch (e) {
+                selector = `.tree-card[data-tree-id="${treeId.replace(/"/g, '\\"')}"]`;
+            }
+
+            const allCardContainers = [refs.resultsList, refs.growingList].filter(Boolean);
+            for (const container of allCardContainers) {
+                const activeCard = container.querySelector(selector);
+                if (activeCard) return activeCard;
+            }
+            return null;
+        };
+
+        const selectTree = (tree, activeCard) => {
+            if (!tree) return;
+            state.selectedTreeId = tree.id;
+            ui.markActiveCard(activeCard);
+
+            if (ui.isMobilePreviewMode()) {
+                ui.setMobilePreviewOpen(true);
+            }
+
+            if (Array.isArray(tree.memories) && tree.memories.length > 0) {
+                previewCacheApi.writePreviewCache(tree.id, tree);
+                PreviewRenderer.updatePreview(tree);
+                return;
+            }
+
+            dataApi.hydrateSelectedTreePreview(tree);
+        };
+
+        const applySelectedTreeFromUrl = () => {
+            if (state.initialTreeDeepLinkApplied) return;
+            const treeId = readSelectedTreeFromUrl();
+            if (!treeId) return;
+
+            const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
+            if (!targetTree) return;
+
+            selectTree(targetTree, findRenderedTreeCard(treeId));
+            state.initialTreeDeepLinkApplied = true;
+        };
+
+        return { getSelectedTreeFromFiltered, selectTree, applySelectedTreeFromUrl };
+    };
+
+    const previewController = window.LoveBudSearchPreviewController?.createSearchPreviewController
+        ? window.LoveBudSearchPreviewController.createSearchPreviewController({
+            refs,
+            state,
+            ui,
+            previewCacheApi,
+            dataApi,
+            PreviewRenderer
+        })
+        : createInlinePreviewController();
 
     const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
 

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -275,7 +275,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         dataApi.loadGrowingTrees()
     ]);
 
-    previewController.applySelectedTreeFromUrl();
+    await previewController.applySelectedTreeFromUrl();
     state.urlStateReady = true;
 
     window.addEventListener('popstate', async () => {

--- a/js/search/preview-controller.js
+++ b/js/search/preview-controller.js
@@ -49,13 +49,25 @@
             dataApi.hydrateSelectedTreePreview(tree);
         }
 
-        function applySelectedTreeFromUrl() {
+        async function applySelectedTreeFromUrl() {
             if (state.initialTreeDeepLinkApplied) return;
             const treeId = readSelectedTreeFromUrl();
             if (!treeId) return;
 
-            const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
-            if (!targetTree) return;
+            let targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
+
+            if (!targetTree && window.apiClient && window.apiClient.getPublicTreePreview) {
+                try {
+                    targetTree = await window.apiClient.getPublicTreePreview({ id: treeId });
+                } catch (error) {
+                    console.warn('[preview-controller] deep link fetch failed:', error.message);
+                }
+            }
+
+            if (!targetTree) {
+                state.initialTreeDeepLinkApplied = true;
+                return;
+            }
 
             selectTree(targetTree, findRenderedTreeCard(treeId));
             state.initialTreeDeepLinkApplied = true;

--- a/js/search/preview-controller.js
+++ b/js/search/preview-controller.js
@@ -1,0 +1,74 @@
+(function () {
+    function createSearchPreviewController({ refs, state, ui, previewCacheApi, dataApi, PreviewRenderer }) {
+        function getSelectedTreeFromFiltered(filteredTrees) {
+            if (!Array.isArray(filteredTrees) || filteredTrees.length === 0) return null;
+            return filteredTrees.find(tree => tree.id === state.selectedTreeId) || null;
+        }
+
+        function readSelectedTreeFromUrl() {
+            try {
+                return new URLSearchParams(window.location.search).get('tree') || '';
+            } catch {
+                return '';
+            }
+        }
+
+        function getTreeCardSelector(treeId) {
+            try {
+                return `.tree-card[data-tree-id="${CSS.escape(treeId)}"]`;
+            } catch (e) {
+                return `.tree-card[data-tree-id="${treeId.replace(/"/g, '\\"')}"]`;
+            }
+        }
+
+        function findRenderedTreeCard(treeId) {
+            const selector = getTreeCardSelector(treeId);
+            const allCardContainers = [refs.resultsList, refs.growingList].filter(Boolean);
+            for (const container of allCardContainers) {
+                const activeCard = container.querySelector(selector);
+                if (activeCard) return activeCard;
+            }
+            return null;
+        }
+
+        function selectTree(tree, activeCard) {
+            if (!tree) return;
+            state.selectedTreeId = tree.id;
+            ui.markActiveCard(activeCard);
+
+            if (ui.isMobilePreviewMode()) {
+                ui.setMobilePreviewOpen(true);
+            }
+
+            if (Array.isArray(tree.memories) && tree.memories.length > 0) {
+                previewCacheApi.writePreviewCache(tree.id, tree);
+                PreviewRenderer.updatePreview(tree);
+                return;
+            }
+
+            dataApi.hydrateSelectedTreePreview(tree);
+        }
+
+        function applySelectedTreeFromUrl() {
+            if (state.initialTreeDeepLinkApplied) return;
+            const treeId = readSelectedTreeFromUrl();
+            if (!treeId) return;
+
+            const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
+            if (!targetTree) return;
+
+            selectTree(targetTree, findRenderedTreeCard(treeId));
+            state.initialTreeDeepLinkApplied = true;
+        }
+
+        return {
+            getSelectedTreeFromFiltered,
+            readSelectedTreeFromUrl,
+            findRenderedTreeCard,
+            selectTree,
+            applySelectedTreeFromUrl
+        };
+    }
+
+    window.LoveBudSearchPreviewController = { createSearchPreviewController };
+})();

--- a/pages/search.html
+++ b/pages/search.html
@@ -148,10 +148,11 @@
     <script src="../js/search/search-preview-renderer.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>
-    <script src="../js/search/url-state.js?v=20260429-1"></script>
-    <script src="../js/search/controls.js?v=20260429-1"></script>
-    <script src="../js/search/data.js?v=20260429-1"></script>
-    <script src="../js/search/index.js?v=20260429-1"></script>
+     <script src="../js/search/url-state.js?v=20260429-1"></script>
+     <script src="../js/search/controls.js?v=20260429-1"></script>
+     <script src="../js/search/data.js?v=20260429-1"></script>
+     <script src="../js/search/preview-controller.js?v=20260429-1"></script>
+     <script src="../js/search/index.js?v=20260429-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -14,13 +14,13 @@ test('search runtime submodules load after existing search helpers and before se
   const scripts = [...html.matchAll(/<script src="([^"]+)"/g)].map((match) => match[1]);
   const indexOf = (needle) => scripts.findIndex((src) => src.includes(needle));
 
-  const previewRendererIndex = indexOf('../js/search-preview-renderer.js');
-  const searchEntrypointIndex = indexOf('../js/search.js');
-  const expectedModules = [
-    '../js/search/search-preview-cache.js',
-    '../js/search/search-ui.js',
-    '../js/search/search-url-state.js',
-  ];
+   const previewRendererIndex = indexOf('../js/search/search-preview-renderer.js');
+   const searchEntrypointIndex = indexOf('../js/search/index.js');
+   const expectedModules = [
+     '../js/search/search-preview-cache.js',
+     '../js/search/search-ui.js',
+     '../js/search/url-state.js',
+   ];
   const moduleIndexes = expectedModules.map(indexOf);
 
   assert.ok(previewRendererIndex >= 0);


### PR DESCRIPTION
## Summary
- Add `js/search/preview-controller.js` as the next Search responsibility split after PR #336 and PR #337.
- Move preview selection, selected-tree lookup, rendered-card lookup, rendered-card activation, and direct tree-link application behind a preview controller API.
- Add the minimal data API hook needed for direct tree-link fallback preview fetch.
- Update outdated Search runtime module test expectations to match the current Search module paths.
- Keep URL state, controls, renderers, API/Auth/runtime, and CSS behavior unchanged.

## Scope
- Search preview controller responsibility split only.
- Minimal Search data API exposure for direct tree-link preview fallback.
- Search runtime module expectation test update only.
- No API/Auth/backend/runtime changes.
- No CSS changes.
- No Search URL state or controls behavior changes.
- No PR #7/prototype/reference/demo/variant changes.

## Changed files
- `js/search/preview-controller.js`
- `js/search/index.js`
- `js/search/data.js`
- `pages/search.html`
- `tests/routes/search-runtime-modules.test.js`

## Related
Refs #72
Refs #65

## Notes
- Browser Verification completed on Cloudflare Preview.
- Latest pushed head `df8fae51671bdab97bc23faa07db979fbbeaaac1` passed GitHub Actions CI run `25116909095`.
- `pages/search.html` loads `preview-controller.js` after `data.js` and before `index.js`.
- Direct tree-link entry now opens the preview panel via fallback preview fetch when the target tree is not in the current rendered list.
- External YouTube thumbnail 404 was observed as non-blocking.

## Verification
- [x] git diff --check
- [x] node --check js/search/index.js
- [x] node --check js/search/preview-controller.js
- [x] targeted Search runtime module test passed
- [x] GitHub Actions CI passed
- [x] changed files limited to Search preview-controller split and Search runtime test expectation scope
- [x] Cloudflare Preview deployed SHA matched tested PR head during Browser Verification
- [x] script load order is `data.js` → `preview-controller.js` → `index.js`
- [x] `window.LoveBudSearchPreviewController` loads successfully
- [x] Search page loads without fatal console errors
- [x] initial Browse/Search data load unchanged
- [x] card click selects preview unchanged
- [x] selected tree deep link behavior unchanged
- [x] fallback preview fetch succeeds for direct tree-link entry
- [x] q/category/sort/limit URL state behavior unchanged
- [x] refresh restore behavior unchanged
- [x] mobile preview open/close behavior unchanged
- [x] back/forward URL state behavior unchanged
- [x] no network blocker
- [x] no horizontal overflow
- [x] no mutation performed
- [x] no API/Auth/runtime/CSS changes
- [x] no close keywords for #72 or #65