### PR TITLE
refactor(search): extract CTA/share action helper from preview renderer

### DIFF
--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -1,0 +1,139 @@
+/**
+ * LoveBud Search Preview Action Helper
+ * v20260501-1
+ * 
+ * CTA and share markup helper for search preview.
+ * Extracted from search-preview-renderer.js to separate concerns.
+ * 
+ * Dependencies: LoveBudSearchPreviewCopyHelper (for copy/locale)
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Get shared utilities from LoveBudSearchSharedUtils
+     * @returns {Object|null} Shared utils instance
+     */
+    function getSharedUtils() {
+        return window.LoveBudSearchSharedUtils || null;
+    }
+
+    /**
+     * Escape HTML for safe rendering
+     * @param {string} value - Value to escape
+     * @returns {string} Escaped HTML
+     */
+    function escapeHtml(value) {
+        const utils = getSharedUtils();
+        if (utils?.escapeHtml) {
+            return utils.escapeHtml(value);
+        }
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\\"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    /**
+     * Get base path for navigation
+     * @returns {string} Base path
+     */
+    function getBasePath() {
+        const utils = getSharedUtils();
+        if (utils?.getBasePath) {
+            return utils.getBasePath();
+        }
+        if (window.LoveBudPath?.getBasePath) {
+            return window.LoveBudPath.getBasePath();
+        }
+        const path = window.location.pathname;
+        return path.indexOf('/pages/') !== -1 ? '' : 'pages/';
+    }
+
+    /**
+     * Get search copy from copy helper with fallbacks
+     * @param {string} key - i18n key
+     * @param {string} fallbackKo - Korean fallback
+     * @param {string} fallbackEn - English fallback
+     * @returns {string} Localized copy
+     */
+    function getSearchCopy(key, fallbackKo, fallbackEn) {
+        const helper = window.LoveBudSearchPreviewCopyHelper;
+        if (helper?.getSearchCopy) {
+            return helper.getSearchCopy(key, fallbackKo, fallbackEn);
+        }
+        // Fallback to basic logic if copy helper not available
+        const locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
+        const dict = window.i18nSearch?.[key];
+        if (dict && typeof dict === 'object') {
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return String(locale).toLowerCase().startsWith('en') ? fallbackEn : fallbackKo;
+    }
+
+    /**
+     * Generate tree detail href for CTA button
+     * @param {Object} tree - Tree object
+     * @returns {string} Detail page href
+     */
+    function getTreeDetailHref(tree) {
+        const memories = Array.isArray(tree?.memories) ? tree.memories : [];
+        const firstMemory = memories[0];
+        if (!tree?.id || !firstMemory?.id) return '';
+        const basePath = getBasePath();
+        return `${basePath}detail.html?id=${encodeURIComponent(firstMemory.id)}&tree=${encodeURIComponent(tree.id)}&from=browse`;
+    }
+
+    /**
+     * Render preview action button (CTA)
+     * @param {Object} tree - Tree object
+     * @returns {string} Button HTML markup
+     */
+    function renderPreviewActionButton(tree) {
+        const href = getTreeDetailHref(tree);
+        if (!href) return '';
+        const label = getSearchCopy(
+            'search.previewOpenTreeCta',
+            '이 트리 열기',
+            'Open this tree'
+        );
+        return `
+            <a href="${escapeHtml(href)}" class="btn-round btn-primary" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
+                <span class="material-symbols-outlined" style="font-size:18px;">play_circle</span>
+                ${escapeHtml(label)}
+            </a>
+        `;
+    }
+
+    /**
+     * Render share button
+     * @param {Object} tree - Tree object
+     * @returns {string} Share button HTML markup
+     */
+    function renderShareButton(tree) {
+        if (!tree?.id) return '';
+        const label = getSearchCopy(
+            'search.previewShareLink',
+            '감상 링크 복사',
+            'Copy view link'
+        );
+        return `
+            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
+                <span class="material-symbols-outlined" style="font-size:16px;">link</span>
+                <span data-share-tree-link-label>${escapeHtml(label)}</span>
+            </button>
+        `;
+    }
+
+    // Public API
+    window.LoveBudSearchPreviewActionHelper = {
+        getTreeDetailHref: getTreeDetailHref,
+        renderPreviewActionButton: renderPreviewActionButton,
+        renderShareButton: renderShareButton
+    };
+
+    console.log('[LoveBudSearchPreviewActionHelper] Search preview action helper loaded v20260501-1');
+})();

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -115,6 +115,10 @@
     }
 
     function getTreeDetailHref(tree) {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.getTreeDetailHref) {
+            return helper.getTreeDetailHref(tree);
+        }
         const memories = Array.isArray(tree?.memories) ? tree.memories : [];
         const firstMemory = memories[0];
         if (!tree?.id || !firstMemory?.id) return '';
@@ -123,6 +127,10 @@
     }
 
     function renderPreviewActionButton(tree) {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.renderPreviewActionButton) {
+            return helper.renderPreviewActionButton(tree);
+        }
         const href = getTreeDetailHref(tree);
         if (!href) return '';
         const label = getSearchCopy(
@@ -139,6 +147,10 @@
     }
 
     function renderShareButton(tree) {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.renderShareButton) {
+            return helper.renderShareButton(tree);
+        }
         if (!tree?.id) return '';
         const label = getSearchCopy(
             'search.previewShareLink',

--- a/pages/search.html
+++ b/pages/search.html
@@ -147,6 +147,7 @@
     <script src="../js/search/search-card-renderer.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
+    <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260427-1"></script>


### PR DESCRIPTION
Issue #557

Extract CTA/share action helper from search preview renderer.

- Add js/search/search-preview-action-helper.js with getTreeDetailHref, renderPreviewActionButton, renderShareButton
- Update search-preview-renderer.js to use action helper with fallbacks  
- Update pages/search.html script load order to load helper before renderer
- Preserve existing public API surface and fallback behavior
- Compatible with copy helper from PR #575
- No functional changes to preview rendering behavior

Changes:
- js/search/search-preview-action-helper.js (new)
- js/search/search-preview-renderer.js (action helper delegation with fallbacks)
- pages/search.html (script load order update)