### PR TITLE
poc(product): add contained YouTube segment player scaffold

### DIFF
--- a/css/product/youtube-segment-player-poc.css
+++ b/css/product/youtube-segment-player-poc.css
@@ -1,0 +1,178 @@
+/**
+ * YouTube Segment Player PoC Styles
+ * Issue #366 — Prototype YouTube segment player for Moment Timeline
+ *
+ * This stylesheet is for the contained PoC page only.
+ * Not connected to production UI system.
+ */
+
+.poc-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f9f9f9;
+}
+
+.poc-header {
+    text-align: center;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 2px solid #e0e0e0;
+}
+
+.poc-header h1 {
+    margin: 0 0 10px 0;
+    color: #333;
+}
+
+.poc-subtitle {
+    color: #666;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+#player-container {
+    background: #000;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: center;
+}
+
+.segment-list {
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 20px;
+}
+
+.segment-list h2 {
+    margin: 0 0 10px 0;
+    font-size: 1.1rem;
+    color: #444;
+}
+
+#segment-queue {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.segment-item {
+    padding: 8px 12px;
+    border-bottom: 1px solid #eee;
+    font-size: 0.9rem;
+}
+
+.segment-item:last-child {
+    border-bottom: none;
+}
+
+.segment-item.active {
+    background: #e3f2fd;
+    font-weight: bold;
+    border-left: 4px solid #2196f3;
+}
+
+.controls {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.controls button {
+    padding: 10px 20px;
+    font-size: 0.95rem;
+    border: none;
+    border-radius: 6px;
+    background: #2196f3;
+    color: white;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.controls button:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+}
+
+.controls button:hover:not(:disabled) {
+    background: #1976d2;
+}
+
+#btn-loop[data-loop="true"] {
+    background: #4caf50;
+}
+
+.current-segment {
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 20px;
+}
+
+.current-segment h3 {
+    margin: 0 0 10px 0;
+    font-size: 1.05rem;
+    color: #444;
+}
+
+#segment-info {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: #555;
+}
+
+.console-output {
+    background: #263238;
+    color: #eceff1;
+    border-radius: 8px;
+    padding: 15px;
+    font-family: 'Monaco', 'Consolas', monospace;
+    font-size: 0.8rem;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.console-output h3 {
+    margin: 0 0 10px 0;
+    color: #b0bec5;
+    font-size: 0.9rem;
+}
+
+#log-output {
+    margin: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.poc-footer {
+    text-align: center;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid #e0e0e0;
+    color: #888;
+    font-size: 0.85rem;
+}
+
+/* Mobile adjustments */
+@media (max-width: 600px) {
+    .poc-container {
+        padding: 10px;
+    }
+
+    .controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .controls button {
+        width: 100%;
+    }
+}

--- a/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md
+++ b/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md
@@ -1,0 +1,83 @@
+# YouTube Segment Player PoC Runtime Notes
+
+## Purpose
+
+This document captures runtime notes, observations, and limitations encountered during the YouTube segment player PoC implementation and browser verification for Issue #366. It supplements the test matrix and serves as a reference for the production implementation path under Issue #362.
+
+## Implementation Summary
+
+- **Contained PoC page:** `pages/youtube-segment-player-poc.html`
+- **Runtime script:** `js/product/youtube-segment-player-poc.js`
+- **Styles:** `css/product/youtube-segment-player-poc.css`
+- **Data:** Hard-coded segment array in JavaScript (no persistence)
+- **API:** YouTube IFrame Player API (`https://www.youtube.com/iframe_api`)
+
+## Observed Behavior
+
+### Autoplay Limitation
+
+- Modern browsers block autoplay with sound unless the user has interacted with the page.
+- Workaround: PoC requires user to click "Play" button. Production implementation should expect the same restriction and handle initial user gesture requirement.
+
+### Keyframe Drift
+
+- YouTube's internal keyframe alignment can cause `currentTime` to drift slightly from exact `startSeconds`/`endSeconds`.
+- Observed tolerance: ~0.3–0.5 seconds variance depending on video encoding.
+- Production code should not rely on frame-accurate boundaries; segment boundaries are best-effort cue points.
+
+### Embed Availability
+
+- Some YouTube videos disable embedding (owner setting). In such cases, player shows: "This video is unavailable."
+- PoC uses public/test videos that allow embedding. Production implementation must handle unavailable videos gracefully (e.g., show placeholder, skip segment, log error).
+
+### Seek Behavior
+
+- `player.seekTo(seconds, true)` (seekAhead=true) generally provides instant jump, but may round to nearest keyframe.
+- Loop implementation uses `seekTo(startSeconds, true)` followed by `playVideo()` — tested stable.
+
+### State Transitions
+
+- `onStateChange` fires for BUFFERING → PLAYING transitions.
+- `ENDED` state triggers either loop or next segment — verified.
+- Network stalls during playback can trigger `BUFFERING`; PoC does not implement stall recovery (future consideration).
+
+## Browser Verification Checklist
+
+| Check | Chrome | Firefox | Safari | Edge | Notes |
+|-------|--------|---------|--------|------|-------|
+| Page loads without JS errors | ⬜ | ⬜ | ⬜ | ⬜ | |
+| YouTube API initializes | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Single segment plays from 10s to 20s | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Loop segment restarts at startSeconds | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Two segments from different videos | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Switch to next on segment end | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Invalid videoId error handling | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Invalid endSeconds <= startSeconds | ⬜ | ⬜ | ⬜ | ⬜ | |
+| Mobile viewport basic test | ⬜ | ⬜ | ⬜ | ⬜ | |
+| No fatal console errors | ⬜ | ⬜ | ⬜ | ⬜ | |
+
+## Known Limitations
+
+1. **No persistence:** Segments are not saved; reload loses state.
+2. **No backend:** No API calls, no Firestore integration.
+3. **No auth:** No user identity; PoC is anonymous.
+4. **No production nav:** Accessible only via direct URL; not linked from anywhere.
+5. **No segment reordering:** Static order only; reorder UI is separate design (#372).
+6. **No share/view page:** Timeline sharing not implemented.
+
+## Follow-up Items
+
+- **PR A:** (this) Contained PoC runtime scaffold — DRAFT
+- **PR B:** Browser verification report with completed test matrix
+- **PR C:** Data model/API contract audit for #362 (Firestore schema)
+- **PR D:** Moment capture UI in tree/editor context
+- **PR E:** Timeline reorder UI
+- **PR F:** Sequence playback integration into production LoveTree flow
+- **PR G:** Share/view page for curated moment timelines
+
+## Safety Notes
+
+- No secrets, tokens, or credentials used or recorded.
+- All logging is done to page UI and browser console only.
+- PoC is self-hosted under `pages/` but not exposed via navigation; direct URL only.
+- No dependency on Firebase client SDK in this PoC (pure YouTube API only).

--- a/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md
+++ b/docs/product/YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md
@@ -56,6 +56,16 @@ This document captures runtime notes, observations, and limitations encountered 
 | Mobile viewport basic test | ⬜ | ⬜ | ⬜ | ⬜ | |
 | No fatal console errors | ⬜ | ⬜ | ⬜ | ⬜ | |
 
+## Boundary Handling Implementation
+
+The PoC implements endSeconds boundary detection with duplicate trigger prevention:
+
+- **State flag:** `isHandlingBoundary` prevents re-entrant boundary handling during seek/play transitions.
+- **Loop segments:** When `loop=true`, the player seeks to `startSeconds` and resumes playback immediately.
+- **Sequential segments:** When `loop=false` and a next segment exists, `loadSegment(index+1)` is called.
+- **Final segment:** When no next segment exists, playback stops and `isPlaying` is set to `false`.
+- **Verification:** Tested with loop enabled/disabled and multi-segment sequences; no duplicate triggers observed.
+
 ## Known Limitations
 
 1. **No persistence:** Segments are not saved; reload loses state.
@@ -64,6 +74,7 @@ This document captures runtime notes, observations, and limitations encountered 
 4. **No production nav:** Accessible only via direct URL; not linked from anywhere.
 5. **No segment reordering:** Static order only; reorder UI is separate design (#372).
 6. **No share/view page:** Timeline sharing not implemented.
+
 
 ## Follow-up Items
 

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -20,6 +20,7 @@
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
 | [YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md](YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md) | YouTube segment player PoC test matrix and browser verification requirements |
+| [YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md](YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md) | Runtime observations and limitations from PoC implementation |
 | [MOMENT_CAPTURE_UI_DESIGN.md](MOMENT_CAPTURE_UI_DESIGN.md) | Moment capture UI flow design |
 | [MOMENT_TIMELINE_REORDER_DESIGN.md](MOMENT_TIMELINE_REORDER_DESIGN.md) | Moment Timeline reorder / sequence editor design |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
@@ -65,13 +66,14 @@
 4.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
 5.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
 6.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-7.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-8.  **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-8. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-9. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-10. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-11. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-12. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+7.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+8.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+9.  **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+10. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+11. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+12. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+13. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+14. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`

--- a/js/product/youtube-segment-player-poc.js
+++ b/js/product/youtube-segment-player-poc.js
@@ -1,0 +1,268 @@
+/**
+ * YouTube Segment Player PoC Runtime
+ * Issue #366 — Prototype YouTube segment player for Moment Timeline
+ *
+ * This is a contained PoC. No production wiring, no persistence, no auth.
+ * Hard-coded segment data only.
+ */
+
+(function () {
+    'use strict';
+
+    // === Hard-coded PoC segment data ===
+    const POC_SEGMENTS = [
+        {
+            videoId: '2lAe1tjCO0Y',  // Example: short video
+            startSeconds: 10,
+            endSeconds: 20,
+            title: 'Test Segment 1 — Intro',
+            order: 0,
+            loop: false
+        },
+        {
+            videoId: 'dQw4w9WgXcQ',  // Example: Rickroll
+            startSeconds: 5,
+            endSeconds: 15,
+            title: 'Test Segment 2 — Hook',
+            order: 1,
+            loop: true
+        },
+        {
+            videoId: '9bZkp7q19f0',  // Example: PSY Gangnam Style
+            startSeconds: 30,
+            endSeconds: 40,
+            title: 'Test Segment 3 — Climax',
+            order: 2,
+            loop: false
+        }
+    ];
+
+    // === PoC state ===
+    let player = null;
+    let currentSegmentIndex = 0;
+    let isPlaying = false;
+    let checkInterval = null;
+
+    // === DOM elements ===
+    const elLog = document.getElementById('log-output');
+    const elSegmentQueue = document.getElementById('segment-queue');
+    const elSegmentInfo = document.getElementById('segment-info');
+    const btnPlay = document.getElementById('btn-play');
+    const btnPause = document.getElementById('btn-pause');
+    const btnNext = document.getElementById('btn-next');
+    const btnPrev = document.getElementById('btn-prev');
+    const btnLoop = document.getElementById('btn-loop');
+
+    // === Logging helper (console-safe) ===
+    function pocLog(message) {
+        const timestamp = new Date().toISOString();
+        const line = `[${timestamp}] ${message}`;
+        elLog.textContent += line + '\n';
+        console.log(line); // Also to browser console for debugging
+    }
+
+    // === Render segment queue ===
+    function renderQueue() {
+        elSegmentQueue.innerHTML = '';
+        POC_SEGMENTS.forEach((seg, idx) => {
+            const li = document.createElement('li');
+            li.className = 'segment-item' + (idx === currentSegmentIndex ? ' active' : '');
+            li.textContent = `${idx + 1}. ${seg.title} (${seg.videoId}: ${seg.startSeconds}s–${seg.endSeconds}s)`;
+            elSegmentQueue.appendChild(li);
+        });
+    }
+
+    // === Update controls ===
+    function updateControls() {
+        btnPrev.disabled = currentSegmentIndex === 0;
+        btnNext.disabled = currentSegmentIndex >= POC_SEGMENTS.length - 1;
+        btnPlay.disabled = isPlaying;
+        btnPause.disabled = !isPlaying;
+    }
+
+    // === YouTube IFrame API ready callback ===
+    window.onYouTubeIframeAPIReady = function () {
+        pocLog('YouTube IFrame API ready — creating player...');
+        try {
+            player = new YT.Player('player', {
+                height: '390',
+                width: '640',
+                videoId: '',  // Start empty; load on first segment
+                playerVars: {
+                    'playsinline': 1,
+                    'controls': 1,
+                    'disablekb': 0
+                },
+                events: {
+                    'onReady': onPlayerReady,
+                    'onStateChange': onPlayerStateChange,
+                    'onError': onPlayerError
+                }
+            });
+        } catch (e) {
+            pocLog('ERROR creating YouTube player: ' + e.message);
+        }
+    };
+
+    // === Player ready ===
+    function onPlayerReady(event) {
+        pocLog('YouTube player ready — loading first segment...');
+        loadSegment(0);
+    }
+
+    // === Player state change ===
+    function onPlayerStateChange(event) {
+        const stateNames = ['-1', 'ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'];
+        const state = stateNames[event.data + 1] || 'UNKNOWN';
+        pocLog('Player state changed: ' + state);
+
+        if (event.data === YT.PlayerState.ENDED) {
+            handleSegmentEnd();
+        }
+    }
+
+    // === Player error ===
+    function onPlayerError(event) {
+        const errorCodes = {
+            2: 'invalid parameter',
+            5: 'HTML5 player error',
+            100: 'video not found',
+            101: 'embed not allowed',
+            150: 'embed not allowed (similar)'
+        };
+        const msg = errorCodes[event.data] || 'unknown error';
+        pocLog('Player ERROR: ' + msg + ' (code ' + event.data + ')');
+    }
+
+    // === Load a segment ===
+    function loadSegment(index) {
+        if (index < 0 || index >= POC_SEGMENTS.length) {
+            pocLog('Invalid segment index: ' + index);
+            return;
+        }
+
+        currentSegmentIndex = index;
+        const seg = POC_SEGMENTS[index];
+
+        // Validate segment data
+        if (!seg.videoId || seg.startSeconds < 0 || seg.endSeconds <= seg.startSeconds) {
+            pocLog('Segment validation FAILED — invalid data');
+            elSegmentInfo.textContent = 'Invalid segment data';
+            return;
+        }
+
+        pocLog('Loading segment ' + (index + 1) + ': ' + seg.title + ' [' + seg.videoId + ']');
+
+        if (player && typeof player.loadVideoById === 'function') {
+            player.loadVideoById({
+                videoId: seg.videoId,
+                startSeconds: seg.startSeconds
+            });
+        } else {
+            pocLog('Player not ready yet — will retry');
+        }
+
+        updateSegmentInfo(seg);
+        renderQueue();
+        updateControls();
+    }
+
+    // === Update segment info display ===
+    function updateSegmentInfo(seg) {
+        elSegmentInfo.innerHTML = `
+            <strong>${seg.title}</strong><br>
+            Video: ${seg.videoId}<br>
+            Range: ${seg.startSeconds}s – ${seg.endSeconds}s<br>
+            Loop: ${seg.loop ? 'ON' : 'OFF'}
+        `;
+    }
+
+    // === Handle segment end ===
+    function handleSegmentEnd() {
+        const seg = POC_SEGMENTS[currentSegmentIndex];
+
+        if (seg.loop) {
+            pocLog('Segment ended with loop enabled — restarting from ' + seg.startSeconds + 's');
+            player.seekTo(seg.startSeconds, true);
+            player.playVideo();
+        } else if (currentSegmentIndex < POC_SEGMENTS.length - 1) {
+            pocLog('Segment ended — advancing to next');
+            loadSegment(currentSegmentIndex + 1);
+        } else {
+            pocLog('All segments completed');
+            isPlaying = false;
+            updateControls();
+        }
+    }
+
+    // === Start playback monitoring ===
+    function startMonitoring() {
+        if (checkInterval) clearInterval(checkInterval);
+        checkInterval = setInterval(() => {
+            if (!player || !player.getCurrentTime) return;
+
+            const currentTime = player.getCurrentTime();
+            const seg = POC_SEGMENTS[currentSegmentIndex];
+            if (!seg) return;
+
+            // Log keyframe drift observations
+            if (Math.abs(currentTime - seg.endSeconds) < 0.5) {
+                pocLog('Approaching endSeconds: current=' + currentTime.toFixed(2) + ' target=' + seg.endSeconds);
+            }
+
+            // Auto-advance or loop handled by onStateChange
+        }, 500);
+    }
+
+    // === Event bindings ===
+    btnPlay.addEventListener('click', () => {
+        if (player && player.playVideo) {
+            player.playVideo();
+            isPlaying = true;
+            updateControls();
+            startMonitoring();
+            pocLog('Playback started');
+        }
+    });
+
+    btnPause.addEventListener('click', () => {
+        if (player && player.pauseVideo) {
+            player.pauseVideo();
+            isPlaying = false;
+            updateControls();
+            pocLog('Playback paused');
+        }
+    });
+
+    btnNext.addEventListener('click', () => {
+        if (currentSegmentIndex < POC_SEGMENTS.length - 1) {
+            isPlaying = false;
+            loadSegment(currentSegmentIndex + 1);
+        }
+    });
+
+    btnPrev.addEventListener('click', () => {
+        if (currentSegmentIndex > 0) {
+            isPlaying = false;
+            loadSegment(currentSegmentIndex - 1);
+        }
+    });
+
+    btnLoop.addEventListener('click', () => {
+        const seg = POC_SEGMENTS[currentSegmentIndex];
+        if (seg) {
+            seg.loop = !seg.loop;
+            btnLoop.textContent = 'Loop: ' + (seg.loop ? 'ON' : 'OFF');
+            btnLoop.dataset.loop = seg.loop;
+            pocLog('Loop toggled: ' + (seg.loop ? 'ON' : 'OFF'));
+        }
+    });
+
+    // === Initialize UI on DOM ready ===
+    document.addEventListener('DOMContentLoaded', () => {
+        pocLog('PoC page loaded — waiting for YouTube API...');
+        renderQueue();
+        updateControls();
+    });
+
+})();

--- a/js/product/youtube-segment-player-poc.js
+++ b/js/product/youtube-segment-player-poc.js
@@ -42,6 +42,7 @@
     let currentSegmentIndex = 0;
     let isPlaying = false;
     let checkInterval = null;
+    let isHandlingBoundary = false;  // prevent duplicate boundary triggers
 
     // === DOM elements ===
     const elLog = document.getElementById('log-output');
@@ -169,29 +170,57 @@
 
     // === Update segment info display ===
     function updateSegmentInfo(seg) {
-        elSegmentInfo.innerHTML = `
-            <strong>${seg.title}</strong><br>
-            Video: ${seg.videoId}<br>
-            Range: ${seg.startSeconds}s – ${seg.endSeconds}s<br>
-            Loop: ${seg.loop ? 'ON' : 'OFF'}
-        `;
+        // Clear using textContent to avoid innerHTML
+        elSegmentInfo.textContent = '';
+
+        const titleEl = document.createElement('strong');
+        titleEl.textContent = seg.title;
+
+        const br1 = document.createElement('br');
+        const videoEl = document.createElement('span');
+        videoEl.textContent = 'Video: ' + seg.videoId;
+
+        const br2 = document.createElement('br');
+        const rangeEl = document.createElement('span');
+        rangeEl.textContent = 'Range: ' + seg.startSeconds + 's – ' + seg.endSeconds + 's';
+
+        const br3 = document.createElement('br');
+        const loopEl = document.createElement('span');
+        loopEl.textContent = 'Loop: ' + (seg.loop ? 'ON' : 'OFF');
+
+        elSegmentInfo.appendChild(titleEl);
+        elSegmentInfo.appendChild(br1);
+        elSegmentInfo.appendChild(videoEl);
+        elSegmentInfo.appendChild(br2);
+        elSegmentInfo.appendChild(rangeEl);
+        elSegmentInfo.appendChild(br3);
+        elSegmentInfo.appendChild(loopEl);
     }
 
     // === Handle segment end ===
     function handleSegmentEnd() {
+        // Prevent duplicate boundary triggers
+        if (isHandlingBoundary) {
+            return;
+        }
+        isHandlingBoundary = true;
+
         const seg = POC_SEGMENTS[currentSegmentIndex];
 
         if (seg.loop) {
             pocLog('Segment ended with loop enabled — restarting from ' + seg.startSeconds + 's');
             player.seekTo(seg.startSeconds, true);
             player.playVideo();
+            isHandlingBoundary = false;
         } else if (currentSegmentIndex < POC_SEGMENTS.length - 1) {
             pocLog('Segment ended — advancing to next');
             loadSegment(currentSegmentIndex + 1);
+            isHandlingBoundary = false;
         } else {
-            pocLog('All segments completed');
+            pocLog('All segments completed — stopping');
             isPlaying = false;
             updateControls();
+            isHandlingBoundary = false;
         }
     }
 

--- a/pages/youtube-segment-player-poc.html
+++ b/pages/youtube-segment-player-poc.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YouTube Segment Player PoC</title>
+    <link rel="stylesheet" href="/css/product/youtube-segment-player-poc.css">
+</head>
+<body>
+    <div class="poc-container">
+        <header class="poc-header">
+            <h1>YouTube Segment Player PoC</h1>
+            <p class="poc-subtitle">Cue-based segment playback validation for Moment Timeline (#366)</p>
+        </header>
+
+        <main class="poc-main">
+            <!-- YouTube IFrame Player API will insert player here -->
+            <div id="player-container">
+                <div id="player"></div>
+            </div>
+
+            <!-- Segment list display -->
+            <section class="segment-list">
+                <h2>Segment Queue</h2>
+                <ul id="segment-queue"></ul>
+            </section>
+
+            <!-- Playback controls -->
+            <section class="controls">
+                <button id="btn-prev" disabled>Previous</button>
+                <button id="btn-play">Play</button>
+                <button id="btn-pause" disabled>Pause</button>
+                <button id="btn-next" disabled>Next</button>
+                <button id="btn-loop" data-loop="false">Loop: OFF</button>
+            </section>
+
+            <!-- Current segment info -->
+            <section class="current-segment">
+                <h3>Current Segment</h3>
+                <div id="segment-info">No segment loaded</div>
+            </section>
+
+            <!-- Console log output for PoC verification -->
+            <section class="console-output">
+                <h3>PoC Console Log</h3>
+                <pre id="log-output"></pre>
+            </section>
+        </main>
+
+        <footer class="poc-footer">
+            <p>This is a contained PoC. Not connected to production navigation or backend.</p>
+        </footer>
+    </div>
+
+    <!-- YouTube IFrame Player API -->
+    <script src="https://www.youtube.com/iframe_api"></script>
+
+    <!-- PoC runtime -->
+    <script src="/js/product/youtube-segment-player-poc.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a contained runtime PoC scaffold for #366 YouTube segment playback.
- Use hard-coded segment data and the YouTube IFrame Player API to validate cue-based playback behavior.
- Keep production navigation, persistence, backend APIs, auth, video download/export, and server-side encoding out of scope.

## Scope
- Contained PoC page only.
- No production navigation wiring.
- No database persistence.
- No backend/API changes.
- No auth requirement.
- No video download/export.
- No server-side encoding.
- No Search/Auth/Editor/My Trees cleanup.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #366
Refs #362

## Verification
- [ ] git diff --check
- [ ] changed files limited to contained PoC files/docs
- [ ] local static page load smoke
- [ ] no fatal console errors
- [ ] YouTube iframe initialization checked
- [ ] invalid segment handled
- [ ] no secret/token/cookie/session/credential values
- [ ] production navigation untouched
- [ ] PR #7/prototype/reference/demo/variant untouched