### PR TITLE
copy(intro): differentiate hero from Home

### DIFF
--- a/js/i18n/i18n-intro.js
+++ b/js/i18n/i18n-intro.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Intro Dictionary
- * v20260423-2
+ * v20260502-587
  *
  * 소개 페이지(intro.html) 번역 키
  */
@@ -11,16 +11,16 @@
   window.i18nIntro = {
     // Hero 섹션
     'intro.heroEyebrow': {
-      ko: '팬 감정 러브트리 · 처음 마음이 이어지는 곳',
-      en: 'Fan feeling LoveTree · where the first feeling connects'
+      ko: '러브트리가 무엇인지 처음 이해하는 곳',
+      en: 'Where LoveTree first becomes clear'
     },
     'intro.heroTitle': {
-      ko: '<span class="title-line">첫 순간이 하나의</span><span class="title-line title-accent">러브트리로</span><span class="title-line">이어져요</span>',
-      en: '<span class="title-line">Your first moment</span><span class="title-line title-accent">becomes one LoveTree</span><span class="title-line">and keeps growing</span>'
+      ko: '<span class="title-line">좋아하게 된 흐름을</span><span class="title-line title-accent">하나의 트리로</span><span class="title-line">읽어보세요</span>',
+      en: '<span class="title-line">Read the path</span><span class="title-line title-accent">of what you love</span><span class="title-line">as one tree</span>'
     },
     'intro.heroLead': {
-      ko: '반했던 장면과 오래 남은 마음을,<br class="pc-only">감정이 이어진 경로로 천천히 남겨 보세요.',
-      en: 'Keep the scene that drew you in and the feelings that stayed,<br class="pc-only">as a path of connected emotion.'
+      ko: '러브트리는 첫 장면, 마음 메모, 다시 보고 싶은 순간을<br class="pc-only">하나의 감정 경로로 묶어 보여주는 공간입니다.',
+      en: 'LoveTree connects the first scene, heart notes, and moments worth revisiting<br class="pc-only">into one emotional path.'
     },
     'intro.heroPrimaryCta': {
       ko: '내 러브트리 시작하기',


### PR DESCRIPTION
Refs #587

## Why this PR exists

This PR updates the Intro hero copy so Intro has a clearer job than Home.

Home can remain the broad entry point. Intro should explain what LoveTree is: a way to connect the first scene, heart notes, and revisitable moments into one emotional path. The current Intro hero language is too close to the general landing promise, so the page does not immediately explain why it exists as a separate page.

This PR keeps the change copy-only and gives Intro a more explanatory product role.

## What changed

`js/i18n/i18n-intro.js` updates the Intro hero eyebrow, headline, and lead copy in Korean and English.

The new Korean copy frames Intro as the place where LoveTree becomes understandable. The new English copy mirrors the same meaning so both languages present the same product role.

## What this PR deliberately does not change

This PR does not change Intro layout, tree visual composition, CTA structure, animation, CSS, Home copy, Browse/Search, My Trees, backend/API behavior, package files, workflows, PR #7, prototype/reference/demo/variant assets, PR #450, or Editor/#520.

## Changed files

- `js/i18n/i18n-intro.js`
  - Updates Intro hero copy only.

## Expected user-facing result

Intro should read less like a duplicate landing hero and more like an explanation of the LoveTree concept. Users should understand that LoveTree connects saved scenes and notes into one emotional path.

## Verification required before ready/merge

The verifier must check:

- Korean Intro hero copy renders correctly.
- English Intro hero copy renders correctly if language switching is checked.
- Desktop and mobile line breaks remain acceptable.
- CTAs still work as before.
- No fatal console errors.
- No horizontal overflow.

## Current verification status

NOT_VERIFIED in browser/runtime. Keep this PR draft until Intro screenshots are reviewed.

## Guardrails

- PR #7/prototype/reference/demo/variant: not touched.
- PR #450: not touched.
- Editor/#520: not touched.