### PR TITLE
docs(design): define Browse sort controls UI

### DIFF
--- a/docs/design/BROWSE_SORT_CONTROLS_UI.md
+++ b/docs/design/BROWSE_SORT_CONTROLS_UI.md
@@ -1,0 +1,74 @@
+# Browse sort controls UI
+
+## Purpose
+
+This document defines the UI and verification frame for Browse sort and result controls.
+
+Browse controls are split across search, category filters, sort chips, result count messaging, and load-more behavior. Issues #606 and #607 concern the visible control model around latest/popular/load-more behavior. Issue #608 separately defines the product semantics of popularity. This document focuses on control presentation and verification.
+
+## Product problem
+
+Browse controls should help users understand how the result set is shaped. If search, category filters, sort options, result count, and load-more controls appear as unrelated chips, users cannot easily tell what changes the data set and what simply continues the current list.
+
+Sort controls should feel like result controls, not category filters. Load-more should feel like continuation, not another sort mode. Result count or result-range messaging should not compete with the actual card grid.
+
+## Relationship to sort semantics
+
+This document does not decide what `popular` means. That decision belongs to the Browse sort semantics document. However, once semantics are confirmed, the UI should present sort controls truthfully and clearly.
+
+If `popular` is not verified, the UI should not over-emphasize it. If `popular` is verified, it should be visually grouped with `latest` as a sort option, not mixed into category chips.
+
+## Recommended UI direction
+
+A future implementation PR should:
+
+- visually group latest/popular controls as sort options;
+- keep load-more visually distinct from sort options;
+- keep search and category filters near the result list they control;
+- avoid making all controls look identical if they perform different roles;
+- make the active sort state clear;
+- keep disabled or unavailable states obvious;
+- preserve URL state behavior if currently supported;
+- preserve keyboard and click behavior.
+
+## Verification checklist
+
+A future implementation PR should verify:
+
+- latest sort active state;
+- popular sort active state if still visible;
+- load-more state before and after click;
+- disabled/no-more state;
+- search interaction with current sort;
+- category filter interaction with current sort;
+- URL state after sort changes;
+- desktop layout readability;
+- mobile 375px layout readability;
+- no horizontal overflow;
+- no card selection regression;
+- no selected hub regression.
+
+## What to avoid
+
+A future PR should avoid:
+
+- mixing popularity semantics with UI-only control polish;
+- changing API sort behavior unless explicitly scoped;
+- changing card rendering while changing control grouping;
+- making load-more look like a category chip;
+- hiding sort state from the user;
+- introducing a control whose target behavior is unverified.
+
+## Non-goals
+
+This document does not implement control UI, API behavior, sort semantics, card rendering, selected hub rendering, Auth behavior, backend behavior, package changes, workflow changes, PR #7 changes, prototype/reference/demo/variant changes, PR #450 changes, My Trees changes, Intro changes, or Editor/#520 changes.
+
+## Issue relationship
+
+This document supports Browse sort/control UI work.
+
+Closes #606
+Closes #607
+Refs #608
+Refs #596
+Refs #597


### PR DESCRIPTION
Refs #606
Refs #607
Refs #608
Refs #596
Refs #597

## Summary
- Adds the Browse sort controls UI document.
- Defines Browse sort-control hierarchy and review boundaries before implementation work.

## Changed files
- `docs/design/BROWSE_SORT_CONTROLS_UI.md`

## Scope
- Docs-only design guidance.
- No Browse runtime behavior changes.

## Out of scope
- Browse CSS changes.
- Browse JavaScript changes.
- Sort behavior changes.
- API behavior changes.
- Card rendering or selected hub rendering changes.
- Auth/backend changes.
- Package or workflow changes.
- PR #7 or prototype/reference/demo/variant paths.
- PR #450, My Trees, Intro, or Editor changes.

## Verification
- Changed files reviewed: docs-only, 1 file.
- GitHub CI: SUCCESS on head `0eb36e21ed384709513aa236cf45475cf369cb1e`.
- Browser verification: NOT_REQUIRED for docs-only content.

## Current status
- Draft remains enabled.
- This PR should not close sort or continuation implementation issues.
- No ready transition or merge performed.

## Guardrails
- Issue close keyword: NO.
- PR #7/prototype/reference/demo/variant: not touched.
- Runtime/Auth/API/backend/package/workflow: not touched.