### PR TITLE
docs(ops): harden agent startup and verification rules

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -36,10 +36,11 @@
 1. `../AGENTS.md`
 2. `./doc_index.md`
 3. `./ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
-4. `./product/PRODUCT_IDENTITY.md`
-5. `./product/BRAND_EXPERIENCE.md`
-6. `./design/UI_DESIGN_SYSTEM.md`
-7. 요청 범위에 맞는 문서군 인덱스
+4. `./ops/AGENT_STARTUP_VERIFICATION_RULES.md`
+5. `./product/PRODUCT_IDENTITY.md`
+6. `./product/BRAND_EXPERIENCE.md`
+7. `./design/UI_DESIGN_SYSTEM.md`
+8. 요청 범위에 맞는 문서군 인덱스
 
 Visibility, private storage, anonymous public exposure, Browse/Search eligibility 판단이 필요하면 아래를 추가로 읽습니다.
 
@@ -63,6 +64,7 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 
 - `./ops/OPERATIONS.md`
 - `./ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+- `./ops/AGENT_STARTUP_VERIFICATION_RULES.md`
 - `./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`
 - `./ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
 - `./ops/BROWSER_VERIFICATION_URL_POLICY.md`
@@ -148,6 +150,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md) - Netlify legacy artifact / removal candidate 감사 기준 및 현황. `netlify/functions/*`, `netlify.toml` removal audit 진행 상태
 - [PARALLEL_WORKTREE_AGENT_POLICY.md](./ops/PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](./ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
+- [AGENT_STARTUP_VERIFICATION_RULES.md](./ops/AGENT_STARTUP_VERIFICATION_RULES.md) - Agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
 - [BROWSER_VERIFICATION_URL_POLICY.md](./ops/BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준
 - [TEST_PREVIEW_SLOTS.md](./ops/TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
 - [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](./ops/MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Cloudflare and Modal runtime diagnostics workflow, request ID correlation, redaction-safe report templates

--- a/docs/ops/AGENT_STARTUP_VERIFICATION_RULES.md
+++ b/docs/ops/AGENT_STARTUP_VERIFICATION_RULES.md
@@ -1,0 +1,325 @@
+# Agent Startup Verification Rules
+
+Issue: #464
+
+This runbook defines the mandatory startup and verification rules for LoveBud agents before GitHub, browser, runtime, fixed-slot, or repository work.
+
+It is docs/process-only. It does not authorize product UI changes, backend changes, Auth changes, database changes, package changes, workflow changes, secret inspection, branch deletion, or merge actions.
+
+## Purpose
+
+LoveBud uses multiple AI agents, models, workstations, and fixed test slots in parallel. Every agent must start from the same operational checklist so tasks do not collide, runtime verification is not overclaimed, dirty worktrees are preserved, and sensitive values are not exposed.
+
+This document standardizes:
+
+- required startup checklist fields,
+- fixed test slot classification,
+- browser verification environment rules,
+- dirty worktree stop behavior,
+- token/secret-safe handling,
+- PR/report status language,
+- handoff expectations.
+
+## Mandatory startup checklist
+
+Before any GitHub, browser, runtime, local repository, or fixed test slot task, the agent report must include or explicitly confirm:
+
+```text
+Agent Startup Checklist
+
+1. Repository:
+2. Current branch/worktree:
+3. git status --short:
+4. Dirty worktree status:
+5. If dirty, STOP performed:
+6. main direct push prohibited acknowledged:
+7. Merge requires CTO approval acknowledged:
+8. PR #7/prototype/reference/demo/variant protected acknowledged:
+9. PR #450 protected if active/relevant acknowledged:
+10. Secret/token/cookie/session/credential output prohibited acknowledged:
+11. Browser verification classification:
+12. Fixed test slot required:
+13. Assigned test slot:
+14. Slot deployed SHA matches PR head SHA:
+15. If no fixed slot, browser result status:
+```
+
+If the task is GitHub Web/API-only and no local repository is used, write `not applicable - GitHub Web/API-only` for local branch/worktree fields rather than inventing values.
+
+## Dirty worktree policy
+
+If `git status --short` is not empty:
+
+- STOP immediately.
+- Do not commit.
+- Do not stash.
+- Do not restore files.
+- Do not checkout files to discard changes.
+- Do not reset.
+- Do not clean.
+- Do not push.
+- Do not merge.
+- Preserve dirty and untracked files.
+- Report the dirty paths without exposing sensitive values.
+- Wait for a clean worktree assignment or explicit CTO disposition.
+
+A dirty worktree does not authorize cleanup. Cleanup is a separate decision.
+
+## Main and PR flow rules
+
+- Never modify `main` directly.
+- Never push directly to `main`.
+- Use one branch per task.
+- Use PR-only merge flow.
+- Prefer squash merge unless the CTO explicitly approves another method.
+- Merge requires CTO approval.
+- PR creation and additional commits require scope discipline.
+- Stop if unauthorized files change.
+- Do not mix UI work with docs/ops/backend/security/runtime work unless explicitly scoped.
+- Do not modify, close, merge, delete, or cleanup PR #7/prototype/reference/demo/variant paths.
+- Do not touch PR #450 files unless the active task explicitly authorizes it.
+
+## Browser verification classification
+
+Before browser work, classify the page or flow.
+
+| Flow type | Fixed test slot required? | Notes |
+| --- | --- | --- |
+| Docs-only | No | Static review or PR diff is usually enough. |
+| Static public page without login/API dependency | Usually no | Cloudflare PR Preview may be sufficient. |
+| CSS-only public landing/intro smoke | Usually no | PR Preview can be enough if no Auth/API runtime state is needed. |
+| Editor | Yes | Data, state, and interaction flows are runtime-sensitive. |
+| My Trees | Yes | Auth/API/user data required. |
+| Login/Auth | Yes | PR Preview alone is not sufficient for final PASS. |
+| API-dependent UI | Yes | Must verify actual deployed API path. |
+| DB-backed data display | Yes | Must verify runtime data path. |
+| User-specific state | Yes | Requires fixed slot and secret-safe auth handling. |
+| CTA click flow that saves/edits/creates/deletes | Yes | Requires fixed slot and runtime verification. |
+| Browse/Search actual data loading | Yes unless public production observation is explicitly requested | Distinguish static layout from data-backed behavior. |
+| Flicker/loading/runtime-state investigation | Yes | PR Preview alone cannot prove stateful runtime behavior. |
+| Production public read observation | No fixed slot if explicitly production-only | Do not mutate data or expose private payloads. |
+
+## Fixed test slot rules
+
+A fixed test slot is required for Auth/API/runtime-sensitive verification.
+
+Rules:
+
+- One fixed test slot is assigned to one PR until verification completes.
+- The slot branch and deployed SHA must match the expected PR head SHA.
+- If slot SHA cannot be confirmed, final result cannot be `PASS`.
+- If slot SHA mismatches, mark `BLOCKED` or `NOT_VERIFIED` and stop browser claims.
+- If login/Auth cannot be completed, final result cannot be `PASS`.
+- Cloudflare PR Preview alone is not sufficient for Login/Auth/API/runtime final PASS.
+- Browser reports must record URL provenance: PR Preview, Branch Preview, fixed test slot, production, or local.
+
+Suggested fixed slot verification fields:
+
+```text
+Fixed Slot Verification
+
+1. Assigned slot:
+2. Slot URL:
+3. PR number:
+4. Expected PR head SHA:
+5. Deployed slot SHA:
+6. SHA match: YES / NO / NOT_VERIFIED
+7. Browser result validity: PASS / NOT_VERIFIED / BLOCKED
+```
+
+## PR Preview allowed cases
+
+Cloudflare PR Preview can be sufficient for:
+
+- docs-only checks,
+- static public pages that do not require login,
+- CSS-only public landing/intro visual smoke,
+- static copy/layout smoke,
+- deployment existence checks,
+- public non-mutating route smoke when explicitly scoped as public observation.
+
+It is not sufficient for:
+
+- Auth-gated flows,
+- user-specific pages,
+- save/edit/delete/create behavior,
+- DB-backed state changes,
+- Editor/My Trees runtime behavior,
+- fixed test slot tasks,
+- final PASS claims for runtime-sensitive flows.
+
+## Token and secret handling policy
+
+Treat the following as sensitive and never output values:
+
+- token
+- secret
+- API key
+- cookie
+- session
+- credential
+- private key
+- SSH key
+- Firebase service-account material
+- OAuth callback/session material
+- test-account password or session state
+- Authorization header value
+- raw private request body
+- private tree or memory content
+
+Allowed reporting terms:
+
+- `PRESENT`
+- `ABSENT`
+- `UNKNOWN`
+- `configured`
+- `not configured`
+- `redacted`
+- `not inspected`
+- `no secret values exposed`
+
+Forbidden:
+
+- printing values,
+- printing partial prefixes/suffixes,
+- decoding secrets,
+- dumping browser storage,
+- dumping cookies,
+- dumping unknown archives,
+- copying raw logs that may contain sensitive values,
+- including screenshots that show sensitive values.
+
+## Log and diagnostics handling
+
+When checking logs, report only redaction-safe metadata:
+
+- route pattern or endpoint category,
+- HTTP method,
+- status code,
+- coarse error category,
+- request ID presence or absence,
+- upstream/degraded header presence or absence,
+- timestamp or relative time if needed,
+- duration bucket if available.
+
+Do not paste raw log lines unless they are confirmed not to contain sensitive values. Prefer summaries over raw output.
+
+## PASS / NOT_VERIFIED / BLOCKED rules
+
+Use `PASS` only when the claim was actually verified in the correct environment.
+
+Use `NOT_VERIFIED` when:
+
+- the environment cannot prove the requested property,
+- a browser flow was not exercised,
+- a private/authenticated path was intentionally excluded,
+- logs were not accessible,
+- fixed slot was not required but runtime proof remains partial,
+- only static inspection was performed.
+
+Use `BLOCKED` when:
+
+- required fixed slot is missing,
+- slot SHA mismatches expected PR head SHA,
+- required credentials/access are unavailable,
+- DNS/network blocks verification,
+- dirty worktree policy requires stopping,
+- required logs cannot be reviewed safely,
+- deployment is stale or mismatched.
+
+Do not convert `NOT_VERIFIED` or `BLOCKED` into `PASS` for narrative convenience.
+
+## Required report shape
+
+Use this compact report format unless the task provides a stricter one.
+
+```text
+Verification Report
+
+1. Computer/model:
+2. Repository:
+3. Task/issue/PR:
+4. Branch:
+5. git status --short:
+6. Dirty worktree status:
+7. Environment type:
+8. Fixed test slot required:
+9. Assigned slot:
+10. Expected head SHA:
+11. Deployed SHA:
+12. SHA match:
+13. Changed files or tested routes:
+14. PASS:
+15. NOT_VERIFIED:
+16. BLOCKED:
+17. Secret/token/cookie/session/credential exposure: NONE / STOP_AND_REPORT
+18. Private payload exposure: NONE / STOP_AND_REPORT
+19. Final recommendation:
+```
+
+## PR body verification environment section
+
+For runtime-sensitive PRs, include or preserve a verification environment section:
+
+```markdown
+## Verification Environment
+
+- [ ] Static/diff-only verification
+- [ ] Cloudflare PR preview verification
+- [ ] Fixed test slot required
+- [ ] Fixed test slot used: test__
+- [ ] Slot deployed SHA matches PR head SHA
+- [ ] Login/Auth verified if required
+- [ ] API/runtime verified if required
+- [ ] Browser result marked NOT_VERIFIED if no fixed slot
+```
+
+Do not mark fixed-slot or login/Auth checks complete unless verified.
+
+## Agent handoff rules
+
+When handing off to another model or workstation:
+
+- Include repository, issue, PR, branch, head SHA, allowed files, forbidden files, and expected verification environment.
+- State whether a new PR will be created.
+- State whether a fixed test slot is assigned.
+- State current blockers.
+- Do not include secrets, tokens, cookies, sessions, credentials, private payloads, or browser storage values.
+- Do not issue duplicate prompts for work already assigned to another active worker.
+- Warn about overlapping files or active PRs.
+
+## Stop conditions
+
+Stop and report when any of the following occur:
+
+- dirty worktree discovered,
+- unauthorized file changed,
+- protected PR #7/prototype/reference/demo/variant path appears in diff,
+- protected PR #450 path appears without authorization,
+- secret/private value is encountered,
+- fixed test slot SHA mismatch,
+- merge conflict or mergeability uncertainty appears,
+- requested task would mix UI and non-UI scopes without approval,
+- runtime verification would require unavailable credentials or unsafe private payload inspection.
+
+## Related documents
+
+- `docs/ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
+- `docs/ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+- `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`
+- `docs/ops/TEST_PREVIEW_SLOTS.md`
+- `docs/ops/MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md`
+- `docs/ops/AGENT_SECURITY.md`
+- `docs/project/VERIFICATION_AND_EVIDENCE.md`
+- `docs/project/VERIFICATION_WARNING_CATALOG.md`
+
+## Closure criteria for #464
+
+This issue can be closed when:
+
+- a single agent startup checklist exists,
+- fixed test slot requirements are documented for Auth/API/runtime flows,
+- dirty worktree stop behavior is explicit,
+- token/secret-safe handling is explicit,
+- reports distinguish `PASS`, `NOT_VERIFIED`, and `BLOCKED`,
+- the initial change remains docs-only with no workflow/package/runtime changes.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -19,24 +19,25 @@
 1. [OPERATIONS.md](OPERATIONS.md) - 현재 운영 전략과 계층 정의
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
-4. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
-5. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
-6. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-7. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-8. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-9. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-10. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-11. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-12. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-13. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-14. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-15. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-16. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-17. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-18. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-19. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-20. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-21. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+4. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
+5. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+6. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+7. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+8. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+9. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+10. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+11. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+12. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+13. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+14. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+15. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+16. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+17. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+18. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+19. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+20. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+21. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+22. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -46,6 +47,7 @@
 |--------|------|
 | [DOC_WORKFLOW.md](DOC_WORKFLOW.md) | 문서 작업 흐름 및 문서군 역할 정의 |
 | [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) | 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준 |
+| [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token/secret-safe reporting 기준 |
 | [PATHS_AND_SHELLS.md](PATHS_AND_SHELLS.md) | 경로 / 셸 기준 |
 | [REMOTE_ACCESS_AND_WSL.md](REMOTE_ACCESS_AND_WSL.md) | 원격 접근 / WSL 기준 |
 | [GIT_SSH_SETUP.md](GIT_SSH_SETUP.md) | Git / SSH 설정 |
@@ -58,6 +60,7 @@
 | [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) | 배포 전/후 검증 체크리스트 |
 | [RUNBOOK.md](RUNBOOK.md) | 운영 및 장애 대응 런북 |
 | [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) | 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준 |
+| [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | agent startup checklist, fixed-slot verification, dirty worktree stop, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [AGENTS.md](AGENTS.md) | ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준 |
 | [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |
 | [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |


### PR DESCRIPTION
## Summary

Refs #464

Adds a docs-only agent startup and verification rules runbook so GitHub/browser/runtime workers consistently apply fixed-slot, dirty-worktree, and token-safe operation rules before acting.

## Scope

- Adds `docs/ops/AGENT_STARTUP_VERIFICATION_RULES.md`
- Updates `docs/ops/ops_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Mandatory agent startup checklist
- Dirty worktree STOP policy
- main/PR flow rules
- Browser verification classification table
- Fixed test slot requirements and SHA match fields
- Cloudflare PR Preview allowed/forbidden cases
- Token/secret/cookie/session/credential handling policy
- Redaction-safe log/diagnostics handling
- PASS / NOT_VERIFIED / BLOCKED rules
- Required verification report shape
- PR body verification environment section
- Handoff and stop-condition rules

## Guardrails

- Docs-only
- No product UI changes
- No backend/Auth/DB/runtime changes
- No package/workflow/config changes
- No branch deletion or merge automation
- No PR #7/prototype/reference/demo/variant changes
- No PR #450 changes
- No secret/token/cookie/session/credential/private payload values included

## Verification

- Changed files limited to docs/ops and docs index scope
- Secret/private payload examples avoided
- Runtime behavior unchanged

draft: pending CTO/reviewer verification