### PR TITLE
docs(debt): reconcile issue 224 verification checklist

### DIFF
--- a/docs/engineering/TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md
+++ b/docs/engineering/TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md
@@ -8,44 +8,95 @@
 
 This document maps Issue #224 technical-debt verification checklist items to their current disposition.
 
-It is not an implementation PR and does not authorize runtime cleanup, deletion, password policy changes, Auth fallback removal, or Editor state migration.
+It classifies each reported item as one of:
 
-## 2. Disposition summary
+- `COMPLETE`
+- `TRANSFERRED`
+- `NOT_APPLICABLE`
+- `STILL_OPEN`
 
-| #224 item | Current disposition | Evidence / related PRs | Next action |
+It is not an implementation PR and does not authorize runtime cleanup, deletion, password policy changes, Auth fallback removal, Editor state migration, deployment configuration changes, or prototype/reference/demo/variant cleanup.
+
+## 2. Issue #224 checklist disposition table
+
+| #224 item | Disposition | Evidence / current judgment | Follow-up owner |
 |---|---|---|---|
-| CORS default allowed origins | Finding appears stale / current active default includes Pages origin | PR #335 documents that the reported Netlify file/default was not present on current main and Modal configuration includes `https://lovebud.pages.dev` | Mark as audit-complete; no Netlify CORS implementation unless new evidence appears |
-| Repeated primary RGBA tokens | Audit complete / implementation deferred | PR #298 documents usage audit and safe candidate/hold areas | Create separate CSS token cleanup PR only after visual review approval |
-| CSS version/prototype folders | Audit complete / no deletion authorized | PR #348 merged folder reference audit | Keep preserved artifacts unless a dedicated removal audit explicitly approves deletion |
-| Auth/editor transitional fallbacks | Ownership mapped / implementation deferred | PR #349 maps Auth cleanup to #78 and Editor fallback/global-state cleanup to #225/#322 | Do not remove fallbacks from #224 directly |
-| `window.currentTreeMemories` global state | Audit owner mapped / migration deferred | PR #322 documents Editor fallback/global state audit path; PR #349 maps ownership | Keep under #225 staged Editor state cleanup |
-| Jest/test framework migration | Audit complete / no immediate migration | PR #329 documents lightweight test runner strategy | Do not add Jest unless a concrete follow-up need is approved |
-| Signup password complexity validation | Audit complete / implementation deferred | PR #327 documents password policy options and guardrails | Create separate Auth UX/security PR only after policy/copy approval |
+| CORS default allowed origins | `NOT_APPLICABLE` for current main / `TRANSFERRED` if legacy audit reopens it | The reported `netlify/functions/_lib/http.js` path is not present on current `main`; active runtime remains Cloudflare Pages + Modal. If a legacy Netlify path reappears, handle under a legacy runtime audit. | Legacy runtime audit / deployment artifact tracker |
+| Repeated hard-coded primary RGBA tokens | `TRANSFERRED` | Hard-coded primary RGBA token cleanup belongs with global CSS hardening implementation, not #224 verification. | Issue #137 / global CSS hardening implementation follow-up |
+| CSS version/prototype folders | `TRANSFERRED` | Version/prototype folders require prototype/reference policy and folder-prefix classification before any deletion. | Prototype/reference policy or folder-prefix audit follow-up |
+| `auth.js` / `editor.js` transitional fallback patterns | `TRANSFERRED` | Auth and Editor fallbacks have separate ownership and should not be fixed together. | Auth fallback: Issue #78; Editor fallback: Issue #225 |
+| `window.currentTreeMemories` global state | `TRANSFERRED` | Editor global state should be handled through EditorStore/editor global-state follow-up work, not #224. | Issue #225 / EditorStore or editor global state follow-up |
+| Jest/test framework migration | `NOT_APPLICABLE` for immediate migration | Current lightweight Node contract tests remain the preferred low-friction strategy unless a concrete test strategy issue proves a framework need. | Separate test strategy issue only if CTO reopens framework migration |
+| Signup password complexity validation | `TRANSFERRED` | Password policy is Auth UX/security work and needs product/security decision plus user-facing copy before implementation. | Separate Auth UX/security follow-up |
 
-## 3. Closure blocker
+## 3. Completed / transferred / not applicable / still open summary
 
-Issue #224 can only close when the issue body or final issue comment records that every checklist item is either:
+### COMPLETE
 
-- completed by an audit PR;
-- marked stale/not applicable with evidence;
-- moved to a dedicated owner issue; or
-- deferred with an explicit follow-up owner.
+No #224 checklist item is implemented by this disposition document. Items that were previously audited remain represented through their follow-up owner documents or trackers.
 
-This document supports that final comment but does not close #224 by itself.
+### TRANSFERRED
 
-## 4. Recommended issue-level disposition
+- Repeated hard-coded primary RGBA tokens → Issue #137 / global CSS hardening implementation.
+- CSS version/prototype folders → prototype/reference policy or folder-prefix audit follow-up.
+- `auth.js` fallback patterns → Issue #78.
+- `editor.js` fallback patterns → Issue #225.
+- `window.currentTreeMemories` global state → Issue #225 / EditorStore or editor global-state follow-up.
+- Signup password complexity validation → separate Auth UX/security follow-up.
 
-Recommended final disposition for #224:
+### NOT_APPLICABLE
 
-- CORS default origin: audit-complete / no action on current main unless new file evidence appears.
-- Primary RGBA tokens: defer implementation to CSS token cleanup follow-up.
-- CSS version folders: audit-complete / no deletion authorized.
-- Auth fallback cleanup: owned by #78 and staged runtime cleanup trackers.
-- Editor fallback/global state: owned by #225 and Editor audit documents.
-- Test framework migration: audit-complete / keep current lightweight tests unless approved.
-- Signup password policy: audit-complete / separate Auth UX/security follow-up required.
+- CORS default allowed origins: not applicable to current `main` as a direct file fix because the reported `netlify/functions/_lib/http.js` path is absent and the active runtime is Cloudflare Pages + Modal. If Netlify legacy runtime work reopens the concern, it should move to a legacy runtime audit.
+- Jest/test framework migration: not applicable as an immediate migration because lightweight Node contract tests remain the preferred current strategy absent a concrete test framework requirement.
 
-## 5. Non-goals
+### STILL_OPEN
+
+- No item should remain open under #224 after the transferred follow-up links are recorded in the issue comment or body.
+- The only administrative open work is to record owner links for transferred items before closing #224.
+
+## 4. Follow-up ownership map
+
+| Area | Owner tracker / follow-up | Implementation rule |
+|---|---|---|
+| Legacy runtime CORS defaults | Legacy runtime audit / deployment artifact follow-up | Do not modify inactive legacy files unless current file presence and runtime relevance are re-established. |
+| Global CSS primary RGBA tokens | Issue #137 / global CSS hardening implementation | No broad search/replace; visual review required for token changes. |
+| Prototype/version folders | Prototype/reference policy or folder-prefix audit follow-up | No automatic deletion; PR #7 and preserved prototype/reference/demo/variant assets remain untouched. |
+| Auth transitional fallbacks | Issue #78 | No Auth fallback removal without provider-boundary and login/Auth smoke validation. |
+| Editor transitional fallbacks | Issue #225 | No broad `editor.js` rewrite; preserve compatibility aliases and startup behavior. |
+| Editor global state / `window.currentTreeMemories` | Issue #225 / EditorStore follow-up | No large EditorStore rewrite in one PR; browser smoke required for state behavior changes. |
+| Test framework strategy | Separate test strategy issue only if needed | Do not add Jest or framework dependencies without a concrete testing gap. |
+| Signup password policy | Separate Auth UX/security follow-up | No stricter validation without approved policy, UX copy, i18n, and Auth smoke. |
+
+## 5. Closure rule
+
+Issue #224 can be closed only after all of the following are true:
+
+1. every checklist item is recorded as `COMPLETE`, `TRANSFERRED`, `NOT_APPLICABLE`, or `STILL_OPEN`;
+2. any transferred item has an owner issue or follow-up axis recorded in the #224 issue comment or body;
+3. any still-open item is either resolved, marked not applicable with evidence, or transferred to a linked follow-up issue;
+4. the #224 final comment states that closure is administrative and does not authorize implementation;
+5. no close keyword is used accidentally from a PR body;
+6. no JS/CSS/HTML/runtime or deployment config files are changed as part of this disposition.
+
+Closing #224 does not authorize implementation.
+
+## 6. Guardrails
+
+- No JS changes.
+- No CSS changes.
+- No HTML/page markup changes.
+- No runtime/Auth/API/Search/MyTrees/Editor behavior changes.
+- No deployment config changes.
+- No package/test framework dependency changes.
+- No password policy implementation.
+- No Auth fallback removal.
+- No Editor fallback removal.
+- No EditorStore or global state migration.
+- No prototype/reference/demo/variant path changes.
+- No PR #7 changes.
+- No close keyword in PR bodies unless CTO explicitly approves issue closure.
+
+## 7. Non-goals
 
 - Do not change CSS tokens in this PR.
 - Do not delete legacy/prototype/reference/demo/variant files.
@@ -53,8 +104,11 @@ Recommended final disposition for #224:
 - Do not implement EditorStore or global state migration.
 - Do not add Jest or change package scripts.
 - Do not strengthen password policy without approved UX copy and Auth smoke.
+- Do not change deployment configuration.
 - Do not close #224 from this document alone.
 
-## 6. Suggested next step
+## 8. Suggested next step
 
-Post an issue comment on #224 that links this document and records the final disposition of each checklist item. If CTO approves, close #224 only after any remaining implementation work is moved to explicit follow-up issues.
+Post an issue comment on #224 that links this document and records the disposition of each checklist item.
+
+If CTO approves, close #224 only after the transferred items have explicit owner links and the final comment states that closure is administrative, not implementation approval.


### PR DESCRIPTION
## Summary
- Add docs-only disposition for Issue #224 technical debt checklist.
- Classify each reported item as complete, transferred, not applicable, or still open.
- Keep implementation and runtime changes out of scope.

## Scope
- Docs-only.
- No JS changes.
- No CSS changes.
- No HTML/page markup changes.
- No runtime/Auth/API/Search/MyTrees/Editor behavior changes.
- No deployment config changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #224
Refs #223
Refs #225

## Verification
- [ ] GitHub diff review
- [ ] Docs-only scope confirmed
- [ ] All seven #224 checklist items classified
- [ ] Follow-up ownership documented
- [ ] No JS/CSS/HTML/runtime changes
- [ ] No deployment config changes
- [ ] No close keyword for #224
- [ ] PR #7/prototype/reference/demo/variant untouched