### PR TITLE
refactor(modal): extract owner read helper boundary

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -42,6 +42,11 @@ from modal_compute.public_reads import (
     fetch_public_memory,
     fetch_public_tree,
 )
+from modal_compute.owner_reads import (
+    fetch_user_trees,
+    fetch_owner_tree,
+    fetch_owner_memories,
+)
 
 
 def add_request_id_to_response(response: Any, request_id: str | None = None) -> Any:
@@ -49,86 +54,6 @@ def add_request_id_to_response(response: Any, request_id: str | None = None) -> 
     if request_id and hasattr(response, 'headers'):
         response.headers["x-lovebud-request-id"] = request_id
     return response
-
-
-def fetch_user_trees(owner_id: str, limit: int = 100) -> list[dict[str, Any]]:
-    query = """
-        SELECT t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at,
-               COUNT(m.id)::int AS memory_count
-        FROM trees t
-        LEFT JOIN memories m
-          ON m.tree_id = t.id
-        WHERE t.owner_id = %s
-        GROUP BY t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at
-        ORDER BY t.created_at DESC
-        LIMIT %s;
-    """
-
-    def operation():
-        with get_db_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(query, (owner_id, limit))
-                return cur.fetchall()
-
-    rows = run_db_with_retry(operation)
-
-    return [normalize_tree_row(row, row.get("memory_count")) for row in rows]
-
-
-def fetch_owner_tree(tree_id: str, owner_id: str) -> dict[str, Any] | None:
-    query = """
-        SELECT t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at,
-               COUNT(m.id)::int AS memory_count
-        FROM trees t
-        LEFT JOIN memories m
-          ON m.tree_id = t.id
-        WHERE t.id = %s
-          AND t.owner_id = %s
-        GROUP BY t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at
-        LIMIT 1;
-    """
-
-    def operation():
-        with get_db_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(query, (tree_id, owner_id))
-                return cur.fetchone()
-
-    row = run_db_with_retry(operation)
-
-    return normalize_tree_row(row, row.get("memory_count")) if row else None
-
-
-def fetch_owner_memories(owner_id: str, tree_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
-    params: list[Any] = [owner_id]
-    filters = ["t.owner_id = %s"]
-
-    if tree_id:
-        params.append(tree_id)
-        filters.append("m.tree_id = %s")
-
-    params.append(limit)
-    query = f"""
-        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
-               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
-               m.created_at, m.updated_at
-        FROM memories m
-        INNER JOIN trees t
-          ON t.id = m.tree_id
-        WHERE {' AND '.join(filters)}
-        ORDER BY m.created_at DESC
-        LIMIT %s;
-    """
-
-    def operation():
-        with get_db_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(query, tuple(params))
-                return cur.fetchall()
-
-    rows = run_db_with_retry(operation)
-
-    return [normalize_memory_row(row) for row in rows]
 
 
 def create_owner_tree(owner_id: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/modal_compute/owner_reads.py
+++ b/modal_compute/owner_reads.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from modal_compute.db import (
+    get_db_connection,
+    run_db_with_retry,
+)
+from modal_compute.validation import (
+    normalize_memory_row,
+    normalize_tree_row,
+)
+
+
+def fetch_user_trees(owner_id: str, limit: int = 100) -> list[dict[str, Any]]:
+    query = """
+        SELECT t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at,
+               COUNT(m.id)::int AS memory_count
+        FROM trees t
+        LEFT JOIN memories m
+          ON m.tree_id = t.id
+        WHERE t.owner_id = %s
+        GROUP BY t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at
+        ORDER BY t.created_at DESC
+        LIMIT %s;
+    """
+
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (owner_id, limit))
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
+
+    return [normalize_tree_row(row, row.get("memory_count")) for row in rows]
+
+
+def fetch_owner_tree(tree_id: str, owner_id: str) -> dict[str, Any] | None:
+    query = """
+        SELECT t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at,
+               COUNT(m.id)::int AS memory_count
+        FROM trees t
+        LEFT JOIN memories m
+          ON m.tree_id = t.id
+        WHERE t.id = %s
+          AND t.owner_id = %s
+        GROUP BY t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at
+        LIMIT 1;
+    """
+
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (tree_id, owner_id))
+                return cur.fetchone()
+
+    row = run_db_with_retry(operation)
+
+    return normalize_tree_row(row, row.get("memory_count")) if row else None
+
+
+def fetch_owner_memories(owner_id: str, tree_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    params: list[Any] = [owner_id]
+    filters = ["t.owner_id = %s"]
+
+    if tree_id:
+        params.append(tree_id)
+        filters.append("m.tree_id = %s")
+
+    params.append(limit)
+    query = f"""
+        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
+               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.created_at, m.updated_at
+        FROM memories m
+        INNER JOIN trees t
+          ON t.id = m.tree_id
+        WHERE {' AND '.join(filters)}
+        ORDER BY m.created_at DESC
+        LIMIT %s;
+    """
+
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, tuple(params))
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
+
+    return [normalize_memory_row(row) for row in rows]

--- a/tests/contracts/modal-owner-read-route-contract.test.js
+++ b/tests/contracts/modal-owner-read-route-contract.test.js
@@ -5,9 +5,14 @@ const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const MODAL_APP = path.join(ROOT, 'modal_compute', 'app.py');
+const OWNER_READS = path.join(ROOT, 'modal_compute', 'owner_reads.py');
 
 function readModalApp() {
   return fs.readFileSync(MODAL_APP, 'utf8');
+}
+
+function readOwnerReads() {
+  return fs.readFileSync(OWNER_READS, 'utf8');
 }
 
 function compact(value) {
@@ -45,7 +50,7 @@ function assertAppearsInOrder(body, tokens, label) {
 }
 
 test('fetch_user_trees keeps owner boundary, limit, parameter order, and normalization', () => {
-  const body = getTopLevelFunction(readModalApp(), 'fetch_user_trees');
+  const body = getTopLevelFunction(readOwnerReads(), 'fetch_user_trees');
   const normalized = compact(body);
 
   assert.match(normalized, /wheret\.owner_id=%s/, 'fetch_user_trees must constrain trees.owner_id');
@@ -59,7 +64,7 @@ test('fetch_user_trees keeps owner boundary, limit, parameter order, and normali
 });
 
 test('fetch_owner_tree keeps tree and owner boundary, limit, parameter order, and missing-row path', () => {
-  const body = getTopLevelFunction(readModalApp(), 'fetch_owner_tree');
+  const body = getTopLevelFunction(readOwnerReads(), 'fetch_owner_tree');
   const normalized = compact(body);
 
   assert.match(normalized, /wheret\.id=%sandt\.owner_id=%s/, 'fetch_owner_tree must constrain tree id and owner id');
@@ -69,7 +74,7 @@ test('fetch_owner_tree keeps tree and owner boundary, limit, parameter order, an
 });
 
 test('fetch_owner_memories keeps owner boundary, optional tree filter, limit, parameter order, and normalization', () => {
-  const body = getTopLevelFunction(readModalApp(), 'fetch_owner_memories');
+  const body = getTopLevelFunction(readOwnerReads(), 'fetch_owner_memories');
   const normalized = compact(body);
 
   assert.match(normalized, /innerjointreestont\.id=m\.tree_id/, 'fetch_owner_memories must join memories to trees');


### PR DESCRIPTION
Refs #553

Depends-on/completed: #552

## Changed files
- `modal_compute/app.py`
- `modal_compute/owner_reads.py`
- `tests/contracts/modal-owner-read-route-contract.test.js`

## Behavior-preserving statement
- Extracts owner-read helper implementations into `modal_compute/owner_reads.py` while keeping route decorators and route handlers in `modal_compute/app.py`.
- Existing helper names remain imported into `app.py`, preserving route/write call sites and response/error behavior.
- No DB/auth/validation logic, owner boundary SQL, limit handling, response shape, not-found behavior, or limit/clamping behavior is intentionally changed.

## Guardrails
- Owner-write helper extraction: no
- Public-read behavior changes: no
- Route decorators moved: no
- Route handlers moved out of `app.py`: no
- DB/auth/validation behavior changes: no
- Response shape/error behavior changes: no
- Cloudflare Functions changes: no
- Frontend JS/CSS/HTML/page changes: no
- Package/workflow/deployment changes: no
- PR #7/prototype/reference/demo/variant impact: no
- PR #450 impact: no
- Secret/private data exposure: no

## Verification
- `git diff --check`: PASS
- `python3 -m py_compile modal_compute/app.py modal_compute/owner_reads.py`: PASS
- `python3 -c ... import modal_compute.owner_reads`: PASS
- `python3 -c ... import modal_compute.app`: PASS
- Modal startup/import smoke: PASS; app object present, no runtime deployment executed
- `node --check tests/contracts/modal-owner-read-route-contract.test.js`: PASS
- `node --test tests/contracts/modal-owner-read-route-contract.test.js`: PASS, 6/6
- `node --test tests/contracts/modal-private-ownership-policy.test.js tests/contracts/modal-owner-write-route-contract.test.js`: PASS
- `node --test tests/contracts/modal-public-read-routes-contract.test.js tests/contracts/modal-public-read-retry-policy.test.js tests/contracts/modal-public-memory-parent-visibility.test.js`: PASS
- `npm test`: PASS, 182/182
- GitHub CI: PASS / success
- Cloudflare Pages Preview: PASS / success

## Runtime import smoke environment
- Environment: Windows 11 / PowerShell 5.1
- Python: 3.11.0
- Head SHA verified: `0bc196ae19ba2fcf34bc0453b345d6df905cc62d`
- Changed files verified: YES

## Final status
- Runtime import smoke: PASS
- Draft PR is ready for CTO ready/merge approval.
