### PR TITLE
perf(browse): add incremental public tree loading

### DIFF
--- a/js/search/data.js
+++ b/js/search/data.js
@@ -56,6 +56,16 @@
                 ui.clearSelectedPreview();
             }
 
+            // Prevent duplicate concurrent requests
+            if (state.isLoadingMore && !resetSelection) {
+                return;
+            }
+
+            // Set loading state for incremental loading
+            if (!resetSelection) {
+                state.isLoadingMore = true;
+            }
+
             // Serve from cache first (stale-while-revalidate)
             let cachedTrees = null;
             if (cache) {
@@ -90,6 +100,7 @@
                     }
                     state.loadError = null;
                     state.apiTreesLoaded = true;
+                    state.hasMoreTrees = apiTrees.length === state.currentLimit;
                     callbacks.renderResults();
                 } else {
                     throw new Error(
@@ -105,6 +116,8 @@
                     state.allTrees = [];
                 }
                 callbacks.renderResults();
+            } finally {
+                state.isLoadingMore = false;
             }
         }
 

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -63,7 +63,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         currentCategory: '전체',
         isRestoringUrlState: false,
         urlStateReady: false,
-        initialTreeDeepLinkApplied: false
+        initialTreeDeepLinkApplied: false,
+        isLoadingMore: false,
+        hasMoreTrees: true
     };
     const previewCache = new Map();
     const callbacks = {};

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -196,10 +196,19 @@
             }
             const loadMoreBtn = document.getElementById('browseLoadMoreBtn');
             if (loadMoreBtn) {
-                loadMoreBtn.disabled = state.currentLimit >= 60;
-                loadMoreBtn.textContent = state.currentLimit >= 60
-                    ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
-                    : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
+                const shouldDisable = state.currentLimit >= 60 || !state.hasMoreTrees || state.isLoadingMore;
+                loadMoreBtn.disabled = shouldDisable;
+
+                if (state.isLoadingMore) {
+                    loadMoreBtn.innerHTML = `
+                        <span class="material-symbols-outlined" style="animation: spin 1s linear infinite;">progress_activity</span>
+                        ${getCurrentLocale() === 'en' ? 'Loading...' : '로딩 중...'}
+                    `;
+                } else {
+                    loadMoreBtn.textContent = state.currentLimit >= 60
+                        ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
+                        : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
+                }
             }
         }
 
@@ -235,7 +244,22 @@
 
             const loadMoreBtn = controls.querySelector('#browseLoadMoreBtn');
             if (loadMoreBtn) {
-                loadMoreBtn.style.display = (state.currentLimit >= 60) ? 'none' : 'inline-flex';
+                const shouldHide = state.currentLimit >= 60 || !state.hasMoreTrees;
+                loadMoreBtn.style.display = shouldHide ? 'none' : 'inline-flex';
+
+                // Update button text and state for loading
+                if (state.isLoadingMore) {
+                    loadMoreBtn.disabled = true;
+                    loadMoreBtn.innerHTML = `
+                        <span class="material-symbols-outlined" style="animation: spin 1s linear infinite;">progress_activity</span>
+                        ${getCurrentLocale() === 'en' ? 'Loading...' : '로딩 중...'}
+                    `;
+                } else {
+                    loadMoreBtn.disabled = false;
+                    loadMoreBtn.textContent = state.currentLimit >= 60
+                        ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
+                        : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
+                }
             }
         }
 
@@ -288,6 +312,8 @@
             });
 
             controls.querySelector('#browseLoadMoreBtn')?.addEventListener('click', async () => {
+                if (state.isLoadingMore || !state.hasMoreTrees) return;
+
                 state.currentLimit = Math.min(state.currentLimit + 10, 60);
                 syncControlsFromState();
                 callbacks.updateUrlState();


### PR DESCRIPTION
## Summary

Refs #456

Adds incremental Browse loading after the initial 6-tree render using the existing Browse/Search client flow.

## Scope

Changed files:
- js/search/index.js
- js/search/data.js
- js/search/search-ui.js

## Implementation

- Preserves the initial limit=6 behavior from PR #461.
- Adds incremental loading state to prevent duplicate concurrent load-more requests.
- Uses the existing load-more control path to increase the current limit and refresh Browse results.
- Tracks whether more trees are likely available based on the current API result length.
- Keeps the change Search/Browse-scoped.

## Verification

PASS:
- Search/Browse scoped changes only
- Initial limit=6 preserved
- First render loads the initial 6 trees only
- Load-more button based incremental loading verified
- Next batch behavior verified
- Duplicate request/race prevention verified via isLoadingMore guard
- Duplicate row prevention verified through API refresh behavior
- Existing filter/sort/search behavior preserved
- Existing URL limit override behavior preserved
- Loading state visible during incremental loading
- Mobile 375px Browse smoke passed
- No horizontal overflow detected
- No fatal console errors observed; only unrelated thumbnail 404s observed
- No CSS changes
- No HTML/pages changes
- No API/backend/Auth/package/workflow changes
- Editor/My Trees untouched
- #424 preview helper files untouched
- PR #7/prototype/reference/demo/variant untouched
- PR #450 untouched
- git diff --check passed

## Guardrails

- No Browse visual-card redesign
- No Editor/My Trees changes
- No Search preview helper extraction changes
- No Auth/API/backend/package/workflow changes
- No package dependency changes

## Notes

This PR implements incremental loading by expanding the requested limit through the existing Browse data flow rather than introducing cursor pagination or backend/API changes.