### PR TITLE
ui(browse): polish selected tree hub preview

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -179,6 +179,103 @@
     line-height: 1.6;
 }
 
+/* Issue #455 PR C: selected-tree hub preview polish. */
+.preview-sidebar {
+    overflow: hidden;
+}
+
+.preview-sidebar::before {
+    content: '';
+    position: absolute;
+    top: 92px;
+    right: 20px;
+    width: 118px;
+    height: 156px;
+    border-radius: 999px;
+    background:
+        radial-gradient(circle at 64% 18%, rgba(144, 73, 81, 0.16) 0 6px, transparent 7px),
+        radial-gradient(circle at 28% 34%, rgba(122, 139, 110, 0.14) 0 5px, transparent 6px),
+        radial-gradient(circle at 52% 48%, rgba(200, 116, 128, 0.14) 0 5px, transparent 6px),
+        linear-gradient(24deg, transparent 42%, rgba(144, 73, 81, 0.12) 43% 47%, transparent 48%),
+        linear-gradient(148deg, transparent 39%, rgba(122, 139, 110, 0.10) 40% 45%, transparent 46%);
+    opacity: 0.78;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.preview-sidebar::after {
+    content: '';
+    position: absolute;
+    top: 146px;
+    right: 72px;
+    width: 8px;
+    height: 104px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(193, 139, 131, 0.28), rgba(144, 73, 81, 0.18));
+    pointer-events: none;
+    z-index: 0;
+}
+
+.preview-sidebar > * {
+    position: relative;
+    z-index: 1;
+}
+
+.preview-panel-header {
+    padding-bottom: 14px;
+    border-bottom: 1px solid rgba(144, 73, 81, 0.08);
+}
+
+.preview-badge {
+    box-shadow: 0 8px 18px rgba(144, 73, 81, 0.08);
+}
+
+.video-container {
+    position: relative;
+    box-shadow: 0 16px 38px rgba(75, 64, 57, 0.10);
+}
+
+.video-container::before {
+    content: '';
+    position: absolute;
+    left: 18px;
+    top: 16px;
+    width: 58px;
+    height: 42px;
+    border-radius: 999px;
+    background:
+        radial-gradient(circle at 68% 26%, rgba(144, 73, 81, 0.50) 0 4px, transparent 5px),
+        radial-gradient(circle at 32% 48%, rgba(122, 139, 110, 0.42) 0 4px, transparent 5px),
+        linear-gradient(32deg, transparent 41%, rgba(144, 73, 81, 0.34) 42% 47%, transparent 48%),
+        rgba(255, 255, 255, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.62);
+    box-shadow: 0 12px 24px rgba(50, 38, 35, 0.12);
+    pointer-events: none;
+    z-index: 2;
+}
+
+.tree-meta {
+    padding: 14px 0 16px;
+    background: rgba(255, 255, 255, 0.34);
+    border-radius: 18px;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    justify-content: space-between;
+    padding-left: 14px;
+    padding-right: 14px;
+}
+
+.tree-meta-item {
+    min-height: 30px;
+    padding: 0 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.58);
+    font-weight: 700;
+}
+
+.preview-panel-emotion-tags span {
+    box-shadow: 0 8px 16px rgba(75, 64, 57, 0.06);
+}
+
 /* Mobile bottom sheet: body scroll lock when sheet is open */
 body.preview-sheet-open {
     overflow: hidden;

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260501-455b">
+    <link rel="stylesheet" href="../css/search.css?v=20260501-455c">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="bokeh-bg">


### PR DESCRIPTION
## Summary

Implements Issue #455 PR C: selected-tree hub preview polish.

This PR keeps the current Browse/Search preview renderer behavior and adds CSS-only polish to make the right-side 감상 허브 feel more like a selected LoveTree preview surface rather than a plain detail panel.

## Scope

- Browse/Search selected-tree hub visual polish.
- Adds a subtle large tree-shape motif to the preview sidebar.
- Adds a lightweight LoveTree mark to the media/preview container.
- Polishes the preview header, stats row, and emotion chips.
- Keeps PR A card clamp/layout and PR B card media/fallback treatment intact.
- Does not change selected-card data, preview behavior, API behavior, or renderer logic.

## Changed files

- `css/search/preview-sidebar.css`
- `pages/search.html`

## Implementation notes

- Uses CSS pseudo-elements on `.preview-sidebar` and `.video-container` for the selected-tree visual cue.
- Keeps the existing renderer's inline content and action buttons unchanged.
- Preserves mobile bottom-sheet behavior by limiting changes to visual polish and inherited stacking.
- Refreshes the Search stylesheet cache key in `pages/search.html` so the updated Search CSS entry is loaded by preview deployments.

## Verification

Repository/API-level checks before PR creation:

- Issue #455 state checked: open.
- Current main preview renderer and preview sidebar CSS inspected after PR #500 merge.
- Branch created from PR #500 merge commit `32215efb5101c4223549c530a0cb566ed8c25018`.
- Diff confirmed as selected preview CSS plus Search stylesheet cache-key only.
- No card renderer, Search JS, backend, package, workflow, Intro, My Trees, or Editor files changed.

Cloudflare Preview visual verification:

- PR head SHA matched expected head SHA: `7ff5e4f621ea781e20f68617b12d0738192855ac`.
- Cloudflare latest commit: `7ff5e4f`.
- Preview URL: `https://8ab4a7fe.lovebud.pages.dev/pages/search.html`.
- Branch Preview URL: `https://ui-issue-455-selected-hub-pr.lovebud.pages.dev`.
- Selected verification URL loaded `search.css?v=20260501-455c`.
- Old stylesheet URL was not loaded.

Visual/browser verification on current Cloudflare Preview:

- Root landing baseline: PASS.
- Desktop Browse/Search verification: PASS.
- Mobile 375px Browse/Search verification: PASS.
- Tree cards render: PASS.
- Selected card/hub update: PASS.
- Selected-tree hub preview surface: PASS.
- Large tree-shape motif: PASS.
- Media/preview LoveTree mark: PASS.
- Mark subtlety/readability: PASS.
- Stats row polish: PASS.
- Emotion chips polish: PASS.
- PR A title/description clamp retained: PASS.
- PR A metadata bottom alignment retained: PASS.
- PR B media/fallback visual retained: PASS.
- Selected card/hub smoke: PASS.
- Search/filter/preview smoke: PASS.
- Mobile sheet/close behavior: PASS.
- Horizontal overflow: none reported.
- Console fatal errors: none reported.

## Not verified by ChatGPT directly

- Browser screenshots were not inspected directly in this ChatGPT session.

## Safety checks

- Existing Browse/Search behavior preserved by scope.
- No data/API/auth/runtime changes.
- PR #7/prototype/reference/demo/variant untouched.
- PR #450/YouTube PoC files untouched.
- No protected values exposed.

Refs #455