### PR TITLE
refactor(editor): extract canvas state boundary helper

### DIFF
--- a/js/editor/editor-canvas-state-boundary.js
+++ b/js/editor/editor-canvas-state-boundary.js
@@ -1,0 +1,128 @@
+function createEditorCanvasStateBoundary(deps) {
+    const {
+        treeId,
+        layoutStorageKey,
+        canvasLayout
+    } = deps || {};
+
+    function getEmptyStoredLayout() {
+        return { positions: {}, offsetX: 0, offsetY: 0 };
+    }
+
+    function normalizeStoredLayout(storedLayout) {
+        const source = storedLayout && typeof storedLayout === 'object'
+            ? storedLayout
+            : getEmptyStoredLayout();
+        return {
+            positions: source.positions && typeof source.positions === 'object' ? source.positions : {},
+            offsetX: typeof source.offsetX === 'number' ? source.offsetX : 0,
+            offsetY: typeof source.offsetY === 'number' ? source.offsetY : 0
+        };
+    }
+
+    function loadStoredLayout() {
+        if (canvasLayout && typeof canvasLayout.createLayoutStore === 'function') {
+            const store = canvasLayout.createLayoutStore(treeId);
+            return normalizeStoredLayout(store.createInitialViewportState());
+        }
+
+        try {
+            const raw = localStorage.getItem(layoutStorageKey);
+            if (!raw || raw === 'null') return getEmptyStoredLayout();
+            return normalizeStoredLayout(JSON.parse(raw));
+        } catch (error) {
+            return getEmptyStoredLayout();
+        }
+    }
+
+    function createViewportState() {
+        const storedLayout = loadStoredLayout();
+        return {
+            offsetX: storedLayout.offsetX,
+            offsetY: storedLayout.offsetY,
+            initialized: false,
+            isPanning: false,
+            startX: 0,
+            startY: 0,
+            isDraggingNode: false,
+            dragNodeId: null,
+            dragStartClientX: 0,
+            dragStartClientY: 0,
+            dragStartWorldX: 0,
+            dragStartWorldY: 0,
+            dragMoved: false,
+            controlsBound: false,
+            globalsBound: false,
+            resizeBound: false,
+            resizeTimer: null,
+            positions: storedLayout.positions,
+            rafScheduled: false,
+            rafFrame: null
+        };
+    }
+
+    function persistStoredPositions(viewportState) {
+        if (canvasLayout && typeof canvasLayout.createLayoutStore === 'function') {
+            const store = canvasLayout.createLayoutStore(treeId);
+            store.persist(viewportState);
+            return;
+        }
+
+        try {
+            localStorage.setItem(layoutStorageKey, JSON.stringify({
+                positions: viewportState.positions,
+                offsetX: viewportState.offsetX,
+                offsetY: viewportState.offsetY
+            }));
+        } catch (error) {}
+    }
+
+    function cancelScheduledFrame(viewportState) {
+        const currentFrame = viewportState.rafFrame;
+        if (!currentFrame) return;
+        cancelAnimationFrame(currentFrame);
+        viewportState.rafFrame = null;
+        viewportState.rafScheduled = false;
+    }
+
+    function scheduleRender(viewportState, render) {
+        if (viewportState.rafScheduled) return;
+        viewportState.rafScheduled = true;
+        viewportState.rafFrame = requestAnimationFrame(() => {
+            viewportState.rafScheduled = false;
+            viewportState.rafFrame = null;
+            render();
+        });
+    }
+
+    function bindResizeHandling(options) {
+        const {
+            viewportState,
+            keepSelectionVisible,
+            persistStoredPositions: persist
+        } = options || {};
+
+        if (!viewportState || viewportState.resizeBound) return;
+        viewportState.resizeBound = true;
+
+        window.addEventListener('resize', () => {
+            if (viewportState.resizeTimer) {
+                clearTimeout(viewportState.resizeTimer);
+            }
+            viewportState.resizeTimer = setTimeout(() => {
+                keepSelectionVisible();
+                persist();
+            }, 120);
+        });
+    }
+
+    return {
+        createViewportState,
+        persistStoredPositions,
+        cancelScheduledFrame,
+        scheduleRender,
+        bindResizeHandling
+    };
+}
+
+window.createEditorCanvasStateBoundary = createEditorCanvasStateBoundary;

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -26,56 +26,12 @@ function createEditorCanvas(deps) {
     const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
-    function loadStoredLayout() {
-        if (typeof canvasLayout.createLayoutStore === 'function') {
-            const store = canvasLayout.createLayoutStore(treeId);
-            const initialState = store.createInitialViewportState();
-            return {
-                positions: initialState.positions,
-                offsetX: initialState.offsetX,
-                offsetY: initialState.offsetY
-            };
-        }
-
-        try {
-            const raw = localStorage.getItem(layoutStorageKey);
-            if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0 };
-            const parsed = JSON.parse(raw);
-            if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0 };
-            return {
-                positions: (parsed.positions && typeof parsed.positions === 'object') ? parsed.positions : {},
-                offsetX: typeof parsed.offsetX === 'number' ? parsed.offsetX : 0,
-                offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0
-            };
-        } catch (e) {
-            return { positions: {}, offsetX: 0, offsetY: 0 };
-        }
-    }
-
-    const storedLayout = loadStoredLayout();
-
-    const viewportState = {
-        offsetX: storedLayout.offsetX,
-        offsetY: storedLayout.offsetY,
-        initialized: false,
-        isPanning: false,
-        startX: 0,
-        startY: 0,
-        isDraggingNode: false,
-        dragNodeId: null,
-        dragStartClientX: 0,
-        dragStartClientY: 0,
-        dragStartWorldX: 0,
-        dragStartWorldY: 0,
-        dragMoved: false,
-        controlsBound: false,
-        globalsBound: false,
-        resizeBound: false,
-        resizeTimer: null,
-        positions: storedLayout.positions,
-        rafScheduled: false,
-        rafFrame: null
-    };
+    const canvasState = window.createEditorCanvasStateBoundary({
+        treeId,
+        layoutStorageKey,
+        canvasLayout
+    });
+    const viewportState = canvasState.createViewportState();
 
     const ROOT_RIGHT_GUTTER = 300;
     const ROOT_BOTTOM_GUTTER = 180;
@@ -87,19 +43,7 @@ function createEditorCanvas(deps) {
     const layoutHelperConstants = { ROOT_RIGHT_GUTTER, ROOT_BOTTOM_GUTTER };
 
     function persistStoredPositions() {
-        if (typeof canvasLayout.createLayoutStore === 'function') {
-            const store = canvasLayout.createLayoutStore(treeId);
-            store.persist(viewportState);
-            return;
-        }
-
-        try {
-            localStorage.setItem(layoutStorageKey, JSON.stringify({
-                positions: viewportState.positions,
-                offsetX: viewportState.offsetX,
-                offsetY: viewportState.offsetY
-            }));
-        } catch (e) {}
+        canvasState.persistStoredPositions(viewportState);
     }
 
     function getMetrics() {
@@ -202,17 +146,10 @@ function createEditorCanvas(deps) {
     }
 
     function bindResizeHandling() {
-        if (viewportState.resizeBound) return;
-        viewportState.resizeBound = true;
-
-        window.addEventListener('resize', () => {
-            if (viewportState.resizeTimer) {
-                clearTimeout(viewportState.resizeTimer);
-            }
-            viewportState.resizeTimer = setTimeout(() => {
-                keepSelectionVisible();
-                persistStoredPositions();
-            }, 120);
+        canvasState.bindResizeHandling({
+            viewportState,
+            keepSelectionVisible,
+            persistStoredPositions
         });
     }
 
@@ -713,12 +650,7 @@ function createEditorCanvas(deps) {
         });
 
         window.addEventListener('mouseup', () => {
-            const currentFrame = viewportState.rafFrame;
-            if (currentFrame) {
-                cancelAnimationFrame(currentFrame);
-                viewportState.rafFrame = null;
-                viewportState.rafScheduled = false;
-            }
+            canvasState.cancelScheduledFrame(viewportState);
 
             let shouldRender = false;
             if (viewportState.isDraggingNode && viewportState.dragNodeId) {
@@ -752,13 +684,7 @@ function createEditorCanvas(deps) {
     };
 
     function scheduleInitCanvas() {
-        if (viewportState.rafScheduled) return;
-        viewportState.rafScheduled = true;
-        viewportState.rafFrame = requestAnimationFrame(() => {
-            viewportState.rafScheduled = false;
-            viewportState.rafFrame = null;
-            initCanvas();
-        });
+        canvasState.scheduleRender(viewportState, initCanvas);
     }
 
     return {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -252,6 +252,7 @@
     <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas.js?v=20260421-5"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -45,6 +45,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-canvas-node.js',
     'js/editor/editor-canvas-interaction.js',
     'js/editor/editor-canvas-viewport.js',
+    'js/editor/editor-canvas-state-boundary.js',
     'js/editor/editor-canvas.js',
     'js/editor/editor-rename-ui.js',
     'js/editor/editor-detail-sidebar-status-boundary.js',
@@ -73,6 +74,16 @@ test('canvas layout helpers load before canvas runtime', () => {
   assertLoadedBefore(
     sources,
     'js/editor/editor-canvas-layout-helpers.js',
+    'js/editor/editor-canvas.js'
+  );
+});
+
+test('canvas state boundary loads before canvas runtime', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(
+    sources,
+    'js/editor/editor-canvas-state-boundary.js',
     'js/editor/editor-canvas.js'
   );
 });


### PR DESCRIPTION
Refs #658

Changed files:
- js/editor/editor-canvas-state-boundary.js
- js/editor/editor-canvas.js
- pages/editor.html
- tests/contracts/editor-script-order-contract.test.js

Behavior equivalence intent:
- Extract viewport state creation/loading, stored position persistence orchestration, RAF scheduling/canceling, and resize debounce handling into a browser-global state boundary helper.
- Preserve classic script loading and global namespace pattern.
- No ES module import/export or type=module conversion.
- Preserve Editor Auth/API/data flow and render behavior.
- Preserve existing interaction helper and layout helper behavior.

Verification:
- git diff --check: PASS
- node --check js/editor/editor-canvas.js: PASS
- node --check js/editor/editor-canvas-state-boundary.js: PASS
- node --test tests/contracts/editor-script-order-contract.test.js: PASS
- npm test: PASS, 191/191
- npm run verify: PASS, 139/139

Browser verification:
- NOT_VERIFIED
- Editor is Auth/API dependent.
- Required next: Cloudflare Preview or fixed test slot with SHA match and logged-in QA Editor smoke.