### PR TITLE
refactor(editor): extract canvas interaction helper boundary

### DIFF
--- a/js/editor/editor-canvas-interaction-helpers.js
+++ b/js/editor/editor-canvas-interaction-helpers.js
@@ -1,0 +1,96 @@
+window.LoveBudEditorCanvasInteractionHelpers = {
+  bindFallbackCanvasPan(options) {
+    const {
+      canvas,
+      viewportState,
+      scheduleInitCanvas,
+      persistStoredPositions,
+      initCanvas,
+      i18n
+    } = options;
+
+    if (viewportState.globalsBound) return;
+    viewportState.globalsBound = true;
+
+    canvas.style.cursor = 'grab';
+    canvas.style.touchAction = 'none';
+
+    canvas.addEventListener('mousedown', (event) => {
+      if (
+        event.target.closest('.memory-node') ||
+        event.target.closest('#addMemoryForm') ||
+        event.target.closest('.memory-add-affordance')
+      ) {
+        return;
+      }
+      viewportState.isPanning = true;
+      viewportState.startX = event.clientX;
+      viewportState.startY = event.clientY;
+      canvas.classList.add('panning');
+      canvas.style.cursor = 'grabbing';
+    });
+
+    window.addEventListener('mousemove', (event) => {
+      if (viewportState.isDraggingNode && viewportState.dragNodeId) {
+        const dx = event.clientX - viewportState.dragStartClientX;
+        const dy = event.clientY - viewportState.dragStartClientY;
+        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) {
+          viewportState.dragMoved = true;
+        }
+        viewportState.positions[viewportState.dragNodeId] = {
+          x: Math.round(viewportState.dragStartWorldX + dx),
+          y: Math.round(viewportState.dragStartWorldY + dy)
+        };
+        scheduleInitCanvas();
+        return;
+      }
+
+      if (!viewportState.isPanning) return;
+      const dx = event.clientX - viewportState.startX;
+      const dy = event.clientY - viewportState.startY;
+      viewportState.startX = event.clientX;
+      viewportState.startY = event.clientY;
+      viewportState.offsetX += dx;
+      viewportState.offsetY += dy;
+      scheduleInitCanvas();
+    });
+
+    window.addEventListener('mouseup', () => {
+      const currentFrame = viewportState.rafFrame;
+      if (currentFrame) {
+        cancelAnimationFrame(currentFrame);
+        viewportState.rafFrame = null;
+        viewportState.rafScheduled = false;
+      }
+
+      let shouldRender = false;
+      if (viewportState.isDraggingNode && viewportState.dragNodeId) {
+        const draggedId = viewportState.dragNodeId;
+        const moved = viewportState.dragMoved;
+        viewportState.isDraggingNode = false;
+        viewportState.dragNodeId = null;
+        viewportState.dragMoved = false;
+        const draggedEl = document.querySelector(`.memory-node[data-memory-id="${draggedId}"]`);
+        if (draggedEl && moved) {
+          draggedEl.dataset.suppressClick = '1';
+          draggedEl.style.cursor = 'grab';
+          shouldRender = true;
+          if (window.LoveBudUI?.showToast) {
+            window.LoveBudUI.showToast(i18n('node_position_adjusted') || '순간 위치를 조정했습니다', 'success', 1800);
+          }
+        }
+      }
+
+      if (viewportState.isPanning) {
+        shouldRender = true;
+      }
+      viewportState.isPanning = false;
+      canvas.classList.remove('panning');
+      canvas.style.cursor = 'grab';
+      if (shouldRender) {
+        persistStoredPositions();
+        initCanvas();
+      }
+    });
+  }
+};

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -22,6 +22,7 @@ function createEditorCanvas(deps) {
     const canvasLayout = window.LoveBudEditorCanvasLayout || {};
     const canvasNode = window.LoveBudEditorCanvasNode || {};
     const canvasInteraction = window.LoveBudEditorCanvasInteraction || {};
+    const canvasInteractionHelpers = window.LoveBudEditorCanvasInteractionHelpers || {};
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
     const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
@@ -512,82 +513,13 @@ function isNodeWithinSafeViewport(pos) {
             return;
         }
 
-        if (viewportState.globalsBound) return;
-        viewportState.globalsBound = true;
-
-        canvas.style.cursor = 'grab';
-        canvas.style.touchAction = 'none';
-
-        canvas.addEventListener('mousedown', (e) => {
-            if (e.target.closest('.memory-node') || e.target.closest('#addMemoryForm') || e.target.closest('.memory-add-affordance')) return;
-            viewportState.isPanning = true;
-            viewportState.startX = e.clientX;
-            viewportState.startY = e.clientY;
-            canvas.classList.add('panning');
-            canvas.style.cursor = 'grabbing';
-        });
-
-        window.addEventListener('mousemove', (e) => {
-            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
-                const dx = e.clientX - viewportState.dragStartClientX;
-                const dy = e.clientY - viewportState.dragStartClientY;
-                if (Math.abs(dx) > 2 || Math.abs(dy) > 2) {
-                    viewportState.dragMoved = true;
-                }
-                viewportState.positions[viewportState.dragNodeId] = {
-                    x: Math.round(viewportState.dragStartWorldX + dx),
-                    y: Math.round(viewportState.dragStartWorldY + dy)
-                };
-                scheduleInitCanvas();
-                return;
-            }
-
-            if (!viewportState.isPanning) return;
-            const dx = e.clientX - viewportState.startX;
-            const dy = e.clientY - viewportState.startY;
-            viewportState.startX = e.clientX;
-            viewportState.startY = e.clientY;
-            viewportState.offsetX += dx;
-            viewportState.offsetY += dy;
-            scheduleInitCanvas();
-        });
-
-window.addEventListener('mouseup', () => {
-            const currentFrame = viewportState.rafFrame;
-            if (currentFrame) {
-                cancelAnimationFrame(currentFrame);
-                viewportState.rafFrame = null;
-                viewportState.rafScheduled = false;
-            }
-
-            let shouldRender = false;
-            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
-                const draggedId = viewportState.dragNodeId;
-                const moved = viewportState.dragMoved;
-                viewportState.isDraggingNode = false;
-                viewportState.dragNodeId = null;
-                viewportState.dragMoved = false;
-                const draggedEl = document.querySelector(`.memory-node[data-memory-id="${draggedId}"]`);
-                if (draggedEl && moved) {
-                    draggedEl.dataset.suppressClick = '1';
-                    draggedEl.style.cursor = 'grab';
-                    shouldRender = true;
-                    if (window.LoveBudUI?.showToast) {
-                        window.LoveBudUI.showToast(i18n('node_position_adjusted') || '순간 위치를 조정했습니다', 'success', 1800);
-                    }
-                }
-            }
-
-            if (viewportState.isPanning) {
-                shouldRender = true;
-            }
-            viewportState.isPanning = false;
-            canvas.classList.remove('panning');
-            canvas.style.cursor = 'grab';
-            if (shouldRender) {
-                persistStoredPositions();
-                initCanvas();
-            }
+        canvasInteractionHelpers.bindFallbackCanvasPan({
+            canvas,
+            viewportState,
+            scheduleInitCanvas,
+            persistStoredPositions,
+            initCanvas,
+            i18n
         });
     };
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -246,6 +246,7 @@
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
+    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260504-651"></script>
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -44,6 +44,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-canvas-layout-helpers.js',
     'js/editor/editor-canvas-node.js',
     'js/editor/editor-canvas-interaction.js',
+    'js/editor/editor-canvas-interaction-helpers.js',
     'js/editor/editor-canvas-viewport.js',
     'js/editor/editor-canvas-state-boundary.js',
     'js/editor/editor-canvas-growth-affordance.js',
@@ -75,6 +76,16 @@ test('canvas layout helpers load before canvas runtime', () => {
   assertLoadedBefore(
     sources,
     'js/editor/editor-canvas-layout-helpers.js',
+    'js/editor/editor-canvas.js'
+  );
+});
+
+test('canvas interaction helpers load before canvas runtime', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(
+    sources,
+    'js/editor/editor-canvas-interaction-helpers.js',
     'js/editor/editor-canvas.js'
   );
 });


### PR DESCRIPTION
Refs #658

Changed files:
- js/editor/editor-canvas-interaction-helpers.js
- js/editor/editor-canvas.js
- pages/editor.html
- tests/contracts/editor-script-order-contract.test.js

Behavior equivalence intent:
- Extract only the fallback canvas pan / drag global event binding from js/editor/editor-canvas.js into a browser-global helper namespace.
- Preserve classic script loading and window.LoveBudEditorCanvasInteractionHelpers; no ES module import/export or type=module conversion.
- Preserve drag, pan, select, save, recenter, and render behavior. The existing LoveBudEditorCanvasInteraction active boundary remains unchanged.

Verification results:
- git diff --check: PASS
- node --check js/editor/editor-canvas.js: PASS
- node --check js/editor/editor-canvas-interaction-helpers.js: PASS
- node --test tests/contracts/editor-script-order-contract.test.js: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification: NOT_VERIFIED
- Editor is Auth/API dependent; local-only PASS is not claimed.
- Required next: Cloudflare Preview or fixed test slot with SHA match and logged-in QA Editor smoke.