### PR TITLE
ui(intro): enrich LoveTree visual minimap

### DIFF
--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -157,9 +157,80 @@
   animation-delay: 1.25s;
 }
 
+.intro-tree-branch.four {
+  bottom: 78px;
+  width: 62px;
+  transform: translateX(-8px) rotate(198deg);
+  animation-delay: 1.5s;
+}
+
+.intro-tree-branch.five {
+  bottom: 58px;
+  width: 56px;
+  transform: translateX(6px) rotate(22deg);
+  animation-delay: 1.75s;
+}
+
 @keyframes introBranchIn {
   from { opacity: 0; }
   to   { opacity: 1; }
+}
+
+.intro-tree-node {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #e8c4b8, #c18b83);
+  box-shadow: 0 4px 12px rgba(144, 73, 81, 0.2);
+  animation: introNodeIn 0.3s ease both;
+}
+
+@keyframes introNodeIn {
+  from { opacity: 0; transform: scale(0); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.intro-tree-node.node-1 {
+  left: 58px;
+  bottom: 156px;
+  animation-delay: 1.8s;
+}
+
+.intro-tree-node.node-2 {
+  right: 52px;
+  bottom: 130px;
+  animation-delay: 1.95s;
+}
+
+.intro-tree-node.node-3 {
+  left: 62px;
+  bottom: 110px;
+  animation-delay: 2.1s;
+}
+
+.intro-tree-node.node-4 {
+  right: 48px;
+  bottom: 86px;
+  animation-delay: 2.25s;
+}
+
+.intro-tree-node.node-5 {
+  left: 66px;
+  bottom: 66px;
+  animation-delay: 2.4s;
+}
+
+.intro-tree-node.node-6 {
+  right: 44px;
+  bottom: 46px;
+  animation-delay: 2.55s;
+}
+
+.intro-tree-node.node-7 {
+  left: 70px;
+  bottom: 30px;
+  animation-delay: 2.7s;
 }
 
 .intro-tree-moment {
@@ -199,10 +270,24 @@
 }
 
 .intro-tree-moment.shared {
-  left: 30px;
-  top: 86px;
+  left: 24px;
+  top: 78px;
   color: #667a55;
   animation-delay: 2.0s;
+}
+
+.intro-tree-moment.revisit {
+  right: 20px;
+  bottom: 92px;
+  color: #8b7355;
+  animation-delay: 2.25s;
+}
+
+.intro-tree-moment.lasting {
+  left: 28px;
+  top: 42px;
+  color: #a67c52;
+  animation-delay: 2.5s;
 }
 
 .intro-tree-caption {
@@ -360,5 +445,49 @@
   .intro-hero-actions .btn-round {
     width: 100%;
     min-height: 54px;
+  }
+
+  /* Mobile: simplify tree visual */
+  .intro-tree-scene {
+    min-height: 280px;
+  }
+
+  .intro-tree-stem {
+    height: 100px;
+    bottom: 32px;
+  }
+
+  .intro-tree-branch.four,
+  .intro-tree-branch.five {
+    display: none;
+  }
+
+  .intro-tree-node.node-5,
+  .intro-tree-node.node-6,
+  .intro-tree-node.node-7 {
+    display: none;
+  }
+
+  .intro-tree-moment.revisit,
+  .intro-tree-moment.lasting {
+    display: none;
+  }
+
+  .intro-tree-moment.first {
+    left: 12px;
+    bottom: 48px;
+    font-size: 11px;
+  }
+
+  .intro-tree-moment.saved {
+    right: 10px;
+    top: 38px;
+    font-size: 11px;
+  }
+
+  .intro-tree-moment.shared {
+    left: 14px;
+    top: 62px;
+    font-size: 11px;
   }
 }

--- a/js/i18n/i18n-intro.js
+++ b/js/i18n/i18n-intro.js
@@ -46,6 +46,14 @@
       ko: '✨ 공개 감상',
       en: '✨ Public view'
     },
+    'intro.sceneRevisit': {
+      ko: '🔄 다시 감상',
+      en: '🔄 Rewatch'
+    },
+    'intro.sceneLasting': {
+      ko: '⭐ 오래 남는 장면',
+      en: '⭐ Lasting scene'
+    },
     'intro.sceneCaption': {
       ko: '흩어진 순간이 이어지면, 사랑에 빠진 흐름이 보입니다.',
       en: 'When scattered moments connect, the path of falling in love appears.'

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -37,9 +37,20 @@
             <div class="intro-tree-branch one"></div>
             <div class="intro-tree-branch two"></div>
             <div class="intro-tree-branch three"></div>
+            <div class="intro-tree-branch four"></div>
+            <div class="intro-tree-branch five"></div>
+            <div class="intro-tree-node node-1"></div>
+            <div class="intro-tree-node node-2"></div>
+            <div class="intro-tree-node node-3"></div>
+            <div class="intro-tree-node node-4"></div>
+            <div class="intro-tree-node node-5"></div>
+            <div class="intro-tree-node node-6"></div>
+            <div class="intro-tree-node node-7"></div>
             <div class="intro-tree-moment first" data-i18n="intro.sceneFirst">🌱 첫 설렘</div>
             <div class="intro-tree-moment saved" data-i18n="intro.sceneSaved">💝 마음 메모</div>
             <div class="intro-tree-moment shared" data-i18n="intro.sceneShared">✨ 공개 감상</div>
+            <div class="intro-tree-moment revisit" data-i18n="intro.sceneRevisit">🔄 다시 감상</div>
+            <div class="intro-tree-moment lasting" data-i18n="intro.sceneLasting">⭐ 오래 남는 장면</div>
           </div>
           <p class="intro-tree-caption" data-i18n="intro.sceneCaption">순간이 이어지면, 좋아하게 된 흐름이 보입니다.</p>
         </div>


### PR DESCRIPTION
## Intro LoveTree Visual Enhancement

### 목표
Intro 페이지의 LoveTree 시각적 표현을 더 풍부한 "growing-tree minimap"으로 개선합니다.

### 변경 내용
- **추가 요소**: 2개 새 가지, 7개 노드, 2개 새 감정 칩
- **모바일 최적화**: 모바일 뷰포트에서 시각적 단순화 적용
- **애니메이션**: 부드러운 트리 성장 애니메이션 유지

### 변경 파일
- `pages/intro.html`: 새 가지, 노드, 감정 칩 요소 추가
- `css/intro/hero.css`: 새 요소 스타일, 애니메이션, 모바일 미디어 쿼리 추가
- `js/i18n/i18n-intro.js`: 누락된 i18n 키 추가 (verify-static CI 수정)

### 검증 체크리스트
- [x] Desktop visual: 5개 가지, 7개 노드, 감정 칩 표시 확인
- [x] Mobile visual: 375x667 뷰포트에서 단순화된 렌더링 확인  
- [x] Language switch: 한국어/영어 전환 시 깨짐 없음 확인
- [x] Sticky scroll: 기존 스크롤 동작 유지 확인
- [x] Console errors: 치명적 에러 없음 확인
- [x] i18n keys: intro.sceneRevisit, intro.sceneLasting 추가 및 verify-static 통과
- [x] Scope: UI-only 변경, backend/API/auth/DB 수정 없음
- [x] Draft: PR은 draft 상태 유지
