### PR TITLE
fix(my-trees): restore LoveTreeMyTreesPage backward compatibility alias

### DIFF
--- a/js/my-trees/my-trees-page.js
+++ b/js/my-trees/my-trees-page.js
@@ -155,11 +155,15 @@
     });
   }
 
-  window.LoveBudMyTreesPage = {
+  var api = {
     STATE: STATE,
     showToast: showToast,
     setState: setState,
     setupHeaderCreateButton: setupHeaderCreateButton,
     setupRetryButton: setupRetryButton
   };
+
+  // Backward compatibility: export both LoveBudMyTreesPage and LoveTreeMyTreesPage
+  window.LoveBudMyTreesPage = api;
+  window.LoveTreeMyTreesPage = api;
 })();


### PR DESCRIPTION
## Summary

Restore backward compatibility alias for My Trees page helpers after PR #378 merge.

## Scope
- Single file change: js/my-trees/my-trees-page.js
- No runtime behavior changes
- No functional logic changes
- No docs/CSS/pages/API/Auth/backend changes
- No PR #7/prototype/reference/demo/variant changes

## Changes
- Extracted export object to ar api = { ... }
- Added both window aliases:
  - window.LoveBudMyTreesPage = api;
  - window.LoveTreeMyTreesPage = api;
- Added backward compatibility comment
- Preserved all existing functionality (STATE, showToast, setState, setupHeaderCreateButton, setupRetryButton)

## Scope Recovery
- Removed out-of-scope docs/product/product_index.md change (conflicts with PR #402)
- Final changed files: 1 (js/my-trees/my-trees-page.js only)
- Rebased on latest main to remove conflict marker commit

## Verification
- git diff --check: PASS
- npm run lint: PASS
- npm test: PASS (114/114 tests)
- npm run verify: PASS (126/126 checks)
- Changed files: 1 (js/my-trees/my-trees-page.js only)
- LoveBudMyTreesPage alias present: YES
- LoveTreeMyTreesPage alias present: YES

## Restrictions
- No close keywords used
- No issue closures
- No runtime behavior changes