### PR TITLE
copy(search): rename popular sort label to match moment count ordering

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -277,7 +277,7 @@
             controls.innerHTML = `
                 <div style="display:flex; gap:8px; flex-wrap:wrap;">
                     <button type="button" class="tag-chip" data-browse-sort="latest">${getCurrentLocale() === 'en' ? 'Latest' : '최신순'}</button>
-                    <button type="button" class="tag-chip" data-browse-sort="popular">${getCurrentLocale() === 'en' ? 'Popular' : '인기순'}</button>
+                    <button type="button" class="tag-chip" data-browse-sort="popular">${getCurrentLocale() === 'en' ? 'Popular' : '많은 순간순'}</button>
                 </div>
                 <button type="button" id="browseLoadMoreBtn" class="tag-chip">${getCurrentLocale() === 'en' ? 'Load more' : '더 보기'}</button>
             `;

--- a/pages/search.html
+++ b/pages/search.html
@@ -151,7 +151,7 @@
     <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260427-1"></script>
+    <script src="../js/search/search-ui.js?v=20260502-1"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
      <script src="../js/search/data.js?v=20260429-1"></script>


### PR DESCRIPTION

Refs #608

## Summary
- Renames the Browse visible sort label from `인기순` to `많은 순간순`.
- Keeps the underlying `sort=popular` value unchanged.
- Aligns visible copy with the current runtime behavior, where popular ordering is based on public memory count.

## Runtime audit basis
The Issue #608 audit found:
- frontend sends `sort=popular`;
- Cloudflare/API forwards it to Modal;
- Modal accepts `popular`;
- backend ordering is public memory count descending, then recency;
- therefore `인기순` overstates the current product semantics.

## Changed files
- `js/search/search-ui.js` — visible label only

## Scope
Copy-only Browse sort label fix.

## Out of scope
- Backend/API query changes
- `sort=popular` value changes
- URL state changes
- analytics/event tracking
- Browse card layout
- selected hub behavior
- first-batch/loading behavior
- CSS
- package/workflow changes
- PR #7 or prototype/reference/demo/variant assets

## Verification
- `git diff --check`: PASS
- JS syntax check: PASS
- `npm run verify`: running (partial output captured)
- Browser fixed-slot verification: REQUIRED before ready/merge because Browse is runtime-rendered

## Guardrails
- Issue close keyword: NO
- Issue #608 close: NO
- ready/merge: NO
- secrets/restricted IDs exposed: NO
