### PR TITLE
docs(engineering): document Modal owner route split boundary

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -128,6 +128,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
 - [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 - [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 large-file candidate inventory, owner routing, extraction guardrails, verification requirements
+- [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements
 - [SCRIPT_LOAD_ORDER.md](./engineering/SCRIPT_LOAD_ORDER.md) - pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, 금지 조합, fixed test slot 검증 기준

--- a/docs/engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md
+++ b/docs/engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md
@@ -1,0 +1,174 @@
+# Modal Owner Route Split Boundary
+
+Issue: #423
+
+This document narrows the remaining Modal repository/query split work after public-read extraction. It is docs-only and does not authorize implementation.
+
+## Current disposition
+
+Completed or separately closed work:
+
+- Public read helper extraction was completed through PR #507.
+- Production public-read runtime verification was completed through #509.
+- Request correlation was completed through #470.
+- Modal structured logging was completed through #472.
+- Cloudflare and Modal diagnostics workflow was documented through #473.
+- Large-file routing now classifies `modal_compute/app.py` as audit-needed through #408.
+
+Remaining #423 work should focus on owner-authenticated read/write boundaries and backend contract test gates.
+
+## Route ownership map
+
+| Route family | Domain | Extraction status | Next action |
+| --- | --- | --- | --- |
+| `/modal/browse/latest` | public read | helper extracted | Keep stable. |
+| `/modal/browse/growing` | public read | helper extracted | Keep stable. |
+| `/modal/community/memories` | public read | helper extracted | Keep stable; preserve parent tree visibility guard. |
+| `/modal/memories/{memory_id}` | public detail read | helper extracted | Keep stable. |
+| `/modal/trees/{tree_id}` | public detail read | helper extracted | Keep stable. |
+| `/modal/private/trees` GET | owner read | not extracted | Candidate after owner read tests. |
+| `/modal/private/trees/{tree_id}` GET | owner read | not extracted | Candidate after owner read tests. |
+| `/modal/private/memories` GET | owner read | not extracted | Candidate after owner read tests. |
+| `/modal/private/trees` POST | owner write | not extracted | Candidate after create-tree tests. |
+| `/modal/private/memories` POST | owner write | not extracted | Candidate after create-memory tests. |
+| `/modal/private/trees/{tree_id}` PUT/DELETE | owner write | not extracted | Candidate after update/delete tests. |
+| `/modal/private/memories/{memory_id}` PUT/DELETE | owner write | not extracted | Candidate after update/delete tests. |
+| `/modal/private/trees/{tree_id}/fork` POST | owner write plus public source read | not extracted | Keep separate from ordinary owner writes. |
+
+## Allowed future PR shapes
+
+### PR A — owner read contract tests
+
+Goal:
+- Add or document tests for owner private tree and memory reads before extraction.
+
+Allowed:
+- test files or docs-only test plan.
+- no route movement.
+- no behavior change.
+
+Required coverage:
+- owner tree list read.
+- owner tree detail read.
+- owner memory list read.
+- non-owner denial or not-found behavior.
+- visibility interactions for owner reads.
+
+### PR B — owner read helper extraction
+
+Precondition:
+- PR A completed or equivalent evidence accepted.
+
+Allowed:
+- extract owner read query helpers from `modal_compute/app.py` into a Modal-owned helper module.
+- keep FastAPI route decorators in `modal_compute/app.py` unless separately approved.
+- preserve response shape and status codes.
+
+Forbidden:
+- no owner write extraction in the same PR.
+- no validation or identity behavior changes unless separately approved and tested.
+
+### PR C — owner write contract tests
+
+Goal:
+- Add or document tests for create, update, delete, and fork behavior before extraction.
+
+Required coverage:
+- create tree.
+- create memory.
+- update tree.
+- update memory.
+- delete tree.
+- delete memory.
+- fork public tree.
+- owner-only access enforcement.
+
+### PR D — owner write helper extraction
+
+Precondition:
+- PR C completed or equivalent evidence accepted.
+
+Allowed:
+- extract owner write helpers by one responsibility family.
+- preserve SQL, validation, response shape, and status codes.
+- keep route decorators in `modal_compute/app.py` unless separately approved.
+
+Forbidden:
+- no public read changes.
+- no route decorator movement.
+- no database schema changes.
+- no Cloudflare gateway changes.
+
+### PR E — route decorator movement, only if still necessary
+
+Precondition:
+- owner read/write helpers are extracted and tests are accepted.
+- CTO explicitly approves decorator movement.
+
+Allowed:
+- one route family at a time.
+
+Forbidden:
+- no broad Modal app rewrite.
+- no route movement mixed with DB, identity, validation, or response-shape changes.
+
+## Backend contract gate
+
+Any implementation PR touching owner-route helpers must verify or explicitly mark `NOT_VERIFIED` for:
+
+- response shape compatibility.
+- status code compatibility.
+- owner-only access guard.
+- private visibility behavior where applicable.
+- public read unaffected.
+- Cloudflare same-origin `/api/*` mapping unaffected.
+- no private payload or credential value exposure in reports.
+
+If tests are not available, the PR must be docs-only or remain blocked until a test plan is accepted.
+
+## Cloudflare boundary
+
+The Cloudflare Pages Function gateway is not part of #423 unless route mapping change is explicitly approved.
+
+Do not change from #423 alone:
+
+- `functions/api/[[path]].js` route matching.
+- request ID propagation.
+- upstream or degraded response headers.
+- same-origin `/api/*` mapping.
+- method-not-allowed or unhandled-route behavior.
+
+Gateway changes require separate gateway ownership approval and API smoke verification.
+
+## Verification expectations
+
+| Change type | Minimum verification |
+| --- | --- |
+| docs-only | static review and changed-file scope check |
+| owner read tests only | test command or documented `NOT_VERIFIED` if no harness exists |
+| owner read helper extraction | backend contract tests plus scoped runtime API smoke |
+| owner write tests only | test command or documented `NOT_VERIFIED` if no harness exists |
+| owner write helper extraction | backend contract tests plus fixed-slot API smoke for safe route groups |
+| route decorator movement | tests plus fixed-slot API smoke and route mapping check |
+
+Production mutation tests are not allowed unless separately approved.
+
+## Closure criteria for #423
+
+#423 should remain open until one of these is true:
+
+1. owner read and owner write helper extraction are completed with accepted tests and runtime verification; or
+2. CTO explicitly decides that further Modal extraction is not currently needed and closes the issue with a disposition note.
+
+This document alone should not close #423. It narrows the remaining work and prevents broad unsafe refactors.
+
+## Guardrails
+
+- No implementation changes.
+- No route decorator movement.
+- No broad Modal route migration.
+- No DB, identity, validation, or response-shape behavior changes.
+- No Cloudflare gateway changes.
+- No package, workflow, or config changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No private payload or credential values included.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -20,22 +20,23 @@
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 4. [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 500+ line large-file candidate inventory, owner routing, extraction guardrails
-5. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
-6. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-7. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-8. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-9. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-10. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-11. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-12. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-13. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-14. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-15. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-16. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-17. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-18. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-19. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-20. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+5. [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements
+6. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
+7. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+8. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+9. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+10. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+11. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+12. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+13. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+14. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+15. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+16. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+17. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+18. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+19. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+20. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+21. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -47,6 +48,7 @@
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
 | [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 정책 |
 | [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) | Issue #408 large-file candidate inventory, owner-domain routing, extraction guardrails, verification requirements |
+| [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) | Issue #423 Modal owner read/write route split boundary, implementation gates, Cloudflare boundary, verification expectations |
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
@@ -82,6 +84,7 @@
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
 - 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
 - #408 large-file candidate 판단은 `LARGE_FILE_MODULARIZATION_CANDIDATES.md`에서 owner routing and forbidden scope를 먼저 확인합니다.
+- #423 Modal owner-route split 판단은 `MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md`에서 completed public-read work, remaining owner read/write gates, and verification expectations를 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.


### PR DESCRIPTION
## Summary

Refs #423

Adds a docs-only Modal owner route split boundary document. This records completed public-read split work and narrows the remaining Modal repository/query split to owner read/write helper boundaries and backend contract gates.

## Scope

- Adds `docs/engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md`
- Updates `docs/engineering/engineering_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Completed public-read and diagnostics disposition
- Modal public read vs owner read/write route ownership map
- Allowed future PR shapes for owner read tests, owner read helper extraction, owner write tests, owner write helper extraction, and optional route decorator movement
- Backend contract gate expectations
- Cloudflare gateway boundary
- Verification expectations by change type
- #423 closure criteria

## Guardrails

- Docs-only
- No implementation changes
- No route decorator movement
- No broad Modal route migration
- No DB, identity, validation, or response-shape behavior changes
- No Cloudflare gateway changes
- No package/workflow/config changes
- No PR #7/prototype/reference/demo/variant changes
- No private payload or credential values included

## Verification

- Changed files limited to docs/engineering and docs index scope
- Runtime behavior unchanged
- #423 intentionally remains open after this PR unless CTO separately records a final disposition

draft: pending CTO/reviewer verification