### PR TITLE
docs(product): define YouTube segment player PoC test matrix

### DIFF
--- a/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md
+++ b/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md
@@ -1,0 +1,112 @@
+# YouTube Segment Player PoC Test Matrix
+
+## Purpose
+
+This document defines the test matrix and browser verification requirements for the YouTube segment player PoC implementation under Issue #366 (Prototype YouTube segment player for Moment Timeline). It is a child PoC of Issue #362 (Moment Timeline planning). This is a docs-only specification; no runtime implementation is performed here.
+
+## PoC Scope
+
+The PoC will validate the feasibility of cue-based YouTube segment playback using the YouTube IFrame Player API. Implemented behaviors:
+
+- Parse YouTube video ID from various URL formats.
+- Load video with YouTube IFrame Player API.
+- Start playback from `startSeconds`.
+- Stop playback at `endSeconds` or advance to next segment.
+- Loop a selected segment by seeking back to `startSeconds`.
+- Sequence-play multiple segments across potentially different videos.
+- Record browser/player behavior and limitations (keyframe drift, autoplay restrictions, embed constraints).
+
+## Non-Goals
+
+The following are explicitly out of scope for this PoC:
+
+- No production UI integration.
+- No database persistence.
+- No video downloading.
+- No video export or file generation.
+- No server-side encoding/transcoding.
+- No Search/Auth/Editor cleanup work.
+- No PR #7/prototype/reference/demo/variant path usage.
+- No connection to LoveTree data model or backend services.
+
+## Candidate Implementation Path
+
+The contained PoC path must be approved by CTO before coding begins:
+
+- Standalone PoC page or sandbox component (not wired to production navigation).
+- Hard-coded test data array of segments (no persistence layer).
+- YouTube IFrame Player API loaded from `https://www.youtube.com/iframe_api`.
+- Playback controls implemented in client-side JavaScript only.
+- Console logging of errors, state transitions, and drift observations.
+- No routing, no backend calls, no auth required.
+
+## Data Shape for PoC Only
+
+The PoC will operate on an array of segment objects:
+
+```typescript
+interface PoCSegment {
+  videoId: string;       // YouTube video ID
+  startSeconds: number;  // Segment start time in seconds
+  endSeconds: number;    // Segment end time in seconds
+  title: string;         // User-facing title
+  order: number;         // Sequence order
+  loop: boolean;         // Whether to loop this segment
+  sourceUrl?: string;    // Optional: original URL for parsing validation
+}
+```
+
+No backend schema, Firestore collection, or API contract is defined in this PoC.
+
+## Test Matrix
+
+The PoC must pass the following test cases (manual browser verification):
+
+| # | Test Case | Expected Outcome |
+|---|-----------|------------------|
+| 1 | Play one segment from 00:10 to 00:20 | Video loads, seeks to 10s, plays until 20s, stops |
+| 2 | Loop one segment | At endSeconds, seeks to startSeconds and continues playing (loop) |
+| 3 | Play two moments from two different YouTube videos | First segment completes, second video loads and plays from its startSeconds |
+| 4 | Switch from one segment to the next | Seamless transition (or documented gap) between segments |
+| 5 | Handle invalid/unavailable video | Player displays error state; console logs error; no crash |
+| 6 | Handle endSeconds earlier than startSeconds | Validation error logged; segment skipped or clamped with documented behavior |
+| 7 | Mobile viewport smoke | Player renders and plays correctly on mobile screen size |
+| 8 | Console fatal error check | No uncaught exceptions; errors reported gracefully |
+| 9 | Network/player error check | Network failures or player API errors handled without crash |
+
+## Browser Verification Requirements
+
+Verification must be conducted across environments:
+
+- **Desktop viewport:** Chrome/Edge (latest), Firefox (latest), Safari (latest)
+- **Mobile viewport:** iOS Safari, Chrome Android
+- **Console:** No fatal errors during normal playback sequence
+- **Network/Player:** Handle `onError` callbacks from YouTube IFrame API
+- **Keyframe drift:** Document any observed deviation from exact `startSeconds`/`endSeconds` due to YouTube keyframe alignment
+- **Autoplay limitations:** Document any autoplay restrictions requiring user gesture
+- **Embed availability:** Document any videos that block embedding (player shows restricted message)
+
+## Relationship to Issue #362
+
+- Issue #362 covers the full Moment Timeline feature: data model, LoveTree linkage, editor integration, reorder UI, persistence, share/view pages.
+- This PoC (#366) validates only the player feasibility: cue-based segment playback and sequence behavior.
+- The PoC does not implement #362's persistence, routing, UI, or tree integration — those are separate follow-up issues.
+
+## Follow-up PR Split (recommended order)
+
+1. **PR A:** Contained PoC runtime page (static HTML + JS sandbox)
+2. **PR B:** Browser verification report (evidence of test matrix completion)
+3. **PR C:** Data model/API contract audit for #362 (Firestore schema, API routes)
+4. **PR D:** Moment capture UI in tree/editor context
+5. **PR E:** Timeline reorder UI
+6. **PR F:** Sequence playback integration into production LoveTree flow
+7. **PR G:** Share/view page for curated moment timelines
+
+## Safety Guardrails
+
+- Refs #366 only for PoC implementation PRs (no close keywords in this doc).
+- Refs #362 for parent feature linkage.
+- Do not use PR #7/prototype/reference/demo/variant paths.
+- No video download/export features at any point.
+- No production persistence in PoC.
+- CTO approval required before moving from PoC to implementation PRs.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -19,6 +19,7 @@
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
+| [YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md](YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md) | YouTube segment player PoC test matrix and browser verification requirements |
 | [MOMENT_CAPTURE_UI_DESIGN.md](MOMENT_CAPTURE_UI_DESIGN.md) | Moment capture UI flow design |
 | [MOMENT_TIMELINE_REORDER_DESIGN.md](MOMENT_TIMELINE_REORDER_DESIGN.md) | Moment Timeline reorder / sequence editor design |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
@@ -61,10 +62,11 @@
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
-4. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-5. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-6. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-7. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+4.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+5.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+6.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+7.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+8.  **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
 8. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
 9. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
 10. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우


### PR DESCRIPTION
## Summary
- Add a docs-only PoC scope and browser test matrix for #366.
- Connect the YouTube segment player PoC to the broader #362 Moment Timeline implementation path.
- Keep runtime implementation, production UI, persistence, video download/export, server-side encoding, and unrelated cleanup out of scope.

## Scope
- Docs-only.
- No YouTube IFrame runtime implementation.
- No production UI.
- No database persistence.
- No video download/export.
- No server-side encoding.
- No Search/Auth/Editor cleanup.
- No runtime/client/backend changes.
- No package or workflow changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #366
Refs #362

## Verification
- [ ] git diff --check
- [ ] changed files limited to docs/product PoC test matrix/index files
- [ ] non-completing issue reference wording only for #366/#362
- [ ] no secret/token/cookie/session/credential values
- [ ] no runtime/client/backend/package/workflow changes
- [ ] PR #7/prototype/reference/demo/variant untouched