### PR TITLE
refactor(detail): extract navigation href boundary

### DIFF
--- a/js/detail.js
+++ b/js/detail.js
@@ -24,9 +24,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const isPagesContext = window.location.pathname.indexOf('/pages/') !== -1;
     const utils = window.LoveBudDetailUtils.createUtils({ isPagesContext });
-    const homeHref = isPagesContext ? '../index.html' : 'index.html';
-    const searchHref = utils.buildPageHref('search');
-    const myTreesHref = utils.buildPageHref('my-trees');
+    const {
+        homeHref,
+        searchHref,
+        myTreesHref,
+        buildPageHref
+    } = utils.createDetailNavigationHrefs();
 
     const video = window.LoveBudDetailVideo.createVideoHelpers({
         tText: utils.tText,
@@ -50,7 +53,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         refs,
         tText: utils.tText,
         escapeHtml: utils.escapeHtml,
-        buildPageHref: utils.buildPageHref,
+        buildPageHref,
         sortTreeMemories: utils.sortTreeMemories,
         isStructuralRootMemory: utils.isStructuralRootMemory,
         buildSoftPanelMarkup: video.buildSoftPanelMarkup
@@ -73,7 +76,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             homeHref,
             searchHref,
             myTreesHref,
-            buildPageHref: utils.buildPageHref
+            buildPageHref
         },
         tText: utils.tText,
         sortTreeMemories: utils.sortTreeMemories,

--- a/js/detail/detail-utils.js
+++ b/js/detail/detail-utils.js
@@ -13,6 +13,12 @@
         const homeHref = isPagesContext ? '../index.html' : 'index.html';
         const searchHref = buildPageHref('search');
         const myTreesHref = buildPageHref('my-trees');
+        const createDetailNavigationHrefs = () => ({
+            homeHref,
+            searchHref,
+            myTreesHref,
+            buildPageHref
+        });
         const i18n = window.t || ((k) => k);
         const tText = (key, fallback) => {
             const translated = i18n(key);
@@ -124,6 +130,7 @@
 
         return {
             buildPageHref,
+            createDetailNavigationHrefs,
             tText,
             escapeHtml,
             prettifyTagLabel,


### PR DESCRIPTION
## Summary

Refs #661

Extract the first narrow Detail page entrypoint boundary from `js/detail.js` into the existing browser-global Detail utility helper.

## Changed files

- `js/detail.js`
- `js/detail/detail-utils.js`

## What changed

- Added `createDetailNavigationHrefs()` to `LoveBudDetailUtils`.
- Updated `js/detail.js` to consume that helper for Detail navigation href wiring.
- Kept the existing script loading model; no ES module import/export conversion.

## Behavior equivalence

- API call URLs and parameters: unchanged.
- Auth/session behavior: unchanged.
- Routes and response handling: unchanged.
- UI copy/layout/CSS: unchanged.
- `pages/detail.html`: unchanged.
- Cache-key query strings: unchanged.

## Conflict avoidance

- Avoids PR #586 conflict surface by not modifying `pages/detail.html`.
- Does not touch PR #7, prototype, reference, demo, or variant paths.

## Verification

- `git diff --check`: PASS
- `node --check js/detail.js`: PASS
- `node --check js/detail/detail-utils.js`: PASS
- Related detail/search route tests: PASS (8/8)
  - `tests/routes/detail-alias-consistency.test.js`
  - `tests/routes/editor-detail-ui-alias-consistency.test.js`
  - `tests/routes/search-runtime-modules.test.js`
- `npm test`: PASS (188/188)
- `npm run verify`: PASS (137/137)

## NOT_VERIFIED

- Runtime Detail browser verification: NOT_VERIFIED
- Cloudflare Preview / fixed-slot validation: NOT_RUN