### PR TITLE
ui(intro): align intro page with LoveTree visual foundation

### DIFF
--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -9,8 +9,8 @@
   grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.72fr);
   gap: var(--hero-gap);
   align-items: center;
-  padding: 52px var(--page-pad-desktop) 32px;
-  max-width: var(--page-shell-max);
+  padding: 52px var(--lovetree-page-pad-desktop) 32px;
+  max-width: var(--lovetree-page-shell-max);
   margin: 0 auto;
   width: 100%;
   min-height: min(820px, calc(100vh - 108px));

--- a/css/intro/how-to.css
+++ b/css/intro/how-to.css
@@ -5,15 +5,15 @@
  */
 
 .intro-section {
-  padding: 44px var(--page-pad-desktop);
-  max-width: var(--page-shell-max);
+  padding: 44px var(--lovetree-page-pad-desktop);
+  max-width: var(--lovetree-page-shell-max);
   margin: 0 auto;
   width: 100%;
   border-top: 1px solid var(--outline-variant);
 }
 
 .intro-section.intro-section-wide {
-  max-width: var(--page-shell-max);
+  max-width: var(--lovetree-page-shell-max);
 }
 
 .intro-section h2 {

--- a/css/intro/responsive.css
+++ b/css/intro/responsive.css
@@ -8,7 +8,7 @@
   .intro-hero {
     grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.6fr);
     gap: 28px;
-    padding: 60px var(--page-pad-desktop) 48px;
+    padding: 60px var(--lovetree-page-pad-desktop) 48px;
   }
 
   .intro-tree-scene {
@@ -23,7 +23,7 @@
   }
 
   .intro-hero, .intro-section, .cta-section {
-    padding: 60px var(--page-pad-mobile) 36px;
+    padding: 60px var(--lovetree-page-pad-mobile) 36px;
   }
 
   .intro-hero h1 {

--- a/css/intro/value.css
+++ b/css/intro/value.css
@@ -16,17 +16,17 @@
   align-items: flex-start;
   gap: 16px;
   padding: 20px;
-  background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96));
-  border-radius: 1.2rem;
-  border: 1px solid rgba(144, 73, 81, 0.08);
+  background: var(--lovetree-soft-surface);
+  border-radius: var(--lovetree-card-radius);
+  border: 1px solid var(--lovetree-soft-surface-border);
   min-height: 148px;
-  box-shadow: 0 10px 24px rgba(75, 64, 57, 0.04);
+  box-shadow: var(--lovetree-card-shadow);
 }
 
 .value-item-featured {
-  background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(255, 245, 246, 0.95));
-  border-color: rgba(144, 73, 81, 0.12);
-  box-shadow: 0 12px 28px rgba(144, 73, 81, 0.06);
+  background: var(--lovetree-soft-surface);
+  border-color: var(--lovetree-soft-surface-border);
+  box-shadow: var(--lovetree-card-shadow);
 }
 
 .value-item .material-symbols-outlined {


### PR DESCRIPTION
## Summary
- Align the Intro page with the shared LoveTree visual foundation tokens and classes.
- Apply lovetree-page-shell and lovetree-soft-surface tokens to page layout and card components.
- Preserve the first landing page as the visual baseline while improving consistency.

## Scope
- Intro page alignment only.
- Minimal CSS changes using shared foundation tokens.
- No Browse/Search, My Trees, Editor, JavaScript, Auth, API, backend, DB, package, or workflow changes.

## Changed files
- css/intro/hero.css
- css/intro/value.css
- css/intro/how-to.css
- css/intro/responsive.css

## Verification
- [x] git diff --check
- [x] Intro page only scope confirmed
- [x] Shared foundation tokens/classes reused where applicable
- [x] Landing page baseline preserved
- [x] No Browse/Search changes
- [x] No My Trees changes
- [x] No Editor changes
- [x] No JavaScript changes
- [x] No Auth/API/backend/DB changes
- [x] No package/workflow changes
- [x] PR #7/prototype/reference/demo/variant untouched
- [x] PR #450/YouTube PoC files untouched
- [x] No secrets/tokens/cookies/session/localStorage values exposed

## Not verified
- [ ] Cloudflare Pages PR Preview verification
- [ ] Fixed test slot verification

## Safety checks
- [x] No close/fix/resolves keywords used
- [x] Only Refs #453 used

Refs #453