### PR TITLE
docs(ops): document global CSS browser smoke checklist

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -72,6 +72,7 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 - `./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md`
 - `./ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
 - `./ops/BROWSER_VERIFICATION_URL_POLICY.md`
+- `./ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`
 - `./ops/TEST_PREVIEW_SLOTS.md`
 - `./ops/KNOWN_CI_E2E_BLOCKERS.md`
 - `./ops/BRANCH_CLEANUP_PLAN.md`
@@ -154,6 +155,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - **index**: [ops_index.md](./ops/ops_index.md)
 - [OPERATIONS.md](./ops/OPERATIONS.md) - 현재 운영 전략 및 인프라 우선순위
 - [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](./ops/SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+- [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](./ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
 - [NETLIFY_LEGACY_ARTIFACT_AUDIT.md](./ops/NETLIFY_LEGACY_ARTIFACT_AUDIT.md) - Netlify legacy artifact / removal candidate 감사 기준 및 현황. `netlify/functions/*`, `netlify.toml` removal audit 진행 상태
 - [PARALLEL_WORKTREE_AGENT_POLICY.md](./ops/PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](./ops/LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준

--- a/docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md
+++ b/docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md
@@ -1,0 +1,205 @@
+# Global CSS Browser Smoke Checklist
+
+Issue: #512
+
+This checklist defines the browser smoke standard for behavior-affecting global CSS work in LoveBud.
+
+It is docs-only. It does not authorize CSS implementation, broad `global.css` rewrites, Search/UI/CSS/JS reorganization, Auth/API/backend changes, package changes, workflow changes, or protected prototype/reference/demo/variant changes.
+
+## Purpose
+
+Global CSS changes can affect many pages at once. Even small selectors for readiness, visibility, focus, layout, or shared controls can regress root navigation, Search/Browse previews, Editor controls, My Trees cards, login forms, or mobile layout.
+
+This checklist creates one reporting standard so future global CSS PRs clearly separate:
+
+- static review,
+- desktop browser smoke,
+- mobile 375px smoke,
+- affected-surface checks,
+- `PASS`, `NOT_VERIFIED`, and `BLOCKED` outcomes.
+
+## When this checklist applies
+
+Use this checklist for any PR that changes or may affect:
+
+- `css/global.css`,
+- files imported by `css/global.css`,
+- global readiness selectors,
+- global visibility helpers,
+- global focus states,
+- shared button/link/form control states,
+- shared layout shells,
+- first-paint or hidden/reveal behavior,
+- Material Symbols or icon readiness behavior,
+- any selector that can affect multiple pages.
+
+Docs-only PRs that merely reference global CSS may cite this document without running browser smoke.
+
+## Environment classification
+
+| Change type | Required environment |
+| --- | --- |
+| Docs-only checklist/disposition | Static review only |
+| Static CSS selector inventory | Static review; browser smoke optional |
+| Global CSS implementation affecting public static pages | Cloudflare PR Preview or branch preview may be sufficient |
+| Global CSS affecting Auth/API/user-state pages | Fixed test slot required |
+| Global CSS affecting Editor, My Trees, Search data-backed behavior | Fixed test slot required unless explicitly scoped as public static observation |
+| Production observation | Read-only public observation only; do not mutate data |
+
+Do not report `PASS` for runtime-sensitive flows when only static review or PR Preview was used.
+
+## Minimum smoke matrix
+
+### 1. Root and shared chrome
+
+Check:
+
+- home page loads without blank first paint,
+- header/nav remains visible and aligned,
+- primary CTA remains visible,
+- Material Symbols/icons are not hidden or oversized,
+- focus-visible state is visible for keyboard navigation where reachable,
+- no horizontal overflow at desktop and mobile 375px,
+- no fatal console errors.
+
+### 2. Intro/public static pages
+
+Check if affected:
+
+- hero layout remains stable,
+- reveal/ready-state behavior does not hide content permanently,
+- CTA and navigation remain clickable,
+- mobile spacing remains readable,
+- no fatal console errors.
+
+### 3. Search/Browse
+
+Check if affected:
+
+- Browse/Search shell renders,
+- cards remain visible,
+- selected preview remains visible where reachable,
+- loading, empty, and error states are not permanently hidden,
+- scroll behavior is not hijacked or locked,
+- mobile 375px layout has no horizontal overflow,
+- distinguish static PR Preview from data-backed fixed-slot verification.
+
+### 4. Editor
+
+Check if affected:
+
+- Editor shell renders,
+- empty state remains visible,
+- populated tree state remains visible where reachable,
+- selected memory/detail state remains visible where reachable,
+- forms and buttons are not hidden by global selectors,
+- focus states do not break inline edit controls,
+- mobile 375px editor smoke is recorded,
+- fixed slot is required for Auth/API/runtime-sensitive claims.
+
+### 5. My Trees
+
+Check if affected:
+
+- My Trees page loads after auth where required,
+- cards/list states remain visible,
+- empty state remains visible,
+- CTA buttons remain visible and clickable,
+- loading state is not permanently hidden,
+- mobile 375px layout has no horizontal overflow,
+- fixed slot is required for authenticated/user-data claims.
+
+### 6. Auth/Login
+
+Check if affected:
+
+- login form renders,
+- input focus states remain visible,
+- submit button remains visible,
+- error/help text remains visible where reachable,
+- mobile 375px layout remains usable,
+- no credential, token, cookie, session, or private payload values are printed in reports.
+
+## PASS / NOT_VERIFIED / BLOCKED rules
+
+Use `PASS` only when the requested behavior was checked in the correct environment.
+
+Use `NOT_VERIFIED` when:
+
+- a surface was not exercised,
+- only static review was performed,
+- a private/authenticated flow was intentionally excluded,
+- fixed slot was required but not used,
+- only PR Preview was used for runtime-sensitive behavior,
+- a page loaded but the relevant state was not reachable.
+
+Use `BLOCKED` when:
+
+- required fixed slot is unavailable,
+- deployed SHA cannot be matched to the PR head,
+- auth/test data is unavailable,
+- network or deployment issues prevent verification,
+- an active overlapping PR owns the same files,
+- verification would require exposing private values.
+
+## Required report shape
+
+Use this report shape for future behavior-affecting global CSS PRs.
+
+```text
+Global CSS Browser Smoke Report
+
+1. PR number:
+2. Branch:
+3. Head SHA:
+4. Changed files:
+5. Environment used:
+6. Fixed slot required: YES / NO
+7. Fixed slot used:
+8. Deployed SHA match: YES / NO / NOT_VERIFIED
+9. Desktop root/shared chrome:
+10. Mobile 375px root/shared chrome:
+11. Search/Browse:
+12. Editor:
+13. My Trees:
+14. Auth/Login:
+15. PASS:
+16. NOT_VERIFIED:
+17. BLOCKED:
+18. Fatal console errors:
+19. Secret/private value exposure: NONE / STOP_AND_REPORT
+20. Final recommendation:
+```
+
+## Relationship to #418
+
+#512 is the verification/disposition layer for behavior-affecting global CSS work after #418 planning and PR #508 ready-state implementation.
+
+#418 can only be closed separately if its completed planning and implementation work is accepted. This checklist does not itself implement global CSS changes.
+
+## Closure criteria for #512
+
+#512 can be closed when:
+
+- a global CSS browser smoke checklist exists,
+- desktop and mobile 375px smoke expectations are documented,
+- root/shared chrome checks are documented,
+- Search/Browse, Editor, My Trees, and Auth/Login regression checks are documented,
+- `PASS`, `NOT_VERIFIED`, and `BLOCKED` reporting rules are documented,
+- fixed-slot requirements are documented for runtime-sensitive flows,
+- the change remains docs-only.
+
+## Guardrails
+
+- Docs-only.
+- No CSS implementation.
+- No broad `global.css` rewrite.
+- No Search/UI/CSS/JS reorganization.
+- No Auth/API/backend/package/workflow changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No PR #450 changes.
+- No `css/editor/status-settings.css` changes.
+- No `css/editor/overrides.css` changes.
+- No `css/editor.css` changes.
+- No PR #527 changes.
+- No Issue #513 changes.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -24,21 +24,22 @@
 6. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
 7. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
 8. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-9. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-10. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-11. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-12. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-13. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-14. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-15. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-16. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-17. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-18. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-19. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-20. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-21. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-22. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-23. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+9. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
+10. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+11. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+12. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+13. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+14. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+15. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+16. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+17. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+18. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+19. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+20. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+21. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+22. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+23. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+24. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -67,6 +68,7 @@
 | [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |
 | [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |
 | [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) | 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준 |
+| [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) | Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
 | [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) | Fixed slot 수동 E2E gate 런북 — slot 배정·SHA provenance·evidence 양식·page 분류·제한 사항 (Issue #136 manual gate 단계) |
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |


### PR DESCRIPTION
## Summary

Refs #512

Adds a docs-only global CSS browser smoke checklist so future behavior-affecting global CSS PRs use a consistent desktop/mobile smoke and PASS/NOT_VERIFIED/BLOCKED reporting standard.

## Scope

- Adds `docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`
- Updates `docs/ops/ops_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Environment classification for docs-only, static CSS inventory, public static page CSS, and runtime-sensitive CSS changes
- Root/shared chrome smoke checklist
- Intro/public static page checklist
- Search/Browse checklist
- Editor checklist
- My Trees checklist
- Auth/Login checklist
- PASS / NOT_VERIFIED / BLOCKED reporting rules
- Required global CSS smoke report shape
- Relationship to #418
- #512 closure criteria

## Guardrails

- Docs-only
- No CSS implementation
- No broad `global.css` rewrite
- No Search/UI/CSS/JS reorganization
- No Auth/API/backend/package/workflow changes
- No PR #7/prototype/reference/demo/variant changes
- No PR #450 changes
- No `css/editor/status-settings.css` changes
- No `css/editor/overrides.css` changes
- No `css/editor.css` changes
- No PR #527 changes
- No Issue #513 changes

## Verification

- Changed files limited to docs/ops and docs index scope
- Excluded editor CSS files untouched
- PR #527 untouched
- Issue #513 untouched
- Runtime behavior unchanged

draft: pending CTO/reviewer verification