### PR TITLE
refactor(editor): stabilize tree meta render boundary

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -39,6 +39,87 @@ function createEditorDetailUI(deps) {
         return icon;
     };
 
+    // ── Tree meta boundary helpers ───────────────────────────────────────────
+    // Responsible: derive visibility metadata, build count label, create share/open buttons,
+    // and render the tree meta block into the mount point. Kept separate from detail content rendering.
+    const buildTreeMetaRenderModel = ({
+        currentTree,
+        treeState,
+        data,
+        isEmptyState,
+        isRootSelected,
+        localSaveMode,
+        resolveTreeTitleText,
+        formatI18nText,
+        createShareTreeButton,
+        createOpenDetailButton,
+        bindShareButton,
+        bindOpenDetailButton,
+        createTreeMetaBlock
+    }) => {
+        const visibility = currentTree.visibility || 'public';
+        const isPublic = visibility === 'public';
+        const visIcon = isPublic ? 'public' : 'lock';
+        const visLabel = isPublic ? i18n('visibility_public') : i18n('visibility_private');
+        const visInfo = isPublic
+            ? formatI18nText('editor_tree_public_info', '이 트리 전체가 공개되어 있어요. 링크가 있는 사람은 감상할 수 있습니다.')
+            : formatI18nText('editor_tree_private_info', '이 트리 전체는 비공개예요. 지금은 나만 볼 수 있습니다.');
+        const displayTreeTitle = resolveTreeTitleText(currentTree.title);
+        const localBadgeText = localSaveMode ? (i18n('local_save_badge') || '로컬 저장') : '';
+        const countForLabel = treeState.totalMomentCount;
+        const treeCountLabel = treeState.hasMoments
+            ? formatI18nText('editor_tree_status_count', `{count}개의 순간이 이 트리 안에서 이어지고 있어요.`, { count: countForLabel })
+            : formatI18nText('editor_tree_status_empty', '아직 첫 순간을 기다리고 있어요.');
+
+        let shareBtn = null;
+        let openDetailBtn = null;
+        if (!isEmptyState && data?.id) {
+            shareBtn = createShareTreeButton();
+            openDetailBtn = createOpenDetailButton();
+        }
+
+        return {
+            displayTreeTitle,
+            visIcon,
+            visLabel,
+            visInfo,
+            isPublic,
+            countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
+            shareButtonEl: shareBtn,
+            openDetailButtonEl: openDetailBtn,
+            shareBtn,
+            openDetailBtn
+        };
+    };
+
+    const renderTreeMetaBoundary = (treeMetaMount, model, treeId, data, { i18n, showToast, bindShareButton, bindOpenDetailButton }) => {
+        if (!treeMetaMount) return;
+
+        treeMetaMount.innerHTML = '';
+        treeMetaMount.appendChild(createTreeMetaBlock({
+            displayTreeTitle: model.displayTreeTitle,
+            visIcon: model.visIcon,
+            visLabel: model.visLabel,
+            visInfo: model.visInfo,
+            isPublic: model.isPublic,
+            countLabel: model.countLabel,
+            shareButtonEl: model.shareButtonEl,
+            openDetailButtonEl: model.openDetailButtonEl
+        }));
+
+        if (model.shareBtn) {
+            bindShareButton({
+                btn: model.shareBtn,
+                data,
+                treeId,
+                i18n,
+                showToast
+            });
+        }
+        bindOpenDetailButton(model.openDetailBtn);
+    };
+    // ──────────────────────────────────────────────────────────────────────────
+
     const getTreeState = () => {
         const canonicalRootId = getCanonicalRootId();
         const treeMemories = getTreeMemories();
@@ -440,74 +521,49 @@ function createEditorDetailUI(deps) {
         }
     };
 
-    const updateDetailPanel = (data) => {
-        const currentTree = getCurrentTreeData() || {};
-        const treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
-        const visibility = currentTree.visibility || 'public';
-        const isPublic = visibility === 'public';
-        const visIcon = isPublic ? 'public' : 'lock';
-        const visLabel = isPublic ? i18n('visibility_public') : i18n('visibility_private');
-        const visInfo = isPublic
-            ? formatI18nText('editor_tree_public_info', '이 트리 전체가 공개되어 있어요. 링크가 있는 사람은 감상할 수 있습니다.')
-            : formatI18nText('editor_tree_private_info', '이 트리 전체는 비공개예요. 지금은 나만 볼 수 있습니다.');
-        const displayTreeTitle = resolveTreeTitleText(currentTree.title);
-        const treeState = getTreeState();
-        const canonicalRootId = treeState.canonicalRootId;
-        const isEmptyState = !!data?.isNewTree && !treeState.hasMoments;
-        const isRootSelected = !isEmptyState && isRootMemory(data, canonicalRootId);
-        const localSaveMode = getLocalSaveMode();
+     const updateDetailPanel = (data) => {
+         const currentTree = getCurrentTreeData() || {};
+         const treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
+         const treeState = getTreeState();
+         const canonicalRootId = treeState.canonicalRootId;
+         const isEmptyState = !!data?.isNewTree && !treeState.hasMoments;
+         const isRootSelected = !isEmptyState && isRootMemory(data, canonicalRootId);
+         const localSaveMode = getLocalSaveMode();
 
-        const headerEl = detailPanel.querySelector('h3');
-        if (headerEl) {
-            headerEl.textContent = formatI18nText('editor_current_hub_heading', '현재 순간 허브');
-        }
+         const headerEl = detailPanel.querySelector('h3');
+         if (headerEl) {
+             headerEl.textContent = formatI18nText('editor_current_hub_heading', '현재 순간 허브');
+         }
 
-        const badgeEl = document.getElementById('detailCurrentMomentBadge');
-        const titleEl = document.getElementById('detailCurrentMomentTitle');
-        const hintEl = document.getElementById('detailCurrentMomentHint');
-        const treeMetaMount = document.getElementById('detailTreeMetaMount');
-        const imgEl = detailPanel.querySelector('.detail-video img');
-        const dateEl = document.getElementById('detailDateText');
-        const tagsContainer = detailPanel.querySelector('.tags-container');
-        const noteEl = document.querySelector('.diary-note');
-        const memoryActions = detailPanel.querySelector('.memory-actions');
+         const badgeEl = document.getElementById('detailCurrentMomentBadge');
+         const titleEl = document.getElementById('detailCurrentMomentTitle');
+         const hintEl = document.getElementById('detailCurrentMomentHint');
+         const treeMetaMount = document.getElementById('detailTreeMetaMount');
+         const imgEl = detailPanel.querySelector('.detail-video img');
+         const dateEl = document.getElementById('detailDateText');
+         const tagsContainer = detailPanel.querySelector('.tags-container');
+         const noteEl = document.querySelector('.diary-note');
+         const memoryActions = detailPanel.querySelector('.memory-actions');
 
-        const localBadgeText = localSaveMode ? (i18n('local_save_badge') || '로컬 저장') : '';
-        const countForLabel = treeState.totalMomentCount;
-        const treeCountLabel = treeState.hasMoments
-            ? formatI18nText('editor_tree_status_count', `{count}개의 순간이 이 트리 안에서 이어지고 있어요.`, { count: countForLabel })
-            : formatI18nText('editor_tree_status_empty', '아직 첫 순간을 기다리고 있어요.');
+         const treeMetaModel = buildTreeMetaRenderModel({
+             currentTree: currentTree || {},
+             treeState,
+             data,
+             isEmptyState,
+             isRootSelected,
+             localSaveMode,
+             resolveTreeTitleText,
+             formatI18nText,
+             createShareTreeButton,
+             createOpenDetailButton,
+             bindShareButton,
+             bindOpenDetailButton,
+             createTreeMetaBlock
+         });
 
-        if (treeMetaMount) {
-            treeMetaMount.innerHTML = '';
-            let shareBtn = null;
-            let openDetailBtn = null;
-
-            if (!isEmptyState && data?.id) {
-                shareBtn = createShareTreeButton();
-                openDetailBtn = createOpenDetailButton();
-            }
-
-            treeMetaMount.appendChild(createTreeMetaBlock({
-                displayTreeTitle,
-                visIcon,
-                visLabel,
-                visInfo,
-                isPublic,
-                countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
-                shareButtonEl: shareBtn,
-                openDetailButtonEl: openDetailBtn
-            }));
-
-            bindShareButton({
-                btn: shareBtn,
-                data,
-                treeId,
-                i18n,
-                showToast
-            });
-            bindOpenDetailButton(openDetailBtn);
-        }
+         if (treeMetaMount) {
+             renderTreeMetaBoundary(treeMetaMount, treeMetaModel, treeId, data, { i18n, showToast, bindShareButton, bindOpenDetailButton });
+         }
 
         if (badgeEl) {
             badgeEl.textContent = isEmptyState


### PR DESCRIPTION
## Summary
- Extract tree meta rendering logic from updateDetailPanel into a dedicated boundary helper.
- BuildTreeMetaRenderModel derives visibility metadata, count label, and button eligibility.
- RenderTreeMetaBoundary mounts the block and binds share/open actions.
- Keeps existing UI/behavior intact; no change to title/memo inline edit, current memory actions, or sidebar status.

## Scope
- Primary target: js/editor/editor-detail-ui.js
- Optional helper: added as private functions within the same file (no new file created)
- No changes to pages/editor.html
- No CSS changes
- No Auth/API/backend/package/workflow changes

## Related
Refs #519

## Changed files
- js/editor/editor-detail-ui.js

## What changed
- Added buildTreeMetaRenderModel() helper to compute all tree meta display data.
- Added renderTreeMetaBoundary() helper to create DOM and bind buttons.
- updateDetailPanel now calls these helpers instead of inline tree meta logic.
- Removed dead variables: visibility, isPublic, visIcon, visLabel, visInfo, displayTreeTitle, localBadgeText, countForLabel, treeCountLabel.

## What did not change
- Title inline edit behavior unchanged.
- Memo inline edit behavior unchanged.
- Current memory card rendering unchanged.
- Sidebar status rendering unchanged.
- Tree visibility update behavior unchanged.
- Detail panel reset logic unchanged.
- No changes to any other editor module.

## Static verification
- [x] git diff --check
- [x] node --check js/editor/editor-detail-ui.js
- [ ] npm test (if available)
- [ ] npm run verify (if available)

## Browser verification
- NOT_VERIFIED — fixed test slot required but not assigned in this task.
- Requires Cloudflare Preview or assigned fixed slot before final PASS.

## Guardrails
- PR #7/prototype/reference/demo/variant untouched
- PR #450/YouTube PoC untouched
- No secrets/tokens/cookies/session/private values exposed