### PR TITLE
refactor(css): extract global header language boundary

### DIFF
--- a/css/global/header-language.css
+++ b/css/global/header-language.css
@@ -1,0 +1,99 @@
+/* Header language toggle and dropdown */
+.lang-toggle {
+    position: relative;
+    display: inline-block;
+}
+
+.lang-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--on-surface-variant);
+}
+
+.lang-toggle-btn:hover {
+    background: var(--surface-container-low);
+    color: var(--primary);
+}
+
+.lang-toggle-btn .material-symbols-outlined {
+    font-size: 18px;
+}
+
+.lang-menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    height: 36px;
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 999px !important;
+    border: 1px solid var(--outline-variant) !important;
+    background: linear-gradient(180deg, rgba(255,255,255,0.94), rgba(248,245,240,0.92)) !important;
+    color: var(--on-surface-variant);
+    box-shadow: 0 8px 18px rgba(75, 64, 57, 0.06);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+    text-decoration: none;
+    min-height: auto;
+    justify-content: flex-start;
+}
+
+.lang-menu-trigger:hover {
+    transform: translateY(-1px);
+    color: var(--primary);
+    border-color: rgba(144, 73, 81, 0.2) !important;
+    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,242,0.96)) !important;
+    box-shadow: 0 12px 24px rgba(75, 64, 57, 0.09);
+}
+
+.lang-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+    border: 1px solid var(--outline-variant);
+    min-width: 90px;
+    z-index: 1000;
+    display: none;
+    overflow: hidden;
+    padding: 4px;
+}
+
+.lang-dropdown.show {
+    display: block;
+}
+
+.lang-option {
+    display: block;
+    width: 100%;
+    padding: 8px 16px;
+    border: none;
+    background: transparent;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--on-surface-variant);
+    cursor: pointer;
+    border-radius: 8px;
+    transition: all 0.15s ease;
+}
+
+.lang-option:hover {
+    background: var(--surface-container-low);
+    color: var(--on-surface);
+}
+
+.lang-option.active {
+    background: rgba(144, 73, 81, 0.1);
+    color: var(--primary);
+}

--- a/css/global/header.css
+++ b/css/global/header.css
@@ -1,3 +1,5 @@
+@import url('./header-language.css');
+
 /* Header Refinement */
 .nav-bar {
     position: sticky;
@@ -68,107 +70,6 @@
     display: flex;
     align-items: center;
     gap: 12px;
-}
-
-
-/* Language Toggle - Compact Dropdown */
-.lang-toggle {
-    position: relative;
-    display: inline-block;
-}
-
-.lang-toggle-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  background: transparent;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  color: var(--on-surface-variant);
-}
-
-.lang-toggle-btn:hover {
-    background: var(--surface-container-low);
-    color: var(--primary);
-}
-
-.lang-toggle-btn .material-symbols-outlined {
-    font-size: 18px;
-}
-
-.lang-menu-trigger {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 12px;
-    height: 36px;
-    font-size: 14px;
-    font-weight: 500;
-    border-radius: 999px !important;
-    border: 1px solid var(--outline-variant) !important;
-    background: linear-gradient(180deg, rgba(255,255,255,0.94), rgba(248,245,240,0.92)) !important;
-    color: var(--on-surface-variant);
-    box-shadow: 0 8px 18px rgba(75, 64, 57, 0.06);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
-    text-decoration: none;
-    min-height: auto;
-    justify-content: flex-start;
-}
-
-.lang-menu-trigger:hover {
-    transform: translateY(-1px);
-    color: var(--primary);
-    border-color: rgba(144, 73, 81, 0.2) !important;
-    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,242,0.96)) !important;
-    box-shadow: 0 12px 24px rgba(75, 64, 57, 0.09);
-}
-
-.lang-dropdown {
-    position: absolute;
-    top: calc(100% + 6px);
-    right: 0;
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
-    border: 1px solid var(--outline-variant);
-    min-width: 90px;
-    z-index: 1000;
-    display: none;
-    overflow: hidden;
-    padding: 4px;
-}
-
-.lang-dropdown.show {
-    display: block;
-}
-
-.lang-option {
-    display: block;
-    width: 100%;
-    padding: 8px 16px;
-    border: none;
-    background: transparent;
-    text-align: left;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--on-surface-variant);
-    cursor: pointer;
-    border-radius: 8px;
-    transition: all 0.15s ease;
-}
-
-.lang-option:hover {
-    background: var(--surface-container-low);
-    color: var(--on-surface);
-}
-
-.lang-option.active {
-    background: rgba(144, 73, 81, 0.1);
-    color: var(--primary);
 }
 
 /* User dropdown menu */


### PR DESCRIPTION
Summary:
- Extract global header language toggle/dropdown rules into css/global/header-language.css.
- Keep css/global/header.css as the global header entry CSS and import the language boundary from there.
- No HTML, JS, markup, Auth/Login, or runtime behavior changes.

Changed files:
- css/global/header.css
- css/global/header-language.css

Verification:
- git diff --check: PASS
- npm run verify: PASS
- CSS diff manually reviewed: language toggle/dropdown rules moved without value changes.

Browser verification:
- PASS: Global header desktop/mobile visual smoke completed on fixed slot test8

Fixed Slot Verification:
- test8 deployed SHA match: PASS (bf5525db3c084ea7feefce43e1dd2c36117f9b27)
- desktop header visual smoke: PASS
- mobile header visual smoke: PASS
- language toggle/dropdown: PASS
- index/search/intro header consistency: PASS
- header CSS loading error: NONE
- unrelated 400 only