### PR TITLE
fix(i18n): handle language parameter

### DIFF
--- a/js/i18n/i18n-core.js
+++ b/js/i18n/i18n-core.js
@@ -14,11 +14,42 @@
   var I18N_KEY = 'lovebud_lang';
   var DEFAULT_LANG = 'ko';
 
+  function isSupportedLang(lang) {
+    return lang === 'ko' || lang === 'en';
+  }
+
+  function getLangFromQuery() {
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      var rawLang = params.get('lang');
+      var lang = rawLang ? rawLang.toLowerCase() : '';
+      if (isSupportedLang(lang)) {
+        return lang;
+      }
+    } catch (e) {
+      console.warn('[i18n] Failed to read language query param:', e);
+    }
+    return '';
+  }
+
+  function persistInitialQueryLang() {
+    var queryLang = getLangFromQuery();
+    if (!queryLang) return;
+    try {
+      localStorage.setItem(I18N_KEY, queryLang);
+      console.log('[i18n] Language set from query param:', queryLang);
+    } catch (e) {
+      console.warn('[i18n] Failed to save query language:', e);
+    }
+  }
+
+  persistInitialQueryLang();
+
   // 현재 언어 가져오기
   function getCurrentLang() {
     try {
       var stored = localStorage.getItem(I18N_KEY);
-      if (stored && (stored === 'ko' || stored === 'en')) {
+      if (isSupportedLang(stored)) {
         return stored;
       }
     } catch (e) {
@@ -29,7 +60,7 @@
 
   // 언어 설정하기
   function setCurrentLang(lang) {
-    if (lang !== 'ko' && lang !== 'en') {
+    if (!isSupportedLang(lang)) {
       console.warn('[i18n] Invalid language:', lang);
       return false;
     }


### PR DESCRIPTION
Refs #672

## Summary
- Update i18n bootstrap language handling for supported URL values.
- Keep the implementation limited to the shared i18n core.

## Root cause
- The i18n core previously used stored language state only.
- URL language selection was not applied before page i18n rendering.

## Changed files
- `js/i18n/i18n-core.js`

## Scope
- Accept `ko` and `en` from the `lang` query parameter.
- Normalize accepted values to lowercase.
- Persist accepted values through the existing stored language model.
- Ignore unsupported values safely.

## Out of scope
- Intro copy changes.
- Dictionary changes.
- Login copy changes.
- My Trees or Browse changes.
- Auth/API/backend behavior.
- Visual redesign.
- Prototype/reference/demo/variant paths.

## Verification
- Static JS syntax check passed on the updated file content.
- Branch diff against `main` is limited to `js/i18n/i18n-core.js`.
- Browser verification: NOT_VERIFIED.

## Browser/test-slot verification required
- Verify Intro with `?lang=en` and `?lang=ko` on a deployed preview or fixed test slot with SHA confirmation.
- Verify desktop and mobile 375px rendering.
- Verify unsupported values are ignored safely.
- Verify no fatal console or page errors.

## Guardrails
- Draft only.
- No direct main update.
- No merge.
- No ready transition.
- No issue close.
- No unrelated files changed.
- Protected prototype/reference/demo/variant areas untouched.