### PR TITLE
ui(browse): enrich card media and fallback tree preview

### DIFF
--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -245,3 +245,82 @@
 .tree-meta-chip .material-symbols-outlined {
     font-size: 14px;
 }
+
+/* Issue #455 PR B: representative media and fallback tree preview polish. */
+.tree-card-media::before {
+    content: '';
+    position: absolute;
+    right: 14px;
+    bottom: 14px;
+    width: 54px;
+    height: 38px;
+    border-radius: 19px;
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.64);
+    box-shadow: 0 12px 24px rgba(50, 38, 35, 0.16);
+    pointer-events: none;
+    z-index: 2;
+}
+
+.tree-card-media-fallback {
+    justify-content: flex-end;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at 24% 18%, rgba(255, 248, 245, 0.98), transparent 48%),
+        radial-gradient(circle at 72% 32%, rgba(255, 229, 225, 0.56), transparent 34%),
+        linear-gradient(135deg, rgba(144, 73, 81, 0.08), rgba(122, 139, 110, 0.08));
+}
+
+.tree-card-media-fallback::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 24px;
+    width: 86px;
+    height: 74px;
+    transform: translateX(-50%);
+    border-radius: 999px;
+    background:
+        radial-gradient(circle at 72% 24%, rgba(144, 73, 81, 0.58) 0 4px, transparent 5px),
+        radial-gradient(circle at 30% 30%, rgba(122, 139, 110, 0.52) 0 4px, transparent 5px),
+        radial-gradient(circle at 48% 58%, rgba(200, 116, 128, 0.52) 0 4px, transparent 5px),
+        linear-gradient(90deg, transparent 20%, rgba(144, 73, 81, 0.32) 21% 24%, transparent 25% 48%, rgba(144, 73, 81, 0.42) 49% 53%, transparent 54%);
+    filter: none;
+    z-index: 1;
+}
+
+.tree-card-media-fallback::after {
+    top: 58px;
+    bottom: auto;
+    width: 8px;
+    height: 46px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(193, 139, 131, 0.92), rgba(144, 73, 81, 0.78));
+    z-index: 1;
+}
+
+.tree-card-media-fallback .fallback-title {
+    position: relative;
+    z-index: 2;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    box-shadow: 0 10px 18px rgba(75, 64, 57, 0.08);
+}
+
+.tree-card-media-fallback .fallback-dots {
+    position: absolute;
+    left: 50%;
+    top: 52px;
+    z-index: 2;
+    gap: 24px;
+    margin-top: 0;
+    transform: translateX(-50%);
+}
+
+.tree-card-media-fallback .fallback-dots span {
+    width: 7px;
+    height: 7px;
+    box-shadow: 0 0 0 5px rgba(144, 73, 81, 0.08);
+}

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260501-455a">
+    <link rel="stylesheet" href="../css/search.css?v=20260501-455b">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="bokeh-bg">


### PR DESCRIPTION
## Summary

Implements Issue #455 PR B: representative visual and fallback tree preview polish for Browse cards.

This PR keeps the existing Search card renderer and DOM structure. It adds CSS-only visual enrichment so media cards carry a subtle LoveTree mark and no-media fallback cards feel like warm mini tree previews instead of plain icon states.

## Scope

- Browse/Search card visual polish.
- Adds CSS-only representative media overlay treatment.
- Adds CSS-only fallback tree minimap treatment using existing fallback DOM and pseudo-elements.
- Keeps PR A title/description clamp and metadata bottom layout intact.
- Does not implement Issue #455 PR C selected-tree hub preview.

## Changed files

- `css/search/tree-card.css`
- `pages/search.html`

## Implementation notes

- Adds a subtle LoveTree mark overlay to `.tree-card-media`.
- Enhances `.tree-card-media-fallback` with a warm gradient, branch-like pseudo-elements, glow nodes, and a pill title treatment.
- Keeps image thumbnails as representative content identity while adding a lightweight LoveTree identity cue.
- Keeps no-media cards visually aligned with media cards.
- Refreshes the Search stylesheet cache key in `pages/search.html` so the updated Search CSS entry is loaded by preview deployments.

## Verification

Repository/API-level checks before PR creation:

- Issue #455 state checked: open.
- Current main Search card CSS inspected after PR #498 merge.
- Search card renderer inspected; fallback DOM is limited to `.tree-card-media-fallback`, `.fallback-title`, and `.fallback-dots`.
- Branch created from PR #498 merge commit `117cd0f472b3619fcdc5ef5727bc8a38c76c1544`.
- Diff confirmed as Browse/Search card CSS plus Search stylesheet cache-key only.
- No JavaScript, backend, package, workflow, Intro, My Trees, or Editor files changed.

Cloudflare Preview visual verification:

- PR head SHA matched expected head SHA: `04c5b0779c9f7f31b54a625fe3eb3c2c8fec856a`.
- Cloudflare latest commit: `04c5b07`.
- Preview URL: `https://77874950.lovebud.pages.dev/pages/search.html`.
- Branch Preview URL: `https://ui-issue-455-browse-card-vis.lovebud.pages.dev`.
- Selected verification URL loaded `search.css?v=20260501-455b`.
- Old stylesheet URL was not loaded.

Visual/browser verification on current Cloudflare Preview:

- Root landing baseline: PASS.
- Desktop Browse/Search verification: PASS.
- Mobile 375px Browse/Search verification: PASS.
- Tree cards render: PASS.
- Media card LoveTree overlay: PASS.
- Overlay subtlety/readability: PASS.
- Fallback/no-image card preview: PASS.
- Fallback tree mini-preview perception: PASS.
- Media/fallback card grammar consistency: PASS.
- Title/description clamp retained: PASS.
- Metadata bottom alignment retained: PASS.
- Card height/rhythm consistency: PASS.
- Selected card/hub smoke: PASS.
- Search/filter/preview smoke: PASS.
- Horizontal overflow: none reported.
- Console fatal errors: none reported.

## Not verified by ChatGPT directly

- Browser screenshots were not inspected directly in this ChatGPT session.

## Safety checks

- Existing Browse/Search behavior preserved by scope.
- No data/API/auth/runtime changes.
- PR #7/prototype/reference/demo/variant untouched.
- PR #450/YouTube PoC files untouched.
- No protected values exposed.

Refs #455