### PR TITLE
fix(search): preserve first batch size across Browse sort changes

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -304,7 +304,6 @@
                     const nextSort = button.dataset.browseSort || 'latest';
                     if (nextSort === state.currentSort) return;
                     state.currentSort = nextSort;
-                    state.currentLimit = 10;
                     syncControlsFromState();
                     callbacks.updateUrlState();
                     await callbacks.loadPublicTrees({ resetSelection: true });


### PR DESCRIPTION
Refs #607

Related: #456, #535, #598, #606

Why this PR is needed

Browse starts with a six-item first batch, but the sort toggle path was overriding the current Browse limit to 10. That made a latest/popular sort change alter both ordering and result count. This PR keeps the sort interaction focused on changing order only.

Changed files

- js/search/search-ui.js

Behavior summary

The Browse sort click handler now updates only `state.currentSort`, then syncs controls, URL state, and reloads public trees. It no longer assigns a hard-coded limit during the sort transition, so the initial six-item first batch remains six. Existing current limit state is preserved, including load-more-expanded state and supported URL limit overrides.

Non-goals

This does not implement scroll-near-bottom loading for #598, does not change or remove the load-more path for #606, does not touch copy-to-my-tree UX for #604, and does not redesign Browse cards, layout, filters, backend, API, auth, or database behavior.

Verification

- git diff --check: PASS
- node --check js/search/search-ui.js: PASS
- npm test: PASS (182 tests)

Browser verification

NOT_DONE / REQUIRED_LATER. Per task scope, no browser, fixed test slot, or production verification was performed.

Guardrails

PR #7 and prototype/reference/demo/variant paths are untouched. PR #450 is untouched. No package, workflow, backend, API, Auth, or DB files were changed.