### PR TITLE
test(ops): ignore media 404 console noise in Cloudflare smoke

### DIFF
--- a/scripts/cloudflare-supplied-url-smoke.js
+++ b/scripts/cloudflare-supplied-url-smoke.js
@@ -54,6 +54,7 @@ async function runTarget(page, target, viewport) {
   const fatalMessages = [];
   const networkFailures = [];
   const networkBlockers = [];
+  let ignoredMedia404Count = 0; // Tracks generic 404 console errors linked to ignored media network responses
 
   page.removeAllListeners('pageerror');
   page.removeAllListeners('console');
@@ -67,6 +68,14 @@ async function runTarget(page, target, viewport) {
   page.on('console', (message) => {
     if (message.type() !== 'error') return;
     const text = message.text();
+    // If a generic "Failed to load resource: 404" console error occurs,
+    // and we have an unacknowledged ignored media 404 network response,
+    // decrement the counter and ignore this console error.
+    if (text === 'Failed to load resource: the server responded with a status of 404 ()' && ignoredMedia404Count > 0) {
+      ignoredMedia404Count--;
+      return; // Ignore this specific console error
+    }
+    // Apply original console error filtering for other cases
     if (!isIgnoredConsoleError(text)) {
       fatalMessages.push(`console.error: ${text}`);
     }
@@ -79,6 +88,11 @@ async function runTarget(page, target, viewport) {
   });
 
   page.on('response', (response) => {
+    // Increment counter for ignored YouTube 404s that might cause generic console errors
+    if (response.status() === 404 && (/ytimg\.com|img\.youtube\.com/.test(response.url()))) {
+      ignoredMedia404Count++;
+    }
+
     if (isNetworkBlocker(response)) {
       networkBlockers.push(`${response.status()} ${response.url()}`);
     }


### PR DESCRIPTION
## Summary
- Fix supplied-url Cloudflare smoke false failure caused by ignored YouTube thumbnail 404 responses surfacing as generic Chromium console errors.
- Keep app/runtime/Search behavior unchanged.
- Preserve failures for real app asset/API/module blockers.

## Scope
- Test/ops smoke script only.
- No app JS/CSS/HTML changes.
- No runtime/Auth/API/Search/MyTrees/Editor behavior changes.
- No package/config changes unless strictly required.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #136

## Verification
- [ ] node --check scripts/cloudflare-supplied-url-smoke.js
- [ ] SMOKE_BASE_URL=https://lovebud.pages.dev npm run smoke:cloudflare
- [ ] SMOKE_BASE_URL=https://test1.lovebud.pages.dev npm run smoke:cloudflare
- [ ] YouTube thumbnail 404 remains non-blocking
- [ ] app asset/API/module blockers still fail
- [ ] no credential/token/session/cookie/header/password exposure
- [ ] no close keyword for #136