### PR TITLE
docs(ops): add editor detail browser smoke checklist

### DIFF
--- a/docs/ops/EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md
+++ b/docs/ops/EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md
@@ -1,0 +1,170 @@
+# Editor Detail UI Browser Smoke Checklist
+
+Issue: #521
+Related: #519, #520, #422, #223, #400
+
+This checklist defines the minimum browser smoke requirements for future editor detail UI implementation PRs. It is docs-only. It does not modify `pages/editor.html`, editor JavaScript, CSS, Auth, API, backend, workflow, package, deployment, prototype, reference, demo, or variant files.
+
+## Purpose
+
+Editor detail UI changes must not be treated as merge-ready from static review alone. Any change that affects current memory card rendering, action buttons, tree meta rendering, inline title edit, inline memo edit, save/cancel/error/hint states, or desktop/mobile editor interactions needs browser evidence.
+
+This document provides the required PASS / NOT_VERIFIED / BLOCKED separation and the fixed-slot expectations for data-loaded or Auth/API-dependent editor behavior.
+
+## Scope
+
+Use this checklist for implementation PRs that touch editor detail UI responsibilities, including:
+
+- current memory card rendering;
+- current memory action buttons;
+- tree meta render boundaries;
+- inline title edit rendering and behavior;
+- inline memo edit rendering and behavior;
+- save, cancel, error, and hint states;
+- selected-memory detail panel state;
+- no-selection or empty detail panel state;
+- desktop and mobile editor behavior.
+
+## Non-goals
+
+- No implementation in this checklist.
+- No workflow automation from this checklist alone.
+- No `js/editor.js` rewrite.
+- No `pages/editor.html` rewrite.
+- No Auth/API/backend/package/workflow changes.
+- No PR #7/prototype/reference/demo/variant changes.
+- No PR #450 changes.
+
+## Verification target policy
+
+Editor detail behavior is Auth/API/data dependent. Local static-server evidence alone is insufficient for final PASS when the scenario requires authenticated data, selected memory state, saved changes, or API-backed UI.
+
+Use one of the following target classes:
+
+| Target | Allowed use | Final PASS allowed? |
+|---|---|---|
+| Local static server | Syntax/load smoke only, no API/Auth/data claims | NO for data-loaded behavior |
+| Cloudflare PR Preview | Static/render smoke and limited runtime smoke when connected to expected backend | YES only with URL provenance and deployed SHA |
+| Fixed test slot | Auth/API/data-loaded editor verification | YES when slot assignment and deployed SHA are confirmed |
+| Production | Post-merge smoke only when explicitly assigned | YES only for post-merge verification |
+
+For fixed test slot verification, record:
+
+- assigned slot name;
+- deployed SHA;
+- browser URL;
+- account role category only;
+- whether secret/private values were exposed: `NO`;
+- PASS / NOT_VERIFIED / BLOCKED result per scenario.
+
+Do not use unassigned fixed slots. Do not treat test slot evidence as valid without deployed SHA provenance.
+
+## Minimum smoke matrix
+
+| Scenario | Required result states | Notes |
+|---|---|---|
+| Editor desktop load | PASS / BLOCKED | Confirm no fatal console errors and editor shell renders |
+| Empty or no-selection state | PASS / NOT_VERIFIED / BLOCKED | Verify where reachable without creating private data exposure |
+| Populated tree with selected memory | PASS / NOT_VERIFIED / BLOCKED | Requires Auth/API/data-capable target |
+| Current memory card visibility | PASS / NOT_VERIFIED / BLOCKED | Confirm content area remains stable; do not print private payloads |
+| Current memory action buttons | PASS / NOT_VERIFIED / BLOCKED | Verify visibility and action binding where reachable |
+| Tree meta rendering | PASS / NOT_VERIFIED / BLOCKED | Confirm title/visibility/count/share/open affordance preservation where applicable |
+| Inline title edit active state | PASS / NOT_VERIFIED / BLOCKED | Verify start/edit UI state without exposing private title values |
+| Inline title edit cancel flow | PASS / NOT_VERIFIED / BLOCKED | Confirm cancel restores previous UI state |
+| Inline title edit save flow | PASS / NOT_VERIFIED / BLOCKED | Requires Auth/API/data-capable target; record only status |
+| Inline memo edit active state | PASS / NOT_VERIFIED / BLOCKED | Verify editor UI state without exposing private memo values |
+| Inline memo edit cancel flow | PASS / NOT_VERIFIED / BLOCKED | Confirm cancel restores previous UI state |
+| Inline memo edit save flow | PASS / NOT_VERIFIED / BLOCKED | Requires Auth/API/data-capable target; record only status |
+| Error/hint rendering | PASS / NOT_VERIFIED / BLOCKED | Use reachable safe state; do not force destructive data failures |
+| Mobile 375px editor smoke | PASS / BLOCKED | Confirm no horizontal overflow and core controls remain reachable |
+| Console errors | PASS / BLOCKED | Fatal errors block final merge readiness |
+
+## Reporting rules
+
+Every future editor detail implementation PR must report:
+
+```text
+Editor detail browser smoke
+verification target: LOCAL_STATIC | PR_PREVIEW | FIXED_SLOT | PRODUCTION
+URL provenance: PRESENT | MISSING
+slot name: <slot-name> | NOT_APPLICABLE
+verified deployed SHA: <sha> | NOT_VERIFIED
+account role category: QA_USER | QA_ADMIN | NOT_APPLICABLE
+private payload exposed: NO
+secret/token/session/cookie exposed: NO
+
+scenario results:
+- desktop editor load: PASS | NOT_VERIFIED | BLOCKED
+- empty/no-selection state: PASS | NOT_VERIFIED | BLOCKED
+- populated tree selected memory: PASS | NOT_VERIFIED | BLOCKED
+- current memory card: PASS | NOT_VERIFIED | BLOCKED
+- action buttons: PASS | NOT_VERIFIED | BLOCKED
+- tree meta rendering: PASS | NOT_VERIFIED | BLOCKED
+- inline title edit active/cancel/save: PASS | NOT_VERIFIED | BLOCKED
+- inline memo edit active/cancel/save: PASS | NOT_VERIFIED | BLOCKED
+- error/hint state: PASS | NOT_VERIFIED | BLOCKED
+- mobile 375px: PASS | NOT_VERIFIED | BLOCKED
+- fatal console errors: NO | YES
+```
+
+A PR may be considered static-review clean while still browser `NOT_VERIFIED`. Do not collapse those statuses.
+
+## Evidence restrictions
+
+Allowed evidence:
+
+- URL provenance;
+- deployed SHA;
+- slot name;
+- account role category;
+- PASS / NOT_VERIFIED / BLOCKED status;
+- console fatal error presence/absence;
+- sanitized screenshots that do not expose private payloads, if separately approved.
+
+Forbidden evidence:
+
+- tree IDs;
+- owner IDs;
+- copied tree IDs;
+- raw memory, memo, title, comment, source URL, thumbnail URL, or private payload values;
+- credentials, tokens, cookies, sessions, API keys, private keys, database URLs;
+- browser storage contents;
+- request or response bodies containing private data;
+- QA account passwords or local credential file contents.
+
+## Merge-readiness interpretation
+
+Use the following interpretation:
+
+- `PASS`: Scenario was verified on an appropriate target and no blocker was found.
+- `NOT_VERIFIED`: Scenario was not checked or requires a stronger target than the one used.
+- `BLOCKED`: Scenario could not be verified because of a target, account, deployment, console, runtime, or data setup blocker.
+
+For PRs that change editor detail behavior:
+
+- Static checks alone are not enough for final merge readiness.
+- Auth/API/data-loaded editor scenarios require PR Preview with valid runtime or fixed test slot verification.
+- Mobile 375px and no fatal console errors are required before final PASS.
+- A missing slot assignment must be reported as `BLOCKED_SLOT_DECISION_MISSING`, not as PASS.
+
+## Relationship to active work
+
+This checklist does not approve or merge any implementation PR. It provides the browser verification gate for current and future editor detail UI PRs, including tree meta boundary work, current memory action work, and inline title/memo edit work.
+
+If another editor PR is active, this docs-only checklist can proceed in parallel only when it does not modify editor runtime, page, CSS, Auth, API, package, workflow, or deployment files.
+
+## Closure criteria for #521
+
+Issue #521 can be closed when:
+
+- an editor detail browser smoke checklist exists;
+- it documents current memory card, action button, tree meta, inline title, inline memo, error/hint, desktop, and mobile coverage;
+- it requires PASS / NOT_VERIFIED / BLOCKED separation;
+- it states local static evidence is insufficient for Auth/API/data-loaded final PASS;
+- it includes fixed-slot / deployed-SHA provenance requirements;
+- it prohibits secret/private payload exposure.
+
+Refs #521
+Refs #422
+Refs #223
+Refs #400

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -26,21 +26,22 @@
 8. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
 9. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
 10. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
-11. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-12. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-13. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-14. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-15. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-16. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-17. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-18. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-19. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-20. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-21. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-22. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-23. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-24. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-25. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+11. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
+12. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+13. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+14. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+15. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+16. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+17. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+18. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+19. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+20. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+21. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+22. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+23. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+24. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+25. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+26. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -71,6 +72,7 @@
 | [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |
 | [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) | 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준 |
 | [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) | Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements |
+| [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) | Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
 | [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) | Fixed slot 수동 E2E gate 런북 — slot 배정·SHA provenance·evidence 양식·page 분류·제한 사항 (Issue #136 manual gate 단계) |
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |


### PR DESCRIPTION
## Summary

Implements #521 as a docs-only browser smoke checklist for future editor detail UI implementation PRs.

## Scope

Changed files:
- `docs/ops/EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md`
- `docs/ops/ops_index.md`

## Included

- Editor detail UI smoke matrix for current memory card, action buttons, tree meta rendering, inline title edit, inline memo edit, error/hint states, desktop load, and mobile 375px.
- PASS / NOT_VERIFIED / BLOCKED status separation.
- Fixed slot, URL provenance, and deployed-SHA requirements for Auth/API/data-loaded editor behavior.
- Explicit statement that local static evidence is insufficient for final PASS on data-loaded editor scenarios.
- Secret/private payload evidence restrictions.
- #521 closure criteria.

## Guardrails

- Docs-only.
- No editor runtime JavaScript changes.
- No `pages/editor.html` changes.
- No CSS changes.
- No Auth/API/backend/package/workflow/deployment changes.
- No PR #7/prototype/reference/demo/variant changes.
- No PR #450 changes.
- No secret/token/session/cookie/private key/private payload exposure.

## Verification

PASS:
- Branch created from main merge commit `2f6c4abbedd6215c9673767fd6707090ddd5a8b1`.
- Changed files limited to docs/ops checklist and ops index.
- Production data mutation: NO.
- Runtime/API/backend implementation: NO.
- Editor runtime/page/CSS changes: NO.
- Auth/Search/My Trees changes: NO.
- Package/workflow/deployment changes: NO.
- PR #7/prototype/reference/demo/variant impact: NO.
- PR #450 impact: NO.
- Secret/private payload exposure: NO.

NOT_VERIFIED:
- Fresh GitHub PR state/checks after creation.
- Ready transition.

Refs #521
Refs #422
Refs #223
Refs #400