### PR TITLE
fix(transition): prevent mobile overflow on reveal wrappers

### DIFF
--- a/css/page-transitions.css
+++ b/css/page-transitions.css
@@ -10,6 +10,8 @@
 .reveal-up,
 .reveal-fade,
 .reveal-scale {
+    box-sizing: border-box;
+    max-width: 100%;
     pointer-events: auto;
 }
 
@@ -19,6 +21,8 @@
 
 .page-transition-enter {
     opacity: 0;
+    overflow-x: hidden;
+    overflow-x: clip;
     transform: translateY(10px);
 }
 


### PR DESCRIPTION
Refs #550

Follow-up to PR #586 production verification.

Changes:
- Add max-width/box-sizing guardrails for transition/reveal opt-in elements.
- Clip horizontal subpixel overflow on page-transition-enter wrappers.

Verification:
- 375px My Trees: PASS
- 375px Detail: PASS
- 375px Login: PASS
- git diff --check: PASS

No JS changes.
No HTML changes.
No Auth/API/runtime behavior changes.