### PR TITLE
docs(product): remove conflict markers from product_index.md

### DIFF
--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -17,18 +17,10 @@
 | [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 public-first 감상 공간 원칙 |
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
-<<<<<<< HEAD
-| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline product/technical plan |
+| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
 | [MOMENT_CAPTURE_UI_DESIGN.md](MOMENT_CAPTURE_UI_DESIGN.md) | Moment capture UI flow design |
-| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
-=======
 | [MOMENT_TIMELINE_REORDER_DESIGN.md](MOMENT_TIMELINE_REORDER_DESIGN.md) | Moment Timeline reorder / sequence editor design |
-<<<<<<< HEAD
->>>>>>> 0e0c994 (docs(product): link Moment Timeline reorder design)
-=======
-| [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
->>>>>>> 1ad8f73 (Reconcile product_index.md: include both MOMENT_TIMELINE_REORDER_DESIGN.md and MOMENT_TIMELINE_PLAN.md)
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
@@ -69,42 +61,15 @@
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
-<<<<<<< HEAD
-<<<<<<< HEAD
-4. **MOMENT_TIMELINE_PLAN.md** - cue-based Moment Timeline plan
-5. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** - YouTube segment player PoC scope and verification criteria
-6. **MOMENT_CAPTURE_UI_DESIGN.md** - Moment capture UI flow design
-7. **UI_COPY_DIET_GUIDE.md** - global UI copy diet guidelines
-8. **MVP_SCOPE.md** - MVP scope and In/Out of Scope
-9. **USER_FLOW.md** - user journey and key flows
-10. **PRODUCT_BRIEF.md** - current execution-based summary
-11. If needed, DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
-=======
-4. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-5. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-6. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-7. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-8. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-9. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-10. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
->>>>>>> 30955f0 (Reconcile product_index.md: include both MOMENT_CAPTURE_UI_DESIGN.md and MOMENT_TIMELINE_PLAN.md)
-=======
-4. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-<<<<<<< HEAD
-5. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-6. **MVP_SCOPE.md** — MVP 범위와 In/Out of Scope
-7. **USER_FLOW.md** — 사용자 여정과 핵심 플로우
-8. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-9. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
->>>>>>> 0e0c994 (docs(product): link Moment Timeline reorder design)
-=======
-5. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-6. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-7. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-8. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-9. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-10. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
->>>>>>> 1ad8f73 (Reconcile product_index.md: include both MOMENT_TIMELINE_REORDER_DESIGN.md and MOMENT_TIMELINE_PLAN.md)
+4. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+5. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+6. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+7. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+8. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+9. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+10. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+11. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+12. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
## Summary

Emergency docs-only cleanup to remove unresolved conflict markers from docs/product/product_index.md.

## Scope
- Docs-only change
- No runtime/code changes
- No PR #7/prototype/reference/demo/variant changes

## Changes
- Removed all conflict markers (<<<<<<< HEAD, =======, >>>>>>>)
- Reconciled file list to preserve all Moment Timeline related documents:
  - MOMENT_TIMELINE_PLAN.md
  - YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md
  - MOMENT_CAPTURE_UI_DESIGN.md
  - MOMENT_TIMELINE_REORDER_DESIGN.md
- Removed duplicate file entries
- Reconciled read order to include all documents naturally

## Verification
- git diff --check: PASS
- npm run lint: PASS
- npm run build: PASS
- Changed files: 1 (docs/product/product_index.md only)

## Restrictions
- No close keywords used
- No issue closures
- No runtime code changes
