### PR TITLE
docs(ops): document Wrangler fixed slot deploy

### DIFF
--- a/docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md
+++ b/docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md
@@ -1,0 +1,159 @@
+# Fixed slot deploy with Wrangler
+
+## Purpose
+
+This document defines the standard manual deployment path for LoveBud fixed test slots before browser verification.
+
+Use this procedure when a PR or issue requires a deployed fixed slot such as `test/slot-4`, `test/slot-5`, or another assigned slot branch before Browse, Search, Editor, My Trees, Auth, or API-dependent browser verification.
+
+This is a docs-only operational procedure. It does not implement a GitHub workflow and does not change runtime behavior.
+
+## Related context
+
+- PR #696 and PR #698 documented the need to separate fixed slot verification from stale slot artifacts.
+- Issue #694 tracks the fixed slot deployment procedure and stale asset guardrail.
+- [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) remains the assignment, SHA provenance, and evidence gate.
+
+## Standard deployment path
+
+The fixed slot deployment standard is **Wrangler direct deploy**.
+
+Do not rely on a normal `git push` to a slot branch as the only deployment signal when the verification depends on fresh static assets. Git push based slot deploy can leave a slot serving stale assets or an older static bundle even when the branch pointer appears correct.
+
+Use Wrangler direct deploy after the slot assignment and before browser verification.
+
+```bash
+npx wrangler pages deploy . --project-name lovebud --branch test/slot-X
+```
+
+Replace `test/slot-X` with the assigned fixed slot branch, for example:
+
+```bash
+npx wrangler pages deploy . --project-name lovebud --branch test/slot-4
+```
+
+## Slot URL format
+
+For a fixed slot branch named `test/slot-X`, the expected Cloudflare Pages URL is:
+
+```text
+https://test-slot-X.lovebud.pages.dev
+```
+
+Examples:
+
+| Slot branch | Expected URL |
+| --- | --- |
+| `test/slot-4` | `https://test-slot-4.lovebud.pages.dev` |
+| `test/slot-5` | `https://test-slot-5.lovebud.pages.dev` |
+
+Do not confuse these URLs with `testX.lovebud.pages.dev`.
+
+```text
+Correct:   https://test-slot-4.lovebud.pages.dev
+Incorrect: https://test4.lovebud.pages.dev
+```
+
+Browser verification evidence must report the exact URL that was actually loaded.
+
+## Required sequence
+
+1. Confirm the PR or task requires fixed slot browser verification.
+2. Confirm the assigned slot branch, such as `test/slot-4`.
+3. Confirm the source branch and source head SHA that should be deployed.
+4. Check out the intended source tree locally.
+5. Run the expected local static checks for the PR scope.
+6. Run Wrangler direct deploy:
+
+   ```bash
+   npx wrangler pages deploy . --project-name lovebud --branch test/slot-X
+   ```
+
+7. Confirm the Wrangler output reports a successful deploy.
+8. Open the expected fixed slot URL, such as `https://test-slot-X.lovebud.pages.dev`.
+9. Perform the browser verification only after the Wrangler deployment succeeds.
+10. Report the deployed SHA/source branch, exact URL, viewport, browser, console/pageerror status, and final status.
+
+## Stale asset guardrail
+
+Treat this output as a stale asset warning:
+
+```text
+Uploaded 0 files
+```
+
+`Uploaded 0 files` may mean Cloudflare did not receive a fresh asset bundle for the verification target. When the purpose of the task is to verify a newly changed UI, Browse behavior, Search behavior, Auth behavior, or static copy, this is not a reliable deployment signal.
+
+If the deployment shows stale-asset risk, do not report browser verification as final PASS. Use a blocked status instead.
+
+```text
+final status: BLOCKED_BY_STALE_ASSET
+```
+
+## What not to use as deploy triggers
+
+Do not use source branch mutations as a workaround for stale fixed slot deployment.
+
+Avoid:
+
+- empty commits;
+- source branch version bumps;
+- arbitrary timestamp or cache-busting changes;
+- unrelated file edits;
+- source branch force-pushes that exist only to trigger deployment;
+- workflow edits for a one-off manual deployment.
+
+The deployment path should not alter the PR source tree unless the PR itself legitimately requires source changes.
+
+## Status values
+
+Use these status values in handoff and verification reports:
+
+| Status | Meaning |
+| --- | --- |
+| `READY_FOR_FIXED_SLOT_DEPLOY` | Slot assignment and source SHA are known; Wrangler deploy has not yet run. |
+| `WRANGLER_DIRECT_DEPLOYED` | Wrangler direct deploy completed for the assigned fixed slot. |
+| `FIXED_SLOT_VERIFIED` | Browser verification completed against the expected fixed slot URL after Wrangler deploy. |
+| `BLOCKED_BY_STALE_ASSET` | Deployment did not provide a reliable fresh asset signal, such as `Uploaded 0 files`. |
+
+## Browse verification rule
+
+Browse verification must run only after Wrangler direct deploy succeeds for the assigned fixed slot.
+
+Do not claim Browse browser PASS from:
+
+- local-only testing;
+- text-only review;
+- an unassigned slot;
+- a stale slot;
+- a URL whose branch/SHA/source provenance is unclear;
+- `testX.lovebud.pages.dev` when the expected fixed slot URL is `test-slot-X.lovebud.pages.dev`.
+
+## Security and reporting restrictions
+
+Do not print or store secrets in deployment or browser verification reports.
+
+Do not expose:
+
+- Cloudflare API token values;
+- session or cookie values;
+- passwords;
+- private keys;
+- database URLs;
+- restricted runtime identifiers.
+
+Report only safe status labels, branch names, public PR numbers, public commit SHAs, and public Cloudflare Pages URLs.
+
+## Non-goals
+
+This document does not:
+
+- add or modify GitHub Actions workflows;
+- change runtime code;
+- change Cloudflare project settings;
+- change API/Auth/backend behavior;
+- change Browse/Search/Editor/My Trees implementation;
+- deploy production;
+- change PR #7 or prototype/reference/demo/variant paths.
+
+Refs #694

--- a/docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md
+++ b/docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md
@@ -23,6 +23,8 @@ Until automated E2E smoke is available, this runbook defines the **manual gate**
 > **This is NOT a reintroduction of Netlify dev.**
 > Netlify remains a legacy artifact / removal candidate and must not be used as a verification target.
 
+For the standard fixed-slot deployment command before browser verification, see [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md).
+
 ---
 
 ## 2. Fixed Slot Scope
@@ -242,6 +244,7 @@ Based on Issue #136 suggested minimal smoke targets:
 
 ## 10. Related Documents
 
+- [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) — Wrangler direct deploy 표준 경로 및 stale asset guardrail
 - [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) — fixed test slot 운영 기준
 - [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) — URL provenance 및 PR Preview 기준
 - [QA_CREDENTIALS.md](QA_CREDENTIALS.md) — QA credential 복원 워크플로우

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -41,7 +41,8 @@
 23. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
 24. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
 25. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-26. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+26. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
+27. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -75,6 +76,7 @@
 | [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) | Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
 | [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) | Fixed slot 수동 E2E gate 런북 — slot 배정·SHA provenance·evidence 양식·page 분류·제한 사항 (Issue #136 manual gate 단계) |
+| [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) | Fixed slot Wrangler direct deploy 표준 경로 — `test/slot-X` 배포, `test-slot-X` URL, stale asset guardrail |
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |
 | [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) | Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, auth/test-account evidence 기준 |
 | [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) | Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식 |


### PR DESCRIPTION
Refs #694

## Summary
- Adds a fixed slot Wrangler direct deploy runbook.
- Documents `npx wrangler pages deploy . --project-name lovebud --branch test/slot-X` as the standard deploy path before fixed slot browser verification.
- Clarifies `test-slot-X.lovebud.pages.dev` URL format and stale asset guardrails.

## Changed files
- `docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md`
- `docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md`
- `docs/ops/ops_index.md`

## Scope
- Docs-only operations guidance.
- Adds links from the manual fixed slot E2E gate and ops index.

## Out of scope
- Runtime code changes.
- Workflow changes.
- Cloudflare configuration changes.
- Production deploy.
- Browser verification execution.
- PR #7 or prototype/reference/demo/variant changes.

## Verification
- Changed files reviewed: docs-only.
- Browser verification: NOT_REQUIRED.
- Runtime/workflow verification: NOT_REQUIRED.

## Guardrails
- No runtime/Auth/API/backend/package/workflow changes.
- No main direct push.
- No ready transition or merge performed.
- No issue close keyword.
- No secrets, tokens, cookies, sessions, passwords, or private keys exposed.
- PR #7/prototype/reference/demo/variant not touched.