### PR TITLE
style(search): remove thumbnail pseudo-button overlay

### DIFF
--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -247,21 +247,6 @@
 }
 
 /* Issue #455 PR B: representative media and fallback tree preview polish. */
-.tree-card-media::before {
-    content: '';
-    position: absolute;
-    right: 14px;
-    bottom: 14px;
-    width: 54px;
-    height: 38px;
-    border-radius: 19px;
-    background: rgba(255, 255, 255, 0.78);
-    border: 1px solid rgba(255, 255, 255, 0.64);
-    box-shadow: 0 12px 24px rgba(50, 38, 35, 0.16);
-    pointer-events: none;
-    z-index: 2;
-}
-
 .tree-card-media-fallback {
     justify-content: flex-end;
     overflow: hidden;


### PR DESCRIPTION
Refs #593

## Why this PR exists

This PR addresses a narrow visual ambiguity in Browse cards with representative thumbnails. The current thumbnail area draws a white rounded pseudo-element in the lower-right corner of media-backed cards. It looks like a small floating button because it has its own white surface, rounded shape, border, and shadow. However, it is not an actual control and it has no independent action.

The user-facing problem is that the Browse card already behaves as the clickable/selectable surface. A button-like shape inside that card implies a second target, such as play, open, select, or preview. Because the overlay is decorative and non-interactive, it creates an avoidable interaction ambiguity. The safest correction is to remove the fake-looking overlay rather than give it more styling or invent an explanation for it.

This PR is intentionally narrow. It does not try to solve the larger product design question of how Browse cards should balance representative thumbnails with LoveTree structure. That broader card-identity decision remains separate. This PR only removes the non-interactive mark that currently reads like a control.

## What changed

`css/search/tree-card.css` no longer defines the late `.tree-card-media::before` rule that created the white rounded overlay on image-backed thumbnail cards. The existing image gradient overlay remains in `.tree-card-media::after`, so media readability and card surface treatment are preserved.

Fallback cards are not redesigned. Their tree-like fallback illustration rules remain in place. The card body, title, subtitle, metadata row, active state, hover state, and card dimensions remain unchanged.

## What this PR deliberately does not change

This PR does not redesign Browse cards. It does not add a new tree signature, minimap, chip, thumbnail treatment, or CTA. It does not change selected hub behavior, search/filter placement, incremental loading, sort behavior, API calls, card rendering logic, or card selection logic.

This PR does not touch `pages/search.html`, Search JavaScript, backend/API/Auth/database/package/workflow files, PR #7, prototype/reference/demo/variant assets, PR #450, or Editor/#520.

## Changed files

- `css/search/tree-card.css`
  - Removes the non-interactive white pseudo-button overlay from `.tree-card-media::before`.
  - Leaves the normal media gradient overlay and fallback tree preview styling intact.

## Expected user-facing result

Media-backed Browse cards should look cleaner and less misleading. Users should no longer see a small white control-like object in the thumbnail corner that appears clickable but does nothing. The card itself remains the interaction surface.

The result should make the Browse grid feel more deliberate while avoiding a larger redesign. Any future LoveTree identity cue for thumbnails should be handled in a separate design PR after the team chooses a card visual strategy.

## Verification

- GitHub CI: PASS / success
- Cloudflare Pages fixed slot deploy: PASS
- Fixed test slot: `test5`
- Fixed test slot URL: `https://test5.lovebud.pages.dev`
- Deployed SHA: `96c39fc85d86fb301a4d939235dd9a8246bfa30b`
- PR head SHA: `96c39fc85d86fb301a4d939235dd9a8246bfa30b`
- SHA match: YES
- Login required: NO; Browse/Search public access

### Desktop verification

- Thumbnail pseudo-button overlay removed: PASS
  - `getComputedStyle(..., '::before').content` returned `none`.
- Image-backed cards balanced: PASS
- Gradient overlay acceptable: PASS
- Fallback cards normal: PASS

### Mobile 375px verification

- Thumbnail pseudo-button overlay removed: PASS
- Layout/clipping: PASS
- Horizontal overflow: NONE

### Browse behavior verification

- Result cards: PRESENT
- Selected hub update after card click: PASS
- Search/filter controls: PRESENT
- Latest/Popular controls: PRESENT
- Load-more: PRESENT
- Console critical errors: NONE; non-fatal external thumbnail 404s observed
- Screenshots captured: YES

## Guardrails

- Issue close keyword: NO.
- Code modified during verification: NO.
- Commit/push during verification: NO.
- Ready state changed during verification: NO.
- Merge performed during verification: NO.
- Issue closed during verification: NO.
- PR #7/prototype/reference/demo/variant: not touched.
- PR #450: not touched.
- Editor/#520: not touched.
- Auth/API/backend/database/package/workflow: not touched.
- Secrets exposed: NO.

## Final verification status

`PR620_BROWSER_FIXED_SLOT_PASS`

Ready for CTO ready/merge approval after draft removal.
