### PR TITLE
ui(search): align Browse controls with result flow

### DIFF
--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -73,6 +73,6 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    margin-top: 18px;
+    margin: 0 0 22px;
     min-width: 0;
 }

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260501-455c">
+    <link rel="stylesheet" href="../css/search.css?v=20260502-596597">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -23,6 +23,20 @@
                 <div class="search-panel-header">
                     <h2 class="headline" data-i18n="search.title">러브트리 감상 둘러보기</h2>
                     <p data-i18n="search.subtitle">첫 순간과 이어진 마음을 따라가 보세요</p>
+                </div>
+            </div>
+
+            <div class="browse-utility-row reveal-up">
+                <div class="search-input-wrapper">
+                    <span class="material-symbols-outlined search-icon">search</span>
+                    <input type="text" id="searchInput" class="search-input" placeholder="아티스트, 첫 순간, 감정으로 찾아보기" required>
+                </div>
+
+                <div class="filter-row" aria-label="감상 보조 필터">
+                    <span class="tag-chip active" data-category="전체">전체</span>
+                    <span class="tag-chip" data-category="입덕">첫 순간</span>
+                    <span class="tag-chip" data-category="성장">이어진 마음</span>
+                    <span class="tag-chip" data-category="최애">깊어진 마음</span>
                 </div>
             </div>
 
@@ -59,34 +73,6 @@
                             <div class="tree-meta-right"><span class="search-skeleton-line search-skeleton-count"></span></div>
                         </div>
                     </div>
-                </div>
-            </div>
-
-            <!-- 새로 자라는 러브트리 섹션 -->
-            <section id="growingTreesSection" class="growing-trees-section" hidden>
-                <div class="growing-trees-head">
-                    <div>
-                        <h3 data-i18n="search.growingTreesTitle">새로 자라는 러브트리</h3>
-                        <p data-i18n="search.growingTreesSubtitle">막 자라기 시작한 마음들</p>
-                    </div>
-                    <span class="growing-trees-badge" data-i18n="search.growingTreesBadge">자라는 중</span>
-                </div>
-                <div id="growingTreesList">
-                    <!-- Populated by JS -->
-                </div>
-            </section>
-
-            <div class="browse-utility-row reveal-up">
-                <div class="search-input-wrapper">
-                    <span class="material-symbols-outlined search-icon">search</span>
-                    <input type="text" id="searchInput" class="search-input" placeholder="아티스트, 첫 순간, 감정으로 찾아보기" required>
-                </div>
-
-                <div class="filter-row" aria-label="감상 보조 필터">
-                    <span class="tag-chip active" data-category="전체">전체</span>
-                    <span class="tag-chip" data-category="입덕">첫 순간</span>
-                    <span class="tag-chip" data-category="성장">이어진 마음</span>
-                    <span class="tag-chip" data-category="최애">깊어진 마음</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Refs #596
Refs #597

## Why this PR exists

This PR is the first Browse/Search follow-up from the current screenshot review. The visible problem is not only that a label or a control sits in an inconvenient place. The larger product problem is that Browse currently reads like several separate page fragments instead of one coherent public LoveTree discovery surface.

The user intent behind the earlier first-batch Browse work was performance-oriented: show a small first set of public LoveTrees quickly, then allow the feed to continue. That first batch is not supposed to become a separate product category. In the current page, however, the `새로 자라는 러브트리` block makes the internal loading concept look like a second Browse section. A user can reasonably read the page as if the first cards and the `새로 자라는` cards are different kinds of content. That is not the intended model.

The search and filter row also appears after the visible card content. Because it sits below the main results and near the `새로 자라는 러브트리` area, it can read as a control for only the lower section instead of a control for the whole Browse result list. Search and filters are not content; they shape the result set. They should be seen before the user scans the result cards.

This PR therefore makes the Browse page read as one result flow: title and subtitle first, search/filter controls second, then the Browse result heading and cards generated by the existing renderer.

## What changed

The static Search page structure now places the `browse-utility-row` directly under the Browse title/subtitle and before `#resultsList`. This means the search input and category chips are visible before the first result cards, which makes their scope clearer. The controls still use the existing IDs/classes and remain bound by the existing Search controls module; this PR does not change the search algorithm, category behavior, URL-state behavior, API calls, card renderer, selected preview, or card click behavior.

The static `growingTreesSection` block was removed from `pages/search.html`. This removes the visible `새로 자라는 러브트리` product-facing section label from Browse. The intention is not to remove incremental loading or to undo first-batch loading work. The intention is to stop exposing a loading/performance concept as if it were a separate content taxonomy.

The Search stylesheet cache key in `pages/search.html` was bumped so the adjusted control spacing is picked up by the deployed page.

`css/search/controls.css` now treats the utility row as an above-results control row. Its margin now creates space below the controls before the result heading/cards rather than pushing the controls down after the card list.

## What this PR deliberately does not change

This PR does not redesign Browse cards. It does not solve the thumbnail/card identity issue, the card text hierarchy issue, the selected hub layout issue, the copy-to-my-tree action issue, or the `이 트리 열기` target issue. Those are tracked separately and should remain separate PRs.

This PR does not change Browse API behavior, database queries, Auth behavior, backend behavior, package dependencies, workflows, PR #7, prototype/reference/demo/variant assets, or PR #450.

This PR does not remove incremental loading. The current JavaScript still owns result loading, sort controls, load-more behavior, selected preview behavior, and data fetching. If the existing runtime still calls the growing-trees data path, that is intentionally not used as a user-facing section in this PR. A later PR can remove dead or redundant data loading only after confirming that no runtime path depends on it.

This PR also does not change the `최신순 / 인기순 / 더 보기` generated controls. Their behavior and hierarchy are already tracked by separate issues, including #606, #607, and #608.

## Changed files

- `pages/search.html`
  - Moves search/filter controls above the results list.
  - Removes the visible `growingTreesSection` markup and its misleading heading/subtitle/badge.
  - Bumps the Search CSS cache key.

- `css/search/controls.css`
  - Adjusts the utility-row spacing so the controls behave like an above-results control row.

## Expected user-facing result

On desktop, Browse should now read in this order: the page title and subtitle explain that this is a LoveTree viewing surface, the search input and filter chips appear as controls for the full result list, and then the result heading/cards appear as the content being controlled. The user should no longer see `새로 자라는 러브트리` as a second content section caused by implementation details.

On mobile, the search input and filter chips should remain usable before the card list. The user should not need to scroll past cards before discovering that filtering/search exists.

## Verification

- GitHub CI: PASS / success
- Cloudflare Pages fixed slot deploy: PASS
- Fixed test slot: `test4`
- Fixed test slot URL: `https://test4.lovebud.pages.dev`
- Deployed SHA: `e39581d`
- PR head SHA: `e39581df250d8af660a9fe5278d92c5ccb2626e1`
- SHA match: YES
- Login required: NO; Browse/Search public access
- Desktop Browse smoke: PASS
- Mobile 375px Browse smoke: PASS
- Search input: PRESENT
- Filter chips: PRESENT
- Latest/Popular controls: PRESENT
- Utility row before results: PASS
- Results list/cards: PRESENT
- Selected hub: PRESENT
- Load-more: PRESENT
- Visual/layout issues: NONE
- Console critical errors: NONE
- Screenshots captured: YES

## Guardrails

- Issue close keyword: NO.
- Code modified during verification: NO.
- Commit/push during verification: NO.
- Ready state changed during verification: NO.
- Merge performed during verification: NO.
- Issue closed during verification: NO.
- PR #7/prototype/reference/demo/variant: not touched.
- PR #450: not touched.
- Editor/#520: not touched.
- Auth/API/backend/database/package/workflow: not touched.
- Secrets exposed: NO.

## Final verification status

`PR619_BROWSER_FIXED_SLOT_PASS`

Ready for CTO ready/merge approval after draft removal.
