### PR TITLE
fix(editor): use auth helper cache reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ Cloudflare Pages에서는 위 경로가 사용자-facing 주소로 노출됩니�
 - source of truth 문서와 충돌하는 판단 금지
 
 세부 협업 규칙은 `AGENTS.md`를 따릅니다.
+

--- a/README.md
+++ b/README.md
@@ -193,4 +193,3 @@ Cloudflare Pages에서는 위 경로가 사용자-facing 주소로 노출됩니�
 - source of truth 문서와 충돌하는 판단 금지
 
 세부 협업 규칙은 `AGENTS.md`를 따릅니다.
-

--- a/js/editor.js
+++ b/js/editor.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorBindings = window.LoveBudEditorBindings || {};
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
+    const readConfirmedAuthCacheFromHelper = editorAuthHelpers.readConfirmedAuthCache || (() => null);
 
     const getHttpStatus = (error) => Number(error?.status || error?.statusCode || error?.response?.status || 0);
 
@@ -748,7 +749,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();
         } catch (e) {}
-        return readConfirmedAuthCache();
+        return readConfirmedAuthCacheFromHelper();
     };
 
     function tryStartEditor(user) {
@@ -759,7 +760,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         if (!user) {
-            var cachedUser = readConfirmedAuthCache();
+            var cachedUser = readConfirmedAuthCacheFromHelper();
             if (!cachedUser || !cachedUser.uid) {
                 redirectToEditorLogin();
                 return;

--- a/js/editor.js
+++ b/js/editor.js
@@ -58,7 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorBindings = window.LoveBudEditorBindings || {};
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
-    const readConfirmedAuthCacheFromHelper = editorAuthHelpers.readConfirmedAuthCache || (() => null);
+    const readConfirmedAuthCacheFromHelper = () => (
+        window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
+    );
 
     const getHttpStatus = (error) => Number(error?.status || error?.statusCode || error?.response?.status || 0);
 
@@ -745,7 +747,9 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     var editorStarted = false;
-    const getConfirmedSessionUser = editorAuthHelpers.getConfirmedSessionUser || function() {
+    const getConfirmedSessionUser = function() {
+        const helper = window.LoveBudEditorAuthHelpers?.getConfirmedSessionUser;
+        if (typeof helper === 'function') return helper();
         try {
             if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();
         } catch (e) {}

--- a/tests/routes/editor-auth-helper-callsite.test.js
+++ b/tests/routes/editor-auth-helper-callsite.test.js
@@ -13,6 +13,7 @@ test('editor auth cache reader is called through the helper namespace binding', 
   const editor = read('js/editor.js');
 
   assert.match(editor, /const\s+editorAuthHelpers\s*=\s*window\.LoveBudEditorAuthHelpers\s*\|\|\s*\{\}/);
-  assert.match(editor, /readConfirmedAuthCacheFromHelper\s*=\s*editorAuthHelpers\.readConfirmedAuthCache\s*\|\|/);
+  assert.match(editor, /readConfirmedAuthCacheFromHelper\s*=\s*\(\)\s*=>\s*\(/);
+  assert.match(editor, /window\.LoveBudEditorAuthHelpers\?\.readConfirmedAuthCache\?\.\(\)/);
   assert.doesNotMatch(editor, /[^.\w]readConfirmedAuthCache\s*\(/);
 });

--- a/tests/routes/editor-auth-helper-callsite.test.js
+++ b/tests/routes/editor-auth-helper-callsite.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+test('editor auth cache reader is called through the helper namespace binding', () => {
+  const editor = read('js/editor.js');
+
+  assert.match(editor, /const\s+editorAuthHelpers\s*=\s*window\.LoveBudEditorAuthHelpers\s*\|\|\s*\{\}/);
+  assert.match(editor, /readConfirmedAuthCacheFromHelper\s*=\s*editorAuthHelpers\.readConfirmedAuthCache\s*\|\|/);
+  assert.doesNotMatch(editor, /[^.\w]readConfirmedAuthCache\s*\(/);
+});


### PR DESCRIPTION
## Summary
- Route editor confirmed-auth cache reads through the `LoveBudEditorAuthHelpers` namespace.
- Remove direct bare `readConfirmedAuthCache()` callsites from `js/editor.js` without changing auth flow behavior.
- Follow-up commit changes the cache reader to lazy lookup `window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.()` at call time.

## Changed files
- `js/editor.js`
- `tests/routes/editor-auth-helper-callsite.test.js`

## Root cause
Fixed slot failed at the original PR head even though SHA matched. Code inspection found no remaining bare call in `js/editor.js`, but the first fix captured `editorAuthHelpers.readConfirmedAuthCache` at DOMContentLoaded setup time. The follow-up now performs lazy namespace lookup at each call, so helper load/cache timing cannot leave a stale undefined global reference path.

## Validation results
- `git diff --check`: PASS
- `node --check js/editor.js`: PASS
- `node --test tests/routes/editor-auth-helper-callsite.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser/fixed slot
NOT_VERIFIED

Refs #694
