### PR TITLE
copy(login): clarify email login CTA

### DIFF
--- a/js/i18n/i18n-login.js
+++ b/js/i18n/i18n-login.js
@@ -43,7 +43,7 @@
       en: 'Or continue with email'
     },
     'email_login': {
-      ko: '이메일로 계속하기',
+      ko: '이메일로 로그인',
       en: 'Continue with email'
     },
 

--- a/pages/login.html
+++ b/pages/login.html
@@ -50,7 +50,7 @@
             <div class="login-divider" data-i18n="or_email">또는 이메일로 시작하기</div>
 
             <button id="login-btn-email" class="btn-round btn-outline login-email-button" data-i18n="email_login">
-                이메일로 시작하기
+                이메일로 로그인
             </button>
 
             <!-- 회원가입 섹션 -->


### PR DESCRIPTION
## Summary
- Clarifies the Korean login page email CTA from `이메일로 시작하기` to `이메일로 로그인`.
- Keeps the existing English email CTA copy unchanged.

## Changed files
- `js/i18n/i18n-login.js`
- `pages/login.html`

## Scope
- Login page email CTA copy only.
- i18n Korean `email_login` copy.
- Static fallback text for the same login email CTA button.

## Out of scope
- Auth flow changes.
- Firebase/Auth backend changes.
- Login form behavior changes.
- Signup/login mode redesign.
- Passwordless/email-link implementation changes.
- PR #7 or prototype/reference/demo/variant changes.
- PR #667/#620/#629 changes.

## Verification
- Compared branch against latest `main`; changed files are limited to the two login CTA copy files above.
- Confirmed this is a copy-only change: no Auth/API/backend behavior files changed.
- Close keyword intentionally not used.
- Browser/runtime verification: NOT_VERIFIED.

## Required browser/test-slot verification before ready or merge
- Login/Auth UI requires fixed test slot verification.
- The fixed test slot deployed SHA must match the PR head SHA before browser PASS can be claimed.
- Email/password login must be exercised where login state is required.
- Google login does not satisfy this verification path.
- Local server, local static server, and local browser checks are not sufficient for browser/runtime PASS.
- Cloudflare Preview alone is not sufficient unless explicitly mapped to the approved fixed-slot/SHA-match process.
- Test slot deployment was not performed in this PR creation pass.

## Guardrails
- No direct `main` modification.
- No merge.
- No ready-for-review transition.
- No issue close.
- No secret/token/session/cookie/header/password/private key/DB URL exposure.
- PR #7 and prototype/reference/demo/variant paths untouched.

Refs #670