### PR TITLE
docs(ops): define auth test slot E2E policy

### DIFF
--- a/docs/ops/AUTH_TEST_SLOT_E2E_POLICY.md
+++ b/docs/ops/AUTH_TEST_SLOT_E2E_POLICY.md
@@ -1,0 +1,35 @@
+# Auth Test Slot E2E Policy
+
+## Purpose
+- Track auth/test-account and fixed-slot E2E policy for #413.
+- Document credential-safe handling and evidence rules.
+
+## Relationship to #445
+- Follow-up documentation for merged PR #445.
+
+## Auth/Test-Account Handling
+- Only owner-approved accounts
+- No credential values exposed
+- No token/cookie/session output
+
+## Fixed Test Slot Assignment
+- One slot per PR
+- SHA provenance required
+- Deployment URL provenance required
+
+## Evidence Requirements
+- PASS / FAIL / BLOCKED / NOT_VERIFIED separated
+- No sensitive screenshots
+
+## Cleanup Policy
+- Track test data cleanup status
+- No private content leakage
+
+## Non-goals
+- No workflow implementation
+- No Playwright implementation
+- No required checks
+
+## Follow-up Split
+- Workflow candidate later
+- Page-specific smoke later


### PR DESCRIPTION
## Summary
- Add a docs-only auth/test-account and fixed-slot E2E policy for #413.
- Define credential-safe handling, slot assignment, SHA provenance, evidence rules, and cleanup reporting.
- Keep workflow changes, Playwright/test implementation, runtime changes, and required checks out of scope.

## Scope
- Docs-only.
- No GitHub Actions workflow changes.
- No package or dependency changes.
- No tests/scripts changes.
- No runtime/client/backend changes.
- No secret/session/test-account values included.
- No PR #7/prototype/reference/demo/variant changes.

## Related
Refs #413

## Verification
- [ ] changed files limited to docs/ops auth test-slot E2E policy/index files
- [ ] non-completing issue reference wording only for #413
- [ ] no secret/token/cookie/session/credential/test-account values
- [ ] no workflow/package/test/runtime changes
- [ ] PR #7/prototype/reference/demo/variant untouched