### PR TITLE
docs: follow-up updates for Issue #242

### DIFF
--- a/docs/ux/ISSUE_242_CLOSURE_DISPOSITION.md
+++ b/docs/ux/ISSUE_242_CLOSURE_DISPOSITION.md
@@ -1,0 +1,52 @@
+# Issue #242 Closure Disposition
+
+## Issue Summary
+
+Issue #242: Audit and document page transition reveal coverage
+
+## Resolution Status
+
+**CLOSED** via docs-only follow-up PR
+
+## Implementation History
+
+### Phase 1: Docs-only Coverage Map (COMPLETED)
+
+- **PR**: #288
+- **Merge Commit**: 988ef395b89625485b07e1387e829d714b9bb8ae
+- **Added Document**: docs/ux/PAGE_TRANSITION_REVEAL_COVERAGE.md
+- **Updated Index**: docs/doc_index.md
+- **Scope**: docs-only coverage map
+- **Runtime, UI, API, Auth, Search, Editor behavior**: unchanged
+
+### Audit Trail
+
+- PR #284 was closed due to contaminated history
+- PR #287 was closed after the force-push incident and superseded by clean replacement PR #288
+
+## Closure Rationale
+
+The phase 1 docs-only coverage map has been successfully merged. Issue #242 is now closed as the initial documentation phase is complete.
+
+## Related Issues
+
+- **Parent UX roadmap**: #239 (remains open as active page UX consistency roadmap/tracking issue)
+
+## Out of Scope
+
+The following remain out of scope for this closure:
+
+- Editor changes
+- Auth runtime changes
+- Search runtime changes
+- API/backend changes
+- prototype/reference/demo/variant changes
+
+## Future Work
+
+Future implementation of actual page transition reveal features should follow the recommended PR sequence outlined in the original issue:
+
+1. ✅ Docs-only coverage map (COMPLETED via PR #288)
+2. ⏳ Shared transition asset-only PR
+3. ⏳ Home/Intro/Browse opt-in PR
+4. ⏳ Login/Detail/MyTrees opt-in PR after smoke validation


### PR DESCRIPTION
Docs-only follow-up for Issue #242 closure disposition. No runtime, UI, API, Auth, Search, or Editor changes.