### PR TITLE
docs(security): add Firebase API key restriction runbook

### DIFF
--- a/docs/security/FIREBASE_API_KEY_RESTRICTION_RUNBOOK.md
+++ b/docs/security/FIREBASE_API_KEY_RESTRICTION_RUNBOOK.md
@@ -1,0 +1,30 @@
+# Firebase API Key Restriction Runbook
+
+## Purpose
+- Track verification of Firebase Web API key restrictions as follow-up for #266.
+- Separate from actual Google Cloud Console changes.
+
+## Owner Prerequisites
+- Owner or authorized team member must verify API key restrictions in Firebase Console or GCP.
+
+## Verification Checklist
+- HTTP referrer restriction posture
+- API usage restriction posture
+- Production/preview domain policy
+
+## Evidence Recording Policy
+- OK: Restricted / Unrestricted / Not verified / Blocked by access
+- NOT OK: key value, prefix/suffix, screenshots
+
+## Decision Outcomes
+- VERIFIED_RESTRICTED
+- NEEDS_RESTRICTION
+- BLOCKED_BY_OWNER_ACCESS
+
+## Follow-Up Path
+- Console change requires explicit CTO approval
+- No repo config change from this PR
+
+## Relationship to #266 and #281
+- #266 remains open
+- #281 not duplicated


### PR DESCRIPTION
## Summary
- Add a docs-only Firebase API key restriction runbook for #266.
- Define owner verification, evidence policy, and follow-up outcomes without exposing key values.
- Keep Google Cloud Console changes, runtime changes, config changes, and secret handling out of scope.

## Scope
- Docs-only.
- No Google Cloud Console changes.
- No Firebase Console changes.
- No API key values included.
- No key prefix/suffix included.
- No runtime/config/workflow/package changes.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #266

## Verification
- [ ] changed files limited to docs/security API key runbook/index files
- [ ] non-completing issue reference wording only for #266
- [ ] no secret/token/cookie/session/credential/API key values
- [ ] no Console/config/workflow/runtime changes
- [ ] PR #7/prototype/reference/demo/variant untouched