### PR TITLE
refactor(detail): extract loading error boundary

### DIFF
--- a/js/detail.js
+++ b/js/detail.js
@@ -61,6 +61,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         tText: utils.tText
     });
 
+    const loadingErrorBoundary = window.createDetailLoadingErrorBoundary({
+        tText: utils.tText,
+        homeHref,
+        searchHref
+    });
+
     const loader = window.LoveBudDetailLoader.createDetailLoader({
         refs,
         hrefs: {
@@ -77,7 +83,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         renderMemoryBase: render.renderMemoryBase,
         renderTreeContext: render.renderTreeContext,
         renderConnectedFragments: connected.renderConnectedFragments,
-        renderMissingMemoryState: render.renderMissingMemoryState,
+        renderMissingMemoryState: loadingErrorBoundary.renderMissingMemoryState,
         applyViewingPageCopy: copy.applyViewingPageCopy
     });
 

--- a/js/detail/detail-loading-error-boundary.js
+++ b/js/detail/detail-loading-error-boundary.js
@@ -1,0 +1,36 @@
+(function () {
+    function createDetailLoadingErrorBoundary({ tText, homeHref, searchHref }) {
+        const renderMissingMemoryState = () => {
+            const detailTopbar = document.querySelector('.detail-topbar');
+            const detailHero = document.getElementById('detailHero');
+            const mainLayout = document.querySelector('.detail-layout');
+            const contentSlot = document.querySelector('.detail-main') || document.querySelector('.detail-content') || mainLayout;
+
+            if (detailTopbar) detailTopbar.style.display = 'none';
+            if (detailHero) detailHero.style.display = 'none';
+            if (mainLayout) mainLayout.style.display = 'block';
+
+            const fallbackHTML = `
+                <div style="max-width: 600px; margin: 80px auto; text-align: center; padding: 48px;">
+                    <span class="material-symbols-outlined" style="font-size: 64px; color: var(--on-surface-variant); opacity: 0.5; margin-bottom: 24px; display: block;">sentiment_dissatisfied</span>
+                    <h2 class="headline" style="font-size: 1.8rem; margin-bottom: 16px; color: var(--on-surface);">${tText('memory_not_found_title', '기억을 찾지 못했어요')}</h2>
+                    <p style="color: var(--on-surface-variant); margin-bottom: 32px; line-height: 1.6;">
+                        ${tText('memory_not_found_desc', '요청하신 기억이 존재하지 않거나 접근할 수 없는 상태입니다.').replace('.', '<br>')}
+                    </p>
+                    <div style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
+                        <a href="${homeHref}" class="btn-round btn-outline" style="text-decoration: none;">${tText('back_to_home', '홈으로')}</a>
+                        <a href="${searchHref}" class="btn-round btn-outline" style="text-decoration: none;">${tText('browse_lovetrees', '러브트리 둘러보기')}</a>
+                    </div>
+                </div>
+            `;
+
+            if (contentSlot) contentSlot.innerHTML = fallbackHTML;
+        };
+
+        return {
+            renderMissingMemoryState
+        };
+    }
+
+    window.createDetailLoadingErrorBoundary = createDetailLoadingErrorBoundary;
+})();

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -95,6 +95,7 @@
 <script src="../js/detail/detail-render.js?v=20260427-1"></script>
 <script src="../js/detail/detail-connected.js?v=20260427-1"></script>
 <script src="../js/detail/detail-loader.js?v=20260427-1"></script>
+<script src="../js/detail/detail-loading-error-boundary.js?v=20260502-1"></script>
 <script src="../js/detail.js?v=20260422-6"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>

--- a/tests/routes/detail-alias-consistency.test.js
+++ b/tests/routes/detail-alias-consistency.test.js
@@ -33,6 +33,7 @@ test('detail runtime submodules load after API client and before detail entrypoi
     '../js/detail/detail-render.js',
     '../js/detail/detail-connected.js',
     '../js/detail/detail-loader.js',
+    '../js/detail/detail-loading-error-boundary.js',
   ];
   const moduleIndexes = expectedModules.map(indexOf);
 


### PR DESCRIPTION
## Summary
- Extract detail missing-memory error state rendering into `createDetailLoadingErrorBoundary(deps)`.
- Keep `js/detail.js` delegating the loader's error-state renderer through the new boundary.

## Scope
- `js/detail.js`
- `js/detail/detail-loading-error-boundary.js`
- `pages/detail.html`
- `tests/routes/detail-alias-consistency.test.js`

## Validation
- `git diff --check`
- `node --check js/detail.js`
- `node --check js/detail/detail-loading-error-boundary.js`
- `npm test`
- `npm run verify`

## Browser/fixed slot
NOT_VERIFIED

Refs #661
