### PR TITLE
docs(editor): audit hidden compatibility overrides

### DIFF
--- a/docs/engineering/EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md
+++ b/docs/engineering/EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md
@@ -1,0 +1,145 @@
+# Editor Hidden Compatibility Override Audit
+
+Issue: #516
+
+This document records the docs/inspection-only audit for the Group G hidden/compatibility selectors in `css/editor/overrides.css`.
+
+This PR does not remove, relocate, or rename selectors. It does not change CSS, HTML, JavaScript, runtime behavior, Auth/API/backend/package/workflow files, PR #7 prototype/reference/demo/variant paths, or PR #450 files.
+
+## Source baseline
+
+The current hidden/compatibility selector block in `css/editor/overrides.css` hides several legacy or compatibility elements with `display: none !important`, followed by two low-risk spacing/text-width overrides:
+
+- `.editor-status-section > h3`
+- `.editor-flow-lead`
+- `#sidebarMomentCount`
+- `#sidebarFlowSummary`
+- `#sidebarSelectionHint`
+- `.editor-add-section-bottom`
+- `.editor-tree-meta-section`
+- `#detailEmptyStartBtn`
+- `.editor-status-card` margin-top override
+- `.editor-canvas-empty-guide__desc`
+
+The earlier selector inventory classifies these as Group G Hidden/Compatibility selectors and marks the hidden display group as HOLD until usage is verified.
+
+## Audit method
+
+Repository search inspected the selector family across:
+
+- `css/editor/overrides.css`
+- `pages/editor.html`
+- existing engineering selector inventory documentation
+
+This audit is intentionally conservative. Search visibility in this document is not a deletion authorization. Any future removal or relocation still requires fresh file search, targeted diff review, and browser verification.
+
+## Selector disposition table
+
+| Selector | Current role | Reference evidence | Disposition | Future action |
+| --- | --- | --- | --- | --- |
+| `.editor-status-section > h3` | Hidden legacy/compatibility status heading | Present in `css/editor/overrides.css`; selector family documented in existing inventory | HOLD | Do not remove without confirming heading ownership in current Editor markup and smoke-testing sidebar/status states. |
+| `.editor-flow-lead` | Hidden flow lead text | Present in `css/editor/overrides.css`; inventory marks Group G HOLD | HOLD | Confirm whether current copy model still needs compatibility hiding before any removal. |
+| `#sidebarMomentCount` | Hidden moment count element | Present in `css/editor/overrides.css`; search indicates relation to `pages/editor.html`/inventory | HOLD | Treat as behavior-adjacent until JS/HTML references are checked immediately before implementation. |
+| `#sidebarFlowSummary` | Hidden sidebar flow summary | Present in `css/editor/overrides.css`; search indicates relation to `pages/editor.html`/inventory | HOLD | Do not remove without checking empty/populated tree sidebar states. |
+| `#sidebarSelectionHint` | Hidden sidebar selection hint | Present in `css/editor/overrides.css`; search indicates relation to `pages/editor.html`/inventory | HOLD | Verify selected-memory and no-selection states before any change. |
+| `.editor-add-section-bottom` | Hidden add-section compatibility surface | Present in `css/editor/overrides.css`; search indicates relation to editor markup/inventory | HOLD | Any removal requires add-memory form and empty tree smoke. |
+| `.editor-tree-meta-section` | Hidden tree meta compatibility surface | Present in `css/editor/overrides.css`; search indicates relation to editor markup/inventory | HOLD | Verify tree meta/status rendering before any removal or relocation. |
+| `#detailEmptyStartBtn` | Hidden detail-panel empty-state button | Present in `css/editor/overrides.css`; search indicates relation to editor markup/inventory | HOLD | Do not remove while Editor empty-state CTA hierarchy depends on center-owned first action. |
+| `.editor-status-card` margin-top override | Spacing normalization for status card | Present in `css/editor/overrides.css`; not a hidden selector | READY_FOR_NARROW_RELOCATION | May move to status/settings ownership only in a small CSS-only PR with sidebar/status smoke. |
+| `.editor-canvas-empty-guide__desc` | Empty guide description width/rhythm | Present in `css/editor/overrides.css`; not a hidden selector | READY_FOR_NARROW_RELOCATION | May move to canvas/empty-state ownership only in a small CSS-only PR with empty editor canvas smoke. |
+
+## Current conclusion
+
+The hidden selector group should remain in place for now. The selectors are compatibility controls rather than simple dead CSS. Removal would be riskier than relocation and requires stronger proof than this audit provides.
+
+The two non-hidden declarations have clearer ownership candidates:
+
+- `.editor-status-card { margin-top: 0; }` can be considered for status/settings ownership.
+- `.editor-canvas-empty-guide__desc` can be considered for canvas empty-state ownership.
+
+Those should not be bundled with hidden-selector removal.
+
+## Allowed future PR shapes
+
+### PR A — No-op disposition / tracking only
+
+Allowed:
+- Keep hidden selectors in `css/editor/overrides.css`.
+- Add comments or documentation only.
+
+### PR B — Narrow spacing relocation
+
+Allowed:
+- Move `.editor-status-card` margin-top override only.
+- CSS-only.
+- Verify sidebar/status card spacing.
+
+Forbidden:
+- No hidden selector removal.
+- No runtime changes.
+
+### PR C — Narrow empty guide relocation
+
+Allowed:
+- Move `.editor-canvas-empty-guide__desc` only.
+- CSS-only.
+- Verify empty editor canvas and mobile 375px.
+
+Forbidden:
+- No hidden selector removal.
+- No broad canvas/paper-tone consolidation.
+
+### PR D — Hidden selector removal only after proof
+
+Allowed only after fresh approval:
+- Remove one hidden selector family at a time.
+- Confirm no active HTML/JS/runtime dependency immediately before removal.
+- Browser-verify empty editor state, populated tree state, selected memory state, add-memory form state, sidebar meta/status rendering, mobile 375px, and fatal console status.
+
+## Forbidden combinations
+
+Do not combine #516 work with:
+
+- Editor paper tone/layout consolidation (#517)
+- Editor detail JS responsibility cleanup (#518/#519/#520)
+- Browse/Search performance work (#456)
+- Search preview helper extraction (#424)
+- Auth/API/backend/package/workflow changes
+- PR #7 prototype/reference/demo/variant paths
+- PR #450 files
+
+## Verification standard for future implementation
+
+Any future CSS implementation under #516 must report:
+
+- exact selector family touched;
+- fresh reference search result;
+- changed files;
+- whether CSS-only was preserved;
+- empty editor state;
+- populated tree state where reachable;
+- selected memory state where reachable;
+- add memory form state where reachable;
+- sidebar meta/status rendering;
+- mobile 375px editor smoke;
+- horizontal overflow;
+- fatal console errors;
+- PASS / PARTIAL / NOT_VERIFIED separated.
+
+## Closure criteria for #516
+
+#516 can be closed when:
+
+- Group G hidden/compatibility selectors are documented;
+- current disposition is recorded;
+- removal is explicitly blocked until proof and browser verification;
+- safe future PR shapes are split;
+- forbidden combinations are documented;
+- no implementation is included in the audit PR.
+
+This audit satisfies the docs/inspection portion of #516. Any future selector removal or relocation must be separately approved.
+
+Refs #516
+Refs #419
+Refs #137
+Refs #399

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -24,10 +24,10 @@
 6. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
 7. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
 8. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
-9. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, #512 verification linkage
+9. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, and #512 verification linkage
 10. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
 11. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-12. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+12. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
 13. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
 14. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
 15. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
@@ -37,8 +37,9 @@
 19. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 20. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
 21. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-22. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-23. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+22. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
+23. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+24. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -56,7 +57,7 @@
 | [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
 | [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) | Issue #511 global focus and visibility selector groups, affected surfaces, forbidden combinations, future narrow PR shapes, and #512 verification linkage |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
-| [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
+| [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, smoke checklist |
 | [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
 | [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) | #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit |
 | [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) | Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준 |
@@ -66,6 +67,7 @@
 | [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) | Auth fallback cleanup, Editor fallback factories, and `window.currentTreeMemories/currentTreeData` ownership mapping for #224/#78/#223/#225 |
 | [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) | Shared header render/mobile nav/language/Auth/path helper 책임과 config/helper extraction defer 기준 |
 | [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) | `css/editor/overrides.css` role-based relocation 사전 audit (구현 없음, cascade 위험 문서, future PR split 계획 (#137 종속)) |
+| [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) | Issue #516 hidden/compatibility selector references, runtime linkage, removal/relocation disposition, and future browser verification gates |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지 및 리뷰 규칙 |
 | [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 이력 |
@@ -101,6 +103,7 @@
 - #224 Auth/Editor fallback checklist 판단은 `AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md`에서 #78/#223/#225 ownership mapping을 먼저 확인합니다.
 - Shared header config/path helper extraction 판단은 `SHARED_HEADER_CONFIG_HELPER_DECISION.md`의 defer 조건과 follow-up trigger를 먼저 확인합니다.
 - `css/editor/overrides.css` relocation 판단은 `EDITOR_OVERRIDES_RELOCATION_AUDIT.md`의 cascade risk 및 future implementation gate를 먼저 확인합니다.
+- Editor hidden/compatibility selector 제거·relocation 판단은 `EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md`의 usage/disposition table을 먼저 확인합니다.
 
 ---
 


### PR DESCRIPTION
## Summary

Refs #516

Adds a docs/inspection-only audit for Editor hidden/compatibility overrides.

## Scope

Changed files:
- docs/engineering/EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md
- docs/engineering/engineering_index.md

## Verification

PASS:
- Docs-only scope confirmed
- No CSS implementation
- No selector removal or rename
- No JS/runtime changes
- No pages changes
- No Search/Browse/My Trees/Auth/API/backend/package/workflow changes
- PR #7/prototype/reference/demo/variant untouched
- PR #450 untouched

Notes:
- Top-level docs/doc_index.md was intentionally not modified to keep this PR narrow and avoid index churn.
- Any future selector removal or relocation under #516 requires separate approval and browser verification.