### PR TITLE
refactor(search): extract copy/locale helper from preview renderer

### DIFF
--- a/js/search/search-preview-copy-helper.js
+++ b/js/search/search-preview-copy-helper.js
@@ -1,0 +1,80 @@
+/**
+ * LoveBud Search Preview Copy Helper
+ * v20260501-1
+ * 
+ * Copy and locale formatting helper for search preview.
+ * Extracted from search-preview-renderer.js to separate concerns.
+ * 
+ * Dependencies: None (standalone helper)
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Get current locale from i18n or document
+     * @returns {string} 'en' or 'ko'
+     */
+    function getCurrentLocale() {
+        const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    /**
+     * Get search copy from i18n dictionary with fallbacks
+     * @param {string} key - i18n key
+     * @param {string} fallbackKo - Korean fallback
+     * @param {string} fallbackEn - English fallback
+     * @returns {string} Localized copy
+     */
+    function getSearchCopy(key, fallbackKo, fallbackEn) {
+        const locale = getCurrentLocale();
+        const dict = window.i18nSearch?.[key];
+        if (dict && typeof dict === 'object') {
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return locale === 'en' ? fallbackEn : fallbackKo;
+    }
+
+    /**
+     * Format search copy with template replacements
+     * @param {string} key - i18n key
+     * @param {Object} replacements - Template variables
+     * @param {string} fallbackKo - Korean fallback template
+     * @param {string} fallbackEn - English fallback template
+     * @returns {string} Formatted copy
+     */
+    function formatSearchCopy(key, replacements, fallbackKo, fallbackEn) {
+        const template = getSearchCopy(key, fallbackKo, fallbackEn);
+        return String(template).replace(/\{(\w+)\}/g, (_, token) => {
+            return Object.prototype.hasOwnProperty.call(replacements, token)
+                ? String(replacements[token])
+                : '';
+        });
+    }
+
+    /**
+     * Format date for locale display (minimal helper for timeline labels)
+     * @param {string|Date} value - Date value
+     * @returns {string} Formatted date
+     */
+    function formatShortDate(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', {
+            month: 'short',
+            day: 'numeric'
+        });
+    }
+
+    // Public API
+    window.LoveBudSearchPreviewCopyHelper = {
+        getCurrentLocale: getCurrentLocale,
+        getSearchCopy: getSearchCopy,
+        formatSearchCopy: formatSearchCopy,
+        formatShortDate: formatShortDate
+    };
+
+    console.log('[LoveBudSearchPreviewCopyHelper] Search preview copy helper loaded v20260501-1');
+})();

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -64,11 +64,19 @@
     }
 
     function getCurrentLocale() {
+        const helper = window.LoveBudSearchPreviewCopyHelper;
+        if (helper?.getCurrentLocale) {
+            return helper.getCurrentLocale();
+        }
         const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
         return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
     }
 
     function getSearchCopy(key, fallbackKo, fallbackEn) {
+        const helper = window.LoveBudSearchPreviewCopyHelper;
+        if (helper?.getSearchCopy) {
+            return helper.getSearchCopy(key, fallbackKo, fallbackEn);
+        }
         const locale = getCurrentLocale();
         const dict = window.i18nSearch?.[key];
         if (dict && typeof dict === 'object') {
@@ -78,6 +86,10 @@
     }
 
     function formatSearchCopy(key, replacements, fallbackKo, fallbackEn) {
+        const helper = window.LoveBudSearchPreviewCopyHelper;
+        if (helper?.formatSearchCopy) {
+            return helper.formatSearchCopy(key, replacements, fallbackKo, fallbackEn);
+        }
         const template = getSearchCopy(key, fallbackKo, fallbackEn);
         return String(template).replace(/\{(\w+)\}/g, (_, token) => {
             return Object.prototype.hasOwnProperty.call(replacements, token)
@@ -197,15 +209,21 @@
 
     function getTimelineLabel(tree, memories) {
         const titleHelper = getSearchTitleHelper();
-        const formatDate = titleHelper?.formatShortDate || ((value) => {
-            if (!value) return '';
-            const date = new Date(value);
-            if (Number.isNaN(date.getTime())) return '';
-            return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', {
-                month: 'short',
-                day: 'numeric'
-            });
-        });
+        const formatDate = titleHelper?.formatShortDate || (() => {
+            const helper = window.LoveBudSearchPreviewCopyHelper;
+            if (helper?.formatShortDate) {
+                return helper.formatShortDate;
+            }
+            return (value) => {
+                if (!value) return '';
+                const date = new Date(value);
+                if (Number.isNaN(date.getTime())) return '';
+                return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', {
+                    month: 'short',
+                    day: 'numeric'
+                });
+            };
+        })();
 
         const updatedAt = tree.updatedAt || '';
         const createdAt = tree.createdAt || '';

--- a/pages/search.html
+++ b/pages/search.html
@@ -146,7 +146,8 @@
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
     <script src="../js/search/search-card-renderer.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260428-1"></script>
+    <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>


### PR DESCRIPTION
Issue #556

Extract copy/locale formatting helper from search preview renderer.

- Add js/search/search-preview-copy-helper.js with getCurrentLocale, getSearchCopy, formatSearchCopy, formatShortDate
- Update search-preview-renderer.js to use helper with fallbacks  
- Update pages/search.html script load order to load helper before renderer
- Preserve existing public API surface and fallback behavior
- No functional changes to preview rendering behavior

Changes:
- js/search/search-preview-copy-helper.js (new)
- js/search/search-preview-renderer.js (helper delegation with fallbacks)
- pages/search.html (script load order update)