### PR TITLE
docs(ops): add agent Wrangler fixed slot rule

### DIFF
--- a/docs/ops/AGENTS.md
+++ b/docs/ops/AGENTS.md
@@ -63,6 +63,23 @@ https://github.com/settings/tokens
 
 The generated token value must remain local to the operator and must not be pasted into chat, docs, PRs, issues, logs, screenshots, or reports.
 
+## Fixed slot deployment rule
+
+When a task requires fixed slot browser verification, agents must treat Wrangler direct deploy as the standard deployment path before reporting final browser verification.
+
+Use the fixed slot deploy procedure in [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md). Do not rely on a plain `git push` to a slot branch as the only deployment signal when fresh assets are required.
+
+Required safe reporting status values include:
+
+- `READY_FOR_FIXED_SLOT_DEPLOY`
+- `WRANGLER_DIRECT_DEPLOYED`
+- `FIXED_SLOT_VERIFIED`
+- `BLOCKED_BY_STALE_ASSET`
+
+Agents must not use empty commits, version bumps, unrelated source edits, or workflow changes merely to trigger fixed slot deployment. If the deploy output indicates stale asset risk, such as `Uploaded 0 files`, report `BLOCKED_BY_STALE_ASSET` instead of final PASS.
+
+For fixed slot URLs, agents must distinguish `https://test-slot-X.lovebud.pages.dev` from `https://testX.lovebud.pages.dev` and report the exact URL used.
+
 ## Forbidden actions
 
 Do not run or request commands that print secret material, including:


### PR DESCRIPTION
Refs #694

## Summary
- Adds a fixed slot deployment rule to the ops agent guidance.
- Requires agents to treat Wrangler direct deploy as the standard fixed slot deployment path before final browser verification.
- Adds safe reporting statuses for fixed slot deployment and stale asset blocking.

## Changed files
- `docs/ops/AGENTS.md`

## Scope
- Docs-only agent operations guidance.
- Complements PR #700 by adding the agent-facing rule that references `FIXED_SLOT_DEPLOY_WITH_WRANGLER.md`.

## Out of scope
- Runtime code changes.
- Workflow changes.
- Cloudflare configuration changes.
- Production deploy.
- Browser verification execution.
- PR #7 or prototype/reference/demo/variant changes.

## Verification
- Changed files reviewed: 1 docs file only.
- Browser verification: NOT_REQUIRED.
- Runtime/workflow verification: NOT_REQUIRED.

## Guardrails
- No runtime/Auth/API/backend/package/workflow changes.
- No main direct push.
- No ready transition or merge performed.
- No issue close keyword.
- No secrets, tokens, cookies, sessions, passwords, or private keys exposed.
- PR #7/prototype/reference/demo/variant not touched.