### PR TITLE
ui(intro): scale LoveTree hero visual

### DIFF
--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -6,7 +6,7 @@
 
 .intro-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.72fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(380px, 0.78fr);
   gap: var(--hero-gap);
   align-items: center;
   padding: 52px var(--lovetree-page-pad-desktop) 32px;
@@ -85,7 +85,7 @@
 
 .intro-hero-visual {
   position: relative;
-  padding: 22px;
+  padding: 20px;
   border-radius: 32px;
   background:
     radial-gradient(circle at 30% 20%, rgba(255, 248, 245, 0.92), transparent 52%),
@@ -97,7 +97,7 @@
 
 .intro-tree-scene {
   position: relative;
-  min-height: 340px;
+  min-height: 390px;
   border-radius: 24px;
   overflow: hidden;
   background:
@@ -119,29 +119,29 @@
 }
 
 .intro-tree-scene::before {
-  left: 31%;
-  right: 24%;
-  top: 72px;
-  height: 178px;
+  left: 24%;
+  right: 16%;
+  top: 66px;
+  height: 224px;
   border: 1px dashed rgba(144, 73, 81, 0.16);
-  transform: rotate(-13deg);
+  transform: rotate(-12deg);
 }
 
 .intro-tree-scene::after {
-  left: 42%;
+  left: 43%;
   top: 44px;
-  width: 112px;
-  height: 218px;
+  width: 132px;
+  height: 262px;
   border: 1px solid rgba(122, 139, 110, 0.12);
-  transform: rotate(18deg);
+  transform: rotate(16deg);
 }
 
 .intro-tree-stem {
   position: absolute;
-  left: 50%;
-  bottom: 42px;
-  width: 14px;
-  height: 148px;
+  left: 51%;
+  bottom: 44px;
+  width: 18px;
+  height: 196px;
   transform-origin: bottom center;
   border-radius: 999px;
   background: linear-gradient(180deg, #c18b83, #904951);
@@ -157,7 +157,7 @@
 .intro-tree-branch {
   position: absolute;
   left: 50%;
-  height: 6px;
+  height: 8px;
   border-radius: 999px;
   background: linear-gradient(90deg, #c18b83, #aa646d);
   transform-origin: left center;
@@ -179,37 +179,37 @@
 }
 
 .intro-tree-branch.one {
-  bottom: 158px;
-  width: 96px;
-  transform: translateX(4px) rotate(-32deg);
+  bottom: 206px;
+  width: 128px;
+  transform: translateX(6px) rotate(-32deg);
   animation-delay: 0.75s;
 }
 
 .intro-tree-branch.two {
-  bottom: 134px;
-  width: 90px;
-  transform: translateX(-6px) rotate(207deg);
+  bottom: 174px;
+  width: 122px;
+  transform: translateX(-8px) rotate(207deg);
   animation-delay: 1.0s;
 }
 
 .intro-tree-branch.three {
-  bottom: 112px;
-  width: 82px;
-  transform: translateX(4px) rotate(28deg);
+  bottom: 142px;
+  width: 112px;
+  transform: translateX(6px) rotate(28deg);
   animation-delay: 1.25s;
 }
 
 .intro-tree-branch.four {
-  bottom: 88px;
-  width: 74px;
-  transform: translateX(-8px) rotate(200deg);
+  bottom: 112px;
+  width: 102px;
+  transform: translateX(-10px) rotate(200deg);
   animation-delay: 1.5s;
 }
 
 .intro-tree-branch.five {
-  bottom: 66px;
-  width: 66px;
-  transform: translateX(6px) rotate(24deg);
+  bottom: 84px;
+  width: 92px;
+  transform: translateX(8px) rotate(24deg);
   animation-delay: 1.75s;
 }
 
@@ -220,8 +220,8 @@
 
 .intro-tree-node {
   position: absolute;
-  width: 13px;
-  height: 13px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: radial-gradient(circle at 32% 28%, #fff4ef 0 22%, #e8c4b8 23% 58%, #c18b83 59% 100%);
   border: 1px solid rgba(255, 255, 255, 0.72);
@@ -235,44 +235,44 @@
 }
 
 .intro-tree-node.node-1 {
-  left: 62%;
-  bottom: 208px;
+  left: 68%;
+  bottom: 264px;
   animation-delay: 1.8s;
 }
 
 .intro-tree-node.node-2 {
-  left: 28%;
-  bottom: 162px;
+  left: 27%;
+  bottom: 206px;
   animation-delay: 1.95s;
 }
 
 .intro-tree-node.node-3 {
-  left: 70%;
-  bottom: 138px;
+  left: 73%;
+  bottom: 174px;
   animation-delay: 2.1s;
 }
 
 .intro-tree-node.node-4 {
-  left: 33%;
-  bottom: 104px;
+  left: 31%;
+  bottom: 138px;
   animation-delay: 2.25s;
 }
 
 .intro-tree-node.node-5 {
-  left: 63%;
-  bottom: 86px;
+  left: 66%;
+  bottom: 108px;
   animation-delay: 2.4s;
 }
 
 .intro-tree-node.node-6 {
-  left: 46%;
-  bottom: 222px;
+  left: 48%;
+  bottom: 282px;
   animation-delay: 2.55s;
 }
 
 .intro-tree-node.node-7 {
-  left: 53%;
-  bottom: 46px;
+  left: 56%;
+  bottom: 58px;
   animation-delay: 2.7s;
 }
 
@@ -281,8 +281,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 34px;
-  padding: 0 12px;
+  min-height: 32px;
+  padding: 0 11px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(144, 73, 81, 0.1);
@@ -313,8 +313,8 @@
 }
 
 .intro-tree-moment.first {
-  left: 16px;
-  bottom: 64px;
+  left: 18px;
+  bottom: 72px;
   color: var(--primary);
   --connector-width: 82px;
   --connector-rotate: -10deg;
@@ -334,36 +334,36 @@
 }
 
 .intro-tree-moment.saved {
-  right: 16px;
-  top: 54px;
-  --connector-width: 58px;
-  --connector-rotate: 18deg;
+  right: 18px;
+  top: 58px;
+  --connector-width: 72px;
+  --connector-rotate: 16deg;
   animation-delay: 1.75s;
 }
 
 .intro-tree-moment.shared {
-  left: 20px;
-  top: 84px;
+  left: 18px;
+  top: 102px;
   color: #667a55;
-  --connector-width: 92px;
-  --connector-rotate: 9deg;
+  --connector-width: 104px;
+  --connector-rotate: 8deg;
   animation-delay: 2.0s;
 }
 
 .intro-tree-moment.revisit {
   right: 18px;
-  bottom: 94px;
+  bottom: 104px;
   color: #8b7355;
-  --connector-width: 62px;
-  --connector-rotate: -16deg;
+  --connector-width: 78px;
+  --connector-rotate: -15deg;
   animation-delay: 2.25s;
 }
 
 .intro-tree-moment.lasting {
-  left: 24px;
-  top: 38px;
+  left: 22px;
+  top: 42px;
   color: #a67c52;
-  --connector-width: 116px;
+  --connector-width: 130px;
   --connector-rotate: -6deg;
   animation-delay: 2.5s;
 }
@@ -525,9 +525,15 @@
     min-height: 54px;
   }
 
-  /* Mobile: simplify tree visual */
+  .intro-hero-visual {
+    padding: 14px !important;
+    border-radius: 26px;
+  }
+
+  /* Mobile: keep the tree as the primary object while reducing label noise */
   .intro-tree-scene {
-    min-height: 280px;
+    min-height: 330px !important;
+    border-radius: 20px;
   }
 
   .intro-tree-scene::before,
@@ -537,19 +543,79 @@
   }
 
   .intro-tree-stem {
-    height: 100px;
-    bottom: 32px;
+    left: 52%;
+    width: 16px;
+    height: 154px;
+    bottom: 34px;
   }
 
-  .intro-tree-branch.four,
+  .intro-tree-branch {
+    height: 7px;
+  }
+
+  .intro-tree-branch.one {
+    bottom: 178px;
+    width: 96px;
+  }
+
+  .intro-tree-branch.two {
+    bottom: 148px;
+    width: 92px;
+  }
+
+  .intro-tree-branch.three {
+    bottom: 120px;
+    width: 86px;
+  }
+
+  .intro-tree-branch.four {
+    bottom: 94px;
+    width: 78px;
+  }
+
   .intro-tree-branch.five {
-    display: none;
+    bottom: 70px;
+    width: 70px;
   }
 
-  .intro-tree-node.node-5,
-  .intro-tree-node.node-6,
+  .intro-tree-node {
+    width: 14px;
+    height: 14px;
+  }
+
+  .intro-tree-node.node-1 {
+    left: 72%;
+    bottom: 226px;
+  }
+
+  .intro-tree-node.node-2 {
+    left: 22%;
+    bottom: 176px;
+  }
+
+  .intro-tree-node.node-3 {
+    left: 76%;
+    bottom: 148px;
+  }
+
+  .intro-tree-node.node-4 {
+    left: 25%;
+    bottom: 118px;
+  }
+
+  .intro-tree-node.node-5 {
+    left: 69%;
+    bottom: 92px;
+  }
+
+  .intro-tree-node.node-6 {
+    left: 45%;
+    bottom: 236px;
+  }
+
   .intro-tree-node.node-7 {
-    display: none;
+    left: 58%;
+    bottom: 48px;
   }
 
   .intro-tree-moment.revisit,


### PR DESCRIPTION
Refs #589
Refs #588

Summary:
- Scale the Intro hero LoveTree visual so the tree reads as the central object inside the right visual card.
- Rebalance the desktop hero grid, visual card spacing, scene height, stem, branches, nodes, and quiet moment chip placement.
- Keep the warm scrapbook tone while avoiding branch/node/chip semantic redesign reserved for #590.

Changed files:
- css/intro/hero.css

Screenshots evidence list:
- Cloudflare Preview desktop Intro hero: artifacts-cf-intro-desktop.png
- Cloudflare Preview Intro visual card close crop: artifacts-cf-intro-visual-card-close-crop.png
- Cloudflare Preview first-fold left copy + right visual: artifacts-cf-intro-first-fold.png
- Cloudflare Preview mobile 375px Intro full page: artifacts-cf-intro-mobile375.png
- Cloudflare Preview Home hero desktop baseline for tone comparison: artifacts-cf-home-desktop.png

Visual QA narrative:
- Tree scale/presence: stem, branches, and nodes are larger and the scene/card are taller, making the tree the visual anchor rather than a small symbol.
- Tree vs diagram reading: labels remain quiet and edge-positioned while the larger organic tree shape carries the composition.
- Card balance with left copy: desktop visual card is wider/taller without stealing the hero from the left copy.
- Warm scrapbook tone: retained soft paper, rose, cream, and muted green treatment aligned with the Home baseline.
- Mobile 375px stability: tree remains large inside the card, labels are reduced, and horizontal overflow measured absent.
- No clutter: no new chips or semantic elements were added; placement/scale only.
- Regression checks: no runtime JS, Auth/API/backend/package/workflow, page-transition, copy, or i18n changes.

Validation:
- git diff --check: PASS
- npm test: PASS, 190/190
- npm run verify: PASS, 138/138
- Cloudflare Preview deploy: PASS, https://c8f59a03.lovebud.pages.dev
- Deployed short SHA: 2144390
- Intro desktop no horizontal overflow: PASS
- Intro mobile 375px no horizontal overflow: PASS
- Intro console fatal errors: PASS
- Home baseline screenshot captured on the same preview: PASS
- prefers-reduced-motion/page-transition behavior unaffected: PASS

Browser verification:
- Cloudflare Preview screenshot QA completed.
- Fixed-slot verification remains optional follow-up if needed by release process.

pages/intro.html touched:
- NO. CSS-only implementation was sufficient.