### PR TITLE
docs(engineering): audit global CSS tokens and readiness selectors

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -81,6 +81,10 @@ PR3 button / badge / chip tone 기준 판단이 필요하면 아래를 추가로
 - `./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
 - `./engineering/REVIEW_GUARDRAILS.md`
 
+Global CSS token/readiness ownership 판단이 필요하면 아래를 추가로 읽습니다.
+
+- `./engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md`
+
 검증 warning / blocker 분류가 필요하면 아래를 추가로 읽습니다.
 
 - `./project/VERIFICATION_WARNING_CATALOG.md`
@@ -131,6 +135,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [API_CONTRACT.md](./engineering/API_CONTRACT.md) - flat camelCase API 계약
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
+- [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage
 - [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 - [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 large-file candidate inventory, owner routing, extraction guardrails, verification requirements
 - [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements

--- a/docs/engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md
+++ b/docs/engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md
@@ -1,0 +1,145 @@
+# Global CSS Token and Readiness Selector Audit
+
+Issue: #510
+
+This document records the current `css/global.css` token and readiness selector ownership audit after #418 planning, PR #508 ready-state implementation, and #512 browser smoke checklist disposition.
+
+This is docs/inspection only. It does not authorize CSS implementation, broad `global.css` rewrite, selector movement, JavaScript readiness changes, Search/Browse CSS changes, Editor or My Trees redesign, Auth/API/backend/package/workflow changes, or protected prototype/reference/demo/variant changes.
+
+## Current file ownership
+
+| File | Current role | Ownership note |
+| --- | --- | --- |
+| `css/global.css` | Global import hub plus shared foundation/control classes | Owns import order and shared visual primitives only. Should not become a page-specific stylesheet. |
+| `css/global/tokens.css` | Global token source | Owns brand palette, surface, radius, spacing, typography, LoveTree shared foundation, and PR2/PR3 control tokens. |
+| `css/global/base.css` | Base element/reset layer | Not audited in this PR; preserve import order. |
+| `css/global/header.css` | Shared header/nav layer | Not audited in this PR; preserve import order. |
+| `css/global/ready-state.css` | Material Symbols/global readiness layer | Owns canonical icon-readiness selector behavior and legacy aliases. |
+| `css/global/transition-polish.css` | Shared transition polish layer | Not audited in this PR; preserve import order. |
+
+## Import order baseline
+
+Current `css/global.css` import order:
+
+```css
+@import url('./global/tokens.css');
+@import url('./global/base.css');
+@import url('./global/header.css');
+@import url('./global/ready-state.css');
+@import url('./global/transition-polish.css');
+```
+
+This order is meaningful:
+
+1. tokens first, because all later layers consume variables.
+2. base before shared components.
+3. header before readiness/transition polish.
+4. ready-state before transition polish so readiness-specific icon visibility can settle before broader polish.
+
+Do not reorder from #510 alone.
+
+## Token group inventory
+
+| Token group | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Brand palette | `css/global/tokens.css` | `OK_AS_IS` | `--primary`, `--primary-rgb`, `--primary-vibrant`, `--primary-soft`, `--secondary`, warm accents. |
+| Surface/text palette | `css/global/tokens.css` | `OK_AS_IS` | Background, surface, and text tokens remain central. |
+| Radius tokens | `css/global/tokens.css` | `OK_AS_IS` | `--radius-default`, `--radius-lg`, `--radius-full`. |
+| LoveTree shared foundation | `css/global/tokens.css` + `css/global.css` | `WATCH` | `--lovetree-*` tokens power `.lovetree-page-shell`, `.lovetree-soft-surface`, `.lovetree-card`, `.lovetree-pill`, `.lovetree-chip`. Future changes affect Search/Browse and other shared surfaces. |
+| Page spacing tokens | `css/global/tokens.css` | `WATCH` | `--page-*`, `--hero-gap`, `--section-gap`, `--divider-margin`; potential overlap with `--lovetree-page-*`. Do not consolidate without visual checks. |
+| Typography/accent tokens | `css/global/tokens.css` + `css/global.css` | `WATCH` | PR2 title/accent alignment depends on these tokens. Future change requires public page smoke. |
+| PR3 control tokens | `css/global.css` root block | `AUDIT_NEEDED` | Control tokens currently live in `css/global.css`, not `tokens.css`. This is acceptable for now but should be revisited before more control token expansion. |
+| Material Symbols readiness transition token | `css/global/ready-state.css` | `OK_AS_IS` | `--lovetree-icon-ready-transition` is readiness-scoped and should stay near readiness selectors. |
+
+## Readiness selector inventory
+
+| Selector or alias | Location | Status | Notes |
+| --- | --- | --- | --- |
+| `.material-symbols-outlined` base hidden state | `css/global.css` and `css/global/ready-state.css` | `DUPLICATE_CANDIDATE` | Both files currently define icon hidden/ready behavior. Do not remove from #510 alone. Future consolidation must verify no raw icon text flash. |
+| `html.material-symbols-ready .material-symbols-outlined` | `css/global.css` and `css/global/ready-state.css` | `CANONICAL_READY_CLASS` | Canonical class. Preserve. |
+| `html.ms-fonts-loaded ...` | `css/global/ready-state.css` | `LEGACY_ALIAS` | Keep for compatibility with older header/auth code paths. |
+| `.material-symbols-outlined.ms-ready` | `css/global/ready-state.css` | `LEGACY_ALIAS` | Element-level alias. Keep until JS ownership confirms it is unused. |
+| `.mobile-nav-toggle::before` ready-state suppression | `css/global/ready-state.css` | `OK_AS_IS` | Header/mobile-nav-specific readiness behavior lives in ready-state layer. |
+| `html:not(.material-symbols-ready):not(.ms-fonts-loaded) ...` | `css/global/ready-state.css` | `OK_AS_IS` | Prevents mobile nav raw icon text before fonts are ready. |
+
+## Observed duplication and ambiguity
+
+### 1. Material Symbols readiness exists in two places
+
+`css/global.css` contains a Material Symbols fallback text guard near the middle of the file, while `css/global/ready-state.css` contains the newer #418/#508 ready-state hardening with canonical and legacy selectors.
+
+Disposition:
+- Do not remove either block from #510.
+- Future consolidation should be one narrow PR only.
+- Required verification: `GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` root/header/mobile smoke, no raw icon text, no hidden icons after readiness.
+
+### 2. Control tokens live in `css/global.css`
+
+The PR3 control token `:root` block currently lives in `css/global.css`, not `css/global/tokens.css`.
+
+Disposition:
+- Accept as current state.
+- Future movement into `tokens.css` can be considered only as a token-only PR.
+- Do not combine token movement with selector behavior changes.
+
+### 3. Shared foundation tokens and page spacing tokens overlap by purpose
+
+`--lovetree-page-*` and `--page-*` tokens both describe page shell rhythm, but they serve different staged UI cleanup paths.
+
+Disposition:
+- Keep both for now.
+- Do not consolidate without Search/Browse, Intro/Home, and shared shell visual smoke.
+
+## Future PR candidates
+
+| Candidate | Scope | Preconditions | Verification |
+| --- | --- | --- | --- |
+| Ready-state dedupe audit | Decide whether the old Material Symbols fallback block in `css/global.css` can be removed or moved | Static selector search and JS readiness ownership check | #512 root/header/mobile smoke; raw icon text check |
+| Control token relocation | Move PR3 control tokens from `css/global.css` to `css/global/tokens.css` if desired | Confirm no cascade/order dependency | Static review plus public page smoke |
+| Page shell token clarification | Document or align `--lovetree-page-*` vs `--page-*` usage | Search/Browse/Home/Intro affected surface list | Desktop and mobile 375px public page smoke |
+| Typography token impact audit | Verify PR2 typography/accent token consumers | Identify Home/Intro/Browse consumers | Public page visual smoke |
+
+## Required verification for future implementation
+
+Use `docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` for any implementation PR that changes token values, readiness selectors, visibility/focus selectors, or import order.
+
+Minimum expectations:
+
+- static CSS review,
+- root/shared chrome smoke,
+- mobile 375px smoke,
+- no raw Material Symbols text flash,
+- no permanently hidden icons,
+- Search/Browse checks if shared cards/chips/previews can be affected,
+- Editor/My Trees/Auth checks only if runtime-sensitive surfaces are affected,
+- separate `PASS`, `NOT_VERIFIED`, and `BLOCKED` outcomes.
+
+## Closure criteria for #510
+
+#510 can be closed when:
+
+- token groups are inventoried,
+- readiness selectors and aliases are inventoried,
+- duplicated or ambiguous readiness/token ownership is documented,
+- future PR candidates are split narrowly,
+- #512 verification checklist is referenced for implementation work,
+- the change remains docs/inspection only.
+
+## Guardrails
+
+- Docs/inspection only.
+- No CSS implementation.
+- No `css/global.css` rewrite.
+- No selector removal or rename.
+- No import order change.
+- No JavaScript readiness logic change.
+- No Search/Browse CSS changes.
+- No Editor or My Trees redesign.
+- No Auth/API/backend/package/workflow changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No PR #450 changes.
+- No `css/editor/status-settings.css` changes.
+- No `css/editor/overrides.css` changes.
+- No `css/editor.css` changes.
+- No PR #527 changes.
+- No Issue #513 changes.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -23,20 +23,21 @@
 5. [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements
 6. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
 7. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-8. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-9. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-10. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-11. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-12. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-13. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-14. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-15. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-16. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-17. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-18. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-19. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-20. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-21. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+8. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
+9. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+10. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+11. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+12. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+13. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+14. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+15. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+16. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+17. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+18. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+19. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+20. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+21. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+22. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -51,6 +52,7 @@
 | [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) | Issue #423 Modal owner read/write route split boundary, implementation gates, Cloudflare boundary, verification expectations |
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
+| [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
@@ -86,6 +88,7 @@
 - #408 large-file candidate 판단은 `LARGE_FILE_MODULARIZATION_CANDIDATES.md`에서 owner routing and forbidden scope를 먼저 확인합니다.
 - #423 Modal owner-route split 판단은 `MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md`에서 completed public-read work, remaining owner read/write gates, and verification expectations를 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
+- CSS import hub, global token/readiness selector ownership, and future readiness dedupe decisions start from `GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` and `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.


### PR DESCRIPTION
## Summary

Refs #510

Adds a docs/inspection-only audit of global CSS token groups and readiness selectors after #418 planning, PR #508 ready-state hardening, and #512 smoke checklist disposition.

## Scope

- Adds `docs/engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md`
- Updates `docs/engineering/engineering_index.md`
- Updates `docs/doc_index.md`

## Included guidance

- Current `css/global.css` import order baseline
- Token group inventory for brand, surface, radius, LoveTree foundation, page spacing, typography, control tokens, and readiness transition
- Readiness selector inventory for Material Symbols canonical and legacy aliases
- Duplicated or ambiguous readiness/token ownership notes
- Future narrow PR candidates
- Required future verification via `docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`
- #510 closure criteria

## Guardrails

- Docs/inspection only
- No CSS implementation
- No `css/global.css` rewrite
- No selector removal or rename
- No import order change
- No JavaScript readiness logic change
- No Search/Browse CSS changes
- No Editor or My Trees redesign
- No Auth/API/backend/package/workflow changes
- No PR #7/prototype/reference/demo/variant changes
- No PR #450 changes
- No `css/editor/status-settings.css` changes
- No `css/editor/overrides.css` changes
- No `css/editor.css` changes
- No PR #527 changes
- No Issue #513 changes

## Verification

- Changed files limited to docs/engineering and docs index scope
- `css/global.css`, `css/global/tokens.css`, and `css/global/ready-state.css` were inspected but not modified
- Excluded editor CSS files untouched
- PR #527 untouched
- Issue #513 untouched
- Runtime behavior unchanged

draft: pending CTO/reviewer verification