### PR TITLE
refactor(editor): extract canvas edge rendering boundary

### DIFF
--- a/js/editor/editor-canvas-edges.js
+++ b/js/editor/editor-canvas-edges.js
@@ -1,0 +1,32 @@
+(function () {
+    function createEditorCanvasEdges(options) {
+        const {
+            svg,
+            canvasViewport = {}
+        } = options || {};
+
+        const drawBranch = (startPos, endPos) => {
+            if (typeof canvasViewport.drawBranch === 'function') {
+                canvasViewport.drawBranch(svg, startPos, endPos);
+                return;
+            }
+
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            const cp1x = startPos.x + (endPos.x - startPos.x) / 2;
+            const d = `M ${startPos.x},${startPos.y} Q ${cp1x},${startPos.y} ${endPos.x},${endPos.y}`;
+            path.setAttribute('d', d);
+            path.setAttribute('class', 'branch-line');
+            path.setAttribute('fill', 'none');
+            path.setAttribute('stroke', 'var(--secondary)');
+            path.setAttribute('stroke-width', '2');
+            path.setAttribute('opacity', '0.5');
+            svg.appendChild(path);
+        };
+
+        return {
+            drawBranch
+        };
+    }
+
+    window.createEditorCanvasEdges = createEditorCanvasEdges;
+})();

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -23,6 +23,7 @@ function createEditorCanvas(deps) {
     const canvasNode = window.LoveBudEditorCanvasNode || {};
     const canvasInteraction = window.LoveBudEditorCanvasInteraction || {};
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
+    const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
     function loadStoredLayout() {
         if (typeof canvasLayout.createLayoutStore === 'function') {
@@ -236,23 +237,7 @@ function createEditorCanvas(deps) {
         });
     }
 
-    const drawBranch = (startPos, endPos) => {
-        if (typeof canvasViewport.drawBranch === 'function') {
-            canvasViewport.drawBranch(svg, startPos, endPos);
-            return;
-        }
-
-        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        const cp1x = startPos.x + (endPos.x - startPos.x) / 2;
-        const d = `M ${startPos.x},${startPos.y} Q ${cp1x},${startPos.y} ${endPos.x},${endPos.y}`;
-        path.setAttribute('d', d);
-        path.setAttribute('class', 'branch-line');
-        path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', 'var(--secondary)');
-        path.setAttribute('stroke-width', '2');
-        path.setAttribute('opacity', '0.5');
-        svg.appendChild(path);
-    };
+    const { drawBranch } = canvasEdges;
 
     function bindNodeDrag(nodeEl, mem) {
         nodeEl.style.cursor = 'grab';

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -249,6 +249,7 @@
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas.js?v=20260421-5"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260422-2"></script>


### PR DESCRIPTION
Refs #658

## Why this PR is needed

`js/editor/editor-canvas.js` is still a large Editor runtime file. The first safe implementation step for Issue #658 is a narrow, behavior-preserving extraction of the already-localized canvas edge rendering boundary. This keeps the canvas refactor reviewable without changing node rendering, layout, pan/zoom, selection, drag, resize, Editor orchestration, API/Auth behavior, or CSS.

## Edge boundary extracted

This PR extracts only the branch/connection edge rendering helper into `js/editor/editor-canvas-edges.js`.

The new browser-global helper exposes `window.createEditorCanvasEdges`. `js/editor/editor-canvas.js` creates that helper with the existing `svg` and `canvasViewport` dependencies, then continues to call `drawBranch` from the same render path as before.

## What this intentionally does not change

This PR does not rewrite the canvas controller, alter node rendering, change layout calculations, change pan/zoom/recenter behavior, change selection or drag handling, change resize behavior, change `js/editor.js`, change detail UI files, change CSS, change API/Auth/backend files, change package files, change workflow files, or touch PR #7 / prototype / reference / demo / variant paths.

## Why behavior should stay the same

The extracted `drawBranch` logic preserves the existing delegation and fallback behavior. It still calls `canvasViewport.drawBranch(svg, startPos, endPos)` when that helper is available. The fallback SVG path construction is unchanged: the same quadratic path calculation, `branch-line` class, `fill`, `stroke`, `stroke-width`, `opacity`, and append target are retained. The caller still removes and redraws `.branch-line` elements from the same canvas render flow.

## Script load order

`pages/editor.html` now loads `js/editor/editor-canvas-edges.js` immediately before `js/editor/editor-canvas.js`.

This is required by the classic browser-global script contract documented in `docs/engineering/SCRIPT_LOAD_ORDER.md`: `editor-canvas-edges.js` defines `window.createEditorCanvasEdges`, and `editor-canvas.js` consumes that global when `createEditorCanvas(deps)` is constructed. No ES module conversion or bundler was introduced.

## Verification

### Static / CI

- `git diff --check`: PASS
- `node --check js/editor/editor-canvas.js`: PASS
- `node --check js/editor/editor-canvas-edges.js`: PASS
- GitHub Actions CI for updated head `1b64f2f947cbfe89a912e128e5ed8163441a2f1c`: SUCCESS

### Fixed-slot / runtime verification

This PR was re-verified after PR #669 was merged into main, because populated edge rendering depended on the selected-tree handoff fix from #669.

- PR #669 handoff fix: MERGED into main before PR #665 merge
- Combined fixed-slot verification before merge: PASS
- Fixed slot used for combined verification: test4
- Combined verification included:
  - PR #665 edge boundary extraction
  - PR #669 selected-tree handoff fix
- My Trees selected nonzero tree opened in Editor: PASS
- URL_TREE_ID_PRESENT: YES
- Editor opens selected tree: PASS
- FIRST_TREE_FALLBACK_NOT_USED: PASS
- Editor memory count: NONZERO
- Canvas node count: NONZERO
- `window.createEditorCanvasEdges`: PRESENT
- `window.createEditorCanvas`: PRESENT
- `path.branch-line` count: NONZERO
- `branch-line` attributes: PRESENT
- Selected node edge persistence: PASS
- Recenter / viewport control edge stability: PASS
- Detail panel regression: PASS
- Title edit interface opens/closes: PASS
- Memo edit interface opens/closes: PASS
- Mobile 375px Editor load: PASS
- Mobile populated tree visible: PASS
- Mobile horizontal overflow: NO
- Console/pageerror fatal: NO
- Network fatal: NO

### Post-#669 branch update

- PR #665 branch was updated after PR #669 merged.
- Updated PR #665 head: `1b64f2f947cbfe89a912e128e5ed8163441a2f1c`
- Base main included PR #669 merge commit.
- Conflict: NO
- Scope drift: NO
- PR #669 file `js/editor/editor-data-loader.js` was not included in PR #665 diff.
- GitHub Actions CI for the updated head: SUCCESS

## Screenshots

Screenshots were saved as local artifacts by the browser verification model and reviewed via user upload when applicable. PR comment image attachment is not required by current operating policy.

## NOT_VERIFIED

- Empty-state behavior: NOT_VERIFIED because populated data was available during fixed-slot verification.
- Full `npm test` / `npm run verify` after the final rebase: NOT_VERIFIED by the browser model; GitHub Actions CI was SUCCESS for the final head.

## Guardrails

- Issue close keyword: NO
- Merge commit used `Refs #658`, not close keywords
- PR #7 / prototype / reference / demo / variant paths untouched
- Secret/private data exposure: NO
- Tree id / owner id / memory id / DB row / credential values not reported

## Final status

MERGED via squash commit `c6c92e3192ed74302db1030b89f881ae530ee251`.

Operational judgment: `MERGED_FIXED_SLOT_VERIFIED`