### PR TITLE
docs(runtime): salvage staged cleanup disposition map

### DIFF
--- a/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
+++ b/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
@@ -6,38 +6,29 @@
 
 ## 1. Purpose
 
-This document maps Issue #225 staged runtime cleanup items to current owners and next steps.
+This document maps Issue #225 staged runtime cleanup items to current disposition, evidence, and next action.
 
 This is a disposition map only. It does not authorize immediate implementation of any staged cleanup items.
 
-## 2. Disposition Summary
+## 2. Current Disposition Summary
 
-### Stage 1: Auth/Login legacy fallback reduction
-- Owner: TBD
-- Status: Staged
-- Next step: Separate owner issue/implementation tracker required before any implementation
+| #225 stage | Current disposition | Evidence / related PRs | Next action |
+|---|---|---|---|
+| Stage 1 — Auth/Login legacy fallback reduction | Deferred / owned by #78 or dedicated Auth fallback implementation tracker | #78, #224/#225 ownership context | Do not remove Auth fallbacks under this disposition doc. Continue only after Auth/Login module contracts and browser smoke gates are stable. |
+| Stage 1 — Editor fallback removal | Audited / implementation deferred | #223, #224, #225, Editor fallback/global state audit context if already documented | Future implementation only after Editor browser smoke matrix and module coverage are ready. |
+| Stage 2 — Editor global state encapsulation | Audited / migration deferred | window.currentTreeMemories, window.currentTreeData, EditorStore/call-site inventory needed | Create dedicated EditorStore/call-site inventory implementation tracker before code changes. |
+| Stage 3 — Optional bundler feasibility | Audit/defer | Static multipage runtime contract, Cloudflare Pages constraints | Do not introduce Vite/Rollup/build-tool adoption unless later implementation proposal is approved. |
+| Stage 4 — Password policy strengthening | Separate Auth UX/security follow-up needed | Signup/password policy context | Separate policy/copy/i18n/validation PRs only after product/security approval. |
 
-### Stage 1: Editor fallback removal
-- Owner: TBD
-- Status: Staged
-- Next step: Separate owner issue/implementation tracker required before any implementation
+## 3. Recommended Tracker Decision
 
-### Stage 2: Editor global state encapsulation
-- Owner: TBD
-- Status: Staged
-- Next step: Separate owner issue/implementation tracker required before any implementation
+Issue #225 should usually remain open while staged runtime cleanup is still active.
 
-### Stage 3: Optional bundler feasibility
-- Owner: TBD
-- Status: Staged
-- Next step: Separate owner issue/implementation tracker required before any implementation
+If CTO wants closure later, first split remaining work into dedicated owner issues.
 
-### Stage 4: Password policy strengthening
-- Owner: TBD
-- Status: Staged
-- Next step: Separate owner issue/implementation tracker required before any implementation
+This document alone does not close Issue #225.
 
-## 3. Non-goals
+## 4. Non-goals
 
 This disposition map does not authorize:
 
@@ -45,23 +36,25 @@ This disposition map does not authorize:
 - Modifying `js/editor.js`
 - Removing any fallback implementations
 - Adding EditorStore
+- Changing memory persistence semantics
 - Converting to `type="module"`
 - Adding Vite/Rollup or other bundlers
 - Changing Cloudflare Pages routing or API
 - Implementing password policy changes
 - Modifying PR #7/prototype/reference/demo/variant paths
+- Closing Issue #225 from this document alone
 
-This document alone does not close Issue #225.
-
-## 4. Closure Conditions
+## 5. Closure Conditions
 
 Issue #225 closure review is only possible after:
 
-- Each stage has been assigned a separate owner issue/implementation tracker
-- Implementation decisions have been made per stage
-- Any implementation work has been tracked in separate PRs
+- Auth/Login fallback reduction owned by #78 or dedicated tracker
+- Editor fallback removal and global state migration have separate trackers
+- Bundler feasibility explicitly deferred or moved to future build-tool tracker
+- Password policy strengthening moved to dedicated Auth UX/security issue
+- Final issue comment records disposition of every stage
 
-## 5. Recommended Immediate Next Step
+## 6. Recommended Immediate Next Step
 
-Add a comment to Issue #225 linking to this disposition map and decide whether to maintain #225 as an umbrella tracker.
+Post #225 issue comment linking this disposition map and decide whether #225 remains umbrella tracker or later split-and-close candidate.
 

--- a/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
+++ b/docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
@@ -1,0 +1,67 @@
+# Staged Runtime Cleanup Disposition
+
+> Status: disposition map only
+> Related: #225
+> Runtime impact: none
+
+## 1. Purpose
+
+This document maps Issue #225 staged runtime cleanup items to current owners and next steps.
+
+This is a disposition map only. It does not authorize immediate implementation of any staged cleanup items.
+
+## 2. Disposition Summary
+
+### Stage 1: Auth/Login legacy fallback reduction
+- Owner: TBD
+- Status: Staged
+- Next step: Separate owner issue/implementation tracker required before any implementation
+
+### Stage 1: Editor fallback removal
+- Owner: TBD
+- Status: Staged
+- Next step: Separate owner issue/implementation tracker required before any implementation
+
+### Stage 2: Editor global state encapsulation
+- Owner: TBD
+- Status: Staged
+- Next step: Separate owner issue/implementation tracker required before any implementation
+
+### Stage 3: Optional bundler feasibility
+- Owner: TBD
+- Status: Staged
+- Next step: Separate owner issue/implementation tracker required before any implementation
+
+### Stage 4: Password policy strengthening
+- Owner: TBD
+- Status: Staged
+- Next step: Separate owner issue/implementation tracker required before any implementation
+
+## 3. Non-goals
+
+This disposition map does not authorize:
+
+- Modifying `js/auth.js`
+- Modifying `js/editor.js`
+- Removing any fallback implementations
+- Adding EditorStore
+- Converting to `type="module"`
+- Adding Vite/Rollup or other bundlers
+- Changing Cloudflare Pages routing or API
+- Implementing password policy changes
+- Modifying PR #7/prototype/reference/demo/variant paths
+
+This document alone does not close Issue #225.
+
+## 4. Closure Conditions
+
+Issue #225 closure review is only possible after:
+
+- Each stage has been assigned a separate owner issue/implementation tracker
+- Implementation decisions have been made per stage
+- Any implementation work has been tracked in separate PRs
+
+## 5. Recommended Immediate Next Step
+
+Add a comment to Issue #225 linking to this disposition map and decide whether to maintain #225 as an umbrella tracker.
+

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -27,11 +27,12 @@
 9. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
 10. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
 11. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-12. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-13. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-14. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-15. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-16. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+12. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+13. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+14. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+15. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+16. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+17. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
 
 ---
 


### PR DESCRIPTION
Summary:
  - Add clean UTF-8 staged runtime cleanup disposition document for Issue #225.
  - Link it from engineering index using current main as source of truth.
  - Avoid the mojibake-corrupted index diff from PR #361.

Scope:
  - Docs-only.
  - No runtime/code changes.
  - No Auth/Editor fallback removal.
  - No EditorStore implementation.
  - No build-tool/package changes.
  - No password policy implementation.
  - No PR #7/prototype/reference/demo/variant changes.

Changed files:
  - docs/engineering/STAGED_RUNTIME_CLEANUP_DISPOSITION.md
  - docs/engineering/engineering_index.md

Related:
  - Refs #225
  - Refs #224
  - Refs #223
  - Refs #78
  - Supersedes PR #361 for salvage purposes

Verification:
  - [x] git diff --check
  - [x] Docs-only disposition map added
  - [x] Engineering index link added without mojibake
  - [x] No runtime/code changes
  - [x] No close keywords for #225