### PR TITLE
refactor(editor): extract canvas layout helper boundary

### DIFF
--- a/js/editor/editor-canvas-layout-helpers.js
+++ b/js/editor/editor-canvas-layout-helpers.js
@@ -1,0 +1,48 @@
+window.LoveBudEditorCanvasLayoutHelpers = {
+  getMetrics(canvas) {
+    return {
+      width: Math.max(canvas.clientWidth || 0, 720),
+      height: Math.max(canvas.clientHeight || 0, 520)
+    };
+  },
+
+  getRootBasePosition(metrics, constants) {
+    return {
+      x: Math.max(
+        360,
+        Math.min(Math.round(metrics.width * 0.42), metrics.width - constants.ROOT_RIGHT_GUTTER)
+      ),
+      y: Math.max(
+        260,
+        Math.min(Math.round(metrics.height * 0.48), metrics.height - constants.ROOT_BOTTOM_GUTTER)
+      )
+    };
+  },
+
+  getRadiusL1(metrics) {
+    return Math.max(180, Math.min(250, Math.round(metrics.width * 0.20)));
+  },
+
+  getRadiusL2(metrics) {
+    return Math.max(130, Math.min(190, Math.round(metrics.width * 0.14)));
+  },
+
+  distributeAngles(count, baseAngle = -10) {
+    if (count <= 0) return [baseAngle];
+    if (count === 1) return [baseAngle];
+
+    const totalSpread = Math.min(220, Math.max(90, (count - 1) * 36));
+    const startAngle = baseAngle - totalSpread / 2;
+
+    return Array.from({ length: count }, (_, i) => {
+      return startAngle + (totalSpread * i / (count - 1));
+    });
+  },
+
+  offsetByAngle(origin, radius, angle) {
+    return {
+      x: origin.x + radius * Math.cos(angle * Math.PI / 180),
+      y: origin.y + radius * Math.sin(angle * Math.PI / 180)
+    };
+  }
+};

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -23,6 +23,7 @@ function createEditorCanvas(deps) {
     const canvasNode = window.LoveBudEditorCanvasNode || {};
     const canvasInteraction = window.LoveBudEditorCanvasInteraction || {};
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
+    const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
     function loadStoredLayout() {
@@ -83,6 +84,7 @@ function createEditorCanvas(deps) {
     const AFFORDANCE_OFFSET_X = 168;
     const AFFORDANCE_OFFSET_Y = 10;
     const AFFORDANCE_CARD_HALF = 108;
+    const layoutHelperConstants = { ROOT_RIGHT_GUTTER, ROOT_BOTTOM_GUTTER };
 
     function persistStoredPositions() {
         if (typeof canvasLayout.createLayoutStore === 'function') {
@@ -101,40 +103,23 @@ function createEditorCanvas(deps) {
     }
 
     function getMetrics() {
-        return {
-            width: Math.max(canvas.clientWidth || 0, 720),
-            height: Math.max(canvas.clientHeight || 0, 520)
-        };
+        return canvasLayoutHelpers.getMetrics(canvas);
     }
 
     function getRootBasePosition() {
-        const metrics = getMetrics();
-        return {
-            x: Math.max(360, Math.min(Math.round(metrics.width * 0.42), metrics.width - ROOT_RIGHT_GUTTER)),
-            y: Math.max(260, Math.min(Math.round(metrics.height * 0.48), metrics.height - ROOT_BOTTOM_GUTTER))
-        };
+        return canvasLayoutHelpers.getRootBasePosition(getMetrics(), layoutHelperConstants);
     }
 
     function getRadiusL1() {
-        const metrics = getMetrics();
-        return Math.max(180, Math.min(250, Math.round(metrics.width * 0.20)));
+        return canvasLayoutHelpers.getRadiusL1(getMetrics());
     }
 
     function getRadiusL2() {
-        const metrics = getMetrics();
-        return Math.max(130, Math.min(190, Math.round(metrics.width * 0.14)));
+        return canvasLayoutHelpers.getRadiusL2(getMetrics());
     }
 
     function distributeAngles(count, baseAngle = -10) {
-        if (count <= 0) return [baseAngle];
-        if (count === 1) return [baseAngle];
-
-        const totalSpread = Math.min(220, Math.max(90, (count - 1) * 36));
-        const startAngle = baseAngle - totalSpread / 2;
-
-        return Array.from({ length: count }, (_, i) => {
-            return startAngle + (totalSpread * i / (count - 1));
-        });
+        return canvasLayoutHelpers.distributeAngles(count, baseAngle);
     }
 
     function getWorldPosition(mem, visited = new Set()) {
@@ -173,10 +158,7 @@ function createEditorCanvas(deps) {
             const angle = angles[idx] !== undefined ? angles[idx] : -10;
             const rootBase = getRootBasePosition();
             const radius = getRadiusL1();
-            return {
-                x: rootBase.x + radius * Math.cos(angle * Math.PI / 180),
-                y: rootBase.y + radius * Math.sin(angle * Math.PI / 180)
-            };
+            return canvasLayoutHelpers.offsetByAngle(rootBase, radius, angle);
         }
 
         const parent = treeMemories.find((m) => m.id === parentId);
@@ -185,10 +167,7 @@ function createEditorCanvas(deps) {
         const childAngle = childAngles[idx] !== undefined ? childAngles[idx] : 0;
         const radius = getRadiusL2();
 
-        return {
-            x: parentPos.x + radius * Math.cos(childAngle * Math.PI / 180),
-            y: parentPos.y + radius * Math.sin(childAngle * Math.PI / 180)
-        };
+        return canvasLayoutHelpers.offsetByAngle(parentPos, radius, childAngle);
     }
 
     const calcPosition = (mem) => {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -247,6 +247,7 @@
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
     <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260420-1"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -41,6 +41,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/utils/media.js',
     'js/editor/editor-root-helpers.js',
     'js/editor/editor-canvas-layout.js',
+    'js/editor/editor-canvas-layout-helpers.js',
     'js/editor/editor-canvas-node.js',
     'js/editor/editor-canvas-interaction.js',
     'js/editor/editor-canvas-viewport.js',
@@ -64,6 +65,16 @@ test('editor helper scripts load before the editor entry script', () => {
   for (const helper of helpers) {
     assertLoadedBefore(sources, helper, 'js/editor.js');
   }
+});
+
+test('canvas layout helpers load before canvas runtime', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(
+    sources,
+    'js/editor/editor-canvas-layout-helpers.js',
+    'js/editor/editor-canvas.js'
+  );
 });
 
 test('data-loader fallback boundary is explicitly mounted before editor entry', () => {


### PR DESCRIPTION
Refs #658

Changed files:
- js/editor/editor-canvas-layout-helpers.js
- js/editor/editor-canvas.js
- pages/editor.html
- tests/contracts/editor-script-order-contract.test.js

Behavior equivalence intent:
- Extract only pure canvas layout calculations for metrics, root base position, L1/L2 radii, angle distribution, and angle offset calculation.
- Preserve browser-global script loading; no ES module import/export.
- Preserve editor canvas behavior for rendering, selection, pan, drag, save, recenter, and full-view paths.

Verification results:
- git diff --check: PASS
- node --check js/editor/editor-canvas.js: PASS
- node --check js/editor/editor-canvas-layout-helpers.js: PASS
- node --test tests/contracts/editor-script-order-contract.test.js: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification status:
- NOT_VERIFIED: Editor is Auth/API dependent; local-only PASS is not claimed.
- Required next: Cloudflare Preview or fixed test slot with SHA match, logged-in QA Editor smoke for load, existing nodes, selection/detail panel, pan/drag, recenter/full-view, fatal console errors, and mobile 375px overflow.