### PR TITLE
docs(security): map frontend rendering XSS boundaries

### DIFF
--- a/docs/security/FRONTEND_RENDERING_XSS_BOUNDARY_AUDIT.md
+++ b/docs/security/FRONTEND_RENDERING_XSS_BOUNDARY_AUDIT.md
@@ -1,0 +1,54 @@
+# Frontend Rendering XSS Boundary Audit
+
+## Purpose
+- Audit-only map for #417.
+- Identify user-controlled fields and rendering surfaces.
+- No sanitizer adoption, no renderer rewrite, no behavior change.
+
+## Rendering Surfaces
+- pages/detail.html and related JS
+- pages/search.html and Search/Browse card/preview JS
+- pages/editor.html and editor preview/detail JS
+- pages/my-trees.html and tree list/card JS
+- js/api/public-tree-adapter.js
+- js/utils/normalize.js
+
+## User-Controlled Fields
+- title
+- memo/note
+- quote
+- artist
+- emotion tags
+- source URL
+- thumbnail URL
+- tree/memory labels
+- comments (if applicable)
+
+## Sink Classification
+- textContent
+- innerHTML
+- template string interpolation
+- URL attributes
+- image/thumbnail attributes
+- dataset attributes
+- Markdown-like or rich text paths
+
+## Audit Questions
+- Which paths use textContent vs innerHTML?
+- Which fields enter HTML strings?
+- Which URLs are canonicalized?
+- Which helpers escape or normalize fields?
+- Which fixes are page-specific vs shared helper fixes?
+
+## Follow-Up Split
+- PR A: docs-only coverage map
+- PR B: representative malicious text contract/smoke tests
+- PR C: shared escape/helper usage if justified
+- PR D: page-specific renderer fixes one page at a time
+
+## Guardrails
+- No broad renderer rewrite
+- No sanitizer dependency
+- No API response shape change
+- No Search/Auth/Editor cleanup mixed in
+- No PR #7/prototype/reference/demo/variant changes


### PR DESCRIPTION
## Summary
- Add a docs-only frontend rendering and XSS boundary audit map for #417.
- Inventory rendering surfaces, user-controlled fields, sink types, and follow-up split.
- Keep sanitizer adoption, renderer rewrites, API changes, runtime changes, and unrelated cleanup out of scope.

## Scope
- Docs-only.
- No runtime/client/backend changes.
- No sanitizer dependency.
- No renderer rewrite.
- No API response shape changes.
- No Search/Auth/Editor cleanup.
- No package or workflow changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #417

## Verification
- [ ] changed files limited to docs/security audit/index files
- [ ] non-completing issue reference wording only for #417
- [ ] no secret/token/cookie/session/credential values
- [ ] no runtime/client/backend/package/workflow changes
- [ ] PR #7/prototype/reference/demo/variant untouched