### PR TITLE
fix(my-trees): keep create modal above backdrop

### DIFF
--- a/css/my-trees/create-modal.css
+++ b/css/my-trees/create-modal.css
@@ -1,6 +1,6 @@
-.create-tree-modal-backdrop { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; padding: 24px; background: rgba(53, 40, 38, 0.34); backdrop-filter: blur(8px); z-index: 1200; }
-.create-tree-modal-backdrop.show { display: flex; }
-.create-tree-modal { width: min(100%, 520px); background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(255,248,249,0.98)); border: 1px solid rgba(144, 73, 81, 0.12); border-radius: 28px; box-shadow: 0 30px 70px rgba(75, 64, 57, 0.18); padding: 28px; }
+.create-tree-modal-backdrop { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; padding: 24px; background: rgba(53, 40, 38, 0.34); backdrop-filter: blur(8px); z-index: 1200; pointer-events: none; }
+.create-tree-modal-backdrop.show { display: flex; pointer-events: auto; }
+.create-tree-modal { position: relative; z-index: 1; width: min(100%, 520px); background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(255,248,249,0.98)); border: 1px solid rgba(144, 73, 81, 0.12); border-radius: 28px; box-shadow: 0 30px 70px rgba(75, 64, 57, 0.18); padding: 28px; pointer-events: auto; }
 .create-tree-modal-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 22px; }
 .create-tree-modal-kicker { display: inline-flex; align-items: center; gap: 6px; min-height: 28px; padding: 0 12px; border-radius: 999px; background: rgba(144, 73, 81, 0.08); color: var(--primary); font-size: 12px; font-weight: 900; margin-bottom: 12px; }
 .create-tree-modal-title { font-size: 1.5rem; font-weight: 900; line-height: 1.2; color: var(--on-surface); letter-spacing: -0.02em; margin: 0 0 8px; }


### PR DESCRIPTION
## Summary

This PR fixes the create-tree modal interaction reported in Issue #678. The modal backdrop could intercept pointer events during the create-tree flow, preventing reliable submission through the visible modal action.

The change keeps the modal panel explicitly above the backdrop interaction layer and preserves pointer events on the visible modal content.

Refs #678
Refs #616

## Scope

Changed file:

- `css/my-trees/create-modal.css`

This PR does not change My Trees batching, scroll continuation, auth, backend/API behavior, editor, search, prototype, reference, demo, or variant paths.

## Verification needed

Browser verification is required before this PR can be considered ready:

- Deploy this PR to an approved test environment.
- Confirm deployed SHA matches PR head SHA.
- Open My Trees after QA login.
- Open create-tree modal from the header create action.
- Enter a title.
- Submit through the visible modal submit button.
- Confirm the create flow advances normally.
- Repeat on desktop and mobile 375px.
- Upload screenshots for direct visual review.

## Guardrails

- Draft PR only.
- Do not ready or merge without CTO approval.
- Do not close Issue #678 until browser verification confirms the modal submit path.
- Do not close Issue #616 as part of this PR.