### PR TITLE
refactor(editor): extract detail tree meta boundary

### DIFF
--- a/js/editor/editor-detail-tree-meta.js
+++ b/js/editor/editor-detail-tree-meta.js
@@ -1,0 +1,278 @@
+(function () {
+    function createEditorDetailTreeMetaBoundary(deps) {
+        const {
+            i18n,
+            formatI18nText,
+            resolveTreeTitleText,
+            createInlineIcon,
+            showToast,
+            openCurrentMomentDetail
+        } = deps;
+
+        const createPillButton = ({ label, icon, tone = 'soft' }) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.style.display = 'inline-flex';
+            btn.style.alignItems = 'center';
+            btn.style.justifyContent = 'center';
+            btn.style.gap = '6px';
+            btn.style.minHeight = '38px';
+            btn.style.padding = tone === 'primary' ? '10px 15px' : '9px 13px';
+            btn.style.borderRadius = '999px';
+            btn.style.fontSize = '12px';
+            btn.style.fontWeight = '800';
+            btn.style.cursor = 'pointer';
+            btn.style.transition = 'transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease';
+            btn.style.border = '1px solid rgba(144,73,81,0.10)';
+            btn.style.boxShadow = tone === 'primary'
+                ? '0 10px 22px rgba(144, 73, 81, 0.18)'
+                : '0 6px 16px rgba(75, 64, 57, 0.06)';
+            btn.style.background = tone === 'primary'
+                ? 'linear-gradient(180deg, rgba(144,73,81,0.98), rgba(144,73,81,0.90))'
+                : 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(247,242,239,0.96))';
+            btn.style.color = tone === 'primary'
+                ? '#fff'
+                : tone === 'ghost'
+                    ? 'var(--on-surface-variant)'
+                    : 'var(--primary)';
+
+            if (tone === 'ghost') {
+                btn.style.background = 'rgba(255,255,255,0.72)';
+                btn.style.borderColor = 'rgba(144,73,81,0.08)';
+            }
+
+            if (icon) btn.appendChild(createInlineIcon(icon, '14px'));
+            btn.appendChild(document.createTextNode(label));
+
+            btn.addEventListener('mouseenter', () => {
+                btn.style.transform = 'translateY(-1px)';
+            });
+            btn.addEventListener('mouseleave', () => {
+                btn.style.transform = 'translateY(0)';
+            });
+
+            return btn;
+        };
+
+        const createShareTreeButton = () => createPillButton({
+            label: formatI18nText('share_link', '링크 복사'),
+            icon: 'content_copy',
+            tone: 'soft'
+        });
+
+        const createOpenDetailButton = () => createPillButton({
+            label: formatI18nText('editor_open_detail', '상세로 보기'),
+            icon: 'open_in_new',
+            tone: 'ghost'
+        });
+
+        const bindShareButton = ({ btn, data, treeId }) => {
+            if (!btn || !data?.id) return;
+            if (btn.dataset.shareBound === '1') return;
+            btn.dataset.shareBound = '1';
+
+            const basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+
+            btn.addEventListener('click', () => {
+                const shareUrl = window.location.origin + '/' + basePath + 'detail.html?id=' + data.id + '&tree=' + treeId;
+                navigator.clipboard?.writeText(shareUrl).then(() => {
+                    showToast(i18n('copied_link') || '링크가 복사되었습니다', 'success');
+                }).catch(() => {
+                    showToast(i18n('copy_link_failed') || '링크 복사에 실패했습니다', 'error');
+                });
+            });
+        };
+
+        const bindOpenDetailButton = (btn) => {
+            if (!btn || typeof openCurrentMomentDetail !== 'function') return;
+            if (btn.dataset.openDetailBound === '1') return;
+            btn.dataset.openDetailBound = '1';
+            btn.addEventListener('click', () => {
+                openCurrentMomentDetail();
+            });
+        };
+
+        const createTreeMetaBlock = ({
+            displayTreeTitle,
+            visIcon,
+            visLabel,
+            visInfo,
+            isPublic,
+            countLabel,
+            shareButtonEl = null,
+            openDetailButtonEl = null
+        }) => {
+            const wrap = document.createElement('div');
+            wrap.style.padding = '20px 20px 18px';
+            wrap.style.borderRadius = '22px';
+            wrap.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.99), rgba(250,246,244,0.97))';
+            wrap.style.boxShadow = '0 14px 30px rgba(75, 64, 57, 0.08)';
+            wrap.style.border = '1px solid rgba(144,73,81,0.10)';
+            wrap.style.display = 'flex';
+            wrap.style.flexDirection = 'column';
+            wrap.style.gap = '14px';
+
+            const topRow = document.createElement('div');
+            topRow.style.display = 'flex';
+            topRow.style.alignItems = 'flex-start';
+            topRow.style.justifyContent = 'space-between';
+            topRow.style.gap = '12px';
+            topRow.style.flexWrap = 'wrap';
+
+            const titleWrap = document.createElement('div');
+            titleWrap.style.display = 'flex';
+            titleWrap.style.flexDirection = 'column';
+            titleWrap.style.gap = '8px';
+            titleWrap.style.flex = '1 1 220px';
+
+            const eyebrow = document.createElement('div');
+            eyebrow.textContent = formatI18nText('current_tree', '현재 트리');
+            eyebrow.style.fontSize = '11px';
+            eyebrow.style.fontWeight = '800';
+            eyebrow.style.letterSpacing = '.08em';
+            eyebrow.style.textTransform = 'uppercase';
+            eyebrow.style.color = 'var(--on-surface-variant)';
+            titleWrap.appendChild(eyebrow);
+
+            const title = document.createElement('div');
+            title.textContent = displayTreeTitle;
+            title.style.fontSize = '24px';
+            title.style.fontWeight = '900';
+            title.style.color = 'var(--on-surface)';
+            title.style.lineHeight = '1.24';
+            title.style.letterSpacing = '-0.04em';
+            titleWrap.appendChild(title);
+
+            const count = document.createElement('div');
+            count.textContent = countLabel;
+            count.style.fontSize = '12px';
+            count.style.color = 'var(--on-surface-variant)';
+            count.style.lineHeight = '1.75';
+            titleWrap.appendChild(count);
+
+            const visBadge = document.createElement('span');
+            visBadge.style.padding = '6px 11px';
+            visBadge.style.borderRadius = '999px';
+            visBadge.style.display = 'inline-flex';
+            visBadge.style.alignItems = 'center';
+            visBadge.style.gap = '5px';
+            visBadge.style.fontSize = '12px';
+            visBadge.style.fontWeight = '700';
+            visBadge.style.boxShadow = '0 4px 12px rgba(75,64,57,0.05)';
+            if (isPublic) {
+                visBadge.style.background = 'rgba(76,175,80,0.1)';
+                visBadge.style.color = '#4caf50';
+                visBadge.style.border = '1px solid rgba(76,175,80,0.25)';
+            } else {
+                visBadge.style.background = 'rgba(158,158,158,0.1)';
+                visBadge.style.color = '#757575';
+                visBadge.style.border = '1px solid rgba(158,158,158,0.25)';
+            }
+            visBadge.appendChild(createInlineIcon(visIcon, '12px'));
+            visBadge.appendChild(document.createTextNode(visLabel));
+
+            topRow.appendChild(titleWrap);
+            topRow.appendChild(visBadge);
+            wrap.appendChild(topRow);
+
+            if (visInfo) {
+                const info = document.createElement('div');
+                info.textContent = visInfo;
+                info.style.fontSize = '12px';
+                info.style.color = 'var(--on-surface-variant)';
+                info.style.lineHeight = '1.75';
+                wrap.appendChild(info);
+            }
+
+            const actionsRow = document.createElement('div');
+            actionsRow.style.display = 'flex';
+            actionsRow.style.alignItems = 'center';
+            actionsRow.style.gap = '8px';
+            actionsRow.style.flexWrap = 'wrap';
+            actionsRow.style.paddingTop = '2px';
+
+            if (shareButtonEl) actionsRow.appendChild(shareButtonEl);
+            if (openDetailButtonEl) actionsRow.appendChild(openDetailButtonEl);
+
+            if (actionsRow.children.length > 0) {
+                wrap.appendChild(actionsRow);
+            }
+
+            return wrap;
+        };
+
+        const buildTreeMetaRenderModel = ({
+            currentTree,
+            treeState,
+            data,
+            isEmptyState,
+            localSaveMode
+        }) => {
+            const visibility = currentTree.visibility || 'public';
+            const isPublic = visibility === 'public';
+            const visIcon = isPublic ? 'public' : 'lock';
+            const visLabel = isPublic ? i18n('visibility_public') : i18n('visibility_private');
+            const visInfo = isPublic
+                ? formatI18nText('editor_tree_public_info', '이 트리 전체가 공개되어 있어요. 링크가 있는 사람은 감상할 수 있습니다.')
+                : formatI18nText('editor_tree_private_info', '이 트리 전체는 비공개예요. 지금은 나만 볼 수 있습니다.');
+            const displayTreeTitle = resolveTreeTitleText(currentTree.title);
+            const localBadgeText = localSaveMode ? (i18n('local_save_badge') || '로컬 저장') : '';
+            const countForLabel = treeState.totalMomentCount;
+            const treeCountLabel = treeState.hasMoments
+                ? formatI18nText('editor_tree_status_count', `{count}개의 순간이 이 트리 안에서 이어지고 있어요.`, { count: countForLabel })
+                : formatI18nText('editor_tree_status_empty', '아직 첫 순간을 기다리고 있어요.');
+
+            let shareBtn = null;
+            let openDetailBtn = null;
+            if (!isEmptyState && data?.id) {
+                shareBtn = createShareTreeButton();
+                openDetailBtn = createOpenDetailButton();
+            }
+
+            return {
+                displayTreeTitle,
+                visIcon,
+                visLabel,
+                visInfo,
+                isPublic,
+                countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
+                shareButtonEl: shareBtn,
+                openDetailButtonEl: openDetailBtn,
+                shareBtn,
+                openDetailBtn
+            };
+        };
+
+        const renderTreeMetaBoundary = (treeMetaMount, model, treeId, data) => {
+            if (!treeMetaMount) return;
+
+            treeMetaMount.innerHTML = '';
+            treeMetaMount.appendChild(createTreeMetaBlock({
+                displayTreeTitle: model.displayTreeTitle,
+                visIcon: model.visIcon,
+                visLabel: model.visLabel,
+                visInfo: model.visInfo,
+                isPublic: model.isPublic,
+                countLabel: model.countLabel,
+                shareButtonEl: model.shareButtonEl,
+                openDetailButtonEl: model.openDetailButtonEl
+            }));
+
+            if (model.shareBtn) {
+                bindShareButton({
+                    btn: model.shareBtn,
+                    data,
+                    treeId
+                });
+            }
+            bindOpenDetailButton(model.openDetailBtn);
+        };
+
+        return {
+            buildTreeMetaRenderModel,
+            renderTreeMetaBoundary
+        };
+    }
+
+    window.createEditorDetailTreeMetaBoundary = createEditorDetailTreeMetaBoundary;
+})();

--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -39,86 +39,15 @@ function createEditorDetailUI(deps) {
         return icon;
     };
 
-    // ── Tree meta boundary helpers ───────────────────────────────────────────
-    // Responsible: derive visibility metadata, build count label, create share/open buttons,
-    // and render the tree meta block into the mount point. Kept separate from detail content rendering.
-    const buildTreeMetaRenderModel = ({
-        currentTree,
-        treeState,
-        data,
-        isEmptyState,
-        isRootSelected,
-        localSaveMode,
-        resolveTreeTitleText,
+    const treeMetaBoundary = window.createEditorDetailTreeMetaBoundary({
+        i18n,
         formatI18nText,
-        createShareTreeButton,
-        createOpenDetailButton,
-        bindShareButton,
-        bindOpenDetailButton,
-        createTreeMetaBlock
-    }) => {
-        const visibility = currentTree.visibility || 'public';
-        const isPublic = visibility === 'public';
-        const visIcon = isPublic ? 'public' : 'lock';
-        const visLabel = isPublic ? i18n('visibility_public') : i18n('visibility_private');
-        const visInfo = isPublic
-            ? formatI18nText('editor_tree_public_info', '이 트리 전체가 공개되어 있어요. 링크가 있는 사람은 감상할 수 있습니다.')
-            : formatI18nText('editor_tree_private_info', '이 트리 전체는 비공개예요. 지금은 나만 볼 수 있습니다.');
-        const displayTreeTitle = resolveTreeTitleText(currentTree.title);
-        const localBadgeText = localSaveMode ? (i18n('local_save_badge') || '로컬 저장') : '';
-        const countForLabel = treeState.totalMomentCount;
-        const treeCountLabel = treeState.hasMoments
-            ? formatI18nText('editor_tree_status_count', `{count}개의 순간이 이 트리 안에서 이어지고 있어요.`, { count: countForLabel })
-            : formatI18nText('editor_tree_status_empty', '아직 첫 순간을 기다리고 있어요.');
-
-        let shareBtn = null;
-        let openDetailBtn = null;
-        if (!isEmptyState && data?.id) {
-            shareBtn = createShareTreeButton();
-            openDetailBtn = createOpenDetailButton();
-        }
-
-        return {
-            displayTreeTitle,
-            visIcon,
-            visLabel,
-            visInfo,
-            isPublic,
-            countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
-            shareButtonEl: shareBtn,
-            openDetailButtonEl: openDetailBtn,
-            shareBtn,
-            openDetailBtn
-        };
-    };
-
-    const renderTreeMetaBoundary = (treeMetaMount, model, treeId, data, { i18n, showToast, bindShareButton, bindOpenDetailButton }) => {
-        if (!treeMetaMount) return;
-
-        treeMetaMount.innerHTML = '';
-        treeMetaMount.appendChild(createTreeMetaBlock({
-            displayTreeTitle: model.displayTreeTitle,
-            visIcon: model.visIcon,
-            visLabel: model.visLabel,
-            visInfo: model.visInfo,
-            isPublic: model.isPublic,
-            countLabel: model.countLabel,
-            shareButtonEl: model.shareButtonEl,
-            openDetailButtonEl: model.openDetailButtonEl
-        }));
-
-        if (model.shareBtn) {
-            bindShareButton({
-                btn: model.shareBtn,
-                data,
-                treeId,
-                i18n,
-                showToast
-            });
-        }
-        bindOpenDetailButton(model.openDetailBtn);
-    };
-    // ──────────────────────────────────────────────────────────────────────────
+        resolveTreeTitleText,
+        createInlineIcon,
+        showToast,
+        openCurrentMomentDetail
+    });
+    const { buildTreeMetaRenderModel, renderTreeMetaBoundary } = treeMetaBoundary;
 
     // ── Title edit boundary helper ──────────────────────────────────────────
     // Responsible: encapsulate inline title edit button creation and state binding.
@@ -330,198 +259,6 @@ function createEditorDetailUI(deps) {
         return formatI18nText('editor_selected_memo_fallback', '이 순간의 마음을 한 줄 남겨두면, 이어진 흐름을 다시 떠올리기 쉬워져요.');
     };
 
-    const createPillButton = ({ label, icon, tone = 'soft' }) => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.style.display = 'inline-flex';
-        btn.style.alignItems = 'center';
-        btn.style.justifyContent = 'center';
-        btn.style.gap = '6px';
-        btn.style.minHeight = '38px';
-        btn.style.padding = tone === 'primary' ? '10px 15px' : '9px 13px';
-        btn.style.borderRadius = '999px';
-        btn.style.fontSize = '12px';
-        btn.style.fontWeight = '800';
-        btn.style.cursor = 'pointer';
-        btn.style.transition = 'transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease';
-        btn.style.border = '1px solid rgba(144,73,81,0.10)';
-        btn.style.boxShadow = tone === 'primary'
-            ? '0 10px 22px rgba(144, 73, 81, 0.18)'
-            : '0 6px 16px rgba(75, 64, 57, 0.06)';
-        btn.style.background = tone === 'primary'
-            ? 'linear-gradient(180deg, rgba(144,73,81,0.98), rgba(144,73,81,0.90))'
-            : 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(247,242,239,0.96))';
-        btn.style.color = tone === 'primary'
-            ? '#fff'
-            : tone === 'ghost'
-                ? 'var(--on-surface-variant)'
-                : 'var(--primary)';
-
-        if (tone === 'ghost') {
-            btn.style.background = 'rgba(255,255,255,0.72)';
-            btn.style.borderColor = 'rgba(144,73,81,0.08)';
-        }
-
-        if (icon) btn.appendChild(createInlineIcon(icon, '14px'));
-        btn.appendChild(document.createTextNode(label));
-
-        btn.addEventListener('mouseenter', () => {
-            btn.style.transform = 'translateY(-1px)';
-        });
-        btn.addEventListener('mouseleave', () => {
-            btn.style.transform = 'translateY(0)';
-        });
-
-        return btn;
-    };
-
-    const createShareTreeButton = () => createPillButton({
-        label: formatI18nText('share_link', '링크 복사'),
-        icon: 'content_copy',
-        tone: 'soft'
-    });
-
-    const createOpenDetailButton = () => createPillButton({
-        label: formatI18nText('editor_open_detail', '상세로 보기'),
-        icon: 'open_in_new',
-        tone: 'ghost'
-    });
-
-    const bindShareButton = ({ btn, data, treeId, i18n, showToast }) => {
-        if (!btn || !data?.id) return;
-        if (btn.dataset.shareBound === '1') return;
-        btn.dataset.shareBound = '1';
-
-        const basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
-
-        btn.addEventListener('click', () => {
-            const shareUrl = window.location.origin + '/' + basePath + 'detail.html?id=' + data.id + '&tree=' + treeId;
-            navigator.clipboard?.writeText(shareUrl).then(() => {
-                showToast(i18n('copied_link') || '링크가 복사되었습니다', 'success');
-            }).catch(() => {
-                showToast(i18n('copy_link_failed') || '링크 복사에 실패했습니다', 'error');
-            });
-        });
-    };
-
-    const bindOpenDetailButton = (btn) => {
-        if (!btn || typeof openCurrentMomentDetail !== 'function') return;
-        if (btn.dataset.openDetailBound === '1') return;
-        btn.dataset.openDetailBound = '1';
-        btn.addEventListener('click', () => {
-            openCurrentMomentDetail();
-        });
-    };
-
-    const createTreeMetaBlock = ({
-        displayTreeTitle,
-        visIcon,
-        visLabel,
-        visInfo,
-        isPublic,
-        countLabel,
-        shareButtonEl = null,
-        openDetailButtonEl = null
-    }) => {
-        const wrap = document.createElement('div');
-        wrap.style.padding = '20px 20px 18px';
-        wrap.style.borderRadius = '22px';
-        wrap.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.99), rgba(250,246,244,0.97))';
-        wrap.style.boxShadow = '0 14px 30px rgba(75, 64, 57, 0.08)';
-        wrap.style.border = '1px solid rgba(144,73,81,0.10)';
-        wrap.style.display = 'flex';
-        wrap.style.flexDirection = 'column';
-        wrap.style.gap = '14px';
-
-        const topRow = document.createElement('div');
-        topRow.style.display = 'flex';
-        topRow.style.alignItems = 'flex-start';
-        topRow.style.justifyContent = 'space-between';
-        topRow.style.gap = '12px';
-        topRow.style.flexWrap = 'wrap';
-
-        const titleWrap = document.createElement('div');
-        titleWrap.style.display = 'flex';
-        titleWrap.style.flexDirection = 'column';
-        titleWrap.style.gap = '8px';
-        titleWrap.style.flex = '1 1 220px';
-
-        const eyebrow = document.createElement('div');
-        eyebrow.textContent = formatI18nText('current_tree', '현재 트리');
-        eyebrow.style.fontSize = '11px';
-        eyebrow.style.fontWeight = '800';
-        eyebrow.style.letterSpacing = '.08em';
-        eyebrow.style.textTransform = 'uppercase';
-        eyebrow.style.color = 'var(--on-surface-variant)';
-        titleWrap.appendChild(eyebrow);
-
-        const title = document.createElement('div');
-        title.textContent = displayTreeTitle;
-        title.style.fontSize = '24px';
-        title.style.fontWeight = '900';
-        title.style.color = 'var(--on-surface)';
-        title.style.lineHeight = '1.24';
-        title.style.letterSpacing = '-0.04em';
-        titleWrap.appendChild(title);
-
-        const count = document.createElement('div');
-        count.textContent = countLabel;
-        count.style.fontSize = '12px';
-        count.style.color = 'var(--on-surface-variant)';
-        count.style.lineHeight = '1.75';
-        titleWrap.appendChild(count);
-
-        const visBadge = document.createElement('span');
-        visBadge.style.padding = '6px 11px';
-        visBadge.style.borderRadius = '999px';
-        visBadge.style.display = 'inline-flex';
-        visBadge.style.alignItems = 'center';
-        visBadge.style.gap = '5px';
-        visBadge.style.fontSize = '12px';
-        visBadge.style.fontWeight = '700';
-        visBadge.style.boxShadow = '0 4px 12px rgba(75,64,57,0.05)';
-        if (isPublic) {
-            visBadge.style.background = 'rgba(76,175,80,0.1)';
-            visBadge.style.color = '#4caf50';
-            visBadge.style.border = '1px solid rgba(76,175,80,0.25)';
-        } else {
-            visBadge.style.background = 'rgba(158,158,158,0.1)';
-            visBadge.style.color = '#757575';
-            visBadge.style.border = '1px solid rgba(158,158,158,0.25)';
-        }
-        visBadge.appendChild(createInlineIcon(visIcon, '12px'));
-        visBadge.appendChild(document.createTextNode(visLabel));
-
-        topRow.appendChild(titleWrap);
-        topRow.appendChild(visBadge);
-        wrap.appendChild(topRow);
-
-        if (visInfo) {
-            const info = document.createElement('div');
-            info.textContent = visInfo;
-            info.style.fontSize = '12px';
-            info.style.color = 'var(--on-surface-variant)';
-            info.style.lineHeight = '1.75';
-            wrap.appendChild(info);
-        }
-
-        const actionsRow = document.createElement('div');
-        actionsRow.style.display = 'flex';
-        actionsRow.style.alignItems = 'center';
-        actionsRow.style.gap = '8px';
-        actionsRow.style.flexWrap = 'wrap';
-        actionsRow.style.paddingTop = '2px';
-
-        if (shareButtonEl) actionsRow.appendChild(shareButtonEl);
-        if (openDetailButtonEl) actionsRow.appendChild(openDetailButtonEl);
-
-        if (actionsRow.children.length > 0) {
-            wrap.appendChild(actionsRow);
-        }
-
-        return wrap;
-    };
-
     const resetDetailViewState = () => {
         const headerEl = detailPanel.querySelector('h3');
         if (headerEl) {
@@ -710,19 +447,11 @@ function createEditorDetailUI(deps) {
              treeState,
              data,
              isEmptyState,
-             isRootSelected,
-             localSaveMode,
-             resolveTreeTitleText,
-             formatI18nText,
-             createShareTreeButton,
-             createOpenDetailButton,
-             bindShareButton,
-             bindOpenDetailButton,
-             createTreeMetaBlock
+             localSaveMode
          });
 
          if (treeMetaMount) {
-             renderTreeMetaBoundary(treeMetaMount, treeMetaModel, treeId, data, { i18n, showToast, bindShareButton, bindOpenDetailButton });
+             renderTreeMetaBoundary(treeMetaMount, treeMetaModel, treeId, data);
          }
 
         if (badgeEl) {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -252,6 +252,7 @@
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas.js?v=20260421-5"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
+    <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260419-1"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260422-3"></script>


### PR DESCRIPTION
Refs #657

## Why this PR is needed

`js/editor/editor-detail-ui.js` is still a large runtime UI factory. The first safe step for Issue #657 is to split out one already-localized rendering boundary without changing the Editor data flow, selected-memory rendering, inline edit flows, CSS, or API behavior.

## Helper boundary extracted

This PR extracts only the detail tree meta boundary into `js/editor/editor-detail-tree-meta.js`.

The new browser-global helper owns the existing tree meta render model, tree meta DOM block construction, tree share button construction/binding, and open-detail button binding. `createEditorDetailUI(deps)` keeps its existing external contract and now delegates that tree meta work to the helper.

## Script load order note

`pages/editor.html` now loads `editor-detail-tree-meta.js` immediately before `editor-detail-ui.js`. This follows the classic browser-global script contract documented in `docs/engineering/SCRIPT_LOAD_ORDER.md`.

## What this intentionally does not change

This PR does not change CSS, inline styles, DOM structure, i18n keys, selected memory detail rendering, title edit behavior, memo edit behavior, sidebar status rendering, data loading, API calls, Auth behavior, `js/editor.js`, `js/editor/editor-canvas.js`, `js/editor/editor-canvas-edges.js`, `js/editor/editor-data-loader.js`, backend/runtime files, package files, workflow files, PR #7 paths, or prototype/reference/demo/variant paths.

## Verification

### Static / CI

After rebasing onto latest main, the PR head is `b4ef34153c99dcf3ead37a02c7195f1991b77bb4`.

- `git diff --check`: PASS
- `node --check js/editor/editor-detail-ui.js`: PASS
- `node --check js/editor/editor-detail-tree-meta.js`: PASS
- GitHub Actions CI for updated head `b4ef34153c99dcf3ead37a02c7195f1991b77bb4`: SUCCESS

Not re-run locally after the final Windows rebase/update:

- `npm test`: NOT_VERIFIED locally after final update
- `npm run verify`: NOT_VERIFIED locally after final update

Prior pre-update static run had passed `npm test` and `npm run verify`; final post-update confidence is anchored by GitHub Actions CI success and targeted syntax/diff checks.

### Fixed-slot / runtime verification

Editor is Auth/API/runtime-sensitive. Browser PASS requires fixed test slot deployment, deployed SHA match, and authenticated email/password test-account state.

- Fixed slot: test3
- PR head SHA: `b4ef34153c99dcf3ead37a02c7195f1991b77bb4`
- Slot deployed SHA matched PR head: YES
- Email/password test-account login: PASS
- Google login used: NO
- Desktop Editor access: PASS
- Mobile 375px Editor access: PASS
- `window.createEditorDetailTreeMetaBoundary`: PRESENT
- `window.createEditorDetailUI`: PRESENT
- Tree meta mount: PASS
- Current tree title/status area: PASS
- Visibility metadata: PASS
- Moment count/status line: PASS
- Title edit interface opens/closes: PASS
- Memo edit interface opens/closes: PASS
- Console/pageerror/network fatal: NO
- Horizontal overflow: NO

### Issue #677 selected-memory verification

Issue #677 was opened to track an apparent missing share/open-detail control state during fixed-slot verification. Follow-up selected-memory verification resolved it as a verification-state dependency, not a PR regression.

- Populated tree state: PRESENT
- Memory node selectable: YES
- Selected detail data id: PRESENT
- Root/tree state controls: MISSING
- Selected memory controls: PRESENT
- Link control: PRESENT
- Link/memo control action: PASS
- Mobile 375px selected memory controls: PASS
- Horizontal overflow: NO
- Fatal console/pageerror/network: NO
- Secret/private data exposure: NO

Operational classification:

`ISSUE_677_VERIFICATION_STATE_ONLY / PR664_UPDATED_FIXED_SLOT_VERIFIED`

## NOT_VERIFIED

- Empty-tree specific share/open-detail behavior remains NOT_VERIFIED in this final pass because the successful runtime verification used populated and selected-memory states.
- Local `npm test` and `npm run verify` were NOT_VERIFIED after the final Windows rebase/update; GitHub Actions CI was SUCCESS for the updated head.

## Guardrails

- Issue close keyword: NO
- Ready/merge action: NO
- PR #7 / prototype / reference / demo / variant paths untouched
- Secret/private data exposure: NO
- Restricted IDs and credential values not reported

## Final status

`READY_FOR_CTO_REVIEW_FIXED_SLOT_VERIFIED`