### PR TITLE
docs(engineering): audit global focus and visibility hardening path

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -85,6 +85,10 @@ Global CSS token/readiness ownership 판단이 필요하면 아래를 추가로 
 
 - `./engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md`
 
+Global focus/visibility hardening 판단이 필요하면 아래를 추가로 읽습니다.
+
+- `./engineering/GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md`
+
 검증 warning / blocker 분류가 필요하면 아래를 추가로 읽습니다.
 
 - `./project/VERIFICATION_WARNING_CATALOG.md`
@@ -136,6 +140,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - stored visibility, anonymous public exposure, Browse/Search eligibility, Browse display filter 개념 분리
 - [CSS_ARCHITECTURE.md](./engineering/CSS_ARCHITECTURE.md) - CSS import hub, split ownership, import order, visual verification 기준
 - [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage
+- [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./engineering/GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector groups, affected surfaces, forbidden combinations, future narrow PR shapes, and #512 verification linkage
 - [CODE_ARCHITECTURE.md](./engineering/CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 - [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./engineering/LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 large-file candidate inventory, owner routing, extraction guardrails, verification requirements
 - [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./engineering/MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements

--- a/docs/engineering/GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md
+++ b/docs/engineering/GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md
@@ -1,0 +1,154 @@
+# Global Focus and Visibility Hardening Audit
+
+Issue: #511
+
+This document records the audit-first path for narrow global focus and visibility CSS hardening after #418 planning, #510 global token/readiness audit, and #512 browser smoke checklist disposition.
+
+This is docs/inspection only. It does not authorize CSS implementation, broad `global.css` rewrites, selector removal, selector rename, JavaScript compensation, Search architecture work, Editor global state work, My Trees redesign, Auth/API/backend/package/workflow changes, or protected prototype/reference/demo/variant changes.
+
+## Current disposition
+
+#511 should be treated as a behavior-sensitive global CSS track. Focus and visibility selectors can affect keyboard accessibility, hidden/empty states, first paint, previews, forms, editor controls, and mobile layout across multiple surfaces.
+
+The safe path is:
+
+1. classify selector group,
+2. identify affected surfaces,
+3. make one narrow implementation PR only if needed,
+4. verify with the #512 browser smoke checklist.
+
+## Related source documents
+
+| Document | Role |
+| --- | --- |
+| `docs/engineering/CSS_ARCHITECTURE.md` | CSS import hub and split ownership baseline. |
+| `docs/engineering/GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` | Token/readiness selector ownership and future PR split. |
+| `docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` | Required desktop/mobile smoke and PASS/NOT_VERIFIED/BLOCKED reporting standard. |
+| `docs/design/BUTTON_BADGE_CHIP_BASELINE.md` | Button, badge, chip tone and focus-ring baseline. |
+
+## Selector group map
+
+| Group | Current evidence | Risk level | Next action |
+| --- | --- | --- | --- |
+| Global focus-visible controls | `css/global.css` includes shared focus-visible rules for buttons and tag chips. | Medium | Keep stable unless a specific accessibility bug is found. |
+| Header/navigation focus states | `css/global/header.css` and global control rules may affect nav/button focus. | Medium | Any change requires root/shared chrome smoke. |
+| Global visibility/readiness selectors | Covered by `css/global/ready-state.css` and #510 readiness audit. | High | Do not change together with focus-visible rules. |
+| Hidden/loading/empty helper behavior | Can affect Search/Browse, Editor, My Trees, and Auth surfaces. | High | Requires affected-surface inventory and #512 smoke matrix. |
+| Shared interactive control states | Buttons, chips, badges, CTAs. | Medium | Keep token-only and selector behavior changes separate. |
+| Page reveal/transition visibility | Connected to transition polish and page reveal documents. | High | Treat as motion/visibility track, not generic focus hardening. |
+
+## Affected surface inventory
+
+| Surface | Focus/visibility risk | Required verification before implementation merge |
+| --- | --- | --- |
+| Root/shared header/nav | Hidden icons, nav toggles, focus-ring loss, first paint flash | Desktop root smoke, mobile 375px smoke, no hidden nav controls |
+| Home/Intro public pages | Hero CTA focus, reveal visibility, title/copy first paint | Public page desktop/mobile smoke |
+| Search/Browse | Cards, selected preview, empty/loading/error states, scroll behavior | Search/Browse regression checklist from #512 |
+| Editor | Controls, forms, preview/detail visibility, inline edit focus, empty/selected states | Fixed slot or explicitly scoped runtime smoke; do not overclaim static review |
+| My Trees | Cards, lists, CTA, loading/empty states | Fixed slot for authenticated/user-data claims |
+| Auth/Login | Input focus, submit button visibility, help/error text | Login smoke without printing sensitive values |
+
+## Allowed future PR shapes
+
+### PR A — Focus-visible selector audit or token-only clarification
+
+Allowed:
+- docs-only or token-reference clarification,
+- no CSS behavior change,
+- no runtime verification claim beyond static review.
+
+### PR B — Narrow focus-visible hardening
+
+Allowed:
+- one selector family only,
+- shared control focus state only,
+- no readiness/visibility hidden-state changes in the same PR.
+
+Required:
+- static CSS review,
+- root/shared chrome smoke,
+- affected public page smoke,
+- mobile 375px smoke,
+- `PASS` and `NOT_VERIFIED` separated.
+
+### PR C — Narrow visibility/helper hardening
+
+Allowed:
+- one hidden/visibility helper family only,
+- no focus-visible token/control change in the same PR.
+
+Required:
+- affected surface inventory,
+- #512 smoke matrix,
+- fixed slot if Editor/My Trees/Auth runtime-sensitive behavior is claimed.
+
+### PR D — Page reveal/transition visibility audit
+
+Allowed:
+- docs-only or very narrow page reveal verification plan.
+
+Forbidden:
+- no global transition rewrite,
+- no page-wide motion application mixed with focus/visibility selector changes.
+
+## Forbidden combinations
+
+Do not combine:
+
+- focus-visible selector changes with Material Symbols readiness selector changes,
+- hidden/visibility helper changes with Search/Browse architecture changes,
+- Editor runtime/global state cleanup with global CSS hardening,
+- My Trees redesign with global visibility hardening,
+- Auth/API/backend/package/workflow changes with CSS focus/visibility changes,
+- broad `global.css` rewrite with any behavior-affecting selector change,
+- PR #7/prototype/reference/demo/variant changes with #511 work,
+- PR #450 changes with #511 work.
+
+## Verification standard
+
+Any implementation PR under #511 must cite `docs/ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` and report:
+
+- environment used,
+- fixed slot required or not,
+- deployed SHA match when runtime smoke is performed,
+- root/shared chrome result,
+- mobile 375px result,
+- affected surface results,
+- `PASS`, `NOT_VERIFIED`, and `BLOCKED` separately,
+- fatal console error status,
+- no private value exposure.
+
+Static review alone is acceptable only for docs/inspection PRs.
+
+## Closure criteria for #511
+
+#511 can be closed when:
+
+- global focus/visibility selector groups are classified,
+- affected surfaces are documented,
+- allowed future PR shapes are split narrowly,
+- forbidden combinations are documented,
+- #512 verification standard is referenced,
+- the change remains docs/inspection only.
+
+This document satisfies the audit/disposition portion of #511. Any future implementation should use a separate issue or PR with explicit CTO approval.
+
+## Guardrails
+
+- Docs/inspection only.
+- No CSS implementation.
+- No broad `global.css` rewrite.
+- No selector removal or rename.
+- No import order change.
+- No JavaScript compensation for CSS behavior.
+- No Search architecture work.
+- No Editor global state work.
+- No My Trees redesign.
+- No Auth/API/backend/package/workflow changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No PR #450 changes.
+- No `css/editor/status-settings.css` changes.
+- No `css/editor/overrides.css` changes.
+- No `css/editor.css` changes.
+- No PR #527 changes.
+- No Issue #513 changes.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -24,20 +24,21 @@
 6. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
 7. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
 8. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
-9. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-10. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-11. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-12. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-13. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-14. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-15. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-16. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-17. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-18. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-19. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-20. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-21. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-22. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+9. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, #512 verification linkage
+10. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+11. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+12. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+13. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+14. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+15. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+16. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+17. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+18. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+19. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+20. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+21. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+22. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+23. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -53,6 +54,7 @@
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
+| [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) | Issue #511 global focus and visibility selector groups, affected surfaces, forbidden combinations, future narrow PR shapes, and #512 verification linkage |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
 | [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
@@ -89,6 +91,7 @@
 - #423 Modal owner-route split 판단은 `MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md`에서 completed public-read work, remaining owner read/write gates, and verification expectations를 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
 - CSS import hub, global token/readiness selector ownership, and future readiness dedupe decisions start from `GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` and `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`.
+- Global focus/visibility hardening decisions start from `GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md` and must use `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` for implementation verification.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.


### PR DESCRIPTION
## Summary

Refs #511

Adds a docs/inspection-only audit for global focus and visibility CSS hardening.

## Scope

Changed files:
- docs/engineering/GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md
- docs/engineering/engineering_index.md
- docs/doc_index.md

## Verification

PASS:
- Docs-only scope confirmed
- No CSS implementation
- No global.css rewrite
- No selector removal or rename
- No JS/runtime changes
- No Search, Editor, My Trees, Auth, API, backend, package, or workflow changes
- PR #7/prototype/reference/demo/variant untouched
- PR #450 untouched
- PR #527 and Issue #513 untouched

## Notes

This PR covers the audit/disposition portion of #511. Future implementation should be separately approved as a narrow CSS PR with browser verification.