### PR TITLE
docs(engineering): define Browse loading runtime evidence

### DIFF
--- a/docs/engineering/BROWSE_LOADING_RUNTIME_EVIDENCE.md
+++ b/docs/engineering/BROWSE_LOADING_RUNTIME_EVIDENCE.md
@@ -1,0 +1,18 @@
+# Browse loading runtime evidence
+
+This document defines the evidence required before Browse loading or prefetch changes are considered ready.
+
+Browse is a data-loaded public surface. Loading work should be verified in the rendered page, not only by code review. A verifier should confirm the initial skeleton, first card batch, search and filter behavior, sort and continuation behavior, selected preview hydration, mobile behavior, console status, and absence of horizontal overflow.
+
+Reports should use safe status labels and should not print private runtime values.
+
+This document does not implement loading behavior or authorize unrelated runtime, package, workflow, prototype, reference, demo, variant, PR #450, My Trees, Intro, or Editor changes.
+
+## Issue relationship
+
+Refs #595
+Refs #596
+Refs #597
+Refs #599
+Refs #606
+Refs #607


### PR DESCRIPTION
Refs #595

## Summary
- Adds the Browse loading runtime evidence document.
- Records the evidence expectations for Browse loading follow-up work.

## Changed files
- `docs/engineering/BROWSE_LOADING_RUNTIME_EVIDENCE.md`

## Scope
- Docs-only engineering evidence map.
- No runtime behavior changes.

## Out of scope
- Browse loading implementation.
- Browse CSS or JavaScript changes.
- API/backend/Auth changes.
- Package or workflow changes.
- PR #7 or prototype/reference/demo/variant paths.

## Verification
- Changed files reviewed: docs-only, 1 file.
- GitHub CI: SUCCESS on head `3c3b5eb89e403b6423386041149854bb21599941`.
- Browser verification: NOT_REQUIRED for docs-only content.

## Current status
- Draft remains enabled.
- This PR should not close implementation or verification issues.
- No ready transition or merge performed.

## Guardrails
- Issue close keyword: NO.
- PR #7/prototype/reference/demo/variant: not touched.
- Runtime/Auth/API/backend/package/workflow: not touched.