### PR TITLE
fix(my-trees): preserve selected tree handoff to editor

### DIFF
--- a/js/editor/editor-data-loader.js
+++ b/js/editor/editor-data-loader.js
@@ -85,29 +85,32 @@
             };
         }
 
-        try {
-            if (apiClient && apiClient.getFirstTree) {
-                const apiTree = await apiClient.getFirstTree();
-                if (apiTree) {
-                    tree = apiTree;
-                    treeLoadStatus = 'loaded';
-                    console.log('[editor] API tree loaded (getFirstTree)');
-                } else if (apiClient.createTree) {
-                    console.log('[editor] No tree found, creating default tree...');
-                    const newTree = await apiClient.createTree({
-                        title: createDefaultTreeTitle(),
-                        visibility: 'public'
-                    });
-                    tree = newTree;
-                    isNewTree = true;
-                    treeLoadStatus = 'created';
-                    console.log('[editor] Default tree created:', newTree);
+        // Only fall back to getFirstTree if no specific treeId was requested
+        if (!urlTreeId) {
+            try {
+                if (apiClient && apiClient.getFirstTree) {
+                    const apiTree = await apiClient.getFirstTree();
+                    if (apiTree) {
+                        tree = apiTree;
+                        treeLoadStatus = 'loaded';
+                        console.log('[editor] API tree loaded (getFirstTree)');
+                    } else if (apiClient.createTree) {
+                        console.log('[editor] No tree found, creating default tree...');
+                        const newTree = await apiClient.createTree({
+                            title: createDefaultTreeTitle(),
+                            visibility: 'public'
+                        });
+                        tree = newTree;
+                        isNewTree = true;
+                        treeLoadStatus = 'created';
+                        console.log('[editor] Default tree created:', newTree);
+                    }
                 }
+            } catch (e) {
+                treeLoadErrorMessage = String(e?.message || '');
+                console.warn('[editor] API tree load failed:', e.message);
+                authRequired = /401|Authentication/i.test(treeLoadErrorMessage);
             }
-        } catch (e) {
-            treeLoadErrorMessage = String(e?.message || '');
-            console.warn('[editor] API tree load failed:', e.message);
-            authRequired = /401|Authentication/i.test(treeLoadErrorMessage);
         }
 
         if (authRequired) {


### PR DESCRIPTION
## Summary

Refs #666 - My Trees to Editor handoff mechanism

When a specific treeId is passed via URL parameter, Editor should only load that specific tree and not fall back to getFirstTree(). This preserves the user's tree selection from My Trees page.

## Changes

- js/editor/editor-data-loader.js: Wrap getFirstTree and createTree fallback in if(!urlTreeId) condition
- Ensures selected tree handoff takes priority over automatic fallback
- Maintains backward compatibility when no treeId is specified

## Verification

### Static Checks
- git diff --check: PASS
- node --check js/editor/editor-data-loader.js: PASS

### Fixed Test Slot (test2)
- Slot URL: https://test2.lovebud.pages.dev
- Deployed SHA: b6ff177b
- Deployed SHA matches branch head: YES
- Test credential used: YES
- Google login: NO

### Browser Verification
- My Trees nonzero tree visible: PRESENT
- URL_TREE_ID_PRESENT: YES
- Editor opens selected tree: PASS
- FIRST_TREE_FALLBACK_NOT_USED: PASS
- Editor memory count: NONZERO (5 memories visible)
- Canvas node count: NONZERO
- Detail panel regression: PASS
- Title edit interface regression: PASS
- Memo edit interface regression: PASS
- Mobile 375px: PASS (no fatal runtime/layout error)
- Console/pageerror fatal: NO
- Network fatal: NO

### Screenshots
- Desktop: editor-desktop-verify.png
- Mobile 375px: editor-mobile-verify.png

### Guardrails
- Secret/private data exposure: NO
- Tree id / owner id / memory id exposure: NO
- PR #7/prototype/reference/demo/variant touched: NO
- PR #665 canvas edge helper untouched: YES
- Issue close: NO

## Ready/Merge
- Ready for review: YES
- Merge: NO