### PR TITLE
docs(ops): require browser slot assignment gate

### DIFF
--- a/docs/ops/BROWSER_VERIFICATION_SLOT_GATE.md
+++ b/docs/ops/BROWSER_VERIFICATION_SLOT_GATE.md
@@ -1,0 +1,162 @@
+# Browser Verification Slot Assignment Gate
+
+Status: Active ops guardrail
+Owner: CTO / Ops Lead
+Scope: browser, network, Auth, API, data-loaded, and fixed-slot verification prompts
+
+## Purpose
+
+This document closes a repeated workflow gap: browser verification tasks sometimes start without an explicit fixed test slot even when the target flow requires one.
+
+The failure mode is not only executor error. It has two owners:
+
+1. The task issuer did not assign a fixed slot before asking for browser verification.
+2. The local/browser executor did not immediately classify the missing slot as a blocking prerequisite.
+
+The fix is a mandatory slot decision gate before every browser/network verification prompt.
+
+## Mandatory slot decision before prompt handoff
+
+Before assigning any browser/network verification task, the requester must write one of these decisions into the task prompt or PR comment:
+
+- `Final PASS target: PR Preview allowed`
+- `Final PASS target: fixed slot assigned: testN`
+- `Final PASS target: local-only allowed`
+- `Final PASS target: not required because docs-only`
+
+If none of those lines is present, the browser verifier must stop before opening URLs and report:
+
+```text
+Final status: BLOCKED_SLOT_DECISION_MISSING
+Reason: browser/network verification requires an explicit final PASS target decision.
+Required CTO action: assign a fixed slot, approve PR Preview as final PASS, approve local-only verification, or classify as docs-only.
+```
+
+## Automatic fixed-slot requirement
+
+A fixed slot must be assigned before final PASS when any of these are true:
+
+- Browse/Search verification depends on API or public data load.
+- The test verifies network request timing, cache write, cache reuse, or prefetch behavior.
+- The page is Auth-gated or account-bound: Editor, My Trees, Settings, Login, account flows.
+- The PR Preview or branch preview is missing, DNS-blocked, MIME-broken, redirects to login unexpectedly, or has unknown SHA provenance.
+- The verification requires stable domain behavior for Firebase/Auth/API/routing/clipboard/deep-link behavior.
+- The task asks for merge-readiness based on browser behavior.
+
+For these cases, a prompt that says only `Cloudflare Preview first` is insufficient. It must also say which fixed slot to use if preview is missing or invalid.
+
+## Requester checklist
+
+Before sending a browser verifier prompt, the requester must fill:
+
+```text
+Slot decision:
+- Final PASS target:
+- If fixed slot: testN / not applicable
+- Test URL:
+- Expected PR head SHA:
+- Deployment SHA match required: YES/NO
+- If PR Preview fails: use assigned fixed slot / stop and report / local-only partial
+```
+
+If the requester cannot assign a slot yet, do not ask for runtime PASS. Ask only for static review or URL discovery.
+
+## Executor startup gate
+
+At the start of a browser/network verification task, the executor must answer:
+
+```text
+1. Does this task require rendered browser/network behavior? YES/NO
+2. Does it involve Auth/API/data/cache/prefetch/deep-link behavior? YES/NO
+3. Is a final PASS target explicitly assigned? YES/NO
+4. If fixed slot is required, which slot was assigned?
+5. If no slot was assigned, stop with BLOCKED_SLOT_DECISION_MISSING.
+```
+
+Do not spend time trying guessed URLs when the slot decision is missing.
+
+## Valid and invalid behavior
+
+Valid:
+
+- PR Preview works and the task explicitly allows PR Preview final PASS.
+- Fixed slot is assigned and deployed SHA matches the expected PR head SHA.
+- Local-only is explicitly allowed and report says `LOCAL_ONLY`.
+- Docs-only verification proceeds from GitHub metadata without browser runtime claims.
+
+Invalid:
+
+- Trying guessed deployment hash URLs as if they are assigned targets.
+- Using `/pr/<number>` paths as final PASS URLs.
+- Searching for preview URLs for a long time when the task already requires a fixed slot.
+- Reporting `NOT_VERIFIED` after preview failure when the correct action was to request or use a fixed slot.
+- Using any fixed slot without explicit assignment.
+- Assuming `test1` by habit.
+
+## Standard blocked report
+
+Use this exact short report when no slot decision exists:
+
+```text
+Browser verification blocked before runtime execution.
+
+Final status: BLOCKED_SLOT_DECISION_MISSING
+Reason:
+- This task requires browser/network verification.
+- The task did not explicitly approve PR Preview final PASS, local-only final PASS, or a fixed slot.
+- Executor must not guess URLs or choose a fixed slot.
+
+Required CTO action:
+- Assign test1-test10, or
+- explicitly approve PR Preview final PASS, or
+- explicitly approve local-only verification, or
+- reclassify the task as docs/static-only.
+
+No code changes, commit, push, ready transition, merge, or issue close performed.
+```
+
+## Standard fixed-slot assignment block
+
+When assigning a slot, use this minimal block:
+
+```text
+Fixed slot assignment:
+- PR:
+- Branch:
+- Expected head SHA:
+- Assigned slot:
+- Test URL:
+- Deploy PR head to assigned slot: YES
+- Deployment SHA match required: YES
+- Other slots allowed: NO
+- Ready/merge/issue close allowed: NO unless separately instructed
+```
+
+## Standard browser verification prompt prefix
+
+Every browser/network verification prompt should start with:
+
+```text
+Slot decision:
+- Final PASS target: <PR Preview allowed | fixed slot assigned: testN | local-only allowed | docs-only no browser>
+- Test URL: <url or not assigned>
+- Expected head SHA: <sha>
+- If PR Preview is invalid: <use assigned fixed slot | stop with BLOCKED_SLOT_DECISION_MISSING>
+```
+
+## Relationship to existing docs
+
+This document does not replace:
+
+- `TEST_PREVIEW_SLOTS.md`
+- `LOCAL_BROWSER_VERIFICATION_STARTUP.md`
+- `BROWSER_VERIFICATION_URL_POLICY.md`
+- `AGENTS_BROWSER_VERIFICATION_ENTRYPOINT.md`
+
+It adds the missing handoff gate that prevents slot assignment from being forgotten.
+
+## Operational rule
+
+No browser/network prompt should leave the CTO handoff without an explicit final PASS target decision.
+
+No browser/network executor should proceed past startup without that decision.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -19,27 +19,28 @@
 1. [OPERATIONS.md](OPERATIONS.md) - 현재 운영 전략과 계층 정의
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
-4. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
-5. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
-6. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
-7. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-8. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-9. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
-10. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-11. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-12. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-13. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-14. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-15. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-16. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-17. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-18. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-19. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-20. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-21. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-22. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-23. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-24. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+4. [BROWSER_VERIFICATION_SLOT_GATE.md](BROWSER_VERIFICATION_SLOT_GATE.md) - 브라우저/network 검증 전 final PASS target 및 fixed slot 배정 gate
+5. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
+6. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+7. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+8. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+9. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+10. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
+11. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+12. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+13. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+14. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+15. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+16. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+17. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+18. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+19. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+20. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+21. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+22. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+23. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+24. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+25. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -63,6 +64,7 @@
 | [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) | 배포 전/후 검증 체크리스트 |
 | [RUNBOOK.md](RUNBOOK.md) | 운영 및 장애 대응 런북 |
 | [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) | 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준 |
+| [BROWSER_VERIFICATION_SLOT_GATE.md](BROWSER_VERIFICATION_SLOT_GATE.md) | browser/network 검증 요청 전 final PASS target 결정, fixed slot 배정 누락 차단, BLOCKED_SLOT_DECISION_MISSING 보고 기준 |
 | [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | agent startup checklist, fixed-slot verification, dirty worktree stop, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [AGENTS.md](AGENTS.md) | ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준 |
 | [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |


### PR DESCRIPTION
## Summary

Refs #456

Adds an ops guardrail to prevent browser/network verification prompts from starting without an explicit final PASS target or fixed slot decision.

## Scope

Changed files:
- docs/ops/BROWSER_VERIFICATION_SLOT_GATE.md
- docs/ops/ops_index.md

## Why

This addresses a repeated workflow failure:
- requester forgets to assign a fixed slot for browser/network verification;
- local/browser executor does not immediately treat the missing slot as a blocker;
- verification then wastes time on guessed or invalid preview URLs.

## Verification

PASS:
- Docs-only scope confirmed
- No runtime/code/CSS/HTML changes
- No Search/Browse implementation changes
- No Editor/My Trees/Auth/API/backend/package/workflow changes
- PR #7/prototype/reference/demo/variant untouched
- PR #450 untouched

## New operating rule

Every browser/network verification prompt must include one explicit final PASS target decision:
- PR Preview allowed;
- fixed slot assigned: testN;
- local-only allowed;
- docs-only no browser.

If missing, executor must stop with BLOCKED_SLOT_DECISION_MISSING.