### PR TITLE
ui(global): polish transition none targets

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -7,6 +7,7 @@
 @import url('./global/tokens.css');
 @import url('./global/base.css');
 @import url('./global/header.css');
+@import url('./global/transition-polish.css');
 
 /* LoveTree Shared Visual Foundation Classes */
 .lovetree-page-shell {

--- a/css/global/transition-polish.css
+++ b/css/global/transition-polish.css
@@ -1,0 +1,51 @@
+/* Issue #420 — targeted transition polish for nav/auth/icon-loading.
+   Scope: global header navigation, auth nav container, Material Symbols ready state.
+   This file intentionally overrides existing transition: none declarations without
+   changing layout, visibility logic, or JavaScript behavior. */
+
+html body .nav-links a {
+    transition:
+        opacity 0.18s ease,
+        color 0.18s ease,
+        background-color 0.18s ease,
+        border-color 0.18s ease;
+}
+
+html body .nav-links a.nav-highlight {
+    transition:
+        background-color 0.18s ease,
+        border-color 0.18s ease,
+        color 0.18s ease,
+        opacity 0.18s ease;
+}
+
+html body #auth-nav,
+html body #auth-nav-container {
+    transition:
+        opacity 0.16s ease,
+        visibility 0.16s ease;
+}
+
+html body .material-symbols-outlined,
+html body .nav-bar .material-symbols-outlined,
+html body .lang-toggle-btn .material-symbols-outlined,
+html body .user-avatar-shell .material-symbols-outlined,
+html body .user-dropdown-menu .material-symbols-outlined,
+html body #auth-nav .material-symbols-outlined {
+    transition: opacity 0.16s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html body .nav-links a,
+    html body .nav-links a.nav-highlight,
+    html body #auth-nav,
+    html body #auth-nav-container,
+    html body .material-symbols-outlined,
+    html body .nav-bar .material-symbols-outlined,
+    html body .lang-toggle-btn .material-symbols-outlined,
+    html body .user-avatar-shell .material-symbols-outlined,
+    html body .user-dropdown-menu .material-symbols-outlined,
+    html body #auth-nav .material-symbols-outlined {
+        transition: none;
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #420 with a narrow global UI/CSS transition polish PR.

This PR does not broadly rewrite global CSS. It adds a small override stylesheet that targets the specific `transition: none` areas called out by #420: global navigation, auth nav visibility, and Material Symbols icon-loading opacity.

## Scope

- Global navigation link transition polish.
- Navigation highlight transition polish.
- Auth nav container opacity/visibility transition polish.
- Material Symbols ready-state opacity transition polish.
- Reduced-motion safety override.

## Changed files

- `css/global.css`
- `css/global/transition-polish.css`

## Implementation notes

- Adds `css/global/transition-polish.css` after `header.css` in the global import hub so it can narrowly override existing `transition: none` declarations without editing header CSS ownership directly.
- Keeps layout, display, visibility, auth state, and icon ready-state logic unchanged.
- Uses only opacity/color/background/border transition properties where applicable.
- Preserves `transition: none` for `prefers-reduced-motion: reduce`.

## Cloudflare Preview browser smoke verification

- PR head SHA matched expected head SHA: `d1ced2939020609ae55d378a9870e182d8340548`.
- Cloudflare latest commit: `d1ced29`.
- Preview URL: `https://e064754c.lovebud.pages.dev`.
- Branch Preview URL: `https://ui-issue-420-transition-none.lovebud.pages.dev`.
- Selected verification URL: `https://e064754c.lovebud.pages.dev/`.
- `css/global.css` loaded successfully.
- `css/global/transition-polish.css` import was detected and applied.
- Root landing load: PASS.
- Desktop shared header: PASS.
- Desktop nav links: PASS.
- Desktop nav hover/active: PASS.
- Nav highlight state: PASS.
- Mobile 375px nav toggle/open-close: NOT_APPLICABLE for current implementation; no mobile horizontal overflow observed.
- Auth nav display: PASS.
- Auth nav flicker/regression: none observed.
- User dropdown/profile smoke: PASS.
- Material Symbols raw text exposure: none observed.
- Material Symbols ready visibility: PASS.
- Reduced-motion media query support confirmed; direct reduced-motion emulation not tested.
- Intro/Search/Login smoke: PASS for tested pages.
- Horizontal overflow: none observed.
- Console fatal errors: none observed.

## Safety checks

- CSS-only implementation.
- No JavaScript changed.
- No HTML/pages changed.
- No Auth/API/backend/DB/package/workflow changes.
- No Search/Editor/My Trees feature changes.
- PR #7/prototype/reference/demo/variant untouched.
- PR #450/YouTube PoC files untouched.
- No protected values exposed.

Refs #420
Refs #137
Refs #399