### PR TITLE
fix(editor): bust cache for editor.js

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -271,7 +271,7 @@
     <script src="../js/editor/editor-entry-fallbacks.js?v=20260422-1"></script>
     <script src="../js/editor/editor-shell-helpers.js?v=20260422-1"></script>
 
-    <script src="../js/editor.js?v=20260422-4"></script>
+    <script src="../js/editor.js?v=20260502-1"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>


### PR DESCRIPTION
Refs #694

Cloudflare Pages stale asset workaround.

This PR updates only the `editor.js` script query version in `pages/editor.html` so Cloudflare fetches the latest deployed editor entry asset instead of continuing to serve the stale cached `v=20260422-4` URL.

Changed files

- pages/editor.html

Behavior summary

The editor runtime source file is unchanged. Only the asset URL query string changes from `v=20260422-4` to `v=20260502-1`, so this is intended as a cache-bust-only deployment with no runtime behavior change.

Non-goals

No JS source, Auth, API, Postgres, Search, My Trees, CSS, build step, workflow, or prototype/reference/demo/variant path changes are included.

Verification

- git diff --check: PASS
- HTML script string check: PASS
- npm run verify: PASS (134/134)

Browser/fixed slot

NOT_VERIFIED.