### PR TITLE
ui(browse): add fallback tree preview for image-less cards

### DIFF
--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -64,7 +64,31 @@
         padding: 0 8px;
         min-height: 24px;
     }
+
+    .tree-card-media-fallback {
+        gap: 8px;
+        padding: 12px;
+    }
+
+    .tree-card-media-fallback::before {
+        font-size: 36px;
+    }
+
+    .tree-card-media-fallback .fallback-title {
+        font-size: 12px;
+    }
+
+    .tree-card-media-fallback .fallback-dots {
+        gap: 4px;
+    }
+
+    .tree-card-media-fallback .fallback-dots span {
+        width: 5px;
+        height: 5px;
+    }
 }
+
+@media (max-width: 768px) {
     .search-container {
         padding: 20px var(--page-pad-mobile) 36px;
         gap: 22px;

--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -88,14 +88,71 @@
     position: absolute;
     inset: 0;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 12px;
     color: var(--primary);
     font-size: 34px;
     font-weight: 900;
     background:
-        radial-gradient(circle at 18% 16%, rgba(255, 245, 246, 0.92), rgba(255,255,255,0.12) 48%),
-        linear-gradient(135deg, rgba(144, 73, 81, 0.09), rgba(122, 139, 110, 0.11));
+        radial-gradient(circle at 20% 20%, rgba(255, 248, 245, 0.95), rgba(255,255,255,0.08) 50%),
+        radial-gradient(circle at 80% 80%, rgba(200, 180, 175, 0.15), transparent 45%),
+        linear-gradient(135deg, rgba(144, 73, 81, 0.08), rgba(122, 139, 110, 0.08));
+    padding: 16px;
+    text-align: center;
+}
+
+.tree-card-media-fallback::before {
+    content: '🌳';
+    font-size: 48px;
+    line-height: 1;
+    filter: drop-shadow(0 2px 4px rgba(144, 73, 81, 0.15));
+}
+
+.tree-card-media-fallback::after {
+    content: '';
+    position: absolute;
+    bottom: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, rgba(144, 73, 81, 0.2), transparent);
+}
+
+.tree-card-media-fallback .fallback-title {
+    font-size: 13px;
+    font-weight: 800;
+    color: var(--on-surface);
+    line-height: 1.3;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.tree-card-media-fallback .fallback-dots {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+}
+
+.tree-card-media-fallback .fallback-dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(144, 73, 81, 0.3);
+}
+
+.tree-card-media-fallback .fallback-dots span:nth-child(2) {
+    background: rgba(122, 139, 110, 0.4);
+}
+
+.tree-card-media-fallback .fallback-dots span:nth-child(3) {
+    background: rgba(200, 180, 175, 0.5);
 }
 
 .tree-card-media-fallback[hidden] {

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -132,10 +132,16 @@
 
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
+        const treeStage = tree?.stage || 'empty';
+        const stageIcon = getTreeIcon(treeStage);
         return `
-            <div class="tree-card-media-fallback" style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;padding:20px;text-align:center;background:linear-gradient(135deg, rgba(250,242,243,0.96), rgba(255,255,255,0.96));width:100%;height:100%;">
-                <span style="font-size:34px;line-height:1;">${escapeHtml(getTreeIcon(tree.stage))}</span>
-                <div style="font-size:13px;font-weight:800;color:var(--on-surface);">${safeTitle}</div>
+            <div class="tree-card-media-fallback">
+                <div class="fallback-title">${safeTitle}</div>
+                <div class="fallback-dots">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </div>
             </div>
         `;
     }


### PR DESCRIPTION
## Summary
- Add a LoveTree-style fallback preview for Browse cards without representative images.
- Keep the stabilized card rhythm from the prior Browse card layout work.
- Improve visual completeness without changing card data, API, or backend behavior.

## Scope
- Browse/Search card fallback visual only.
- No Editor, My Trees, Intro, Auth, API, backend, DB, package, or workflow changes.
- No image upload/storage behavior changes.

## Related
Refs #455

## Verification
- [x] git diff --check
- [x] Changed files limited to Browse/Search UI scope
- [ ] Representative image cards still render normally
- [ ] Image-less cards show fallback tree preview
- [ ] Card height rhythm remains stable
- [ ] Title/description clamp remains intact
- [ ] Metadata remains bottom-pinned
- [ ] Mobile 375px layout verified
- [ ] No fatal console errors
- [x] Editor/My Trees files untouched
- [x] Intro files untouched
- [x] Auth/API/backend/DB files untouched
- [x] package/workflow files untouched
- [x] PR #7/prototype/reference/demo/variant untouched
- [x] PR #450/YouTube PoC files untouched
- [x] No secrets/tokens/cookies/session values exposed