### PR TITLE
ui(intro): simplify sticky narrative section

### DIFF
--- a/css/intro/how-to.css
+++ b/css/intro/how-to.css
@@ -40,10 +40,9 @@
 }
 
 .intro-section-text {
-  position: sticky;
-  top: 120px;
-  max-height: 50vh;
-  overflow-y: auto;
+  position: static;
+  max-height: none;
+  overflow-y: visible;
   padding-right: 1rem;
 }
 


### PR DESCRIPTION
## Summary

Simplifies the Intro page sticky narrative behavior for Issue #458.

The `처음은 이렇게 남겨요` section no longer keeps the left text in a sticky scroll position on desktop. The text now remains in normal document flow with the adjacent cards, reducing the chance that the section is perceived as a rendering or layout bug.

## Scope

- Intro page CSS-only UX polish.
- Removes the desktop sticky behavior from `.intro-section-text`.
- Keeps the existing mobile stacked behavior.
- Preserves the Intro page visual foundation and card styling.

## Changed files

- `css/intro/how-to.css`

## Verification

Repository/API-level checks before PR creation:

- Issue #458 state checked: open.
- Source of sticky behavior identified in `css/intro/how-to.css`.
- Branch created from current main merge commit `b3d383a4a330454394f06755ce9c5c7e626ef0df`.
- Diff confirmed as one Intro CSS file only.
- No JavaScript, page HTML, backend, package, workflow, Browse/Search, My Trees, or Editor files changed.

Cloudflare Preview visual verification:

- Preview URL: `https://c968c7a6.lovebud.pages.dev/pages/intro.html`
- Preview deployed SHA matched PR head SHA: `24081950d3270759051a93438e25b0a3d7a8ed98`
- Desktop Intro verification: PASS.
- Sticky/floating perception: RESOLVED.
- Section/card connection: PASS.
- Mobile 375px verification: PASS.
- Horizontal overflow: none reported.
- Root landing baseline: PASS.
- Console fatal errors: none reported.

## Not verified by ChatGPT directly

- Browser screenshots were not inspected directly in this ChatGPT session.

## Safety checks

- CSS-only scope maintained.
- No behavior/runtime files changed.
- PR #7/prototype/reference/demo/variant untouched.
- PR #450/YouTube PoC files untouched.
- No protected values exposed.

Refs #458