### PR TITLE
docs(ops): document source-of-truth hygiene disposition

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -52,6 +52,10 @@ Prototype/reference/demo/variant 폴더 정리, 보존, repo hygiene 판단이 �
 - `./design/PROTOTYPE_REFERENCE_POLICY.md`
 - `./reference/PROTOTYPE_INDEX.md` - reference only: prototype / variant / demo / reference 경로 목록과 active production route 아님을 명시한 canonical inventory
 
+Docs source-of-truth hygiene, stale-doc classification, archive routing 판단이 필요하면 아래를 추가로 읽습니다.
+
+- `./ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md`
+
 UI polish 단계 분리, PR3/PR4/PR5 범위 판단이 필요하면 아래를 추가로 읽습니다.
 
 - `./design/UI_POLISH_ROADMAP.md`
@@ -149,6 +153,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 
 - **index**: [ops_index.md](./ops/ops_index.md)
 - [OPERATIONS.md](./ops/OPERATIONS.md) - 현재 운영 전략 및 인프라 우선순위
+- [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](./ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
 - [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md) - Netlify legacy artifact / removal candidate 감사 기준 및 현황. `netlify/functions/*`, `netlify.toml` removal audit 진행 상태
 - [PARALLEL_WORKTREE_AGENT_POLICY.md](./ops/PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](./ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준

--- a/docs/ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md
+++ b/docs/ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md
@@ -1,0 +1,152 @@
+# Source-of-Truth Hygiene Disposition
+
+Issue: #425
+
+This document defines how LoveBud handles stale documentation, source-of-truth routing, and documentation hygiene without changing runtime behavior.
+
+This is a docs-only disposition. It does not authorize implementation, file deletion, broad documentation rewrites, runtime changes, CSS changes, workflow changes, or protected prototype/reference/demo/variant changes.
+
+## Purpose
+
+LoveBud has many narrow operating documents created through staged PRs. This is useful, but it can create confusion when older documents, checklists, and issue-specific audits overlap with newer source-of-truth documents.
+
+The purpose of #425 is to define a durable hygiene rule:
+
+- prefer updating existing source-of-truth documents,
+- make ownership and routing explicit,
+- avoid duplicate docs for the same decision,
+- preserve historical audit documents unless explicitly reviewed,
+- keep docs cleanup separate from implementation.
+
+## Source-of-truth hierarchy
+
+Use this hierarchy when documents appear to overlap.
+
+| Area | Primary source |
+| --- | --- |
+| Product identity and public-first policy | `docs/product/PRODUCT_IDENTITY.md` |
+| Brand tone and experience | `docs/product/BRAND_EXPERIENCE.md` |
+| Publication/privacy/visibility policy | `docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md` |
+| UI design system | `docs/design/UI_DESIGN_SYSTEM.md` |
+| Prototype/reference/demo/variant inventory | `docs/reference/PROTOTYPE_INDEX.md` |
+| Runtime/API contract | `docs/engineering/API_CONTRACT.md` |
+| Browse/Search visibility guard | `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md` |
+| Code architecture and large-file policy | `docs/engineering/CODE_ARCHITECTURE.md` |
+| Large-file candidate routing | `docs/engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md` |
+| Modal owner route split boundary | `docs/engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md` |
+| CSS architecture | `docs/engineering/CSS_ARCHITECTURE.md` |
+| Script load order | `docs/engineering/SCRIPT_LOAD_ORDER.md` |
+| Active operations policy | `docs/ops/OPERATIONS.md` |
+| Parallel agent and worktree policy | `docs/ops/PARALLEL_WORKTREE_AGENT_POLICY.md` |
+| Agent startup and verification rules | `docs/ops/AGENT_STARTUP_VERIFICATION_RULES.md` |
+| Browser URL provenance | `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md` |
+| Fixed test slots | `docs/ops/TEST_PREVIEW_SLOTS.md` |
+| Cloudflare/Modal diagnostics | `docs/ops/MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md` |
+| Security posture planning | `docs/security/security_index.md` and linked security docs |
+| Migration state | `docs/migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md` |
+
+If a document is not listed here, treat it as supporting context unless its own header explicitly declares source-of-truth status.
+
+## Hygiene classification
+
+Use these labels when reviewing stale or overlapping docs.
+
+| Label | Meaning | Action |
+| --- | --- | --- |
+| `SOURCE_OF_TRUTH` | Current decision authority for a domain | Update in place when policy changes. |
+| `SUPPORTING_CONTEXT` | Useful background or audit detail | Keep linked if still helpful. |
+| `HISTORICAL_AUDIT` | Completed issue/PR evidence | Keep unless misleading or explicitly archived. |
+| `SUPERSEDED` | Replaced by a newer source | Add pointer to current source or archive after review. |
+| `DUPLICATE_CANDIDATE` | Overlaps with another document | Prefer consolidation through a narrow docs-only PR. |
+| `ARCHIVE_CANDIDATE` | No longer part of active workflow | Archive only after explicit review. |
+
+## Stale documentation indicators
+
+A document may need hygiene review if it:
+
+- names Netlify as active production runtime instead of legacy artifact,
+- names Vercel as primary runtime instead of transitional or secondary,
+- contradicts Cloudflare Pages + Modal as the active runtime baseline,
+- treats anonymous public exposure and Browse/Search eligibility as the same concept,
+- omits the parent tree visibility guard for public memory reads,
+- treats prototype/reference/demo/variant paths as cleanup candidates,
+- lacks fixed-slot requirements for Auth/API/runtime browser verification,
+- uses close/fix/resolve issue keywords in tracker/disposition PRs when the issue must remain open,
+- duplicates a newer source-of-truth document without linking to it.
+
+## Update routing rules
+
+When a doc update is needed:
+
+1. Identify the source-of-truth document first.
+2. Update that document in place if the policy itself changed.
+3. If only a narrow audit is needed, create a supporting document and link it from the relevant index.
+4. If an older doc conflicts with the source of truth, add a pointer or disposition note instead of rewriting the full historical record.
+5. Do not delete or archive without explicit review.
+6. Keep docs hygiene separate from runtime implementation.
+
+## Forbidden combinations
+
+Do not combine docs hygiene with:
+
+- runtime code changes,
+- Auth/API/backend changes,
+- CSS or UI implementation,
+- package or workflow changes,
+- broad file moves,
+- prototype/reference/demo/variant cleanup,
+- PR #7 changes,
+- PR #450 changes,
+- protected active PR files unless explicitly scoped.
+
+## Index maintenance rules
+
+When adding or updating docs:
+
+- Update `docs/doc_index.md` only when the document should be discoverable from the top level.
+- Update the relevant section index, such as `docs/ops/ops_index.md` or `docs/engineering/engineering_index.md`, when the document belongs to that section.
+- Do not add every issue-specific audit to the top-level `먼저 읽기` list.
+- Reserve top-level `먼저 읽기` for active operating policy and high-frequency routing documents.
+- Prefer concise descriptions that state whether a document is source-of-truth, audit, checklist, runbook, or historical context.
+
+## Archive rules
+
+Archiving is allowed only after explicit review.
+
+Before archive:
+
+- confirm the document is not linked as a source of truth,
+- identify the replacement document,
+- preserve useful historical context if needed,
+- avoid breaking existing index links,
+- keep archive-only PRs docs-only.
+
+Do not archive protected prototype/reference/demo/variant material from this issue.
+
+## Closure criteria for #425
+
+#425 can be closed when:
+
+- a source-of-truth hierarchy is documented,
+- stale-doc classification labels exist,
+- update routing rules are documented,
+- archive rules are documented,
+- index maintenance rules are documented,
+- the change remains docs-only,
+- no protected files or excluded PRs/issues are touched.
+
+## Guardrails
+
+- Docs-only.
+- No runtime changes.
+- No CSS/UI implementation.
+- No package or workflow changes.
+- No file deletion.
+- No broad documentation rewrite.
+- No PR #7/prototype/reference/demo/variant changes.
+- No PR #450 changes.
+- No `css/editor/status-settings.css` changes.
+- No `css/editor/overrides.css` changes.
+- No `css/editor.css` changes.
+- No PR #527 changes.
+- No Issue #513 changes.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -31,13 +31,14 @@
 13. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
 14. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
 15. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-16. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-17. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-18. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-19. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-20. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-21. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-22. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+16. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+17. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+18. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+19. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+20. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+21. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+22. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+23. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -48,6 +49,7 @@
 | [DOC_WORKFLOW.md](DOC_WORKFLOW.md) | 문서 작업 흐름 및 문서군 역할 정의 |
 | [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) | 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준 |
 | [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token/secret-safe reporting 기준 |
+| [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) | Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules |
 | [PATHS_AND_SHELLS.md](PATHS_AND_SHELLS.md) | 경로 / 셸 기준 |
 | [REMOTE_ACCESS_AND_WSL.md](REMOTE_ACCESS_AND_WSL.md) | 원격 접근 / WSL 기준 |
 | [GIT_SSH_SETUP.md](GIT_SSH_SETUP.md) | Git / SSH 설정 |
@@ -70,6 +72,7 @@
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |
 | [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) | Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, auth/test-account evidence 기준 |
 | [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) | Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식 |
+| [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) | Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules |
 | [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) | Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리 |
 | [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) | browse summary의 Modal 우선 경로와 Modal security contract 기준 |
 | [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) | 반복 CI/E2E 실패의 원인 분리 및 exception merge 판단 기준 |


### PR DESCRIPTION
## Summary

Refs #425

Adds a docs-only source-of-truth hygiene disposition document so stale documentation, source routing, archive candidates, and index maintenance are handled consistently.

## Scope

- Adds `docs/ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md`
- Updates `docs/ops/ops_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Source-of-truth hierarchy
- Stale documentation indicators
- Hygiene classification labels
- Update routing rules
- Forbidden combinations
- Index maintenance rules
- Archive review rules
- #425 closure criteria

## Guardrails

- Docs-only
- No runtime changes
- No CSS/UI implementation
- No package/workflow changes
- No file deletion
- No broad documentation rewrite
- No PR #7/prototype/reference/demo/variant changes
- No PR #450 changes
- No `css/editor/status-settings.css` changes
- No `css/editor/overrides.css` changes
- No `css/editor.css` changes
- No PR #527 changes
- No Issue #513 changes

## Verification

- Changed files limited to docs/ops and docs index scope
- Excluded CSS/editor files untouched
- PR #527 untouched
- Issue #513 untouched
- Runtime behavior unchanged

draft: pending CTO/reviewer verification