### PR TITLE
refactor(editor): relocate memory mode override styles

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -15,5 +15,6 @@
 @import url("./editor/memory-form.css");
 @import url("./editor/detail-panel.css");
 @import url("./editor/responsive.css");
+@import url("./editor/mode-selection.css");
 @import url("./editor/overrides.css");
 @import url("./editor/responsive-tail.css");

--- a/css/editor/mode-selection.css
+++ b/css/editor/mode-selection.css
@@ -1,0 +1,63 @@
+/**
+ * LoveBud Editor Memory Mode Selection CSS
+ * Relocated from css/editor/overrides.css Group D (lines 499-556)
+ * Contains memory mode and form support styling
+ */
+
+.editor-memory-mode-group {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin: 4px 0 2px;
+}
+
+.editor-memory-mode-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 0 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(144,73,81,0.12);
+    background: rgba(255,255,255,0.84);
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.18s ease;
+}
+
+.editor-memory-mode-chip.is-active {
+    color: var(--primary);
+    border-color: rgba(144,73,81,0.22);
+    background: rgba(144,73,81,0.08);
+    box-shadow: 0 8px 20px rgba(75,64,57,0.05);
+}
+
+.editor-memory-mode-chip .material-symbols-outlined {
+    font-size: 18px;
+}
+
+.editor-form-support-note {
+    margin: -4px 0 2px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 12px 14px;
+    border-radius: 16px;
+    background: rgba(255,255,255,0.68);
+    border: 1px solid rgba(144,73,81,0.08);
+    color: var(--on-surface-variant);
+    font-size: 12px;
+    line-height: 1.6;
+}
+
+.editor-form-support-note .material-symbols-outlined {
+    font-size: 16px;
+    color: var(--primary);
+    margin-top: 1px;
+}
+
+.editor-form-field.is-deemphasized {
+    opacity: 0.72;
+}

--- a/css/editor/overrides.css
+++ b/css/editor/overrides.css
@@ -496,63 +496,6 @@ body .editor-canvas-title h2 {
     margin-top: 4px;
 }
 
-.editor-memory-mode-group {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    margin: 4px 0 2px;
-}
-
-.editor-memory-mode-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    min-height: 40px;
-    padding: 0 14px;
-    border-radius: 999px;
-    border: 1px solid rgba(144,73,81,0.12);
-    background: rgba(255,255,255,0.84);
-    color: var(--on-surface-variant);
-    font-size: 13px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: all 0.18s ease;
-}
-
-.editor-memory-mode-chip.is-active {
-    color: var(--primary);
-    border-color: rgba(144,73,81,0.22);
-    background: rgba(144,73,81,0.08);
-    box-shadow: 0 8px 20px rgba(75,64,57,0.05);
-}
-
-.editor-memory-mode-chip .material-symbols-outlined {
-    font-size: 18px;
-}
-
-.editor-form-support-note {
-    margin: -4px 0 2px;
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 12px 14px;
-    border-radius: 16px;
-    background: rgba(255,255,255,0.68);
-    border: 1px solid rgba(144,73,81,0.08);
-    color: var(--on-surface-variant);
-    font-size: 12px;
-    line-height: 1.6;
-}
-
-.editor-form-support-note .material-symbols-outlined {
-    font-size: 16px;
-    color: var(--primary);
-    margin-top: 1px;
-}
-
-.editor-form-field.is-deemphasized {
-    opacity: 0.72;
-}
 
 .editor-layout {
     background: linear-gradient(180deg,#fff8f0 0%,#f8ede2 52%,#f5e6dc 100%);


### PR DESCRIPTION
## Summary
- Move the editor memory mode and form-support override selector group out of css/editor/overrides.css.
- Add the relocated selector group to css/editor/mode-selection.css.
- Preserve existing selector names, declarations, cascade behavior, and editor mode switching behavior.

## Scope
- Editor CSS relocation only.
- No selector rename, visual redesign, JavaScript behavior change, Auth/API/backend change, package change, or workflow change.
- No Browse/Search, My Trees, Detail, global CSS, or public tree adapter changes.

## Related
Refs #419

## Verification
- [x] git diff --check
- [x] Changed files limited to allowed Editor CSS scope
- [x] Relocated selectors removed from css/editor/overrides.css`n- [x] Relocated selectors present in css/editor/mode-selection.css`n- [x] No selector rename or CSS value change
- [x] Editor memory mode chips visible
- [x] Mode chips show 노래 / 영상 / 글
- [x] Mode chip switching works
- [x] Active chip styling preserved
- [x] Form support note rendering preserved
- [x] .editor-form-field.is-deemphasized styling preserved
- [x] Mobile 375px chip display verified
- [x] No fatal console errors
- [x] No JS/runtime/Auth/API/backend changes
- [x] PR #7/prototype/reference/demo/variant untouched
- [x] PR #450/YouTube PoC files untouched
- [x] No secrets/tokens/cookies/session values exposed