### PR TITLE
refactor(editor): stabilize inline memo edit boundary

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -195,6 +195,89 @@ function createEditorDetailUI(deps) {
 
         titleContainer.appendChild(editBtn);
     };
+
+    // ── Memo edit boundary helper ────────────────────────────────────────────
+    // Responsible: encapsulate inline memo edit textarea, buttons, and state binding.
+    // Does not affect title edit or current memory actions.
+    const createMemoEditBoundary = (memoContainer, data, { updateSelectedMemoryFields, showToast, formatI18nText, getMemoFallbackText, isEmptyState }) => {
+        memoContainer.innerHTML = '';
+
+        const memoBody = document.createElement('div');
+        memoBody.style.lineHeight = '1.8';
+        memoBody.style.fontSize = '0.95rem';
+        memoBody.style.color = 'var(--on-surface)';
+        memoBody.style.whiteSpace = 'pre-line';
+        memoBody.textContent = isEmptyState
+            ? getMemoFallbackText({ isEmptyState: true })
+            : (data.memo || formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요'));
+        memoContainer.appendChild(memoBody);
+
+        if (isEmptyState || typeof updateSelectedMemoryFields !== 'function') return;
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'memory-edit-button';
+        editBtn.style.marginTop = '10px';
+        editBtn.style.marginLeft = '0';
+        editBtn.innerHTML = '<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:2px;">edit</span>' + formatI18nText('editMemoryNote', '메모 수정');
+
+        editBtn.onclick = () => {
+            memoContainer.innerHTML = '';
+
+            const textarea = document.createElement('textarea');
+            textarea.className = 'memory-edit-textarea';
+            textarea.value = data.memo || '';
+
+            const hintDiv = document.createElement('div');
+            hintDiv.className = 'memory-edit-hint';
+            hintDiv.textContent = formatI18nText('noteSaveHint', 'Ctrl+Enter로 저장할 수 있어요.');
+
+            const actions = document.createElement('div');
+            actions.className = 'memory-edit-actions';
+
+            const saveBtn = document.createElement('button');
+            saveBtn.className = 'btn-save';
+            saveBtn.textContent = formatI18nText('saveMemoryNote', '메모 저장');
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.className = 'btn-cancel';
+            cancelBtn.textContent = formatI18nText('cancelMemoryNote', '취소');
+
+            actions.appendChild(cancelBtn);
+            actions.appendChild(saveBtn);
+
+            memoContainer.appendChild(textarea);
+            memoContainer.appendChild(hintDiv);
+            memoContainer.appendChild(actions);
+
+            textarea.focus();
+
+            const endEdit = () => { updateDetailPanel(data); };
+
+            const saveEdit = async () => {
+                const newMemo = textarea.value.trim();
+                saveBtn.disabled = true;
+                cancelBtn.disabled = true;
+                if (await updateSelectedMemoryFields({ memo: newMemo })) {
+                    if (showToast) showToast(formatI18nText('memoryUpdateSaved', '순간을 수정했어요.'), 'success');
+                    endEdit();
+                } else {
+                    if (showToast) showToast(formatI18nText('memoryUpdateFailed', '순간을 수정하지 못했어요.'), 'error');
+                    saveBtn.disabled = false;
+                    cancelBtn.disabled = false;
+                }
+            };
+
+            cancelBtn.onclick = endEdit;
+            saveBtn.onclick = saveEdit;
+
+            textarea.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); saveEdit(); }
+                if (e.key === 'Escape') { e.preventDefault(); endEdit(); }
+            });
+        };
+
+        memoContainer.appendChild(editBtn);
+    };
     // ──────────────────────────────────────────────────────────────────────────
 
     const getTreeState = () => {
@@ -726,69 +809,13 @@ function createEditorDetailUI(deps) {
                 : (data.memo || formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요'));
             memoContainer.appendChild(memoBody);
 
-            if (!isEmptyState && typeof updateSelectedMemoryFields === 'function') {
-                const editBtn = document.createElement('button');
-                editBtn.className = 'memory-edit-button';
-                editBtn.style.marginTop = '10px';
-                editBtn.style.marginLeft = '0';
-                editBtn.innerHTML = '<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:2px;">edit</span>' + formatI18nText('editMemoryNote', '메모 수정');
-                editBtn.onclick = () => {
-                    memoContainer.innerHTML = '';
-
-                    const textarea = document.createElement('textarea');
-                    textarea.className = 'memory-edit-textarea';
-                    textarea.value = data.memo || '';
-
-                    const hintDiv = document.createElement('div');
-                    hintDiv.className = 'memory-edit-hint';
-                    hintDiv.textContent = formatI18nText('noteSaveHint', 'Ctrl+Enter로 저장할 수 있어요.');
-
-                    const actions = document.createElement('div');
-                    actions.className = 'memory-edit-actions';
-
-                    const saveBtn = document.createElement('button');
-                    saveBtn.className = 'btn-save';
-                    saveBtn.textContent = formatI18nText('saveMemoryNote', '메모 저장');
-
-                    const cancelBtn = document.createElement('button');
-                    cancelBtn.className = 'btn-cancel';
-                    cancelBtn.textContent = formatI18nText('cancelMemoryNote', '취소');
-
-                    actions.appendChild(cancelBtn);
-                    actions.appendChild(saveBtn);
-
-                    memoContainer.appendChild(textarea);
-                    memoContainer.appendChild(hintDiv);
-                    memoContainer.appendChild(actions);
-
-                    textarea.focus();
-
-                    const endEdit = () => { updateDetailPanel(data); };
-
-                    const saveEdit = async () => {
-                        const newMemo = textarea.value.trim();
-                        saveBtn.disabled = true;
-                        cancelBtn.disabled = true;
-                        if (await updateSelectedMemoryFields({ memo: newMemo })) {
-                            if (showToast) showToast(formatI18nText('memoryUpdateSaved', '순간을 수정했어요.'), 'success');
-                            endEdit();
-                        } else {
-                            if (showToast) showToast(formatI18nText('memoryUpdateFailed', '순간을 수정하지 못했어요.'), 'error');
-                            saveBtn.disabled = false;
-                            cancelBtn.disabled = false;
-                        }
-                    };
-
-                    cancelBtn.onclick = endEdit;
-                    saveBtn.onclick = saveEdit;
-
-                    textarea.addEventListener('keydown', (e) => {
-                        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); saveEdit(); }
-                        if (e.key === 'Escape') { e.preventDefault(); endEdit(); }
-                    });
-                };
-                memoContainer.appendChild(editBtn);
-            }
+            createMemoEditBoundary(memoContainer, data, {
+                updateSelectedMemoryFields,
+                showToast,
+                formatI18nText,
+                getMemoFallbackText,
+                isEmptyState
+            });
 
             noteEl.appendChild(memoContainer);
 


### PR DESCRIPTION
## Summary
- Extract inline memo edit rendering and state binding into a dedicated boundary helper within editor-detail-ui.js.
- Added createMemoEditBoundary() to encapsulate memo edit textarea, hint, buttons, and save/cancel/error handling.
- updateDetailPanel now delegates memo edit UI to this helper, reducing inline complexity.
- Keeps existing UI/behavior intact: open/edit/save/cancel/error/hint flow unchanged.
- Title inline edit intentionally not touched in this PR (handled by PR #574).

## Scope
- Primary target: js/editor/editor-detail-ui.js
- No changes to js/editor.js
- No changes to pages/editor.html
- No CSS changes

## Related
Refs #520

## Changed files
- js/editor/editor-detail-ui.js

## What changed
- Added createMemoEditBoundary() private helper inside createEditorDetailUI.
- Inline memo edit textarea/button DOM construction moved into helper.
- Dead code removal: removed duplicated inline edit variables/logic from updateDetailPanel.
- Net change: +90/-63 lines.

## What did not change
- Inline title edit behavior completely unchanged (PR #574).
- Current memory card rendering unchanged.
- Tree meta rendering unchanged (tree meta boundary was PR #551).
- Sidebar status rendering unchanged.
- Detail panel reset logic unchanged.
- No changes to any other editor module.

## Static verification
- [x] git diff --check
- [x] node --check js/editor/editor-detail-ui.js
- [ ] npm test (if available)
- [ ] npm run verify (if available)

## Browser verification
- NOT_VERIFIED — fixed test slot required but not assigned in this task.
- Requires Cloudflare Preview or assigned fixed slot before final PASS.

## Guardrails
- PR #7/prototype/reference/demo/variant untouched
- PR #450/YouTube PoC untouched
- No secrets/tokens/cookies/session/private values exposed