### PR TITLE
ui(my-trees): simplify card hierarchy and primary action

### DIFF
--- a/css/my-trees/cards.css
+++ b/css/my-trees/cards.css
@@ -13,19 +13,20 @@
 .tree-card-text-title { font-size: 1rem; font-weight: 800; line-height: 1.4; color: var(--on-surface); word-break: keep-all; }
 .tree-card-text-memo { font-size: 12px; line-height: 1.55; color: var(--on-surface-variant); display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; word-break: keep-all; }
 .tree-card-thumb-caption { position: absolute; left: 16px; right: 16px; bottom: 14px; padding: 10px 12px; border-radius: 999px; background: rgba(255,255,255,0.78); backdrop-filter: blur(8px); font-size: 12px; font-weight: 700; color: var(--on-surface); text-align: center; }
-.tree-card-info { padding: 18px 18px 20px; display: flex; flex-direction: column; gap: 8px; }
+.tree-card-info { padding: 18px 18px 22px; display: flex; flex-direction: column; gap: 7px; min-height: 114px; }
 .tree-card-title-row { display: flex; align-items: flex-start; gap: 10px; justify-content: space-between; }
-.tree-card-title { font-size: 1.04rem; font-weight: 700; color: var(--on-surface); line-height: 1.3; flex: 1; }
+.tree-card-title { font-size: 1.04rem; font-weight: 700; color: var(--on-surface); line-height: 1.3; flex: 1; overflow-wrap: anywhere; }
 .tree-card-count-pill, .tree-card-moment-badge { display: inline-flex; align-items: center; justify-content: center; padding: 6px 10px; border-radius: 999px; background: var(--lovetree-pill-bg); color: var(--lovetree-pill-text); border: 1px solid var(--lovetree-pill-border); font-size: 12px; font-weight: 800; white-space: nowrap; }
-.tree-card-subcopy { font-size: 12px; color: var(--on-surface-variant); line-height: 1.45; }
+.tree-card-subcopy { font-size: 12px; color: var(--on-surface-variant); line-height: 1.45; min-height: 18px; }
 .tree-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 0.85rem; color: var(--on-surface-variant); }
 .tree-card-date { font-size: 12px; }
 .tree-card-visibility { display: flex; align-items: center; gap: 4px; font-size: 12px; padding: 4px 10px; border-radius: 99px; background: var(--lovetree-chip-bg); border: 1px solid var(--lovetree-chip-border); color: var(--lovetree-chip-text); }
 .tree-card-visibility.public { background: rgba(122, 139, 110, 0.1); color: var(--secondary); }
 .tree-card-visibility.private { background: var(--lovetree-pill-bg); color: var(--lovetree-pill-text); }
-.tree-card-menu { position: absolute; right: 14px; bottom: 14px; width: 38px; height: 38px; display: flex; align-items: center; justify-content: center; background: var(--lovetree-chip-bg); border: 1px solid var(--lovetree-chip-border); border-radius: 50%; cursor: pointer; opacity: 1; transition: opacity 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease; z-index: 10; box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08); }
-.tree-card:hover .tree-card-menu { transform: translateY(-1px); }
-.tree-card-menu:hover { background: rgba(255, 255, 255, 1); box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12); }
+.tree-card-menu { position: absolute; right: 14px; bottom: 14px; width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; border-radius: 50%; cursor: pointer; opacity: 0.42; transition: opacity 0.2s ease, transform 0.2s ease, background 0.2s ease; z-index: 10; color: var(--on-surface-variant); }
+.tree-card:hover .tree-card-menu, .tree-card:focus-within .tree-card-menu { opacity: 0.86; transform: translateY(-1px); }
+.tree-card-menu:hover { opacity: 1; color: var(--on-surface); background: rgba(255,255,255,0.64); }
+.tree-card-menu .material-symbols-outlined { font-size: 20px; }
 .tree-card-dropdown { position: absolute; right: 14px; bottom: 58px; background: var(--lovetree-soft-surface); border: 1px solid var(--lovetree-soft-surface-border); border-radius: 12px; box-shadow: var(--lovetree-card-shadow); min-width: 148px; padding: 6px 0; z-index: 20; display: none; }
 .tree-card-dropdown.show { display: block; }
 .dropdown-item { display: flex; align-items: center; gap: 8px; padding: 10px 16px; font-size: 13px; color: var(--on-surface); cursor: pointer; transition: background 0.15s ease; }

--- a/js/my-trees/my-trees-i18n-refresh.js
+++ b/js/my-trees/my-trees-i18n-refresh.js
@@ -60,7 +60,7 @@
 
     document.querySelectorAll('.tree-card-dropdown').forEach(function(dropdown) {
       var card = dropdown.closest('.tree-card');
-      var isPublic = !!card?.querySelector('.tree-card-visibility.public');
+      var isPublic = card?.dataset?.visibility !== 'private';
       var visibilityItem = dropdown.querySelector('.dropdown-item.visibility');
       var renameItem = dropdown.querySelector('.dropdown-item.rename');
       var deleteItem = dropdown.querySelector('.dropdown-item.delete');

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -184,10 +184,8 @@
             ? '<img class="tree-card-thumb-image" src="' + escapeHtml(thumbnail) + '" alt="' + escapeHtml(title) + '">'
             : (textVisual || buildMiniTreeSVG(tree)),
         '</div>',
-        '<div class="tree-card-thumb-topline">',
-          '<span class="tree-card-moment-badge" data-count="' + momentCount + '">' + (i18n('myTrees.moment_count_compact') || '순간 {count}개').replace('{count}', String(momentCount)) + '</span>',
-        '</div>',
-        '<div class="tree-card-thumb-caption">' + moodLabel + '</div>',
+        (momentCount > 0 ? '<div class="tree-card-thumb-topline"><span class="tree-card-moment-badge" data-count="' + momentCount + '">' + (i18n('myTrees.moment_count_compact') || '순간 {count}개').replace('{count}', String(momentCount)) + '</span></div>' : ''),
+        (momentCount > 0 ? '<div class="tree-card-thumb-caption">' + moodLabel + '</div>' : ''),
       '</div>'
     ].join('');
   }
@@ -354,22 +352,39 @@
     var card = document.createElement('div');
     card.className = 'tree-card' + selectedClass;
     card.style.cursor = 'pointer';
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.dataset.visibility = normalizedTree.visibility;
 
-    card.addEventListener('click', function (e) {
-      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown') || e.target.closest('.tree-card-manage-btn')) {
-        return;
-      }
+    var openTree = function () {
       if (typeof onNavigate === 'function') {
         onNavigate(normalizedTree);
       } else {
         window.location.href = 'editor.html?treeId=' + encodeURIComponent(normalizedTree.id);
       }
+    };
+
+    card.addEventListener('click', function (e) {
+      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
+        return;
+      }
+      openTree();
+    });
+
+    card.addEventListener('keydown', function (e) {
+      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
+        return;
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openTree();
+      }
     });
 
     card.innerHTML = [
       buildTreeThumbVisual(normalizedTree, i18n),
-      '<button class="tree-card-menu" id="' + menuBtnId + '" type="button" aria-label="' + escapeHtml(i18n('myTrees.card_menu') || '트리 관리 열기') + '">',
-        '<span class="material-symbols-outlined" style="font-size:20px;color:var(--on-surface);">more_vert</span>',
+      '<button class="tree-card-menu" id="' + menuBtnId + '" type="button" aria-label="' + escapeHtml(i18n('myTrees.card_menu') || '트리 메뉴 열기') + '">',
+        '<span class="material-symbols-outlined" aria-hidden="true">more_vert</span>',
       '</button>',
       '<div class="tree-card-dropdown" id="' + dropdownId + '">',
         '<div class="dropdown-item visibility" data-action="visibility">',
@@ -388,28 +403,17 @@
       '<div class="tree-card-info">',
         '<div class="tree-card-title-row">',
           '<div class="tree-card-title">' + escapeHtml(title) + '</div>',
-          '<span class="tree-card-count-pill" data-count="' + momentCount + '">' + (i18n('myTrees.moment_count_compact') || '순간 {count}개').replace('{count}', String(momentCount)) + '</span>',
         '</div>',
         '<div class="tree-card-subcopy">' + metaMood + '</div>',
-        '<div class="tree-card-meta">',
-          '<span class="tree-card-visibility ' + visClass + '">',
-            '<span class="material-symbols-outlined" style="font-size:12px;">' + (visClass === 'public' ? 'public' : 'lock') + '</span>',
-            visLabel,
-          '</span>',
-          date ? '<span class="tree-card-date">' + date + '</span>' : '',
-        '</div>',
-        '<div class="tree-card-manage-row">',
-          '<button type="button" class="tree-card-manage-btn tree-card-select-btn">' + (selectedClass ? (i18n('myTrees.card_selected') || '선택됨') : (i18n('myTrees.card_select') || '선택')) + '</button>',
-          '<button type="button" class="tree-card-manage-btn tree-card-open-btn">' + (i18n('myTrees.card_open') || '열어보기') + '</button>',
-        '</div>',
+        (normalizedTree.visibility === 'private'
+          ? '<div class="tree-card-meta"><span class="tree-card-visibility private"><span class="material-symbols-outlined" style="font-size:12px;">lock</span>' + visLabel + '</span></div>'
+          : ''),
       '</div>'
     ].join('');
 
     setTimeout(function () {
       var menuBtn = document.getElementById(menuBtnId);
       var dropdown = document.getElementById(dropdownId);
-      var selectBtn = card.querySelector('.tree-card-select-btn');
-      var openBtn = card.querySelector('.tree-card-open-btn');
 
       if (menuBtn && dropdown) {
         menuBtn.addEventListener('click', function (e) {
@@ -445,25 +449,6 @@
         });
       }
 
-      if (selectBtn) {
-        selectBtn.addEventListener('click', function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof onSelect === 'function') {
-            onSelect(normalizedTree.id);
-          }
-        });
-      }
-
-      if (openBtn) {
-        openBtn.addEventListener('click', function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof onNavigate === 'function') {
-            onNavigate(normalizedTree);
-          }
-        });
-      }
     }, 0);
 
     return card;


### PR DESCRIPTION
Summary
- Simplify My Trees card hierarchy so the card itself remains the primary open action.
- Remove duplicate visible open/select CTAs, default public visibility label, and empty moment-count badge.
- Keep the empty status phrase and show a quiet private-only meta label.

Changed files
- css/my-trees/cards.css
- js/my-trees/my-trees-i18n-refresh.js
- js/my-trees/my-trees-ui.js

Scope
- My Trees card UI hierarchy and small responsive spacing cleanup only.
- No behavior change to Auth, API, backend, data loading, or package/workflow files.

Validation
- git diff --check: PASS
- node --check js/my-trees/my-trees-ui.js: PASS
- node --check js/my-trees/my-trees-i18n-refresh.js: PASS
- npm test: PASS
- npm run verify: PASS

Browser/fixed slot
- NOT_VERIFIED
- fixed-slot browser verification required for authenticated My Trees UI.

Refs #621