### PR TITLE
docs(security): track remaining #266 ops posture gaps

### DIFF
--- a/docs/security/ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md
+++ b/docs/security/ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md
@@ -1,0 +1,102 @@
+# Issue #266 Remaining Ops Posture Gaps
+
+## Purpose
+
+This document tracks the remaining operational security posture gaps identified during the partial verification of Issue #266 (Ops: Firebase Console and deployment secret posture verification). It serves as a follow-up tracker after the initial checklist and disposition documentation. This is a docs-only document; no Firebase Console, Google Cloud Console, Modal, or Netlify settings are changed here.
+
+## Current Disposition
+
+- Issue #266 remains **OPEN** in PARTIAL state.
+- The Firestore Rules hardening gap is already tracked separately by Issue #281.
+- Related PRs (#300, #376, #435, #438, #441) are docs/planning/checklist only — none of them modified Firebase Console, Firestore Rules, runtime code, workflows, or secrets.
+
+## Remaining Gap A: Firebase API Key Restriction Hardening
+
+**Owner:** Google Cloud Project/IAM Owner
+
+**Verification needed:**
+- Confirm HTTP referrer restrictions are configured for Firebase Web API key(s).
+- Confirm API usage restrictions limit the key to only necessary Firebase/Google Cloud APIs.
+- Verify authorized production/preview domains policy aligns with current deployment domains.
+
+**Recording policy (FORBIDDEN):**
+- Actual API key value.
+- Key prefix/suffix.
+- Credential screenshots.
+
+**Possible outcomes:**
+- `VERIFIED_RESTRICTED` — Restrictions are properly configured.
+- `NEEDS_RESTRICTION` — Restrictions require hardening.
+- `BLOCKED_BY_OWNER_ACCESS` — Insufficient access to verify.
+
+## Remaining Gap B: Secret Rotation Owner/Cadence Documentation
+
+**Owner:** Modal Secret Owner
+
+**Verification needed:**
+- Confirm the owner of `FIREBASE_SERVICE_ACCOUNT_JSON` secret in Modal.
+- Confirm rotation owner and established rotation cadence.
+- Optionally record last rotation metadata only if owner approves and no secret material is exposed.
+
+**Recording policy (FORBIDDEN):**
+- Service account JSON content.
+- `private_key` field.
+- `client_email` field.
+- Any token/session/cookie values.
+- Partial credential values.
+
+**Possible outcomes:**
+- `VERIFIED_OWNER_AND_CADENCE` — Ownership and cadence are documented.
+- `NEEDS_ROTATION` — Secret requires immediate rotation.
+- `NEEDS_OWNER_ASSIGNMENT` — No clear owner or cadence defined.
+- `BLOCKED_BY_OWNER_ACCESS` — Insufficient access to verify.
+
+## Remaining Gap C: Legacy Authorized Domain Cleanup Decision
+
+**Owner:** Firebase Console / Auth Owner
+
+**Verification needed:**
+- Review Firebase Authentication authorized domains list.
+- Identify legacy domains from old deployments (Netlify/Vercel/preview environments).
+- Determine whether legacy domains are still required or candidates for removal.
+
+**Note:** Actual domain removal is not part of this tracking document; only the decision posture is tracked here.
+
+**Possible outcomes:**
+- `VERIFIED_REQUIRED` — All listed domains are actively required.
+- `NEEDS_LEGACY_DOMAIN_REMOVAL` — Legacy domains should be removed.
+- `NEEDS_CTO_DECISION` — Requires policy decision on domain allow-list scope.
+- `BLOCKED_BY_OWNER_ACCESS` — Insufficient access to verify.
+
+## Relationship to Issue #281
+
+- Issue #281 remains the dedicated Firestore Rules hardening follow-up.
+- This document does not duplicate #281 scope.
+- Issue #266 should not wait on #281 implementation details beyond the explicit linkage unless CTO requires full hardening before closure.
+
+## Recommended Issue Handling
+
+Issue #266 remains open until the remaining gaps are either:
+
+- Verified and documented,
+- Linked to dedicated follow-up issues (e.g., separate issues for API key restrictions, secret rotation, domain cleanup), or
+- Explicitly accepted by CTO as tracked elsewhere.
+
+Use `Refs #266` only. Do **not** use `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` keywords in any related PR bodies.
+
+## Non-Goals
+
+This document does not authorize or imply the following:
+
+- No Firebase Console configuration changes.
+- No Google Cloud API key restriction changes.
+- No Modal secret rotation or modification.
+- No Netlify/Vercel environment changes.
+- No authorized domain removal.
+- No Firestore Rules deployment or modification.
+- No `firestore.rules`, `firebase.json`, or `.firebaserc` changes.
+- No package or dependency changes.
+- No GitHub Actions workflow changes.
+- No runtime/client/backend code changes.
+- No credential disclosure or secret value recording.
+- No PR #7/prototype/reference/demo/variant changes.

--- a/docs/security/ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md
+++ b/docs/security/ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md
@@ -82,7 +82,7 @@ Issue #266 remains open until the remaining gaps are either:
 - Linked to dedicated follow-up issues (e.g., separate issues for API key restrictions, secret rotation, domain cleanup), or
 - Explicitly accepted by CTO as tracked elsewhere.
 
-Use `Refs #266` only. Do **not** use `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, or `resolved` keywords in any related PR bodies.
+Use `Refs #266` only. Use non-completing issue reference wording in related PR bodies unless CTO explicitly approves issue completion.
 
 ## Non-Goals
 

--- a/docs/security/security_index.md
+++ b/docs/security/security_index.md
@@ -11,6 +11,7 @@ This folder contains LoveBud security policy, posture, and rollout planning docu
 | [SECURITY_ISSUES_266_281_DISPOSITION.md](SECURITY_ISSUES_266_281_DISPOSITION.md) | Disposition document for Firebase Console/secret posture verification (#266) and Firestore Rules hardening (#281) |
 | [FIRESTORE_RULES_SOURCE_TRACKING.md](FIRESTORE_RULES_SOURCE_TRACKING.md) | Scaffold for Firestore Rules source tracking and baseline capture prerequisites (Related to #281) |
 | [FIREBASE_CONSOLE_SECRET_POSTURE_CHECKLIST.md](FIREBASE_CONSOLE_SECRET_POSTURE_CHECKLIST.md) | Checklist for Firebase Console and deployment secret posture verification (#266) |
+| [ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md](ISSUE_266_REMAINING_OPS_POSTURE_GAPS.md) | Tracker for remaining #266 ops posture gaps after partial verification |
 
 ## Guardrails
 


### PR DESCRIPTION

## Summary
- Add docs-only security remaining ops posture gaps for #266.
- Document Firebase Console and local ops security gaps that need attention.
- Keep runtime implementation, config changes, and unrelated cleanup out of scope.

## Scope
- Docs-only.
- No runtime implementation.
- No config changes.
- No workflow changes.
- No package changes.
- No Firebase Console settings changes.
- No Search/Auth/Editor cleanup.
- No runtime/client/backend changes.
- No package or workflow changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #266

## Verification
- [x] git diff --check
- [x] changed files limited to docs/security remaining-gap docs/index files
- [x] non-completing issue reference wording only for #266
- [x] no secret/token/cookie/session/credential values
- [x] no Console/config/workflow/runtime changes
- [x] PR #7/prototype/reference/demo/variant untouched
