### PR TITLE
docs(ops): add Modal runtime diagnostics workflow

### DIFF
--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -35,7 +35,8 @@
 17. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
 18. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
 19. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-20. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+20. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+21. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 


### PR DESCRIPTION
## Scope
- Add comprehensive Modal runtime diagnostics workflow for Issue #473
- Document Cloudflare ↔ Modal verification procedures
- Include request ID correlation verification steps
- Provide blocked-state reporting templates for PR #477
- Add structured log verification checklist for Modal logging PRs
- Include redaction-safe reporting guidelines
- Update ops_index.md with new workflow document
- No runtime changes, docs-only

## Why this is needed
PR #477 (Modal structured logging) is blocked because no Modal runtime verification procedures exist in the repository. This workflow provides the missing runbook for future Modal runtime verification, including blocked-state reporting templates that address the current PR #477 blocker.

## Relationship to PR #477 blocker
- PR #477 status: BLOCKED_MODAL_VERIFICATION_RUNBOOK_NOT_FOUND
- This workflow provides the missing runbook
- Enables future Modal runtime verification for PR #477 and similar PRs
- Includes specific templates for blocked-state reporting

## Changed files
- docs/ops/MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md (new)
- docs/ops/ops_index.md (updated)

## Scope repair note
This PR was initially created from a branch that included PR #477 Modal logging changes. The branch has been repaired to include only docs-only changes as required by Issue #473 scope. The modal_compute/ files from PR #477 have been removed from this PR diff.

## Verification
- Static verification: PASS (git diff --check, npm run verify 128/128)
- Changed files limited to docs/ops/ only
- No secret values or private payload examples
- No runtime/package/workflow changes
- No sensitive data exposure in documentation
- Scope repaired to docs-only as required by Issue #473

## Not verified
- Runtime verification not applicable (docs-only)
- Modal deployment/log access not tested (provides procedures only)

## Safety notes
- All reporting templates use redaction-safe language
- No secret values, tokens, or credentials documented
- Blocked-state templates prevent unauthorized access attempts
- Structured log verification focuses on field presence, not content

Refs #473