### PR TITLE
ui(global): harden Material Symbols ready state

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -7,6 +7,7 @@
 @import url('./global/tokens.css');
 @import url('./global/base.css');
 @import url('./global/header.css');
+@import url('./global/ready-state.css');
 @import url('./global/transition-polish.css');
 
 /* LoveTree Shared Visual Foundation Classes */

--- a/css/global/ready-state.css
+++ b/css/global/ready-state.css
@@ -1,0 +1,34 @@
+/* Issue #418 — global ready-state hardening.
+   Scope: Material Symbols ready-class consistency and shared global ready states.
+   The canonical JS class is `material-symbols-ready`; legacy aliases remain
+   supported so older header/auth code paths do not regress. */
+
+:root {
+    --lovetree-icon-ready-transition: opacity 0.16s ease;
+}
+
+html body .material-symbols-outlined {
+    opacity: 0;
+    transition: var(--lovetree-icon-ready-transition);
+}
+
+html.material-symbols-ready body .material-symbols-outlined,
+html.ms-fonts-loaded body .material-symbols-outlined,
+html body .material-symbols-outlined.ms-ready {
+    opacity: 1;
+}
+
+html.material-symbols-ready body .mobile-nav-toggle::before,
+html.ms-fonts-loaded body .mobile-nav-toggle::before {
+    display: none;
+}
+
+html:not(.material-symbols-ready):not(.ms-fonts-loaded) body .mobile-nav-toggle .material-symbols-outlined:not(.ms-ready) {
+    display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --lovetree-icon-ready-transition: none;
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #418 with a narrow global ready-state hardening PR.

This PR adds a small global stylesheet for Material Symbols ready-state consistency. It keeps `material-symbols-ready` as the canonical ready class while preserving compatibility with existing alias selectors.

## Changed files

- `css/global.css`
- `css/global/ready-state.css`

## Scope

- Material Symbols ready-state CSS consistency.
- Shared icon-ready opacity transition token.
- Compatibility for `material-symbols-ready`, `ms-fonts-loaded`, and `.material-symbols-outlined.ms-ready`.
- Mobile nav fallback icon consistency.
- Reduced-motion safety override.

## Verification required

Browser smoke should verify root/header load, icon ready visibility, mobile nav fallback behavior, no raw icon text exposure, no fatal console errors, and no horizontal overflow.

## Safety checks

- CSS-only implementation.
- No JavaScript changed.
- No HTML/pages changed.
- No Auth/API/backend/DB/package/workflow changes.
- No Search/Editor/My Trees feature changes.
- PR #7/prototype/reference/demo/variant untouched.
- PR #450/YouTube PoC files untouched.
- No protected values exposed.

Refs #418
Refs #137
Refs #399