### PR TITLE
docs(ops/security): update agent security rules

### DIFF
--- a/docs/ops/AGENTS.md
+++ b/docs/ops/AGENTS.md
@@ -1,0 +1,147 @@
+# Ops Agent Security Rules
+
+Refs #299
+
+## Purpose
+
+This document defines secret-safe operating rules for LoveBud agents that inspect GitHub, local paths, credentials, deployment settings, or verification environments.
+
+Agents and central systems must not request, display, store, summarize, or transmit raw token or secret values. They may only guide local operators by referencing approved paths, secret names, and presence/status checks.
+
+## Core rule
+
+Model-side or central-system work has no need to see secret values.
+
+Allowed reports are limited to status words such as:
+
+- `PRESENT`
+- `MISSING`
+- `EXISTS`
+- `GITIGNORED`
+- `REDACTED`
+- `PASS`
+- `BLOCKED`
+
+Do not include raw values, partial values, prefixes, suffixes, hashes, screenshots, copied file contents, command output that contains values, or environment dumps.
+
+## Allowed local paths to reference
+
+Agents may reference these local paths by name only:
+
+- `.secrets/`
+- `.env`
+- `.env.*`
+- `~/.config/gh/hosts.yml`
+
+Referencing a path does not authorize printing its contents.
+
+## Allowed checks
+
+Safe checks may confirm only existence, ignored status, or required key presence without values.
+
+PowerShell examples:
+
+```powershell
+Test-Path .secrets/lovebud-runtime.env
+Test-Path .env
+Test-Path ~/.config/gh/hosts.yml
+```
+
+Git examples:
+
+```bash
+git check-ignore .secrets/lovebud-runtime.env
+git check-ignore .env
+git check-ignore .env.local
+```
+
+GitHub token creation may be directed to:
+
+```text
+https://github.com/settings/tokens
+```
+
+The generated token value must remain local to the operator and must not be pasted into chat, docs, PRs, issues, logs, screenshots, or reports.
+
+## Forbidden actions
+
+Do not run or request commands that print secret material, including:
+
+```bash
+cat .env
+cat .env.*
+cat .secrets/*
+printenv
+env
+set
+echo $GH_TOKEN
+echo $CLOUDFLARE_API_TOKEN
+```
+
+```powershell
+Get-Content .env
+Get-Content .env.*
+Get-Content .secrets/*
+echo $env:GH_TOKEN
+echo $env:CLOUDFLARE_API_TOKEN
+Get-ChildItem Env:
+```
+
+Also forbidden:
+
+- file content output for credential-bearing files;
+- full environment variable dumps;
+- token value recording or exposure;
+- screenshots containing tokens, cookies, session data, or private keys;
+- PR/Issue comments that include tokens or credential values;
+- committing plaintext credential files.
+
+## Local automation pattern
+
+Use this pattern when a local command needs a secret:
+
+1. Operator stores the secret in an approved local path.
+2. Automation references the path.
+3. The local machine reads the value into process memory.
+4. The command receives the value through the CLI, environment, stdin, or approved credential manager.
+5. Reports include only status, never the value.
+
+Safe report example:
+
+```text
+credential path: .secrets/lovebud-runtime.env
+credential file: EXISTS
+credential file gitignored: YES
+required key: PRESENT
+secret value exposed: NO
+```
+
+## PR and Issue safety guidance
+
+PR and Issue comments should include only:
+
+- scope;
+- related Issue or PR number;
+- whether merge is needed;
+- whether CTO approval is required;
+- verification status without secret values.
+
+Do not mix static verification PASS with functional PASS.
+
+Examples:
+
+- `git diff --check: PASS` means whitespace/static diff is clean only.
+- `Cloudflare Preview smoke: PASS` means browser/runtime verification passed for the stated URL only.
+- `Docs-only scope: PASS` does not imply runtime behavior was verified.
+
+PR merge requires explicit CTO approval in the current task. Authentication or write permission is not authorization.
+
+## Incident rule
+
+If a secret, token, cookie, session, private key, Authorization header, database URL, service-account JSON, or credential value appears in output, stop immediately and report:
+
+```text
+SECURITY_INCIDENT_SECRET_EXPOSURE
+```
+
+Do not repeat the exposed value.

--- a/docs/ops/AGENT_SECURITY.md
+++ b/docs/ops/AGENT_SECURITY.md
@@ -1,0 +1,124 @@
+# Agent Secret Handling Policy
+
+Refs #299
+
+## Purpose
+
+This document centralizes the LoveBud rule that agents may guide local credential setup but must not view, print, store, summarize, or transmit credential values.
+
+## Model and central-system boundary
+
+Models, connector sessions, PR comments, Issue comments, documentation, screenshots, and central logs must not contain raw secrets.
+
+Allowed information:
+
+- credential name;
+- local path;
+- existence status;
+- gitignored status;
+- required key presence status;
+- token generation URL.
+
+Forbidden information:
+
+- token value;
+- partial token value;
+- cookie value;
+- session value;
+- private key material;
+- service account JSON;
+- database URL value;
+- Authorization header value;
+- full environment dump.
+
+## Approved local paths
+
+Agents may refer to these paths only as paths:
+
+- `.secrets/`
+- `.env`
+- `.env.*`
+- `~/.config/gh/hosts.yml`
+
+Do not print file contents from these paths.
+
+## Approved existence checks
+
+PowerShell:
+
+```powershell
+Test-Path .secrets
+Test-Path .env
+Test-Path .env.local
+Test-Path ~/.config/gh/hosts.yml
+```
+
+Git:
+
+```bash
+git check-ignore .secrets/lovebud-runtime.env
+git check-ignore .env
+git check-ignore .env.local
+```
+
+Allowed reports:
+
+```text
+.secrets/: EXISTS
+.env.local: EXISTS
+.env.local: GITIGNORED
+GH_TOKEN: PRESENT
+secret value exposed: NO
+```
+
+## GitHub token setup
+
+Agents may direct local operators to create tokens at:
+
+```text
+https://github.com/settings/tokens
+```
+
+The token must be copied only into the approved local credential store or CLI credential manager. It must not be pasted into chat, issue comments, PR comments, docs, screenshots, or logs.
+
+## Local automation pattern
+
+Use path indirection rather than value disclosure:
+
+1. Local operator creates or updates a credential file in an approved ignored path.
+2. Automation references the file path.
+3. Local process reads the value.
+4. CLI or script receives the value without printing it.
+5. Report includes only `PRESENT`, `MISSING`, `EXISTS`, `GITIGNORED`, `PASS`, or `BLOCKED`.
+
+## PR and Issue comments
+
+Safe comments may include:
+
+- scope summary;
+- changed file list;
+- related issue number;
+- merge needed or not needed;
+- CTO approval required or not yet given;
+- static verification status;
+- functional verification status, only when actually performed.
+
+Do not conflate:
+
+- static validation with browser/runtime behavior;
+- docs-only review with functional PASS;
+- authentication capability with authorization to merge.
+
+## Merge authority
+
+PR merge requires explicit CTO approval for that PR in the current task. Do not infer approval from authentication, CI success, or previous similar merges.
+
+## Incident response
+
+If a value is exposed, stop immediately and report only:
+
+```text
+SECURITY_INCIDENT_SECRET_EXPOSURE
+```
+
+Do not repeat the exposed value.

--- a/docs/ops/GITHUB_AUTH_TOKEN_USAGE.md
+++ b/docs/ops/GITHUB_AUTH_TOKEN_USAGE.md
@@ -33,6 +33,14 @@ gh auth status
 
 Do not print credential values or copy credential-store contents into reports.
 
+GitHub token creation may be directed to:
+
+```text
+https://github.com/settings/tokens
+```
+
+The generated token value must remain local to the operator and must not be pasted into chat, docs, PRs, issues, screenshots, logs, or reports.
+
 ---
 
 ## 3. Secret handling rules
@@ -41,13 +49,21 @@ Secret Handling Clarification
 
 Agents must never print, paste, summarize, screenshot, log, commit, or expose secret values.
 
-However, agents may use secrets locally when required for authorized project operations, provided that the value is not displayed, copied, summarized, committed, or persisted outside the approved local secret store.
+Model-side or central-system work must not access actual token or secret values. Agents may guide operators by naming the required credential, approved path, and safe presence check only.
+
+However, local machine processes may use secrets when required for authorized project operations, provided that the value is not displayed, copied, summarized, committed, or persisted outside the approved local secret store.
 
 **Allowed:**
 - Referring to secret names, required locations, and expected presence.
+- Referencing approved local paths only as paths:
+  - `.secrets/`
+  - `.env`
+  - `.env.*`
+  - `~/.config/gh/hosts.yml`
 - Checking whether a required secret file exists.
 - Checking whether required secret keys are present, without printing values.
-- Loading a local secret file into an environment for an authorized command or test.
+- Checking whether local secret files are ignored with `git check-ignore`.
+- Loading a local secret file into an environment for an authorized command or test, without displaying the value.
 - Using secrets through approved tools such as gh, wrangler, firebase, npm scripts, or local test runners.
 - Reporting only redacted status:
   - `GH_TOKEN: PRESENT`
@@ -66,29 +82,36 @@ However, agents may use secrets locally when required for authorized project ope
 - Running commands that echo secrets to stdout/stderr.
 - Running commands that dump all environment variables.
 - Including secret values directly in command lines that may be stored in shell history or process lists.
+- Asking a model, connector, or central system to read and display a credential file.
 
 **Clarification:**
-- Secret files may be read by machine processes only for authorized local execution or key-presence validation.
+- Secret files may be read by local machine processes only for authorized local execution or key-presence validation.
 - Secret values must not be displayed to the agent, user, logs, PRs, issues, screenshots, or reports.
-- Reports may contain only `EXISTS` / `MISSING` / `PRESENT` / `GITIGNORED` / `SUCCESS` / `FAIL`.
+- Reports may contain only `EXISTS` / `MISSING` / `PRESENT` / `GITIGNORED` / `SUCCESS` / `FAIL` / `REDACTED`.
 - If a secret value is accidentally displayed or logged, stop work and report `SECURITY_INCIDENT_SECRET_EXPOSURE` without repeating the secret.
 
-**PowerShell guidance to include or summarize:**
-**Allowed:**
-- `Test-Path .secrets/lovebud-runtime.env`
-- `git check-ignore .secrets/lovebud-runtime.env`
-- Parsing required key names and reporting only `PRESENT`/`MISSING`
-- Loading values into process environment without printing them
+**PowerShell guidance:**
 
-**Forbidden:**
-- `cat .secrets/lovebud-runtime.env`
-- `type .secrets/lovebud-runtime.env`
-- `Get-Content .secrets/lovebud-runtime.env` when output is displayed
-- `echo $env:GH_TOKEN`
-- `printenv`
-- `env`
-- `set`
-- commands that dump full environment variables
+Allowed:
+
+```powershell
+Test-Path .secrets/lovebud-runtime.env
+Test-Path .env
+Test-Path .env.local
+Test-Path ~/.config/gh/hosts.yml
+git check-ignore .secrets/lovebud-runtime.env
+```
+
+Forbidden:
+
+```powershell
+cat .secrets/lovebud-runtime.env
+type .secrets/lovebud-runtime.env
+Get-Content .secrets/lovebud-runtime.env
+echo $env:GH_TOKEN
+echo $env:CLOUDFLARE_API_TOKEN
+Get-ChildItem Env:
+```
 
 ---
 
@@ -101,6 +124,7 @@ Local-only paths that may contain secrets are:
 - `.secrets/`
 - `.env`
 - `.env.*`
+- `~/.config/gh/hosts.yml`
 
 These paths must not be committed, copied into docs, pasted into PR comments, or included in screenshots.
 
@@ -110,7 +134,29 @@ Do not create new credential files inside the repository unless the CTO explicit
 
 ---
 
-## 5. GitHub CLI usage rules
+## 5. Local automation pattern
+
+Use path indirection rather than value disclosure.
+
+1. Operator stores the credential in an approved local path.
+2. Automation references only the path.
+3. The local process reads the value into process memory.
+4. The CLI or script receives the value without printing it.
+5. Reports include only status words such as `PRESENT`, `MISSING`, `EXISTS`, `GITIGNORED`, `PASS`, or `BLOCKED`.
+
+Safe report example:
+
+```text
+credential path: .secrets/lovebud-runtime.env
+credential file: EXISTS
+credential file gitignored: YES
+required key: PRESENT
+secret value exposed: NO
+```
+
+---
+
+## 6. GitHub CLI usage rules
 
 Before write operations, verify repository and account context:
 
@@ -135,7 +181,7 @@ Merge is forbidden unless the CTO explicitly approves that merge in the current 
 
 ---
 
-## 6. Browser login rules
+## 7. Browser login rules
 
 Browser login may be used to inspect GitHub PRs, issues, checks, deployments, and deployment bot comments.
 
@@ -151,7 +197,7 @@ When a browser session is needed only for inspection, keep the action read-only.
 
 ---
 
-## 7. Connector vs local GitHub access
+## 8. Connector vs local GitHub access
 
 Connector-based access and local GitHub access are separate trust surfaces.
 
@@ -174,7 +220,7 @@ Do not assume connector state and local branch state are equivalent. Verify both
 
 ---
 
-## 8. Write permission guardrails
+## 9. Write permission guardrails
 
 Authentication does not imply authorization.
 
@@ -194,7 +240,29 @@ Use task-specific permission, not account capability, as the source of authority
 
 ---
 
-## 9. Reporting template
+## 10. PR and Issue safety guidance
+
+PR and Issue comments should include only:
+
+- scope;
+- related Issue or PR number;
+- whether merge is needed;
+- whether CTO approval is required;
+- verification status without secret values.
+
+Do not mix static verification PASS with functional PASS.
+
+Examples:
+
+- `git diff --check: PASS` means whitespace/static diff is clean only.
+- `Docs-only scope: PASS` means file scope was checked only.
+- `Cloudflare Preview smoke: PASS` means browser/runtime verification passed for the stated URL only.
+
+PR merge requires explicit CTO approval in the current task.
+
+---
+
+## 11. Reporting template
 
 Use this compact report when GitHub authentication is relevant:
 
@@ -214,8 +282,10 @@ GitHub Auth Context Report
 
 ---
 
-## 10. Related documents
+## 12. Related documents
 
+- [AGENTS.md](AGENTS.md)
+- [AGENT_SECURITY.md](AGENT_SECURITY.md)
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md)
 - [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md)
 - [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md)

--- a/docs/ops/QA_CREDENTIALS.md
+++ b/docs/ops/QA_CREDENTIALS.md
@@ -12,6 +12,56 @@
 
 ---
 
+## Security boundary
+
+Models, connector sessions, PR comments, Issue comments, screenshots, docs, and central systems must not access or expose actual QA credential values.
+
+Allowed information is limited to:
+
+- approved local path names;
+- bundle path names;
+- whether a file exists;
+- whether a local credential path is gitignored;
+- whether required keys are present;
+- whether verification used a Cloudflare Preview or fixed test slot.
+
+Allowed status words include only:
+
+- `EXISTS`
+- `MISSING`
+- `PRESENT`
+- `GITIGNORED`
+- `PASS`
+- `BLOCKED`
+- `REDACTED`
+
+Forbidden:
+
+- printing plaintext QA credentials;
+- printing bundle passwords;
+- printing partial values, prefixes, suffixes, or last characters;
+- committing plaintext `.local/test-accounts.json`;
+- dumping environment variables;
+- pasting credential file contents into chat, PRs, Issues, logs, screenshots, or reports.
+
+Approved local checks:
+
+```powershell
+Test-Path .local/test-accounts.json
+Test-Path .local/test-accounts.example.json
+git check-ignore .local/test-accounts.json
+```
+
+Do not run commands that print credential file contents, such as:
+
+```powershell
+Get-Content .local/test-accounts.json
+type .local/test-accounts.json
+cat .local/test-accounts.json
+```
+
+---
+
 ## Overview
 
 This document describes two distinct workflows for managing QA test credentials:
@@ -39,6 +89,7 @@ Do not conflate these two workflows. The temporary handoff branch (`ops/temp-qa-
 - **Local Runtime**: Uses decrypted `.local/test-accounts.json` (gitignored)
 - **No Plaintext**: Credentials never committed in plain text
 - **Bundle Password**: Never documented in repository
+- **Reports**: Use status only; never values
 
 ---
 
@@ -90,9 +141,9 @@ Step 2: Does .local/test-accounts.json already exist on your machine?
 
 1. Pull latest branch containing the bundle
 2. Locate bundle: `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`
-3. Extract using the bundle password (obtained via secure channel from bundle custodian)
+3. Extract using the bundle password obtained via secure channel from bundle custodian
 4. Copy extracted `test-accounts.json` to `.local/test-accounts.json`
-5. Verify format matches `.local/test-accounts.example.json`
+5. Verify format matches `.local/test-accounts.example.json` without printing values
 
 #### Multi-Clone / Worktree Setup
 
@@ -104,6 +155,8 @@ mkdir -p .local
 # Copy restored credentials from your master restore location
 cp /path/to/your/restored/test-accounts.json .local/
 ```
+
+Do not print the restored file contents.
 
 ---
 
@@ -129,7 +182,7 @@ cp /path/to/your/restored/test-accounts.json .local/
 1. Read Issue #351 for the current handoff file location and instructions
 2. Obtain bundle password via secure channel
 3. Extract bundle and copy to `.local/test-accounts.json`
-4. Verify credentials are valid
+4. Verify credentials are valid without printing values
 5. Report: `credential source: temporary handoff (Issue #351)`
 
 ---
@@ -138,9 +191,9 @@ cp /path/to/your/restored/test-accounts.json .local/
 
 ### Bundle Creation (Persistent)
 
-1. Prepare credentials file with all 10 slots
+1. Prepare credentials file with all 10 slots locally
 2. Create password-protected ZIP bundle
-3. Commit bundle to `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`
+3. Commit encrypted bundle only to `docs/ops/qa-credential-bundle/test-accounts-encrypted.zip`
 4. Update `docs/ops/qa-credential-bundle/README.md` with commit SHA and date
 5. Distribute bundle password through secure channel
 6. Once persistent bundle is committed, mark Issue #351 temporary handoff as superseded
@@ -185,8 +238,9 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
 ### Local Setup
 
 - [ ] `.local/test-accounts.json` exists
-- [ ] File format matches example structure
-- [ ] All QA slots are populated
+- [ ] `.local/test-accounts.json` is gitignored
+- [ ] File format matches example structure without printing values
+- [ ] All QA slots are populated, reported only as `PRESENT`/`MISSING`
 - [ ] Credentials are valid for testing
 
 ### Multi-Repository Usage
@@ -205,6 +259,7 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
 - Distribute bundle passwords through secure channels
 - Rotate credentials regularly
 - Verify bundle integrity after extraction
+- Report only path/status information
 
 ### Don'ts
 
@@ -213,6 +268,8 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
 - Never share bundle passwords in plaintext channels
 - Never store bundle passwords in scripts
 - Never treat `ops/temp-qa-credential-handoff` branch as a permanent source
+- Never print credential file contents
+- Never dump all environment variables
 
 ---
 
@@ -224,7 +281,7 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
    - Check if persistent bundle exists in `docs/ops/qa-credential-bundle/`
    - If not: use temporary handoff (Issue #351)
    - If yes: extract bundle and restore
-   - Verify bundle password
+   - Verify bundle password through secure channel
    - Check file permissions
 
 2. **Procedure appears to work but bundle was not used**
@@ -233,12 +290,12 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
 
 3. **Invalid credential format**
    - Compare with `.local/test-accounts.example.json`
-   - Verify JSON structure
-   - Check for missing required fields
+   - Verify JSON structure without printing values
+   - Report only missing required keys as `MISSING`
 
 4. **Bundle extraction fails**
    - Verify bundle file integrity
-   - Check bundle password
+   - Check bundle password through secure channel
    - Re-download bundle from repository if corrupted
 
 ### Recovery Procedures
@@ -246,9 +303,9 @@ Final verification for PR #350 must be performed against a **fixed test slot** o
 If credentials are lost or corrupted:
 
 1. Check if persistent bundle exists in `docs/ops/qa-credential-bundle/`
-2. If yes: extract from persistent bundle (contact custodian for password)
+2. If yes: extract from persistent bundle after contacting custodian for password
 3. If no: use temporary handoff via Issue #351
-4. Verify all QA slots work correctly
+4. Verify all QA slots work correctly without printing values
 
 ---
 
@@ -261,6 +318,8 @@ procedure validation result: PROCEDURE WORKS | PARTIALLY WORKS | BLOCKED
 credential source:           persistent bundle | temporary handoff (Issue #351) | pre-existing local file
 secret values exposed:       NO
 bundle committed to repo:    YES | NO
+credential file:             EXISTS | MISSING
+credential file gitignored:  YES | NO
 verification environment:    Cloudflare PR Preview | fixed test slot | [other]
 ```
 
@@ -277,6 +336,8 @@ verification environment:    fixed test slot
 
 ## Related Documents
 
+- [AGENTS.md](AGENTS.md)
+- [AGENT_SECURITY.md](AGENT_SECURITY.md)
 - [qa-credential-bundle/README.md](qa-credential-bundle/README.md) — persistent bundle commit status
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md)
 - [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md)

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -19,16 +19,18 @@
 1. [OPERATIONS.md](OPERATIONS.md) - 현재 운영 전략과 계층 정의
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
-4. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-5. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-6. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-7. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-8. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-9. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-10. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-11. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-12. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-13. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+4. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+5. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+6. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+7. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+8. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+9. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+10. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+11. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+12. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+13. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+14. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+15. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -50,6 +52,8 @@
 | [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) | 배포 전/후 검증 체크리스트 |
 | [RUNBOOK.md](RUNBOOK.md) | 운영 및 장애 대응 런북 |
 | [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) | 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준 |
+| [AGENTS.md](AGENTS.md) | ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준 |
+| [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |
 | [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |
 | [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) | 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |


### PR DESCRIPTION
Refs #299. Update all agent/security docs to restrict token/secret exposure to paths only. Merge requires CTO approval.

## Summary
- Add ops agent security rules for path-only secret handling.
- Add agent secret handling policy with approved local paths, safe existence checks, and forbidden value exposure rules.
- Update GitHub auth token and QA credential docs to clarify that models/central systems must not access actual values.
- Link the new security docs from the ops index.

## Scope
- Docs-only.
- No code, JS, CSS, HTML, runtime, workflow, or credential file changes.
- No secret values added or exposed.
- No PR #7/prototype/reference/demo/variant changes.

## Verification
- [ ] GitHub diff review
- [ ] Docs-only scope confirmed
- [ ] Secret/data exposure: NO
- [ ] PR #7/prototype/reference/demo/variant untouched
- [ ] Merge requires CTO approval