### PR TITLE
ui(search): stabilize Browse card text hierarchy

### DIFF
--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -28,30 +28,35 @@
 
 @media (max-width: 375px) {
     .tree-card {
-        height: 300px;
+        height: 324px;
         padding: 12px;
     }
 
+    .tree-card-featured .tree-card-media,
     .tree-card-media {
-        height: 120px;
+        height: 122px;
+        min-height: 122px;
         margin: 0 0 12px;
     }
 
     .tree-card-body {
-        gap: 8px;
+        grid-template-rows: 2.86rem 2.58rem auto;
+        row-gap: 8px;
         padding: 4px;
     }
 
     .tree-title {
-        font-size: 1.3rem;
-        min-height: 2.1em;
-        max-height: 2.1em;
+        font-size: 1.24rem;
+        line-height: 1.14;
+        min-height: 2.28em;
+        max-height: 2.28em;
     }
 
     .tree-subtitle {
         font-size: 0.88rem;
-        min-height: 1.7em;
-        max-height: 1.7em;
+        line-height: 1.46;
+        min-height: 2.92em;
+        max-height: 2.92em;
     }
 
     .tree-meta-row {

--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -16,7 +16,7 @@
         0 20px 48px rgba(75, 64, 57, 0.1),
         0 0 0 1px rgba(255, 255, 255, 0.62) inset;
     min-width: 0;
-    height: 320px;
+    height: 336px;
 }
 
 .tree-card::before {
@@ -52,13 +52,14 @@
 }
 
 .tree-card-featured .tree-card-media {
-    min-height: 210px;
+    height: 150px;
+    min-height: 150px;
 }
 
 .tree-card-media {
     position: relative;
-    height: 140px;
-    margin: 0 0 16px;
+    height: 136px;
+    margin: 0 0 14px;
     overflow: hidden;
     border-radius: 1.45rem;
     background:
@@ -161,9 +162,9 @@
 }
 
 .tree-card-body {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+    display: grid;
+    grid-template-rows: 3.22rem 2.74rem auto;
+    row-gap: 8px;
     padding: 4px 6px 6px;
     flex: 1;
     min-width: 0;
@@ -172,10 +173,10 @@
 }
 
 .tree-title {
-    font-size: 1.46rem;
+    font-size: 1.36rem;
     font-weight: 900;
     line-height: 1.18;
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
     display: -webkit-box !important;
     -webkit-line-clamp: 2 !important;
     line-clamp: 2;
@@ -190,9 +191,9 @@
 }
 
 .tree-subtitle {
-    font-size: 0.92rem;
+    font-size: 0.9rem;
     color: var(--on-surface-variant);
-    line-height: 1.58;
+    line-height: 1.52;
     margin: 0;
     display: -webkit-box !important;
     -webkit-line-clamp: 2 !important;
@@ -202,9 +203,19 @@
     text-overflow: ellipsis;
     word-break: break-word;
     hyphens: auto;
-    min-height: 3.16em;
-    max-height: 3.16em;
-    flex: 0 0 3.16em;
+    min-height: 3.04em;
+    max-height: 3.04em;
+    align-self: start;
+}
+
+.tree-subtitle-derived {
+    color: var(--on-surface-variant);
+    font-weight: 720;
+}
+
+.tree-subtitle-fallback {
+    color: rgba(108, 89, 83, 0.72);
+    font-weight: 650;
 }
 
 .tree-meta-row {
@@ -212,12 +223,12 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    padding-top: 12px;
+    padding-top: 10px;
     border-top: 1px solid rgba(144,73,81,0.08);
     font-size: 13px;
     color: var(--on-surface-variant);
-    flex-shrink: 0;
     margin-top: auto;
+    min-width: 0;
 }
 
 .tree-meta-left,
@@ -226,6 +237,11 @@
     align-items: center;
     gap: 8px;
     min-width: 0;
+}
+
+.tree-meta-right {
+    justify-content: flex-end;
+    overflow: hidden;
 }
 
 .tree-meta-chip {

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260428-1
+ * v20260503-591
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -205,6 +205,7 @@
          const safeTitle = escapeHtml(displayTitleRaw);
          const emotionTag = renderEmotionTags(tree.emotionTags);
          const countLabel = memoryCount > 0 ? `${memoryCount}개의 순간` : '대표 순간 준비 중';
+         const hasDerivedDescription = Boolean(displayTheme || primaryTag);
          const softMoodLine = displayTheme
              ? `${displayTheme}와 함께 시작된 마음`
              : primaryTag
@@ -212,13 +213,16 @@
                  : memoryCount > 0
                      ? '첫 순간에서 이어진 감정을 천천히 따라가 보세요.'
                      : '이제 막 열리기 시작한 공개 러브트리예요.';
+         const subtitleClass = hasDerivedDescription
+             ? 'tree-subtitle tree-subtitle-derived'
+             : 'tree-subtitle tree-subtitle-fallback';
 
          return `
              <div class="tree-card ${index === 0 ? 'tree-card-featured' : ''}" id="tree-card-${safeTreeId}" data-tree-id="${safeTreeId}" style="animation-delay: ${index * 0.05}s;">
                  ${renderRepresentativeMedia(tree, firstMem, displayTitleRaw)}
                  <div class="tree-card-body">
                      <div class="tree-title">${safeTitle}</div>
-                     <p class="tree-subtitle">${escapeHtml(softMoodLine)}</p>
+                     <p class="${subtitleClass}">${escapeHtml(softMoodLine)}</p>
                      <div class="tree-meta-row">
                          <div class="tree-meta-left">
                              <span class="tree-meta-chip">
@@ -381,5 +385,5 @@
         }
     };
 
-     console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260428-1');
+    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260503-591');
  })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260502-596597">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-591">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -131,7 +131,7 @@
     <script src="../js/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
-    <script src="../js/search/search-card-renderer.js?v=20260428-1"></script>
+    <script src="../js/search/search-card-renderer.js?v=20260503-591"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>


### PR DESCRIPTION
Refs #591

Changed files:
- css/search/tree-card.css
- css/search/responsive.css
- js/search/search-card-renderer.js
- pages/search.html

Summary:
- Stabilize Browse tree card text slots so long titles keep a two-line clamp without collapsing the description/meta rhythm.
- Reduce featured card media pressure so first-row cards keep the same body grammar.
- Keep custom/tag-derived descriptions readable while giving fallback descriptions a quieter, intentional visual treatment.
- Refresh Search CSS/renderer cache keys for the fixed-slot browser verification path.

Fallback description handling:
- Fallback description copy is still shown, not hidden, to avoid empty/uneven card bodies.
- The renderer now marks derived descriptions and fallback descriptions with separate subtitle classes.
- CSS tones fallback subtitles down without changing API/data behavior or copy.

Scope:
- API/data/backend/Auth unchanged.
- No selected hub redesign.
- No runtime Browse API behavior changes.

Validation:
- git diff --check: PASS
- node --check js/search/search-card-renderer.js: PASS
- node --test tests/contracts/public-tree-fallback-boundary.test.js tests/contracts/growing-trees-api-contract.test.js tests/contracts/public-tree-adapter-module.test.js: PASS
- npm test: PASS, 191/191
- npm run verify: PASS, 139/139

Browser verification:
- NOT_PERFORMED
- Browser verification requires separate fixed-slot deployment and SHA-matched verification.
- Local/static checks only; browser PASS is not claimed in this PR.