### PR TITLE
refactor(editor): relocate canvas toolbar CSS

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -12,6 +12,7 @@
 @import url("./editor/layout.css");
 @import url("./editor/sidebar.css");
 @import url("./editor/canvas.css");
+@import url("./editor/canvas-toolbar.css");
 @import url("./editor/memory-form.css");
 @import url("./editor/detail-panel.css");
 @import url("./editor/responsive.css");

--- a/css/editor/canvas-toolbar.css
+++ b/css/editor/canvas-toolbar.css
@@ -1,0 +1,65 @@
+/**
+ * LoveBud Editor Canvas Toolbar Styles
+ * Issue #515 - Canvas Toolbar CSS Relocation
+ * 
+ * Extracted from css/editor/overrides.css for better role ownership
+ * Contains Editor Canvas Topbar & Toolbar selectors
+ */
+
+/* Editor Canvas Topbar */
+.editor-canvas-topbar {
+    position: absolute;
+    top: 22px;
+    left: 24px;
+    right: 24px;
+    z-index: 7;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 18px;
+    pointer-events: none;
+}
+
+.editor-canvas-topbar > * {
+    pointer-events: auto;
+}
+
+/* Editor Canvas Title & Caption */
+.editor-canvas-title h2 {
+    margin: 10px 0 0;
+    font-size: 1.76rem;
+    line-height: 1.12;
+    letter-spacing: -0.05em;
+    color: #553f35;
+}
+
+.editor-canvas-caption {
+    margin: 7px 0 0;
+    max-width: 360px;
+    color: #9a8175;
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+/* Editor Canvas Toolbar */
+.editor-canvas-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    border-radius: 999px;
+    background: rgba(255,250,244,0.82);
+    border: 1px solid rgba(230,207,194,0.78);
+    box-shadow: 0 14px 30px rgba(161,119,96,0.10);
+    backdrop-filter: blur(8px);
+}
+
+.editor-canvas-toolbar .sidebar-btn {
+    min-height: 38px;
+    padding: 0 14px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.74);
+    border: 1px solid rgba(221,198,184,0.84);
+    color: #7f6258;
+    box-shadow: none;
+}

--- a/css/editor/overrides.css
+++ b/css/editor/overrides.css
@@ -354,60 +354,6 @@ body .editor-canvas-title h2 {
     text-align: center;
 }
 
-.editor-canvas-topbar {
-    position: absolute;
-    top: 22px;
-    left: 24px;
-    right: 24px;
-    z-index: 7;
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 18px;
-    pointer-events: none;
-}
-
-.editor-canvas-topbar > * {
-    pointer-events: auto;
-}
-
-.editor-canvas-title h2 {
-    margin: 10px 0 0;
-    font-size: 1.76rem;
-    line-height: 1.12;
-    letter-spacing: -0.05em;
-    color: #553f35;
-}
-
-.editor-canvas-caption {
-    margin: 7px 0 0;
-    max-width: 360px;
-    color: #9a8175;
-    font-size: 13px;
-    line-height: 1.6;
-}
-
-.editor-canvas-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px;
-    border-radius: 999px;
-    background: rgba(255,250,244,0.82);
-    border: 1px solid rgba(230,207,194,0.78);
-    box-shadow: 0 14px 30px rgba(161,119,96,0.10);
-    backdrop-filter: blur(8px);
-}
-
-.editor-canvas-toolbar .sidebar-btn {
-    min-height: 38px;
-    padding: 0 14px;
-    border-radius: 999px;
-    background: rgba(255,255,255,0.74);
-    border: 1px solid rgba(221,198,184,0.84);
-    color: #7f6258;
-    box-shadow: none;
-}
 
 .editor-status-section > h3,
 .editor-flow-lead,


### PR DESCRIPTION
## Summary

Refs #515

Relocates Editor canvas topbar and toolbar CSS selectors from css/editor/overrides.css into the role-owned css/editor/canvas-toolbar.css stylesheet.

## Scope

Changed files:
- css/editor.css
- css/editor/canvas-toolbar.css
- css/editor/overrides.css

## Verification

PASS:
- CSS-only scope confirmed
- Changed files limited to allowed Editor CSS files
- Target canvas toolbar selectors relocated
- Selector/declaration intent preserved
- Import/load order preserved
- test6 fixed slot deployment completed for PR #534
- test6 latest deployed commit matched PR head SHA 6a1a828
- CSS files loaded without MIME type errors
- Empty editor canvas verified
- Canvas toolbar visible and aligned on desktop
- Mobile 375px editor smoke passed
- No horizontal overflow detected
- No Search/#456 files changed
- No Search preview/#424 files changed
- PR #7/prototype/reference/demo/variant untouched
- PR #450 untouched
- No Auth/API/backend/package/workflow changes
- git diff --check passed

NOT_VERIFIED:
- Populated editor canvas: requires authenticated session with tree data
- Selected memory/detail state: requires authenticated session with memory data

Notes:
- One expected 401/auth-related console error was observed and is not attributed to this CSS-only change.
- Verification target: https://test6.lovebud.pages.dev/pages/editor.html

## Guardrails

- No selector rename
- No declaration-intent change
- No JavaScript/runtime behavior change
- No Search/Browse changes
- No Search preview helper extraction changes
- No Auth/API/backend/package/workflow changes