### PR TITLE
fix(editor): prevent mobile canvas overflow

### DIFF
--- a/css/editor/responsive-tail.css
+++ b/css/editor/responsive-tail.css
@@ -1,2 +1,3 @@
 @media (max-width:1024px) { .editor-layout { padding:12px; gap:12px; } .sidebar, .detail-panel, .canvas-area { border-radius:24px; } .editor-canvas-topbar { position:absolute; top:14px; left:14px; right:14px; flex-direction:column; } .editor-canvas-title h2 { font-size:1.42rem; } }
 @media (max-width:768px) { .editor-canvas-caption { display:none; } .editor-canvas-toolbar { width:100%; justify-content:center; box-sizing:border-box; } .editor-status-card { padding:18px 16px; } }
+@media (max-width:768px) { .editor-layout { width:100%; max-width:100%; min-width:0; overflow-x:hidden; overflow-x:clip; } .sidebar, .detail-panel, .canvas-area { box-sizing:border-box; min-width:0; max-width:100%; } .canvas-area { width:100%; flex:1 1 auto; } .canvas-svg { max-width:100%; } }


### PR DESCRIPTION
Production audit follow-up for Editor 375px horizontal overflow.

Changes:
- Add mobile-only width guardrails for the Editor layout and primary panes.
- Release mobile min-width pressure on sidebar, canvas, and detail panel.
- Keep the canvas and SVG capped to the viewport width.

Validation:
- git diff --check: PASS
- npm test: PASS
- npm run verify: PASS
- Local 375px smoke: PASS, scrollWidth <= clientWidth, canvas visible in static Editor layout, no fatal console error on unauth redirect path.

No JS changes.
No HTML changes.
No Auth/API/data logic changes.