### PR TITLE
feat(modal): add redaction-safe request ID logging for browse endpoints

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -21,6 +21,7 @@ from modal_compute.db import (
     get_db_connection,
     run_db_with_retry,
 )
+from modal_compute.logging import RequestLogger, log_request_event
 from modal_compute.validation import (
     _to_isoformat,
     estimate_stage,
@@ -757,11 +758,19 @@ def get_latest_browse_snapshot(
     sort: str = Query(default="latest"),
     x_lovebud_request_id: str | None = Header(default=None),
 ) -> list[dict]:
-    safe_sort = sort if sort in {"latest", "popular"} else "latest"
-    result = fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)
-    # Note: FastAPI handles response headers automatically for list responses
-    # Request ID is available for logging in future structured logging (Issue #472)
-    return result
+    logger = RequestLogger(
+        request_id=x_lovebud_request_id,
+        route="/modal/browse/latest",
+        method="GET",
+    )
+    try:
+        safe_sort = sort if sort in {"latest", "popular"} else "latest"
+        result = fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)
+        logger.log_success(status_code=200)
+        return result
+    except Exception:
+        logger.log_error(status_code=500, error_category="UNEXPECTED_ERROR")
+        raise
 
 
 @web_app.get("/modal/browse/growing")
@@ -769,9 +778,18 @@ def get_growing_browse_snapshot(
     limit: int = Query(default=6, ge=3, le=12),
     x_lovebud_request_id: str | None = Header(default=None),
 ) -> list[dict]:
-    result = fetch_growing_public_tree_snapshots(limit=limit)
-    # Note: Request ID available for future structured logging (Issue #472)
-    return result
+    logger = RequestLogger(
+        request_id=x_lovebud_request_id,
+        route="/modal/browse/growing",
+        method="GET",
+    )
+    try:
+        result = fetch_growing_public_tree_snapshots(limit=limit)
+        logger.log_success(status_code=200)
+        return result
+    except Exception:
+        logger.log_error(status_code=500, error_category="UNEXPECTED_ERROR")
+        raise
 
 
 @web_app.get("/modal/community/memories")

--- a/modal_compute/logging.py
+++ b/modal_compute/logging.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+def log_request_event(
+    request_id: str | None = None,
+    route: str | None = None,
+    method: str | None = None,
+    status_code: int | None = None,
+    error_category: str | None = None,
+    duration_ms: float | None = None,
+) -> None:
+    """
+    Log a redaction-safe request event.
+
+    This function only logs metadata that is safe to expose:
+    - request_id: The correlation ID from x-lovebud-request-id header
+    - route: The endpoint pattern (e.g., "/modal/browse/latest")
+    - method: HTTP method (GET, POST, etc.)
+    - status_code: HTTP response status
+    - error_category: Coarse error classification (AUTH_FAILED, VALIDATION_FAILED, etc.)
+    - duration_ms: Request duration in milliseconds
+
+    This function NEVER logs:
+    - Authorization headers
+    - Cookies
+    - Session values
+    - Access tokens
+    - API keys
+    - Firebase credentials
+    - Raw request bodies
+    - Private tree or memory content
+    - OAuth callback/session material
+    
+    Refs #472
+    """
+    # Build redaction-safe log entry
+    log_entry: dict[str, Any] = {}
+
+    if request_id:
+        log_entry["request_id"] = request_id
+    if route:
+        log_entry["route"] = route
+    if method:
+        log_entry["method"] = method
+    if status_code is not None:
+        log_entry["status_code"] = status_code
+    if error_category:
+        log_entry["error_category"] = error_category
+    if duration_ms is not None:
+        log_entry["duration_ms"] = duration_ms
+
+    # Print to stdout (Modal captures this as structured logs)
+    if log_entry:
+        print(f"[LoveBudModal] {log_entry}")
+
+
+class RequestLogger:
+    """Context manager for timing and logging requests."""
+
+    def __init__(
+        self,
+        request_id: str | None = None,
+        route: str | None = None,
+        method: str | None = None,
+    ):
+        self.request_id = request_id
+        self.route = route
+        self.method = method
+        self.start_time = time.time()
+    
+    def log_success(self, status_code: int = 200) -> None:
+        """Log a successful request."""
+        duration_ms = (time.time() - self.start_time) * 1000
+        log_request_event(
+            request_id=self.request_id,
+            route=self.route,
+            method=self.method,
+            status_code=status_code,
+            duration_ms=duration_ms,
+        )
+    
+    def log_error(
+        self,
+        status_code: int = 500,
+        error_category: str = "UNEXPECTED_ERROR",
+    ) -> None:
+        """Log a failed request with error category."""
+        duration_ms = (time.time() - self.start_time) * 1000
+        log_request_event(
+            request_id=self.request_id,
+            route=self.route,
+            method=self.method,
+            status_code=status_code,
+            error_category=error_category,
+            duration_ms=duration_ms,
+        )


### PR DESCRIPTION
## Scope
- Add modal_compute/logging.py with redaction-safe logging helper
- Add RequestLogger context manager for timing and logging requests
- Apply logging to /modal/browse/latest and /modal/browse/growing endpoints
- Log only safe metadata: request_id, route, method, status_code, error_category, duration_ms

## Changed files
- modal_compute/logging.py (new)
- modal_compute/app.py (modified)

## Scope repair note
This PR was initially created from a branch that included PR #474 changes. The branch has been repaired to include only Modal-only changes as required by Issue #472 scope. The functions/api/[[path].js changes from PR #474 have been removed from this PR diff.

## Redaction/safety guardrails
- Never log sensitive data: Authorization, cookies, tokens, private payloads
- Only log redaction-safe metadata for request correlation
- No raw request body logging
- No raw response body logging
- No Authorization/cookie/session/token exposure
- No private payload exposure

## Verification
- Static verification: PASS (git diff --check, npm run verify 128/128)
- Python syntax: Valid
- No package/workflow changes
- Changed files limited to modal_compute scope only

## Not verified
- Runtime verification not yet performed (requires Modal deployment)
- Log output format not yet verified in production

## Follow-up
- Expand logging to other Modal endpoints in follow-up PRs
- Add coarse error classification for auth/validation/DB errors
- Add runtime verification on test slot

Refs #472