### PR TITLE
ui(shared): add LoveTree visual foundation tokens

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -8,6 +8,87 @@
 @import url('./global/base.css');
 @import url('./global/header.css');
 
+/* LoveTree Shared Visual Foundation Classes */
+.lovetree-page-shell {
+    max-width: var(--lovetree-page-shell-max);
+    margin: 0 auto;
+    padding: 0 var(--lovetree-page-pad-desktop);
+}
+
+@media (max-width: 1024px) {
+    .lovetree-page-shell {
+        padding: 0 var(--lovetree-page-pad-tablet);
+    }
+}
+
+@media (max-width: 480px) {
+    .lovetree-page-shell {
+        padding: 0 var(--lovetree-page-pad-mobile);
+    }
+}
+
+.lovetree-soft-surface {
+    background: var(--lovetree-soft-surface);
+    border: 1px solid var(--lovetree-soft-surface-border);
+    border-radius: var(--lovetree-card-radius);
+    box-shadow: var(--lovetree-card-shadow);
+}
+
+.lovetree-card {
+    background: var(--lovetree-soft-surface);
+    border: 1px solid var(--lovetree-soft-surface-border);
+    border-radius: var(--lovetree-card-radius);
+    box-shadow: var(--lovetree-card-shadow);
+    padding: 20px;
+}
+
+.lovetree-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: var(--radius-full);
+    background: var(--lovetree-pill-bg);
+    border: 1px solid var(--lovetree-pill-border);
+    color: var(--lovetree-pill-text);
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.18s ease;
+}
+
+.lovetree-pill:hover {
+    background: var(--lovetree-pill-hover-bg);
+}
+
+.lovetree-pill:active,
+.lovetree-pill.is-active {
+    background: var(--lovetree-pill-active-bg);
+}
+
+.lovetree-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 0 14px;
+    border-radius: var(--radius-full);
+    background: var(--lovetree-chip-bg);
+    border: 1px solid var(--lovetree-chip-border);
+    color: var(--lovetree-chip-text);
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.18s ease;
+}
+
+.lovetree-chip.is-active {
+    background: var(--lovetree-chip-active-bg);
+    color: var(--lovetree-chip-active-text);
+    border-color: var(--lovetree-chip-active-border);
+    box-shadow: 0 8px 20px rgba(75, 64, 57, 0.05);
+}
+
 
 
 

--- a/css/global/tokens.css
+++ b/css/global/tokens.css
@@ -33,6 +33,30 @@
     --radius-lg: 2rem;
     --radius-full: 9999px;
 
+    /* LoveTree Shared Visual Foundation */
+    --lovetree-page-shell-max: 1280px;
+    --lovetree-page-pad-desktop: 24px;
+    --lovetree-page-pad-tablet: 24px;
+    --lovetree-page-pad-mobile: 16px;
+
+    --lovetree-soft-surface: #f8f5f0;
+    --lovetree-soft-surface-border: rgba(144, 73, 81, 0.08);
+    --lovetree-card-shadow: 0 4px 20px rgba(75, 64, 57, 0.05);
+    --lovetree-card-radius: 16px;
+
+    --lovetree-pill-bg: rgba(144, 73, 81, 0.08);
+    --lovetree-pill-border: rgba(144, 73, 81, 0.22);
+    --lovetree-pill-text: var(--primary);
+    --lovetree-pill-hover-bg: rgba(144, 73, 81, 0.12);
+    --lovetree-pill-active-bg: rgba(144, 73, 81, 0.16);
+
+    --lovetree-chip-bg: rgba(255, 255, 255, 0.84);
+    --lovetree-chip-border: rgba(144, 73, 81, 0.12);
+    --lovetree-chip-text: var(--on-surface-variant);
+    --lovetree-chip-active-bg: var(--lovetree-pill-bg);
+    --lovetree-chip-active-text: var(--primary);
+    --lovetree-chip-active-border: var(--lovetree-pill-border);
+
     /* Page width rhythm */
     --page-brand-max: 1280px;
     --page-work-max: 1440px;


### PR DESCRIPTION
## Summary
- Add a narrow shared LoveTree visual foundation for future active-page UI alignment.
- Introduce reusable page-shell/surface/pill/chip styling primitives aligned with the first-page baseline.
- Keep page-specific Intro, Browse, and My Trees redesign work out of this PR.

## Scope
- UI/CSS foundation only.
- No JavaScript, Auth, API, backend, DB, package, or workflow changes.
- No broad page redesign.
- No Editor changes.

## Related
Refs #453

## Verification
- [x] git diff --check
- [x] Changed files limited to allowed UI/CSS scope
- [x] Landing page baseline not degraded
- [x] Intro page still loads
- [x] Browse/Search page still loads
- [x] My Trees page still loads
- [x] Desktop visual smoke
- [x] Mobile 375px smoke
- [x] No fatal console errors
- [x] No JS/runtime/Auth/API/backend changes
- [x] PR #7/prototype/reference/demo/variant untouched
- [x] PR #450/YouTube PoC files untouched
- [x] No secrets/tokens/cookies/session values exposed