### PR TITLE
ui(intro): shape LoveTree visual semantics

### DIFF
--- a/css/intro/hero.css
+++ b/css/intro/hero.css
@@ -101,9 +101,9 @@
   border-radius: 24px;
   overflow: hidden;
   background:
-    radial-gradient(circle at 28% 12%, rgba(255, 248, 246, 0.96), transparent 38%),
-    radial-gradient(circle at 80% 22%, rgba(242, 234, 228, 0.72), transparent 28%),
-    radial-gradient(circle at 50% 68%, rgba(255, 225, 220, 0.38), transparent 34%),
+    radial-gradient(circle at 34% 22%, rgba(255, 248, 246, 0.96), transparent 38%),
+    radial-gradient(circle at 72% 30%, rgba(242, 234, 228, 0.68), transparent 30%),
+    radial-gradient(circle at 50% 72%, rgba(255, 225, 220, 0.34), transparent 34%),
     linear-gradient(180deg, rgba(255, 249, 245, 0.92), rgba(244, 248, 238, 0.96));
   border: 1px solid rgba(144, 73, 81, 0.07);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
@@ -120,33 +120,66 @@
 
 .intro-tree-scene::before {
   left: 24%;
-  right: 16%;
-  top: 66px;
-  height: 224px;
-  border: 1px dashed rgba(144, 73, 81, 0.16);
-  transform: rotate(-12deg);
+  right: 15%;
+  top: 62px;
+  height: 238px;
+  background:
+    radial-gradient(circle at 54% 42%, rgba(255, 242, 238, 0.62), transparent 50%),
+    radial-gradient(circle at 32% 58%, rgba(244, 248, 238, 0.44), transparent 46%);
+  border: 1px solid rgba(144, 73, 81, 0.06);
+  box-shadow: 0 18px 44px rgba(144, 73, 81, 0.045) inset;
+  transform: rotate(-10deg);
 }
 
 .intro-tree-scene::after {
-  left: 43%;
-  top: 44px;
-  width: 132px;
-  height: 262px;
-  border: 1px solid rgba(122, 139, 110, 0.12);
-  transform: rotate(16deg);
+  left: 39%;
+  top: 64px;
+  width: 168px;
+  height: 236px;
+  background: radial-gradient(circle at 50% 46%, rgba(122, 139, 110, 0.08), transparent 58%);
+  border: 1px solid rgba(122, 139, 110, 0.05);
+  transform: rotate(13deg);
 }
 
 .intro-tree-stem {
   position: absolute;
   left: 51%;
   bottom: 44px;
-  width: 18px;
+  width: 19px;
   height: 196px;
   transform-origin: bottom center;
   border-radius: 999px;
-  background: linear-gradient(180deg, #c18b83, #904951);
-  box-shadow: 0 10px 24px rgba(144, 73, 81, 0.16), 0 0 0 5px rgba(144, 73, 81, 0.035);
+  background:
+    linear-gradient(90deg, rgba(255, 236, 230, 0.24), transparent 32%),
+    linear-gradient(180deg, #c9968d 0%, #aa646d 48%, #904951 100%);
+  box-shadow: 0 12px 26px rgba(144, 73, 81, 0.18), 0 0 0 5px rgba(144, 73, 81, 0.035);
   animation: introStemGrow 0.7s cubic-bezier(0.34, 1.3, 0.64, 1) 0.15s both;
+}
+
+.intro-tree-stem::before,
+.intro-tree-stem::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+
+.intro-tree-stem::before {
+  left: 4px;
+  top: 14px;
+  bottom: 18px;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 241, 235, 0.42), rgba(255, 241, 235, 0));
+}
+
+.intro-tree-stem::after {
+  left: 50%;
+  bottom: -8px;
+  width: 42px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(144, 73, 81, 0.16), transparent 68%);
+  transform: translateX(-50%);
 }
 
 @keyframes introStemGrow {
@@ -156,60 +189,82 @@
 
 .intro-tree-branch {
   position: absolute;
-  left: 50%;
-  height: 8px;
+  left: 51%;
+  height: 9px;
   border-radius: 999px;
-  background: linear-gradient(90deg, #c18b83, #aa646d);
-  transform-origin: left center;
-  box-shadow: 0 4px 12px rgba(144, 73, 81, 0.1);
+  background:
+    linear-gradient(180deg, rgba(255, 242, 236, 0.24), transparent 58%),
+    linear-gradient(90deg, #aa646d 0%, #c18b83 66%, #deb3aa 100%);
+  transform-origin: 0 50%;
+  box-shadow: 0 5px 14px rgba(144, 73, 81, 0.11);
   animation: introBranchIn 0.45s ease both;
+}
+
+.intro-tree-branch::before {
+  content: "";
+  position: absolute;
+  right: 18%;
+  top: 50%;
+  width: 28px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(193, 139, 131, 0.7), rgba(222, 179, 170, 0));
+  transform: translateY(-50%) rotate(var(--twig-rotate, 22deg));
+  transform-origin: left center;
+  opacity: 0.7;
 }
 
 .intro-tree-branch::after {
   content: "";
   position: absolute;
-  right: -5px;
+  right: -6px;
   top: 50%;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  background: rgba(255, 244, 242, 0.94);
-  border: 1px solid rgba(144, 73, 81, 0.14);
+  background: radial-gradient(circle at 34% 28%, #fff9f5 0 24%, #eccbc0 25% 60%, #c18b83 61% 100%);
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  box-shadow: 0 7px 16px rgba(144, 73, 81, 0.15), 0 0 0 5px rgba(144, 73, 81, 0.045);
   transform: translateY(-50%);
 }
 
 .intro-tree-branch.one {
   bottom: 206px;
-  width: 128px;
-  transform: translateX(6px) rotate(-32deg);
+  width: 132px;
+  transform: translateX(1px) rotate(-31deg);
+  --twig-rotate: -28deg;
   animation-delay: 0.75s;
 }
 
 .intro-tree-branch.two {
   bottom: 174px;
-  width: 122px;
-  transform: translateX(-8px) rotate(207deg);
+  width: 126px;
+  transform: translateX(-4px) rotate(209deg);
+  --twig-rotate: 28deg;
   animation-delay: 1.0s;
 }
 
 .intro-tree-branch.three {
   bottom: 142px;
-  width: 112px;
-  transform: translateX(6px) rotate(28deg);
+  width: 116px;
+  transform: translateX(0) rotate(29deg);
+  --twig-rotate: 24deg;
   animation-delay: 1.25s;
 }
 
 .intro-tree-branch.four {
   bottom: 112px;
-  width: 102px;
-  transform: translateX(-10px) rotate(200deg);
+  width: 104px;
+  transform: translateX(-5px) rotate(202deg);
+  --twig-rotate: -24deg;
   animation-delay: 1.5s;
 }
 
 .intro-tree-branch.five {
   bottom: 84px;
-  width: 92px;
-  transform: translateX(8px) rotate(24deg);
+  width: 94px;
+  transform: translateX(1px) rotate(25deg);
+  --twig-rotate: 22deg;
   animation-delay: 1.75s;
 }
 
@@ -220,13 +275,22 @@
 
 .intro-tree-node {
   position: absolute;
-  width: 16px;
-  height: 16px;
+  width: 15px;
+  height: 15px;
   border-radius: 50%;
-  background: radial-gradient(circle at 32% 28%, #fff4ef 0 22%, #e8c4b8 23% 58%, #c18b83 59% 100%);
+  background: radial-gradient(circle at 32% 26%, #fffaf6 0 22%, #eac9bf 23% 58%, #c18b83 59% 100%);
   border: 1px solid rgba(255, 255, 255, 0.72);
-  box-shadow: 0 6px 16px rgba(144, 73, 81, 0.22), 0 0 0 5px rgba(144, 73, 81, 0.06);
+  box-shadow: 0 7px 18px rgba(144, 73, 81, 0.2), 0 0 0 6px rgba(144, 73, 81, 0.045);
   animation: introNodeIn 0.3s ease both;
+}
+
+.intro-tree-node::after {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: inherit;
+  background: radial-gradient(circle at 36% 28%, rgba(255, 255, 255, 0.82), transparent 58%);
+  pointer-events: none;
 }
 
 @keyframes introNodeIn {
@@ -235,44 +299,44 @@
 }
 
 .intro-tree-node.node-1 {
-  left: 68%;
-  bottom: 264px;
+  left: 70%;
+  bottom: 262px;
   animation-delay: 1.8s;
 }
 
 .intro-tree-node.node-2 {
-  left: 27%;
-  bottom: 206px;
+  left: 25%;
+  bottom: 211px;
   animation-delay: 1.95s;
 }
 
 .intro-tree-node.node-3 {
-  left: 73%;
-  bottom: 174px;
+  left: 76%;
+  bottom: 176px;
   animation-delay: 2.1s;
 }
 
 .intro-tree-node.node-4 {
-  left: 31%;
-  bottom: 138px;
+  left: 28%;
+  bottom: 142px;
   animation-delay: 2.25s;
 }
 
 .intro-tree-node.node-5 {
-  left: 66%;
-  bottom: 108px;
+  left: 68%;
+  bottom: 111px;
   animation-delay: 2.4s;
 }
 
 .intro-tree-node.node-6 {
-  left: 48%;
-  bottom: 282px;
+  left: 50%;
+  bottom: 236px;
   animation-delay: 2.55s;
 }
 
 .intro-tree-node.node-7 {
-  left: 56%;
-  bottom: 58px;
+  left: 55%;
+  bottom: 70px;
   animation-delay: 2.7s;
 }
 
@@ -299,11 +363,12 @@
   position: absolute;
   top: 50%;
   width: var(--connector-width, 42px);
-  height: 2px;
+  height: 4px;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(144, 73, 81, 0.08), rgba(144, 73, 81, 0.28));
+  background: linear-gradient(90deg, rgba(144, 73, 81, 0.03), rgba(193, 139, 131, 0.24), rgba(144, 73, 81, 0.08));
+  opacity: 0.72;
   transform: translateY(-50%) rotate(var(--connector-rotate, 0deg));
-  transform-origin: center;
+  transform-origin: var(--connector-origin, center);
   pointer-events: none;
 }
 
@@ -316,8 +381,9 @@
   left: 18px;
   bottom: 72px;
   color: var(--primary);
-  --connector-width: 82px;
-  --connector-rotate: -10deg;
+  --connector-width: 74px;
+  --connector-rotate: -12deg;
+  --connector-origin: left center;
   animation-delay: 1.5s;
 }
 
@@ -336,8 +402,9 @@
 .intro-tree-moment.saved {
   right: 18px;
   top: 58px;
-  --connector-width: 72px;
-  --connector-rotate: 16deg;
+  --connector-width: 64px;
+  --connector-rotate: 15deg;
+  --connector-origin: right center;
   animation-delay: 1.75s;
 }
 
@@ -345,8 +412,9 @@
   left: 18px;
   top: 102px;
   color: #667a55;
-  --connector-width: 104px;
-  --connector-rotate: 8deg;
+  --connector-width: 92px;
+  --connector-rotate: 10deg;
+  --connector-origin: left center;
   animation-delay: 2.0s;
 }
 
@@ -354,8 +422,9 @@
   right: 18px;
   bottom: 104px;
   color: #8b7355;
-  --connector-width: 78px;
-  --connector-rotate: -15deg;
+  --connector-width: 66px;
+  --connector-rotate: -13deg;
+  --connector-origin: right center;
   animation-delay: 2.25s;
 }
 
@@ -363,8 +432,9 @@
   left: 22px;
   top: 42px;
   color: #a67c52;
-  --connector-width: 130px;
-  --connector-rotate: -6deg;
+  --connector-width: 112px;
+  --connector-rotate: -5deg;
+  --connector-origin: left center;
   animation-delay: 2.5s;
 }
 


### PR DESCRIPTION
Refs #590
Refs #588

Summary:
- Refine the Intro hero LoveTree visual so the right-side artwork reads as one organic LoveTree rather than a line/dot/label diagram.
- Preserve the #589 scale/composition from PR #724 while softening the diagram-like background guides, strengthening trunk/branch continuity, and making nodes read as memory/fruit points attached to the tree.
- Keep the warm scrapbook LoveBud tone without adding chips or increasing visual density.

Changed files:
- css/intro/hero.css

Screenshot evidence list:
- Cloudflare Preview desktop Intro hero: artifacts-cf-issue590-intro-desktop.png
- Cloudflare Preview Intro visual card close crop: artifacts-cf-issue590-card-crop.png
- Cloudflare Preview first-fold left copy + right visual: artifacts-cf-issue590-first-fold.png
- Cloudflare Preview mobile 375px Intro full page: artifacts-cf-issue590-mobile375.png
- Cloudflare Preview Home hero desktop baseline for tone comparison: artifacts-cf-issue590-home-desktop.png

Visual QA narrative:
The #589 tree scale and right-card composition are preserved. This pass changes how the existing visual reads: the trunk now has more trunk-like shading and base glow, the primary branches emerge from the stem with softer branch-end memory points, and secondary twig strokes make the silhouette feel more grown than plotted. The background rings have been softened into a canopy haze so they no longer compete as diagram geometry. Existing chips remain in place as quiet labels, with subdued branch-like connectors so they feel anchored to the tree system rather than floating as independent stickers. The result is richer but still light, warm, and uncluttered.

Itemized verdicts:
- tree scale/presence: PRESERVED from #589; no large rework of hero/card scale.
- tree completeness: IMPROVED; trunk, primary branches, secondary twigs, and fruit-like nodes form one silhouette.
- moment/node meaning: IMPROVED; nodes read more like glowing memory/fruit points at branch ends and junctions.
- chip/branch relationship: IMPROVED; existing chips are quieter and visually tied back with softened branch-like connectors.
- motion/storytelling: PRESERVED; existing grow-in sequence remains, with no runtime JS or page-transition changes.
- first-page/Home baseline alignment: PRESERVED; soft paper, rose, cream, and muted green tone stay aligned with Home.
- no clutter: PASS; no new chips, no extra label count, and only subtle twig/pseudo-element refinement.
- responsive behavior: PASS; mobile 375px keeps the tree readable and avoids horizontal overflow.
- regression checks: PASS; no copy/i18n, JS, Auth/API/backend/package/workflow, page-transition, or unrelated page changes.

Validation:
- git diff --check: PASS
- npm test: PASS, 190/190
- npm run verify: PASS, 138/138
- Cloudflare Preview deploy: PASS, https://46bb5874.lovebud.pages.dev
- Deployed short SHA: 1cc6bdf
- Intro desktop no horizontal overflow: PASS
- Intro mobile 375px no horizontal overflow: PASS
- Intro console fatal errors: PASS
- Home baseline screenshot captured on the same preview: PASS
- prefers-reduced-motion/page-transition behavior unaffected: PASS

Browser verification:
- Cloudflare Preview screenshot QA completed.
- Fixed-slot verification remains optional follow-up if needed by release process.

pages/intro.html touched:
- NO. CSS-only implementation was sufficient.