### PR TITLE
docs(design): define Browse hub icon noise cleanup

### DIFF
--- a/docs/design/BROWSE_HUB_ICON_NOISE_CLEANUP.md
+++ b/docs/design/BROWSE_HUB_ICON_NOISE_CLEANUP.md
@@ -1,0 +1,10 @@
+# Browse hub icon noise cleanup
+
+## Issue relationship
+
+Refs #600
+Refs #594
+Refs #599
+Refs #601
+Refs #602
+Refs #603


### PR DESCRIPTION
Refs #600

## Summary
- Adds the Browse hub icon-noise cleanup scope document.
- Defines the design scope for reducing decorative/icon noise in the Browse selected hub.

## Changed files
- `docs/design/BROWSE_HUB_ICON_NOISE_CLEANUP.md`

## Scope
- Docs-only design scope.
- No runtime behavior changes.

## Out of scope
- Browse hub implementation.
- Browse CSS or JavaScript changes.
- Selected hub renderer changes.
- API/backend/Auth changes.
- Package or workflow changes.
- PR #7 or prototype/reference/demo/variant paths.

## Verification
- Changed files reviewed: docs-only, 1 file.
- GitHub CI: SUCCESS on head `c6dac0ac330d70147e8db5e897c869821940d620`.
- Browser verification: NOT_REQUIRED for docs-only content.

## Current status
- Draft remains enabled.
- This PR should not close implementation issues.
- No ready transition or merge performed.

## Guardrails
- Issue close keyword: NO.
- PR #7/prototype/reference/demo/variant: not touched.
- Runtime/Auth/API/backend/package/workflow: not touched.