### PR TITLE
refactor(editor): extract detail UI builders

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -58,9 +58,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorBindings = window.LoveBudEditorBindings || {};
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
-    const readConfirmedAuthCacheFromHelper = () => (
-        window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
-    );
+    const readConfirmedAuthCacheFromHelper = editorAuthHelpers.readConfirmedAuthCache || (() => null);
+    const getConfirmedSessionUser = editorAuthHelpers.getConfirmedSessionUser || function() {
+        try {
+            if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();
+        } catch (e) {}
+        return readConfirmedAuthCacheFromHelper();
+    };
+    const hasConfirmedSessionUser = editorAuthHelpers.hasConfirmedSessionUser || (() => !!getConfirmedSessionUser());
 
     const getHttpStatus = (error) => Number(error?.status || error?.statusCode || error?.response?.status || 0);
 
@@ -747,14 +752,6 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     var editorStarted = false;
-    const getConfirmedSessionUser = function() {
-        const helper = window.LoveBudEditorAuthHelpers?.getConfirmedSessionUser;
-        if (typeof helper === 'function') return helper();
-        try {
-            if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();
-        } catch (e) {}
-        return readConfirmedAuthCacheFromHelper();
-    };
 
     function tryStartEditor(user) {
         if (editorStarted) {

--- a/js/editor.js
+++ b/js/editor.js
@@ -58,7 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorBindings = window.LoveBudEditorBindings || {};
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
-    const readConfirmedAuthCacheFromHelper = editorAuthHelpers.readConfirmedAuthCache || (() => null);
+    const readConfirmedAuthCacheFromHelper = () => (
+        window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
+    );
     const getConfirmedSessionUser = editorAuthHelpers.getConfirmedSessionUser || function() {
         try {
             if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();

--- a/js/editor/editor-detail-ui-builders.js
+++ b/js/editor/editor-detail-ui-builders.js
@@ -1,0 +1,49 @@
+(function () {
+    function createEditorDetailUIBuilders({ formatI18nText }) {
+        const createInlineIcon = (name, size = '12px') => {
+            const icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined';
+            icon.style.fontSize = size;
+            icon.textContent = name;
+            return icon;
+        };
+
+        const getDisplayEmotionTags = (data, options = {}) => {
+            const opts = options || {};
+            const isRootSelected = !!opts.isRootSelected;
+            const isEmptyState = !!opts.isEmptyState;
+            const rawTags = Array.isArray(data?.emotionTags) ? data.emotionTags.filter(Boolean) : [];
+            const normalizedTags = rawTags.map((tag) => {
+                const trimmed = String(tag || '').trim();
+                if (!trimmed) return '';
+                if (trimmed === '기록') {
+                    return formatI18nText('editor_root_emotion_tag', '첫 마음');
+                }
+                return trimmed;
+            }).filter(Boolean);
+
+            if (normalizedTags.length > 0) return normalizedTags;
+            if (!isEmptyState && isRootSelected) return [formatI18nText('editor_root_emotion_tag', '첫 마음')];
+            return [];
+        };
+
+        const getMemoFallbackText = (options = {}) => {
+            const opts = options || {};
+            if (opts.isEmptyState) {
+                return formatI18nText('empty_tree_memo', '아직 비어 있는 자리예요. 첫 순간을 심으면 이 트리가 당신의 흐름으로 자라나기 시작해요.');
+            }
+            if (opts.isRootSelected) {
+                return formatI18nText('editor_root_memo_fallback', '이 장면이 왜 시작이 되었는지 남겨두면, 다음 순간들이 더 자연스럽게 이어져요.');
+            }
+            return formatI18nText('editor_selected_memo_fallback', '이 순간의 마음을 한 줄 남겨두면, 이어진 흐름을 다시 떠올리기 쉬워져요.');
+        };
+
+        return {
+            createInlineIcon,
+            getDisplayEmotionTags,
+            getMemoFallbackText
+        };
+    }
+
+    window.createEditorDetailUIBuilders = createEditorDetailUIBuilders;
+})();

--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -31,13 +31,56 @@ function createEditorDetailUI(deps) {
         return text;
     };
 
-    const createInlineIcon = (name, size = '12px') => {
-        const icon = document.createElement('span');
-        icon.className = 'material-symbols-outlined';
-        icon.style.fontSize = size;
-        icon.textContent = name;
-        return icon;
+    const createEditorDetailUIBuilders = window.createEditorDetailUIBuilders || function({ formatI18nText }) {
+        const createInlineIcon = (name, size = '12px') => {
+            const icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined';
+            icon.style.fontSize = size;
+            icon.textContent = name;
+            return icon;
+        };
+
+        const getDisplayEmotionTags = (data, options = {}) => {
+            const opts = options || {};
+            const isRootSelected = !!opts.isRootSelected;
+            const isEmptyState = !!opts.isEmptyState;
+            const rawTags = Array.isArray(data?.emotionTags) ? data.emotionTags.filter(Boolean) : [];
+            const normalizedTags = rawTags.map((tag) => {
+                const trimmed = String(tag || '').trim();
+                if (!trimmed) return '';
+                if (trimmed === '기록') {
+                    return formatI18nText('editor_root_emotion_tag', '첫 마음');
+                }
+                return trimmed;
+            }).filter(Boolean);
+
+            if (normalizedTags.length > 0) return normalizedTags;
+            if (!isEmptyState && isRootSelected) return [formatI18nText('editor_root_emotion_tag', '첫 마음')];
+            return [];
+        };
+
+        const getMemoFallbackText = (options = {}) => {
+            const opts = options || {};
+            if (opts.isEmptyState) {
+                return formatI18nText('empty_tree_memo', '아직 비어 있는 자리예요. 첫 순간을 심으면 이 트리가 당신의 흐름으로 자라나기 시작해요.');
+            }
+            if (opts.isRootSelected) {
+                return formatI18nText('editor_root_memo_fallback', '이 장면이 왜 시작이 되었는지 남겨두면, 다음 순간들이 더 자연스럽게 이어져요.');
+            }
+            return formatI18nText('editor_selected_memo_fallback', '이 순간의 마음을 한 줄 남겨두면, 이어진 흐름을 다시 떠올리기 쉬워져요.');
+        };
+
+        return {
+            createInlineIcon,
+            getDisplayEmotionTags,
+            getMemoFallbackText
+        };
     };
+    const {
+        createInlineIcon,
+        getDisplayEmotionTags,
+        getMemoFallbackText
+    } = createEditorDetailUIBuilders({ formatI18nText });
 
     // ── Tree meta boundary integration ───────────────────────────────────────
     // Use extracted helper from PR #664 for tree meta boundary
@@ -70,36 +113,6 @@ function createEditorDetailUI(deps) {
             hasMoments: totalMomentCount > 0,
             hasVisibleMoments: visibleMomentCount > 0
         };
-    };
-
-    const getDisplayEmotionTags = (data, options = {}) => {
-        const opts = options || {};
-        const isRootSelected = !!opts.isRootSelected;
-        const isEmptyState = !!opts.isEmptyState;
-        const rawTags = Array.isArray(data?.emotionTags) ? data.emotionTags.filter(Boolean) : [];
-        const normalizedTags = rawTags.map((tag) => {
-            const trimmed = String(tag || '').trim();
-            if (!trimmed) return '';
-            if (trimmed === '기록') {
-                return formatI18nText('editor_root_emotion_tag', '첫 마음');
-            }
-            return trimmed;
-        }).filter(Boolean);
-
-        if (normalizedTags.length > 0) return normalizedTags;
-        if (!isEmptyState && isRootSelected) return [formatI18nText('editor_root_emotion_tag', '첫 마음')];
-        return [];
-    };
-
-    const getMemoFallbackText = (options = {}) => {
-        const opts = options || {};
-        if (opts.isEmptyState) {
-            return formatI18nText('empty_tree_memo', '아직 비어 있는 자리예요. 첫 순간을 심으면 이 트리가 당신의 흐름으로 자라나기 시작해요.');
-        }
-        if (opts.isRootSelected) {
-            return formatI18nText('editor_root_memo_fallback', '이 장면이 왜 시작이 되었는지 남겨두면, 다음 순간들이 더 자연스럽게 이어져요.');
-        }
-        return formatI18nText('editor_selected_memo_fallback', '이 순간의 마음을 한 줄 남겨두면, 이어진 흐름을 다시 떠올리기 쉬워져요.');
     };
 
     // ── Inline edit boundary integration ───────────────────────────────────────

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -254,6 +254,7 @@
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260502-2"></script>
+    <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260419-1"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260422-3"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -46,6 +46,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-canvas-viewport.js',
     'js/editor/editor-canvas.js',
     'js/editor/editor-rename-ui.js',
+    'js/editor/editor-detail-ui-builders.js',
     'js/editor/editor-detail-ui.js',
     'js/editor/editor-memory-actions.js',
     'js/editor/editor-memory-form.js',
@@ -69,6 +70,12 @@ test('data-loader fallback boundary is explicitly mounted before editor entry', 
 
   assertLoadedBefore(sources, 'js/editor/editor-data-loader.js', 'js/editor/editor-data-loader-fallbacks.js');
   assertLoadedBefore(sources, 'js/editor/editor-data-loader-fallbacks.js', 'js/editor.js');
+});
+
+test('detail UI builders load before detail UI', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(sources, 'js/editor/editor-detail-ui-builders.js', 'js/editor/editor-detail-ui.js');
 });
 
 test('entry fallback boundary is explicitly mounted before editor entry', () => {

--- a/tests/routes/editor-detail-ui-alias-consistency.test.js
+++ b/tests/routes/editor-detail-ui-alias-consistency.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+test('editor detail UI builder boundary exposes the expected factory', () => {
+  const builders = read('js/editor/editor-detail-ui-builders.js');
+
+  assert.match(builders, /window\.createEditorDetailUIBuilders\s*=/);
+  assert.match(builders, /createInlineIcon/);
+  assert.match(builders, /getDisplayEmotionTags/);
+  assert.match(builders, /getMemoFallbackText/);
+});
+
+test('editor detail UI delegates pure builders through the boundary', () => {
+  const detailUi = read('js/editor/editor-detail-ui.js');
+
+  assert.match(detailUi, /window\.createEditorDetailUIBuilders/);
+  assert.match(detailUi, /createEditorDetailUIBuilders\(\{\s*formatI18nText\s*\}\)/);
+});


### PR DESCRIPTION
## Summary
- Extract pure editor detail UI builder helpers behind `createEditorDetailUIBuilders`.
- Keep `createEditorDetailUI()` public API and existing dependency injection keys unchanged.
- Preserve DOM ids/classes/data attributes, i18n keys, copy, and fallback behavior.

## Changed files
- `js/editor/editor-detail-ui.js`
- `js/editor/editor-detail-ui-builders.js`
- `tests/routes/editor-detail-ui-alias-consistency.test.js`

## No behavior change
This is a narrow builder extraction only. Inline edit save/cancel, visibility/share/open-detail behavior, script type/module usage, and existing fallbacks are unchanged.

## Validation
- `git diff --check`
- `node --check js/editor/editor-detail-ui.js`
- `node --check js/editor/editor-detail-ui-builders.js`
- `node --test tests/routes/editor-detail-ui-alias-consistency.test.js`
- `npm test`
- `npm run verify`

## Browser/fixed slot
NOT_VERIFIED

Refs #657
