### PR TITLE
refactor(auth): extract ready session bridge boundary

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -212,128 +212,22 @@ function fireAuthReadyCallbacks(user) {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 var __authCacheModule = window.LoveBudAuthCache || null;
+var __authCacheBridge = __authCacheModule &&
+  typeof __authCacheModule.createConfirmedAuthCacheBridge === 'function'
+  ? __authCacheModule.createConfirmedAuthCacheBridge({
+      cacheKey: AUTH_CACHE_KEY,
+      confirmedKey: AUTH_CONFIRMED_KEY,
+      tokenKey: AUTH_TOKEN_KEY
+    })
+  : null;
 
-function isInvalidAuthSessionError(error) {
-  if (__authCacheModule) return __authCacheModule.isInvalidAuthSessionError(error);
-  var message = String((error && (error.code || error.message)) || '');
-  return /USER_NOT_FOUND|user-not-found|invalid-user-token|token.*expired|user token/i.test(message);
-}
-
-function clearStaleFirebaseAuthState() {
-  if (__authCacheModule) {
-    __authCacheModule.clearStaleFirebaseAuthState();
-    return;
-  }
-  var prefixes = ['firebase:authUser:', 'firebase:pendingRedirect:', 'firebase:redirectUser:'];
-  function clearStorage(storage) {
-    if (!storage) return;
-    var keys = [];
-    for (var i = 0; i < storage.length; i++) {
-      var key = storage.key(i);
-      if (key && prefixes.some(function (p) { return key.indexOf(p) === 0; })) {
-        keys.push(key);
-      }
-    }
-    keys.forEach(function (k) { try { storage.removeItem(k); } catch (e) {} });
-  }
-  try { clearStorage(window.localStorage); } catch (e) {}
-  try { clearStorage(window.sessionStorage); } catch (e) {}
-}
-
-function getCachedAuthUser() {
-  if (__authCacheModule) {
-    return __authCacheModule.getCachedAuthUser(AUTH_CACHE_KEY, AUTH_CONFIRMED_KEY);
-  }
-  try {
-    if (localStorage.getItem(AUTH_CONFIRMED_KEY) !== 'true') return null;
-    var raw = localStorage.getItem(AUTH_CACHE_KEY);
-    if (!raw || raw === 'null') return null;
-    var parsed = JSON.parse(raw);
-    if (!parsed || !parsed.uid) return null;
-    return parsed;
-  } catch (e) {
-    return null;
-  }
-}
-
-function setConfirmedAuthCache(user) {
-  if (__authCacheModule) {
-    __authCacheModule.setConfirmedAuthCache(user, AUTH_CACHE_KEY, AUTH_CONFIRMED_KEY, AUTH_TOKEN_KEY);
-    return;
-  }
-  try {
-    if (user && user.uid) {
-      var cacheData = { uid: user.uid, displayName: user.displayName || '', email: user.email || '' };
-      localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify(cacheData));
-      localStorage.setItem(AUTH_CONFIRMED_KEY, 'true');
-      return;
-    }
-  } catch (e) {}
-  clearConfirmedAuthCache();
-}
-
-function clearConfirmedAuthCache() {
-  if (__authCacheModule) {
-    __authCacheModule.clearConfirmedAuthCache(AUTH_CACHE_KEY, AUTH_CONFIRMED_KEY, AUTH_TOKEN_KEY);
-    return;
-  }
-  try {
-    localStorage.removeItem(AUTH_CACHE_KEY);
-    localStorage.removeItem(AUTH_CONFIRMED_KEY);
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-  } catch (e) {}
-}
-
-function getCachedAuthToken() {
-  if (__authCacheModule) {
-    return __authCacheModule.getCachedAuthToken(AUTH_TOKEN_KEY);
-  }
-  try {
-    var raw = localStorage.getItem(AUTH_TOKEN_KEY);
-    if (!raw || raw === 'null') return null;
-    var parsed = JSON.parse(raw);
-    if (!parsed || !parsed.token || !parsed.expiresAt) return null;
-    if (Date.now() >= Number(parsed.expiresAt) - 30000) return null;
-    return parsed;
-  } catch (e) {
-    return null;
-  }
-}
-
-async function persistConfirmedAuthSession(user) {
-  if (__authCacheModule) {
-    await __authCacheModule.persistConfirmedAuthSession(user, AUTH_CACHE_KEY, AUTH_CONFIRMED_KEY, AUTH_TOKEN_KEY);
-    return;
-  }
-  try {
-    if (!user || !user.uid) {
-      clearConfirmedAuthCache();
-      return;
-    }
-
-    var cacheData = {
-      uid: user.uid,
-      displayName: user.displayName || '',
-      email: user.email || ''
-    };
-
-    localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify(cacheData));
-    localStorage.setItem(AUTH_CONFIRMED_KEY, 'true');
-
-    if (typeof user.getIdTokenResult === 'function') {
-      var tokenResult = await user.getIdTokenResult();
-      if (tokenResult && tokenResult.token) {
-        localStorage.setItem(AUTH_TOKEN_KEY, JSON.stringify({
-          uid: user.uid,
-          token: tokenResult.token,
-          expiresAt: new Date(tokenResult.expirationTime).getTime()
-        }));
-      }
-    }
-  } catch (e) {
-    console.warn('[auth] Failed to persist confirmed session:', e);
-  }
-}
+function isInvalidAuthSessionError(error) { return __authCacheBridge.isInvalidAuthSessionError(error); }
+function clearStaleFirebaseAuthState() { __authCacheBridge.clearStaleFirebaseAuthState(); }
+function getCachedAuthUser() { return __authCacheBridge.getCachedAuthUser(); }
+function setConfirmedAuthCache(user) { __authCacheBridge.setConfirmedAuthCache(user); }
+function clearConfirmedAuthCache() { __authCacheBridge.clearConfirmedAuthCache(); }
+function getCachedAuthToken() { return __authCacheBridge.getCachedAuthToken(); }
+async function persistConfirmedAuthSession(user) { await __authCacheBridge.persistConfirmedAuthSession(user); }
 
 // ── Preload redirect target data after login ────────────────────────────────────
 function preloadRedirectTargetData() {

--- a/js/auth/auth-cache.js
+++ b/js/auth/auth-cache.js
@@ -135,6 +135,32 @@
     }
   }
 
+  function createConfirmedAuthCacheBridge(options) {
+    var cacheKey = options && options.cacheKey;
+    var confirmedKey = options && options.confirmedKey;
+    var tokenKey = options && options.tokenKey;
+
+    return {
+      isInvalidAuthSessionError: isInvalidAuthSessionError,
+      clearStaleFirebaseAuthState: clearStaleFirebaseAuthState,
+      getCachedAuthUser: function () {
+        return getCachedAuthUser(cacheKey, confirmedKey);
+      },
+      setConfirmedAuthCache: function (user) {
+        return setConfirmedAuthCache(user, cacheKey, confirmedKey, tokenKey);
+      },
+      clearConfirmedAuthCache: function () {
+        return clearConfirmedAuthCache(cacheKey, confirmedKey, tokenKey);
+      },
+      getCachedAuthToken: function () {
+        return getCachedAuthToken(tokenKey);
+      },
+      persistConfirmedAuthSession: function (user) {
+        return persistConfirmedAuthSession(user, cacheKey, confirmedKey, tokenKey);
+      },
+    };
+  }
+
   window.LoveBudAuthCache = {
     isInvalidAuthSessionError: isInvalidAuthSessionError,
     clearStaleFirebaseAuthState: clearStaleFirebaseAuthState,
@@ -143,5 +169,6 @@
     clearConfirmedAuthCache: clearConfirmedAuthCache,
     getCachedAuthToken: getCachedAuthToken,
     persistConfirmedAuthSession: persistConfirmedAuthSession,
+    createConfirmedAuthCacheBridge: createConfirmedAuthCacheBridge,
   };
 })();


### PR DESCRIPTION
Refs #705

This PR keeps the auth runtime behavior unchanged while moving the confirmed-auth cache/session bridge out of the root auth entrypoint.

The root `js/auth.js` now delegates confirmed auth cache reads, token reads, stale Firebase auth cleanup, and confirmed session persistence through `LoveBudAuthCache.createConfirmedAuthCacheBridge()`. The underlying storage keys, public `window.*` contracts, auth ready flow, login page delegation, Firebase provider behavior, and protected-route policy are preserved.

Changed files:
- `js/auth.js`
- `js/auth/auth-cache.js`

Static and contract verification:
- diff check: PASS
- syntax checks: PASS
- targeted contract test: PASS
- full test suite: PASS
- static verification: PASS

Fixed-slot deployment:
- slot: `test8`
- URL: https://test8.lovebud.pages.dev
- expected SHA: `acbbb08b330ba8a77b9907da774e522e7d5f93a7`
- deployed SHA: `acbbb08b330ba8a77b9907da774e522e7d5f93a7`
- SHA match: YES
- Wrangler deploy: PASS

Fixed-slot browser verification:
- login page load: PASS
- QA login: PASS
- confirmed auth/session state: PRESENT
- My Trees access: PASS
- Editor access: PASS
- logout: PASS
- logout protected-route redirect: PASS
- relogin: PASS
- mobile 375px overflow: PASS
- console fatal errors: NONE
- network blocker: NONE

CTO status:
- FIXED_SLOT_VERIFIED
- Ready for CTO merge consideration.