### PR TITLE
docs(ops): audit local file hygiene and pg dependency usage

### DIFF
--- a/docs/ops/LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md
+++ b/docs/ops/LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md
@@ -1,0 +1,387 @@
+# Local File Hygiene and pg Dependency Usage Audit
+
+**Status**: Completed audit (follow-up to Issue #429)
+**Owner**: CTO / Ops Lead
+**Scope**: docs-only audit - no implementation changes
+**Related**: Issue #429, Issue #223, Issue #425
+
+---
+
+## 1. Purpose
+
+This document provides a comprehensive audit of local file hygiene and `pg` dependency usage boundaries in the LoveBud repository. It establishes safe verification commands, observed tracked-file boundaries, and follow-up guardrails for maintaining repository hygiene without disrupting the current runtime architecture.
+
+**Key finding**: Issue #429 audit was previously completed via PR #432, but this follow-up audit provides additional clarity on current state and operational boundaries.
+
+---
+
+## 2. `.local/` Tracked-File Safety Boundary
+
+### 2.1 Current State Assessment
+
+**`.local/` directory**: NOT PRESENT in repository
+- No `.local/` directory exists in current codebase
+- No tracked files under `.local/` path
+- This simplifies the tracked-file boundary assessment
+
+**Tracked local files status**:
+- `.secrets/` - PRESENT (contains runtime environment files)
+- `.env*` files - NOT TRACKED (properly gitignored)
+- Local development artifacts - NOT TRACKED
+
+### 2.2 Safe Verification Commands
+
+```bash
+# Check for .local/ directory presence
+Test-Path .local
+
+# Verify .secrets/ directory is gitignored
+git check-ignore .secrets/
+
+# Check for any tracked local files that shouldn't be
+git ls-files | Select-String "^\.local/"
+
+# Verify .env files are properly ignored
+git check-ignore .env .env.local .env.production
+```
+
+### 2.3 Tracked-File Safety Boundaries
+
+**Allowed tracked local files**:
+- `.secrets/lovebud-runtime.env` - Runtime environment configuration
+- Documentation files under `docs/` - Operational guidance
+
+**Forbidden tracked files**:
+- Any files under `.local/` (directory doesn't exist)
+- Secret values in plaintext
+- Local development artifacts
+- Temporary build files
+
+---
+
+## 3. Secret-Safe Local File Handling
+
+### 3.1 Current Secret Handling Pattern
+
+**Primary secret store**: `.secrets/lovebud-runtime.env`
+- Contains runtime environment variables
+- Properly gitignored (verified via `git check-ignore`)
+- Used by local scripts and CI workflows
+
+**Safe handling principles**:
+1. **Path-only references**: Always reference secret files by path, never by content
+2. **Redacted reporting**: Use status words like `PRESENT`, `MISSING`, `EXISTS`, `GITIGNORED`
+3. **No value exposure**: Never output secret values in logs, reports, or comments
+4. **Environment loading**: Load secrets into process memory only for authorized commands
+
+### 3.2 Verification Commands (Secret-Safe)
+
+```powershell
+# Check secret file existence (no content exposure)
+Test-Path .secrets/lovebud-runtime.env
+
+# Verify gitignore status
+git check-ignore .secrets/lovebud-runtime.env
+
+# Check for required secret keys (presence only)
+$secretContent = Get-Content .secrets/lovebud-runtime.env | Select-String "CLOUDFLARE_API_TOKEN"
+if ($secretContent) { Write-Output "CLOUDFLARE_API_TOKEN: PRESENT" }
+```
+
+### 3.3 Forbidden Operations
+
+```powershell
+# FORBIDDEN: Never output secret values
+Get-Content .secrets/lovebud-runtime.env
+cat .secrets/lovebud-runtime.env
+$env:CLOUDFLARE_API_TOKEN
+
+# FORBIDDEN: Never dump all environment variables
+Get-ChildItem Env:
+env
+printenv
+```
+
+---
+
+## 4. Local/Generated/Test Artifact Distinction
+
+### 4.1 Current Artifact Classification
+
+**Local development artifacts** (NOT TRACKED):
+- `.env*` files
+- Local build outputs
+- Development logs
+- Temporary test files
+
+**Generated artifacts** (SELECTIVELY TRACKED):
+- Build outputs in `dist/` (if present)
+- Compiled documentation (if present)
+- Test reports (selectively tracked)
+
+**Test artifacts** (MINIMAL TRACKING):
+- E2E test screenshots (when explicitly needed for evidence)
+- Smoke test reports (when needed for PR verification)
+
+### 4.2 Boundary Principles
+
+1. **Local-only**: Files that should never be committed (`.env*`, local configs)
+2. **Generated-but-tracked**: Build outputs needed for deployment (minimal)
+3. **Test-evidence**: Artifacts needed for PR verification (selective, redacted)
+
+---
+
+## 5. `pg` Dependency Usage Trace
+
+### 5.1 Current Dependency State
+
+**`pg` package**: PRESENT in `package.json`
+- Version: `^8.12.0`
+- Listed under `dependencies` (not `devDependencies`)
+- Used for PostgreSQL database connections
+
+### 5.2 Usage Boundary Analysis
+
+**Primary usage contexts**:
+1. **Local development scripts**: Database operations during development
+2. **CI/CD workflows**: Database migrations and testing
+3. **Cloudflare Functions**: NOT USED (functions use Modal runtime)
+
+**Boundary observations**:
+- `pg` is NOT used in Cloudflare Functions runtime
+- Functions use Modal for database operations
+- `pg` is used only in local development and CI contexts
+
+### 5.3 Safe Verification Commands
+
+```bash
+# Check pg dependency presence
+npm list pg
+
+# Verify pg version
+npm list pg --depth=0
+
+# Check for pg usage in scripts (no code execution)
+Select-String -Path "scripts/*.js" -Pattern "require.*pg|import.*pg"
+
+# Check for pg usage in Cloudflare Functions
+Select-String -Path "functions/*" -Pattern "require.*pg|import.*pg"
+```
+
+---
+
+## 6. Cloudflare Functions vs Local Script Dependency Boundary
+
+### 6.1 Runtime Architecture Separation
+
+**Cloudflare Functions runtime**:
+- **Database access**: Modal runtime (PostgreSQL via Modal)
+- **Local dependencies**: Minimal, function-specific
+- **No direct `pg` usage**: Functions do not use `pg` package directly
+
+**Local scripts runtime**:
+- **Database access**: Direct PostgreSQL via `pg` package
+- **Development context**: Local development, CI/CD, migrations
+- **Full `pg` usage**: Local scripts can use `pg` directly
+
+### 6.2 Boundary Enforcement
+
+**Cloudflare Functions constraints**:
+- Cannot use `pg` package directly
+- Must use Modal runtime for database operations
+- Limited to function-specific dependencies
+
+**Local script permissions**:
+- Can use `pg` package for database operations
+- Can access local environment files
+- Can perform migrations and maintenance tasks
+
+---
+
+## 7. Dependency Removal Assessment
+
+### 7.1 Current Assessment: DO NOT REMOVE
+
+**Reasons to keep `pg` dependency**:
+1. **Local development**: Essential for local database operations
+2. **CI/CD workflows**: Required for automated testing and migrations
+3. **Maintenance tasks**: Needed for database administration scripts
+4. **No runtime conflict**: Not used in Cloudflare Functions, so no deployment impact
+
+**Removal risks**:
+- Breaks local development workflow
+- Disables CI/CD database operations
+- Prevents database maintenance tasks
+- No runtime benefit (functions don't use it anyway)
+
+### 7.2 Dependency Management Strategy
+
+**Current strategy**: MAINTAIN
+- Keep `pg` in `dependencies` (not `devDependencies`)
+- Continue local development and CI usage
+- Maintain clear boundary with Cloudflare Functions
+
+**Future considerations**:
+- If local development moves to Modal-only, consider removal
+- If CI/CD moves to Modal-based operations, consider removal
+- No immediate action required
+
+---
+
+## 8. Runtime Impact Assessment
+
+### 8.1 Current Runtime Impact: NONE
+
+**Cloudflare Pages frontend**: No impact
+- Frontend does not use `pg` directly
+- No runtime dependency on `pg`
+
+**Cloudflare Functions**: No impact
+- Functions use Modal runtime
+- No direct PostgreSQL connections
+
+**Local development**: MAINTAINED
+- Scripts continue to work as expected
+- No breaking changes to local workflow
+
+### 8.2 Deployment Impact: NONE
+
+**Package size**: Minimal impact
+- `pg` package not deployed to Cloudflare Functions
+- Only affects local development environment
+
+**Build process**: No impact
+- Build scripts don't use `pg` directly
+- No changes to deployment pipeline
+
+---
+
+## 9. Audit-Only Conclusion
+
+### 9.1 Summary
+
+This audit confirms that the LoveBud repository maintains proper local file hygiene and appropriate `pg` dependency usage boundaries:
+
+1. **`.local/` directory**: Not present, simplifying tracked-file boundaries
+2. **Secret handling**: Properly implemented with `.secrets/` and gitignore rules
+3. **`pg` dependency**: Appropriately used in local context, not in Cloudflare Functions
+4. **Runtime separation**: Clear boundary between local scripts and Cloudflare Functions
+5. **No removal needed**: `pg` dependency should be maintained for local development
+
+### 9.2 Operational Status
+
+**Current state**: HEALTHY
+- No tracked local files that shouldn't be tracked
+- Proper secret handling procedures in place
+- Clear dependency usage boundaries
+- No runtime impact from current dependency structure
+
+**Recommendation**: MAINTAIN CURRENT STATE
+- No immediate changes required
+- Continue current secret handling practices
+- Maintain `pg` dependency for local development
+- Preserve Cloudflare Functions vs local script boundaries
+
+---
+
+## 10. Follow-up Axes and Guardrails
+
+### 10.1 Monitoring Requirements
+
+**Regular checks** (monthly):
+- Verify no new tracked local files appear
+- Confirm secret files remain gitignored
+- Check `pg` usage remains within local context
+
+**Trigger events**:
+- New local development scripts added
+- Changes to Cloudflare Functions architecture
+- Dependency updates in `package.json`
+
+### 10.2 Guardrails
+
+**DO NOT**:
+- Add `.local/` directory to repository
+- Commit secret values in plaintext
+- Use `pg` in Cloudflare Functions
+- Remove `pg` dependency without local development alternative
+
+**DO**:
+- Maintain current secret handling practices
+- Keep `pg` in local development context
+- Preserve Cloudflare Functions vs local script boundaries
+- Use secret-safe verification commands
+
+### 10.3 Future Work Separation
+
+If implementation changes are needed, create separate issues/PRs:
+- **Issue #429**: Audit and documentation (COMPLETED)
+- **Future issue**: Local development workflow changes
+- **Future issue**: Cloudflare Functions architecture changes
+- **Future issue**: Dependency management strategy updates
+
+---
+
+## 11. Verification Commands
+
+### 11.1 Repository Hygiene Check
+
+```powershell
+# Check for .local/ directory
+Write-Output ".local/ directory exists: $(Test-Path .local)"
+
+# Check for tracked local files
+$trackedLocalFiles = git ls-files | Select-String "^\.local/"
+Write-Output "Tracked local files: $($trackedLocalFiles.Count)"
+
+# Verify .secrets/ is gitignored
+Write-Output ".secrets/ gitignored: $(git check-ignore .secrets/ -eq '.secrets/')"
+
+# Check .env files are gitignored
+$envFiles = @(".env", ".env.local", ".env.production")
+$envFiles | ForEach-Object {
+    Write-Output "$_ gitignored: $(git check-ignore $_ -eq $_)"
+}
+```
+
+### 11.2 Dependency Check
+
+```bash
+# Check pg dependency
+npm list pg --depth=0
+
+# Verify pg not used in Cloudflare Functions
+find functions/ -name "*.js" -exec grep -l "pg" {} \; | wc -l
+
+# Check pg usage in local scripts
+find scripts/ -name "*.js" -exec grep -l "pg" {} \; | wc -l
+```
+
+### 11.3 Secret Handling Check
+
+```powershell
+# Verify secret file exists and is gitignored
+Write-Output "Secret file exists: $(Test-Path .secrets/lovebud-runtime.env)"
+Write-Output "Secret file gitignored: $(git check-ignore .secrets/lovebud-runtime.env -eq '.secrets/lovebud-runtime.env')"
+
+# Check for secret key presence (no value exposure)
+$secretContent = Get-Content .secrets/lovebud-runtime.env | Select-String "CLOUDFLARE_API_TOKEN"
+Write-Output "CLOUDFLARE_API_TOKEN key present: $(($secretContent -ne $null).ToString().ToUpper())"
+```
+
+---
+
+## 12. Related Documents
+
+- [Issue #429](https://github.com/skerishKang/LoveBud/issues/429) - Original audit request
+- [PR #432](https://github.com/skerishKang/LoveBud/pull/432) - Previous audit completion
+- [AGENTS.md](AGENTS.md) - Agent secret handling policy
+- [AGENT_SECURITY.md](AGENT_SECURITY.md) - Secret handling guardrails
+- [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub authentication usage
+- [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Environment naming audit
+
+---
+
+**Document version**: 1.0  
+**Last updated**: 2026-05-01  
+**Next review**: 6 months or when dependency architecture changes

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -33,7 +33,8 @@
 15. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
 16. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
 17. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-18. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+18. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+19. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a docs-only audit for Issue #429 covering local file hygiene and pg dependency usage boundaries.
- Document .local/ tracked-file safety boundaries and secret-safe local file handling.
- Clarify Cloudflare Functions vs local script dependency boundaries.
- No runtime, dependency, workflow, or package changes are included.

## Scope
- Docs-only.
- No file deletion.
- No .gitignore changes.
- No dependency removal.
- No package/workflow/scripts changes.
- No runtime/backend/API/auth changes.

## Verification
- [x] git diff --check
- [x] changed files reviewed
- [x] docs-only scope confirmed
- [x] no secrets exposed
- [x] Refs #429 only; no close keyword

Refs #429