### PR TITLE
docs(design): restore Browse scroll boundary close keyword

### DIFF
--- a/docs/design/BROWSE_HUB_SCROLL_BOUNDARY.md
+++ b/docs/design/BROWSE_HUB_SCROLL_BOUNDARY.md
@@ -65,7 +65,7 @@ This document does not implement CSS or JavaScript changes. It does not change B
 
 This document supports Issue #599 and should guide a later narrow implementation PR.
 
-Refs #599
+Closes #599
 Refs #594
 Refs #600
 Refs #601


### PR DESCRIPTION
## Summary
- Restores the Issue #599 close keyword in the Browse hub scroll-boundary document.
- This corrects the earlier replacement from `Closes #599` to `Refs #599`.

## Changed files
- `docs/design/BROWSE_HUB_SCROLL_BOUNDARY.md`

## Scope
- Docs-only correction.
- One-line issue relationship restoration.

## Verification
- Changed files checked: 1 docs file only.
- Diff is limited to `Refs #599` -> `Closes #599`.
- Browser verification: NOT_REQUIRED.

## Guardrails
- No runtime/Auth/API/backend/package/workflow changes.
- No PR #7/prototype/reference/demo/variant changes.
- Draft PR only; no ready/merge performed by this creation step.

Closes #599