### PR TITLE
docs(ops): add environment naming and runtime terminology audit for Issue #431

### DIFF
--- a/docs/ops/ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md
+++ b/docs/ops/ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md
@@ -1,0 +1,147 @@
+# Environment Naming and Runtime Terminology Audit
+
+## Purpose
+
+Audit `NETLIFY_DATABASE_URL` usage locations and meaning in a secret-safe manner. Review README, AGENTS, and docs runtime terminology for alignment with current operational baseline. Establish consistent terminology: Cloudflare Pages + Modal + Neon as active runtime, Netlify/Vercel as legacy/transitional artifacts. This is a docs-only audit - no environment variable rename, code/config changes, migration, or runtime structure changes.
+
+## Safe Verification Commands
+
+Commands that do not output actual values:
+
+```bash
+# Environment variable usage trace
+git grep -n "NETLIFY_DATABASE_URL" -- ':!*.env' ':!*.local*'
+git grep -n "DATABASE_URL" -- ':!*.env' ':!*.local*'
+
+# Runtime terminology scan
+git grep -n "Netlify" README.md AGENTS.md docs
+git grep -n "Vercel" README.md AGENTS.md docs
+git grep -n "Cloudflare" README.md AGENTS.md docs
+git grep -n "Modal" README.md AGENTS.md docs
+git grep -n "Neon" README.md AGENTS.md docs
+```
+
+## Usage Category Summary
+
+### NETLIFY_DATABASE_URL Usage
+
+| Category | Files | Impact | Rename Risk | Notes |
+|----------|-------|--------|-------------|-------|
+| Scripts | `scripts/*.js`, `scripts/*.bat`, `scripts/*.ps1` | High | High | Broad script ecosystem uses legacy name |
+| Docs | `docs/ops/*.md`, `docs/migration/*.md` | Medium | Medium | Documentation references and examples |
+| Engineering | `docs/engineering/*.md` | Medium | Medium | Architecture docs reference legacy naming |
+| Reports | `docs/reports/*.md` | Low | Low | Historical reports contain legacy references |
+
+### Runtime Terminology Distribution
+
+| Platform | Current Status | Doc Frequency | Alignment |
+|----------|----------------|---------------|-----------|
+| Cloudflare Pages | **Active runtime entry** | High | ✅ Consistent |
+| Modal | **Active runtime compute** | High | ✅ Consistent |
+| Neon | **Active persistence** | Medium | ✅ Consistent |
+| Netlify | **Legacy artifact** | High | ⚠️ Mixed legacy references |
+| Vercel | **Transitional fallback** | Medium | ⚠️ Mixed transitional references |
+
+## Terminology Alignment Notes
+
+### Current Consistent Usage
+
+**Active Runtime Components:**
+- Cloudflare Pages: "active runtime entry", "same-origin `/api/*` router", "static frontend"
+- Modal: "active runtime compute", "browse summary", "private/community read/write"
+- Neon: "active persistence", "PostgreSQL database", "data storage"
+
+**Legacy/Transitional Components:**
+- Netlify: "legacy artifact", "removal candidate", "not active production backend"
+- Vercel: "deprecated transitional fallback", "upstream under audit", "secondary adapter"
+
+### Areas Needing Alignment
+
+1. **Script Environment Variable Names**
+   - Many scripts still reference `NETLIFY_DATABASE_URL` as primary
+   - Active runtime uses Modal, but variable name suggests Netlify ownership
+   - Impact: High - script ecosystem broad usage
+
+2. **Documentation Examples**
+   - Several docs still use Netlify-first examples for environment setup
+   - Migration docs reference Netlify-to-Modal transitions
+   - Impact: Medium - documentation guidance only
+
+3. **Historical Report References**
+   - Past reports contain Netlify/Vercel as if they were active
+   - Some security docs still list Netlify as potential active target
+   - Impact: Low - historical context
+
+## Follow-up Axes and Guardrails
+
+### Axes for Future Work
+
+1. **Environment Variable Naming (High Impact)**
+   - Current: `NETLIFY_DATABASE_URL` used across scripts/docs
+   - Desired: Platform-agnostic naming (e.g., `DATABASE_URL`, `POSTGRES_URL`)
+   - Guardrail: Do not rename without separate implementation approval
+   - Prerequisite: Modal runtime stability confirmed
+
+2. **Script Modernization (High Impact)**
+   - Current: Scripts assume Netlify-first environment
+   - Desired: Platform-agnostic script patterns
+   - Guardrail: Maintain backward compatibility during transition
+   - Prerequisite: Environment variable naming decision
+
+3. **Documentation Refresh (Medium Impact)**
+   - Current: Mixed legacy/active terminology
+   - Desired: Consistent active runtime terminology
+   - Guardrail: Preserve historical context in appropriate sections
+   - Prerequisite: Runtime terminology alignment complete
+
+4. **Security Posture Alignment (Low Impact)**
+   - Current: Some security docs reference legacy platforms as active
+   - Desired: Clear distinction between active vs legacy platforms
+   - Guardrail: Do not change actual security configurations
+   - Prerequisite: Platform ownership clearly documented
+
+### Guardrails for This Audit
+
+- **No Implementation Changes**: This audit documents current state only
+- **No Environment Variable Rename**: `NETLIFY_DATABASE_URL` rename requires separate approval
+- **No Runtime Structure Changes**: Current Cloudflare + Modal + Neon stack preserved
+- **No Secret Exposure**: All verification commands are safe (no value output)
+- **PR #7/Prototype Protection**: Do not touch prototype/reference/demo/variant paths
+- **Issue Isolation**: Do not modify issues #464, #450, or UI PRs #460/#462/#463
+
+### Decision Points Requiring CTO Input
+
+1. **Environment Variable Rename Strategy**
+   - Keep `NETLIFY_DATABASE_URL` for compatibility?
+   - Migrate to platform-agnostic naming?
+   - Timeline for rename implementation?
+
+2. **Script Transition Approach**
+   - Gradual migration with backward compatibility?
+   - Clean break with new script patterns?
+   - Migration tooling vs manual updates?
+
+3. **Documentation Update Priority**
+   - Focus on operational docs first?
+   - Update all references simultaneously?
+   - Preserve historical context vs clean slate?
+
+## Current State Summary
+
+- **Active Runtime**: Cloudflare Pages + Modal + Neon (consistent across docs)
+- **Legacy References**: Netlify/Vercel still referenced in scripts/docs
+- **Environment Variables**: `NETLIFY_DATABASE_URL` widely used despite Modal active runtime
+- **Security Posture**: Clear distinction between active vs legacy needed in some docs
+- **Implementation Impact**: High for variable rename, medium for doc updates, low for terminology alignment
+
+## Verification Commands for Future Audits
+
+```bash
+# Re-run after any changes to verify alignment
+git grep -n "NETLIFY_DATABASE_URL" -- ':!*.env' ':!*.local*' | wc -l
+git grep -n "active runtime" docs/ | grep -v "legacy\|transitional"
+git grep -n "legacy.*Netlify\|Netlify.*legacy" docs/
+git grep -n "transitional.*Vercel\|Vercel.*transitional" docs/
+```
+
+This audit provides the baseline for any future environment variable naming or script modernization work. No changes are implemented in this audit - it documents current state and provides guardrails for future implementation decisions.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -32,7 +32,8 @@
 14. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
 15. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
 16. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-17. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+17. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+18. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -63,6 +64,7 @@
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |
 | [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) | Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, auth/test-account evidence 기준 |
 | [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) | Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식 |
+| [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) | Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리 |
 | [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) | browse summary의 Modal 우선 경로와 Modal security contract 기준 |
 | [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) | 반복 CI/E2E 실패의 원인 분리 및 exception merge 판단 기준 |
 | [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) | PR #49~#58 이후 merged/stale branch cleanup 후보와 보존 branch 분류 기준 |


### PR DESCRIPTION
## Summary
- Add comprehensive environment naming and runtime terminology audit for Issue #431
- Document NETLIFY_DATABASE_URL usage across scripts/docs in secret-safe manner
- Establish Cloudflare Pages + Modal + Neon as active runtime terminology
- Categorize Netlify/Vercel as legacy/transitional artifacts
- Provide safe verification commands without secret exposure
- Include usage category summary and impact analysis
- Document follow-up axes and guardrails for future implementation

## Scope
- Docs-only audit
- No environment variable rename
- No code or configuration changes
- No migration
- No runtime structure changes
- No PR #7/prototype/reference/demo/variant changes
- No Issue #464, PR #450, or UI PR #460/#462/#463 changes

## Changed Files
- docs/ops/ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md - New comprehensive audit document
- docs/ops/ops_index.md - Updated to reference new audit document

## Related
Refs #431

## Verification
- [ ] changed files limited to docs/ops/** only
- [ ] no close keyword
- [ ] no secret/token/cookie/session/credential values exposed
- [ ] no code/runtime/UI/CSS/workflow changes
- [ ] PR #7/prototype/reference/demo/variant untouched
- [ ] Issue #464 untouched
- [ ] PR #450 untouched
- [ ] UI PR #460/#462/#463 untouched