### PR TITLE
perf(browse): reduce initial public tree load size

### DIFF
--- a/js/search/index.js
+++ b/js/search/index.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         currentPreviewRequestId: 0,
         currentQuery: '',
         currentSort: 'latest',
-        currentLimit: 10,
+        currentLimit: 6,
         currentCategory: '전체',
         isRestoringUrlState: false,
         urlStateReady: false,

--- a/js/search/url-state.js
+++ b/js/search/url-state.js
@@ -1,7 +1,7 @@
 (function () {
     const DEFAULT_CATEGORY = '전체';
     const DEFAULT_SORT = 'latest';
-    const DEFAULT_LIMIT = 10;
+    const DEFAULT_LIMIT = 6;
     const MAX_LIMIT = 60;
 
     function createSearchUrlState({ refs, state, ui }) {


### PR DESCRIPTION
## Summary

Reduce Browse page initial public tree load size from 10 to 6 to improve initial page load performance.

## Scope

- Changed `js/search/index.js`: reduced `currentLimit` default from 10 to 6
- Changed `js/search/url-state.js`: reduced `DEFAULT_LIMIT` from 10 to 6 (restoreStateFromUrl was overriding initial state before first load)
- No UI/CSS/copy changes
- No API/backend/auth changes
- No package/workflow changes
- Preserves existing cache, race prevention, and filter/sort logic

## Related

Refs #456

## Verification checklist

- [x] git diff --check passed
- [x] Changed files: js/search/index.js, js/search/url-state.js
- [x] Initial limit changed from 10 to 6
- [x] url-state DEFAULT_LIMIT also changed from 10 to 6
- [x] API limit parameter confirmed to use new default (limit=6 in network requests)
- [x] Cache/race logic unchanged
- [x] Filter/sort behavior unchanged
- [x] Browser/network verification: limit=6 in network requests (verified on Cloudflare preview 89bd7754.lovebud.pages.dev)
- [x] First screen renders max 6 initial trees (UI shows "지금 먼저 볼 6개")
- [x] URL ?limit=10 override still works (verified)
- [x] No fatal console errors (YouTube thumbnail 404 is existing data issue, unrelated to PR)
- [x] No UI/CSS/copy modifications
- [x] No runtime/backend/API/auth modifications
- [x] No package/workflow modifications
- [x] PR #450 files untouched
- [x] PR #7/prototype/reference/demo/variant untouched
- [x] Ready/merge NOT performed (ready transition only)
