### PR TITLE
docs(design): map active page UX and transition coverage

### DIFF
--- a/docs/design/ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md
+++ b/docs/design/ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md
@@ -1,16 +1,14 @@
 # Active Page UX Consistency Roadmap
 
+Refs #239
+
 ## Purpose
 
-This document records the active-page UX consistency roadmap for Issue #239 before implementation begins.
+This document records the pre-implementation active page UX consistency audit and roadmap for LoveBud. It is documentation-only and does not authorize CSS, JavaScript, HTML, runtime, Auth, API, Search, My Trees, or Editor changes.
 
-The goal is to align heading hierarchy, hero/header treatment, page copy, and motion/reveal behavior across operating pages without mixing documentation, copy, CSS, motion, or runtime changes in one PR.
+## Active page scope
 
-This roadmap is planning-only. It does not approve direct implementation, page edits, CSS changes, JavaScript changes, runtime changes, or prototype/reference/demo cleanup.
-
-## Page Scope
-
-The active-page scope for this roadmap is:
+Included active pages:
 
 - `index.html`
 - `pages/intro.html`
@@ -18,194 +16,69 @@ The active-page scope for this roadmap is:
 - `pages/my-trees.html`
 - `pages/detail.html`
 - `pages/login.html`
-- `pages/settings.html` classification only
+- `pages/settings.html` for classification only
 
-`pages/settings.html` is included for classification so future card/modal entry behavior can be aligned, but it should not be treated as a broad first-phase implementation target without a separate plan.
-
-## Excluded Scope
-
-The following are explicitly excluded from this roadmap's implementation phases unless a separate CTO-approved task says otherwise:
+Excluded surfaces:
 
 - `pages/editor.html`
 - PR #7
-- prototype/reference/demo/variant paths
-- quiet/hotspot/scrapbook demo/reference assets
-- editor-specific quiet-first work
-- runtime, data loading, auth, API, Modal, or database behavior
+- prototype / reference / demo / variant paths
+- preserved reference assets such as `quiet/**`, `hotspot-prototype/**`, `scrapbook-demo/**`, and equivalent historical design experiments
 
-## Page Type Classification
+## Page type classification
 
-| Page type | Pages | Primary UX role | Notes |
-| --- | --- | --- | --- |
-| Brand Hero | `index.html`, `pages/intro.html` | Brand entry, first impression, product positioning | Copy and hero rhythm should feel aligned without duplicating the exact layout. |
-| Browse Header | `pages/search.html` | Discovery/browse entry | Must not interfere with search skeletons, result loading, preview behavior, or API-driven state. |
-| Workspace Header | `pages/my-trees.html` | Authenticated owner workspace entry | Must preserve auth-pending behavior, loading/error/empty/loaded states, and create-tree flows. |
-| Detail Hero | `pages/detail.html` | Public tree detail entry | Must preserve placeholder and hydrate behavior. |
-| Auth Card Entry | `pages/login.html` | Authentication entry | Must preserve redirect target handling and auth boot behavior. |
-| Settings Modal/Card Entry | `pages/settings.html` | Account/settings control surface | Classification only until a dedicated settings pass is approved. |
+| Page | Classification | Notes |
+| --- | --- | --- |
+| `index.html` | Brand Hero | Current visual source of truth. |
+| `pages/intro.html` | Brand Hero | Structurally close to Home, but product-facing copy should prefer `러브트리` over generic `나무`. |
+| `pages/search.html` | Browse Header | Needs heading and eyebrow hierarchy audit before CSS work. |
+| `pages/my-trees.html` | Workspace Header | Should read as an emotional record space, not as a generic dashboard. |
+| `pages/detail.html` | Detail Hero | Should remain a detail-focused page, not an oversized Brand Hero. |
+| `pages/login.html` | Auth Card Entry | Auth flow should remain stable while copy aligns with product language. |
+| `pages/settings.html` | Settings Modal/Card Entry | Classification only; runtime/history behavior belongs in a separate bug path. |
 
-## Work Breakdown
+## Current findings
 
-### 1. Docs/design roadmap
+- Home is the current visual source of truth for active page tone, rhythm, and brand presence.
+- Intro is visually related to Home but weakens brand language when it uses generic `나무` where product-facing copy should say `러브트리`.
+- Search/Browse has a Browse Header role, but the heading hierarchy and eyebrow treatment need a focused audit before implementation.
+- My Trees should align with the emotional record and memory-space framing rather than generic dashboard language.
+- Detail should retain its detail-first role and avoid being promoted into a large Brand Hero pattern.
+- Login may adopt product language while preserving auth entry behavior and redirect flows.
+- Settings runtime/history bugs are outside this visual consistency roadmap.
+- Shared page enter and upward text reveal are not consistently applied across active non-editor pages.
 
-Create this roadmap as the planning baseline for Issue #239.
+## Product language rules to preserve
 
-Scope:
+Use product-facing language consistently where the user is learning, browsing, or returning to their own records:
 
-- Document active page types.
-- Separate implementation phases.
-- Define guardrails for future copy, CSS, and motion work.
+- `러브트리`
+- `첫 순간`
+- `이어진 마음`
+- `감정 경로`
 
-Non-goals:
+Avoid generic language that dilutes the product identity when the page is product-facing. Generic terms may remain where a technical or neutral context needs them.
 
-- No page HTML changes.
-- No CSS changes.
-- No JavaScript changes.
-- No runtime behavior changes.
+## Recommended PR sequence
 
-### 2. Copy-only Intro brand alignment
-
-Recommended future PR type: copy-only.
-
-Scope:
-
-- Align `index.html` and `pages/intro.html` brand positioning.
-- Keep layout and runtime unchanged.
-- Avoid broad hero redesign.
-
-Validation:
-
-- Changed files limited to relevant page copy only.
-- No CSS/JS/runtime changes.
-- Browser smoke for landing and intro pages.
-
-### 3. Copy-only Search/My Trees/Login heading refinement
-
-Recommended future PR type: copy-only and page-specific.
-
-Scope:
-
-- Refine heading/subheading language for:
-  - `pages/search.html`
-  - `pages/my-trees.html`
-  - `pages/login.html`
-- Preserve current state containers, auth behavior, redirect behavior, and API/data loading.
-
-Validation:
-
-- No selector changes.
-- No CSS/JS changes.
-- Search and my-trees state behavior smoke required after copy changes.
-
-### 4. Heading token/CSS hierarchy
-
-Recommended future PR type: CSS-only after copy baseline is reviewed.
-
-Scope:
-
-- Define narrow heading hierarchy rules for active pages.
-- Prefer page-scoped CSS over broad global rules.
-- Avoid `css/global.css` motion or heading rewrites unless explicitly approved.
-
-Validation:
-
-- Changed files limited to approved page CSS files.
-- Desktop and mobile visual smoke for each opted-in page.
-- No runtime/API/Auth changes.
-
-### 5. Shared transition/reveal asset PR
-
-Recommended future PR type: asset-only.
-
-Scope:
-
-- Add shared transition/reveal assets only.
-- Keep assets inert unless a page explicitly opts in.
-- Respect `prefers-reduced-motion`.
-- Avoid overlays and pointer-event blocking.
-
-Relation:
-
-- This is tracked primarily under Issue #242.
-- PR #294 is the asset-only transition work and must not close Issue #239.
-
-### 6. Low-risk page opt-in
-
-Recommended future PR type: page-specific opt-in after shared assets exist.
-
-Candidate pages:
-
-- `index.html`
-- `pages/intro.html`
-
-Scope:
-
-- Opt in only low-risk static/brand pages first.
-- Avoid Search, My Trees, Detail, Login, and Settings until static pages pass smoke.
-
-Validation:
-
-- Desktop/mobile visual smoke.
-- Reduced-motion behavior check.
-- No click-blocking or delayed interaction.
-
-### 7. Auth/data-sensitive page opt-in after smoke validation
-
-Recommended future PR type: one page or one page group at a time.
-
-Candidate pages:
-
-- `pages/search.html`
-- `pages/my-trees.html`
-- `pages/detail.html`
-- `pages/login.html`
-- `pages/settings.html` only after dedicated settings approval
-
-Required guardrail:
-
-- Do not mask loading, auth-pending, skeleton, placeholder, error, empty, or loaded states.
-- Do not delay API/data/auth execution.
-- Do not add blocking overlays.
-- Do not alter route, redirect, or event behavior.
+1. Copy-only Intro hero brand alignment.
+2. Copy-only Search, My Trees, and Login heading refinement.
+3. Heading token and CSS hierarchy PR.
+4. Shared page transition/reveal asset PR.
+5. Low-risk opt-in transition application.
+6. Auth/data-sensitive opt-in after smoke validation.
 
 ## Guardrails
 
-- No broad CSS changes.
-- No runtime changes.
-- No `css/global.css` motion implementation without explicit approval.
-- No editor changes.
-- No prototype/reference/demo/variant changes.
+- No runtime behavior changes.
+- No Auth/API/Search/MyTrees JavaScript changes in copy-only PRs.
+- No `pages/editor.html` changes.
 - No PR #7 changes.
-- Split copy, CSS, motion, and runtime work into separate PRs.
-- Keep each page opt-in small and independently verifiable.
-- Do not mix Issue #239 UX consistency work with Issue #242 transition coverage implementation unless explicitly approved.
-- Do not mix this work with Search/Auth/MyTrees/Editor/API/Modal implementation changes.
+- No prototype/reference/demo/variant path changes.
+- No broad CSS redesign.
+- No global motion injection.
+- Keep copy, CSS token, runtime routing, and motion changes split into separate PRs.
 
-## Relation to Issue #242
+## Closure note
 
-Issue #242 handles page transition/reveal coverage and the motion asset/application sequence.
-
-Issue #239 remains the parent UX consistency tracker for active-page heading, hero, copy, and visual rhythm alignment.
-
-Therefore:
-
-- #242 documentation and motion asset PRs should not close #239.
-- PR #294 should not close #239.
-- Future #242 page opt-in phases should be referenced from #239 only when they materially affect active-page UX consistency.
-- #239 implementation should still split copy, heading hierarchy, and page motion adoption into separate PRs.
-
-## Open Implementation Queue
-
-Recommended order:
-
-1. Merge docs-only roadmap after review.
-2. Complete shared transition/reveal asset work under #242.
-3. Run copy-only brand alignment for `index.html` and `pages/intro.html`.
-4. Run copy-only heading refinements for Search/My Trees/Login.
-5. Add narrow heading hierarchy CSS after copy settles.
-6. Opt in static Brand Hero pages to shared reveal assets.
-7. Opt in data/auth-sensitive pages only after smoke validation.
-
-## Non-Closure Note
-
-Issue #239 should remain open after this document lands because the implementation phases are still pending.
+Issue #239 should remain open until the CTO decides the roadmap and follow-up implementation split satisfy the tracking goal. This document intentionally uses `Refs #239` and no close keyword.

--- a/docs/design/PAGE_TRANSITION_COVERAGE_MAP.md
+++ b/docs/design/PAGE_TRANSITION_COVERAGE_MAP.md
@@ -1,0 +1,61 @@
+# Page Transition Coverage Map
+
+Refs #242
+
+## Purpose
+
+This document records current active non-editor page transition and upward text reveal coverage before implementation. It is documentation-only and does not add motion assets, page opt-ins, CSS, JavaScript, HTML, or runtime behavior changes.
+
+## Current coverage
+
+| Page | Current transition/reveal coverage | Status |
+| --- | --- | --- |
+| `index.html` | `.reveal` based scroll reveal exists. | PARTIAL |
+| `pages/intro.html` | Tree grow animation exists, but no shared hero text reveal or shared page enter transition. | PARTIAL |
+| `pages/login.html` | No shared page enter transition. | MISSING |
+| `pages/search.html` | No shared page enter transition. | MISSING |
+| `pages/detail.html` | No shared page enter transition. | MISSING |
+| `pages/my-trees.html` | No shared page enter transition. | MISSING |
+
+## Direction
+
+Do not add motion directly to `css/global.css`.
+
+Preferred future opt-in assets:
+
+- `css/page-transitions.css`
+- `js/page-transitions.js`
+
+Implementation should happen only after documentation and page-type classification. Motion assets should be inert until a page explicitly opts in.
+
+## Risk notes
+
+- Search skeleton must remain visible immediately.
+- Detail placeholders must not be hidden from runtime replacement.
+- My Trees auth-pending visibility must not regress.
+- Login redirect notice and auth modal behavior must not be blocked.
+- Motion must respect `prefers-reduced-motion`.
+- No overlay or transition may block clicks.
+- Transition setup must not delay API, Auth, data loading, or route handling.
+
+## Recommended PR sequence
+
+1. Docs-only coverage map.
+2. Shared transition asset-only PR.
+3. Home/Intro/Browse opt-in PR.
+4. Login/Detail/MyTrees opt-in PR after smoke validation.
+
+## Guardrails
+
+- No `pages/editor.html` changes.
+- No Auth runtime changes.
+- No Search runtime changes.
+- No API/backend changes.
+- No prototype/reference/demo/variant changes.
+- No PR #7 changes.
+- No motion implementation in this docs-only PR.
+- No close keyword for Issue #242 unless CTO decides the audit phase is complete.
+
+## Closure note
+
+Issue #242 should remain open unless the CTO decides this docs-only coverage map satisfies the audit phase. This document intentionally uses `Refs #242` and no close keyword.

--- a/docs/design/design_index.md
+++ b/docs/design/design_index.md
@@ -25,6 +25,8 @@ design/
 |--------|------|
 | [UI_DESIGN_SYSTEM.md](UI_DESIGN_SYSTEM.md) | LoveBud UI/UX 디자인 시스템과 화면 기준 |
 | [UI_POLISH_ROADMAP.md](UI_POLISH_ROADMAP.md) | PR #49, #51, #62, #63, #66, #67, #69, #70 이후 public UI polish와 Search 후속 작업 범위 분리 기준 |
+| [ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md](ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md) | active page UX consistency audit 및 구현 전 roadmap |
+| [PAGE_TRANSITION_COVERAGE_MAP.md](PAGE_TRANSITION_COVERAGE_MAP.md) | active non-editor page transition/reveal coverage map |
 | [BUTTON_BADGE_CHIP_BASELINE.md](BUTTON_BADGE_CHIP_BASELINE.md) | button / badge / chip tone 통일 기준 |
 | [BUTTON_BASELINE_CONSOLIDATION_PLAN.md](BUTTON_BASELINE_CONSOLIDATION_PLAN.md) | global.css button baseline 중복 정의 정리 계획 |
 | [PRIMARY_COLOR_TOKEN_CLEANUP_PLAN.md](PRIMARY_COLOR_TOKEN_CLEANUP_PLAN.md) | `rgba(144, 73, 81, X)` 반복을 `--primary-rgb` token 기반으로 단계 정리하기 위한 계획 |


### PR DESCRIPTION
Summary:
- Add docs-only active page UX consistency roadmap refresh for Issue #239.
- Add docs-only page transition/reveal coverage map for Issue #242.
- Keep implementation, CSS, JS, HTML, and runtime behavior out of scope.

Scope:
- Docs-only.
- No CSS changes.
- No JS changes.
- No HTML/page markup changes.
- No runtime/Auth/API/Search/MyTrees behavior changes.
- No pages/editor.html changes.
- No PR #7/prototype/reference/demo/variant changes.

Changed files:
- docs/design/ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md
- docs/design/PAGE_TRANSITION_COVERAGE_MAP.md
- docs/design/design_index.md

Related:
Refs #239
Refs #242

Verification:
- [ ] GitHub diff review
- [ ] Docs-only scope confirmed
- [ ] Active page classification documented
- [ ] Transition/reveal coverage documented
- [ ] Recommended PR sequence documented
- [ ] No CSS/JS/HTML/runtime changes
- [ ] No pages/editor.html changes
- [ ] No close keywords for #239/#242
- [ ] PR #7/prototype/reference/demo/variant untouched

Notes:
- Existing `docs/design/ACTIVE_PAGE_UX_CONSISTENCY_ROADMAP.md` was refreshed instead of recreated.
- Issue #239 and Issue #242 remain open unless CTO separately decides docs-only audit coverage is sufficient for a phase closure.