### PR TITLE
docs(engineering): inventory large-file modularization candidates

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -127,6 +127,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
 - [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
+- [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 large-file candidate inventory, owner routing, extraction guardrails, verification requirements
 - [SCRIPT_LOAD_ORDER.md](./engineering/SCRIPT_LOAD_ORDER.md) - pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, 금지 조합, fixed test slot 검증 기준

--- a/docs/engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md
+++ b/docs/engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md
@@ -1,0 +1,130 @@
+# Large File Modularization Candidates
+
+Issue: #408
+
+This document records the initial LoveBud large-file modularization inventory for files that exceed or approach the 500-line reviewability threshold.
+
+This is an audit document only. It does not authorize refactors, file moves, ES module conversion, bundler adoption, route movement, CSS relocation, or runtime behavior changes.
+
+## Purpose
+
+LoveBud prefers reviewable, owner-scoped files so parallel agents can inspect and change work safely. Large files are not automatically bad, but they increase review cost and make unrelated behavior easier to mix.
+
+This inventory is intended to:
+
+- make large or near-large operating files visible,
+- route each candidate to its existing owner issue or domain,
+- prevent broad refactors created only from line-count pressure,
+- define allowed next steps and forbidden scope before implementation,
+- preserve runtime-sensitive verification requirements.
+
+## Safe refresh commands
+
+Run these from a clean worktree. They print paths and counts only; they do not inspect secrets or local-only files.
+
+```bash
+# Operating source files over or near the 500-line reviewability threshold.
+find js css pages functions modal_compute scripts -type f \
+  \( -name '*.js' -o -name '*.css' -o -name '*.html' -o -name '*.py' -o -name '*.ps1' \) \
+  -not -path './node_modules/*' \
+  -not -path './.local/*' \
+  -not -path './.git/*' \
+  -print0 \
+  | xargs -0 wc -l \
+  | sort -nr
+
+# Runtime-focused subset.
+wc -l js/editor.js modal_compute/app.py 'functions/api/[[path]].js' css/editor/overrides.css 2>/dev/null
+
+# Secret-safe tracked-file check; path names only.
+git ls-files '.local' 'docs/ops/qa-credential-bundle' '*.zip' '*.age'
+```
+
+Do not print `.env`, `.local`, credential, token, cookie, session, or private payload values.
+
+## Classification labels
+
+| Status | Meaning |
+| --- | --- |
+| `OK_AS_IS` | Large but stable, clear owner, no near-term pressure. |
+| `WATCH` | Near threshold or moderately large; monitor before nearby work grows it. |
+| `AUDIT_NEEDED` | Large and ownership boundaries should be documented before implementation. |
+| `EXTRACTION_CANDIDATE` | Large plus active symptoms, repeated edits, mixed responsibilities, or existing owner tracker. |
+
+Line count alone is never enough to justify extraction.
+
+## Initial candidate inventory
+
+The line-count bands below are based on GitHub content inspection and should be refreshed with the safe commands above before any implementation PR.
+
+| File | Line band | Owner domain | Current status | Existing tracker | Recommended next step | Forbidden scope | Verification if implementation occurs |
+| --- | ---: | --- | --- | --- | --- | --- | --- |
+| `js/editor.js` | 1000+ | Editor runtime shell | `EXTRACTION_CANDIDATE` | #225, #422, #518-#521 | Continue audit-first split by one responsibility: data loading, detail UI handoff, canvas orchestration, fallback aliases, or global state cleanup. | No broad rewrite, no `pages/editor.html` rewrite, no Auth/API/backend/package/workflow changes, no PR #7/prototype changes. | Fixed test slot required for Editor runtime; desktop + mobile 375px; empty/populated/selected-memory states; no fatal console errors. |
+| `modal_compute/app.py` | 500+ | Modal backend route and owner write/read orchestration | `AUDIT_NEEDED` | #423 | Continue staged repository/query split after contract tests. Public read extraction is done; owner read/write boundaries remain. | No route decorator movement without explicit approval; no broad Modal route migration; do not combine DB/auth/validation changes with route movement. | Backend contract tests plus runtime/API verification for affected routes; fixed slot or production public-read observation as scoped. |
+| `css/editor/overrides.css` | 500+ | Editor CSS override/cascade layer | `EXTRACTION_CANDIDATE` | #419, #513-#517 | Continue role-based relocation only after selector family audit and browser visual verification. | No broad editor redesign, no selector rename/removal without proof, no JS/runtime changes, no Browse/Search/My Trees changes. | Editor visual smoke: empty, populated, selected memory, inline edit, add memory form, mobile 375px, no fatal console errors. |
+| `functions/api/[[path]].js` | Near 500 | Cloudflare Pages Functions API gateway/proxy | `WATCH` | #470, #473, future gateway-specific tracker if needed | Keep stable after request correlation and diagnostics docs. Create a gateway audit only if additional route/proxy logic grows materially. | No gateway rewrite, no request/auth behavior change, no package/workflow/config changes from #408. | Public API smoke and Auth/API fixed-slot verification for affected route groups. |
+| `pages/editor.html` | Likely 500+ or near threshold | Editor page shell and script order | `WATCH` | #422, #518-#521 | Do not split from #408 alone. Treat any shell/script-order change as runtime-sensitive Editor work. | No page rewrite, no script reorder without `SCRIPT_LOAD_ORDER.md` review, no CSS/JS behavior mix unless scoped. | Fixed test slot; Editor load, auth state, selected/empty states, mobile smoke. |
+| `pages/search.html` | Likely near threshold | Search/Browse page shell | `WATCH` | #424, #456 | Keep under Search/Browse owner trackers; do not create a duplicate extraction issue unless shell grows further. | No Search adapter/API/UI state changes bundled together; no broad Search rewrite. | Browse/Search data-backed smoke requires fixed slot or explicitly scoped production public observation. |
+| `js/search-preview-renderer.js` | Candidate by ownership pressure, exact count to refresh | Search preview renderer | `AUDIT_NEEDED` | #424 | Route future extraction to #424; one helper family at a time. | No `updatePreview` behavior change without browser smoke; no API/adapter changes in same PR. | Search/Browse preview browser smoke with selected preview and mobile state. |
+| `js/auth.js` | Candidate by historical ownership pressure, exact count to refresh | Auth bootstrap/session/cache | `AUDIT_NEEDED` | #78 | Use Auth/Login active provider transition plan before any split. | No provider switch, token handling change, or login redirect behavior change from #408. | Fixed test slot; login/logout/protected page flows; no token/cookie/session value exposure. |
+| `docs/ops/*` long runbooks | 500+ possible | Ops documentation | `OK_AS_IS` or `WATCH` | owning issue per runbook | Long docs are acceptable when they are source-of-truth runbooks; split only when navigation suffers. | Do not split docs in a way that hides guardrails or weakens startup instructions. | Docs-only review; no runtime verification required. |
+
+## Owner routing notes
+
+### Editor
+
+`js/editor.js`, `pages/editor.html`, and editor CSS candidates must not be handled by a broad large-file cleanup PR. Route them to the active Editor trackers:
+
+- #225 for fallback/global-state cleanup framing.
+- #422 and #518-#521 for editor detail UI responsibility boundaries.
+- #419 and #513-#517 for editor CSS override relocation and consolidation.
+
+### Modal
+
+`modal_compute/app.py` is the current Modal route shell and owner/private route orchestration file. It should continue through #423 staged split work. Public read helper extraction has already begun, but owner read/write and route ownership require separate contract tests and runtime verification.
+
+### Cloudflare gateway
+
+`functions/api/[[path]].js` is a gateway/proxy file. It now carries request ID propagation, Modal route mapping, upstream/degraded headers, and method/unhandled-route responses. Keep it stable unless a gateway-specific issue approves a narrow extraction.
+
+### Search/Browse
+
+Search/Browse large-file pressure should not create duplicate work. Route preview renderer work to #424 and performance/loading work to #456. Data-backed browser verification must follow fixed-slot or explicitly scoped production-observation rules.
+
+### Auth
+
+Auth large-file pressure must route through #78 and the Auth/Login active provider transition plan. Do not refactor token/session logic from a line-count audit alone.
+
+### Docs
+
+Long docs can be acceptable when they are source-of-truth operating runbooks. For docs, line count is secondary to discoverability, index placement, and whether the document mixes unrelated ownership domains.
+
+## Recommended follow-up sequence
+
+1. Keep #408 as the standing visibility tracker until this inventory lands.
+2. Do not create new implementation issues for files that already have owner trackers.
+3. For each implementation follow-up, require one owner domain and one responsibility boundary per PR.
+4. Refresh exact line counts before implementation.
+5. Require browser/runtime/fixed-slot verification only when runtime-sensitive files change.
+
+## Closure criteria for #408
+
+#408 can be closed after this inventory is merged if the CTO accepts that:
+
+- candidates are visible in one document,
+- owner routing prevents broad refactors,
+- existing trackers own the implementation paths,
+- no behavior change occurred in the audit PR,
+- future extraction remains one issue/PR per owner domain and responsibility boundary.
+
+## Guardrails
+
+- No implementation changes.
+- No file moves.
+- No ES module conversion.
+- No bundler adoption.
+- No runtime behavior changes.
+- No Auth/API/Search/My Trees/Editor behavior changes from this audit.
+- No package/workflow/config changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No secret/token/cookie/session/credential/private payload inspection or output.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -19,22 +19,23 @@
 1. [API_CONTRACT.md](./API_CONTRACT.md) - API 응답 계약 (flat camelCase)
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
-4. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
-5. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-6. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-7. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-8. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-9. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-10. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-11. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-12. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-13. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-14. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-15. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-16. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-17. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-18. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-19. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+4. [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 500+ line large-file candidate inventory, owner routing, extraction guardrails
+5. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
+6. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+7. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+8. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+9. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+10. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+11. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+12. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+13. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+14. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+15. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+16. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+17. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+18. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+19. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+20. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -45,6 +46,7 @@
 | [API_CONTRACT.md](./API_CONTRACT.md) | 프론트엔드 API가 따르는 flat camelCase 계약 |
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
 | [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 정책 |
+| [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) | Issue #408 large-file candidate inventory, owner-domain routing, extraction guardrails, verification requirements |
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
@@ -79,6 +81,7 @@
 - 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
 - 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
+- #408 large-file candidate 판단은 `LARGE_FILE_MODULARIZATION_CANDIDATES.md`에서 owner routing and forbidden scope를 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.


### PR DESCRIPTION
## Summary

Refs #408

Adds a docs-only large-file modularization candidate inventory so 500+ line or near-threshold files are routed to owner domains before any extraction work.

## Scope

- Adds `docs/engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md`
- Updates `docs/engineering/engineering_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Safe refresh commands for line-count inventory
- Classification labels: `OK_AS_IS`, `WATCH`, `AUDIT_NEEDED`, `EXTRACTION_CANDIDATE`
- Candidate routing for Editor, Modal, Cloudflare gateway, Search/Browse, Auth, and long docs
- Existing tracker mapping to avoid duplicate broad refactor issues
- Recommended follow-up sequence
- Closure criteria for #408
- Guardrails against broad refactors from line count alone

## Guardrails

- Docs-only
- No implementation changes
- No file moves
- No ES module conversion
- No bundler adoption
- No runtime behavior changes
- No Auth/API/Search/My Trees/Editor behavior changes
- No package/workflow/config changes
- No PR #7/prototype/reference/demo/variant changes
- No secret/token/cookie/session/credential/private payload values included

## Verification

- Changed files limited to docs/engineering and docs index scope
- Secret/private payload examples avoided
- Runtime behavior unchanged

draft: pending CTO/reviewer verification