### PR TITLE
ui(search): make Browse cards feel like LoveTree cards

### DIFF
--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -75,8 +75,18 @@
         padding: 12px;
     }
 
+    .tree-card-media::before {
+        right: 10px;
+        bottom: 10px;
+        width: 54px;
+        height: 40px;
+        opacity: 0.62;
+    }
+
     .tree-card-media-fallback::before {
-        font-size: 36px;
+        top: 20px;
+        width: 74px;
+        height: 62px;
     }
 
     .tree-card-media-fallback .fallback-title {
@@ -84,7 +94,8 @@
     }
 
     .tree-card-media-fallback .fallback-dots {
-        gap: 4px;
+        top: 47px;
+        gap: 20px;
     }
 
     .tree-card-media-fallback .fallback-dots span {

--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -4,6 +4,7 @@
     padding: 14px;
     background:
         radial-gradient(circle at 30% 20%, rgba(255, 248, 245, 0.92), transparent 52%),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.86), rgba(255, 248, 245, 0.64)),
         rgba(255, 255, 255, 0.82);
     border-radius: 1.85rem;
     border: 1px solid rgba(144, 73, 81, 0.08);
@@ -39,6 +40,12 @@
         0 0 0 1px rgba(255, 255, 255, 0.82) inset;
 }
 
+.tree-card:hover .tree-card-media::before,
+.tree-card.is-active .tree-card-media::before {
+    opacity: 0.9;
+    transform: translateY(-1px);
+}
+
 .tree-card.is-active {
     border-color: rgba(144, 73, 81, 0.22);
     box-shadow:
@@ -64,9 +71,14 @@
     border-radius: 1.45rem;
     background:
         radial-gradient(circle at 20% 15%, rgba(255, 245, 246, 0.95), rgba(255,255,255,0.18) 46%),
+        radial-gradient(circle at 78% 18%, rgba(255, 255, 255, 0.68), transparent 30%),
         linear-gradient(135deg, rgba(144, 73, 81, 0.12), rgba(122, 139, 110, 0.12));
     isolation: isolate;
     flex-shrink: 0;
+    border: 1px solid rgba(255, 255, 255, 0.58);
+    box-shadow:
+        0 0 0 1px rgba(144, 73, 81, 0.04) inset,
+        0 12px 24px rgba(75, 64, 57, 0.08);
 }
 
 .tree-card-media img {
@@ -75,14 +87,41 @@
     min-height: inherit;
     object-fit: cover;
     display: block;
+    position: relative;
+    z-index: 0;
+}
+
+.tree-card-media::before {
+    content: '';
+    position: absolute;
+    right: 14px;
+    bottom: 12px;
+    width: 64px;
+    height: 48px;
+    border-radius: 999px;
+    opacity: 0.72;
+    pointer-events: none;
+    z-index: 1;
+    transform: translateY(0);
+    transition: opacity 0.28s ease, transform 0.28s ease;
+    background:
+        radial-gradient(circle at 74% 24%, rgba(255, 246, 244, 0.94) 0 4px, transparent 5px),
+        radial-gradient(circle at 36% 22%, rgba(255, 246, 244, 0.9) 0 3px, transparent 4px),
+        radial-gradient(circle at 54% 52%, rgba(255, 226, 224, 0.82) 0 4px, transparent 5px),
+        linear-gradient(62deg, transparent 24%, rgba(255, 248, 245, 0.76) 25% 28%, transparent 29% 46%, rgba(255, 248, 245, 0.7) 47% 50%, transparent 51%),
+        linear-gradient(90deg, transparent 17%, rgba(255, 248, 245, 0.68) 18% 21%, transparent 22%);
+    filter: drop-shadow(0 8px 14px rgba(75, 64, 57, 0.12));
 }
 
 .tree-card-media::after {
     content: '';
     position: absolute;
     inset: 0;
-    background: linear-gradient(to top, rgba(50, 38, 35, 0.22), rgba(50, 38, 35, 0.03) 58%, rgba(255,255,255,0));
+    background:
+        linear-gradient(to top, rgba(50, 38, 35, 0.20), rgba(50, 38, 35, 0.03) 58%, rgba(255,255,255,0)),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.18), transparent 38%);
     pointer-events: none;
+    z-index: 2;
 }
 
 .tree-card-media-fallback {
@@ -268,6 +307,7 @@
     overflow: hidden;
     background:
         radial-gradient(circle at 24% 18%, rgba(255, 248, 245, 0.98), transparent 48%),
+        radial-gradient(circle at 50% 38%, rgba(255, 238, 235, 0.72), transparent 36%),
         radial-gradient(circle at 72% 32%, rgba(255, 229, 225, 0.56), transparent 34%),
         linear-gradient(135deg, rgba(144, 73, 81, 0.08), rgba(122, 139, 110, 0.08));
 }
@@ -282,10 +322,13 @@
     transform: translateX(-50%);
     border-radius: 999px;
     background:
-        radial-gradient(circle at 72% 24%, rgba(144, 73, 81, 0.58) 0 4px, transparent 5px),
-        radial-gradient(circle at 30% 30%, rgba(122, 139, 110, 0.52) 0 4px, transparent 5px),
-        radial-gradient(circle at 48% 58%, rgba(200, 116, 128, 0.52) 0 4px, transparent 5px),
-        linear-gradient(90deg, transparent 20%, rgba(144, 73, 81, 0.32) 21% 24%, transparent 25% 48%, rgba(144, 73, 81, 0.42) 49% 53%, transparent 54%);
+        radial-gradient(circle at 72% 24%, rgba(144, 73, 81, 0.62) 0 4px, transparent 5px),
+        radial-gradient(circle at 30% 30%, rgba(122, 139, 110, 0.58) 0 4px, transparent 5px),
+        radial-gradient(circle at 48% 58%, rgba(200, 116, 128, 0.58) 0 4px, transparent 5px),
+        radial-gradient(circle at 58% 18%, rgba(255, 255, 255, 0.88) 0 14px, transparent 15px),
+        linear-gradient(33deg, transparent 28%, rgba(144, 73, 81, 0.24) 29% 32%, transparent 33%),
+        linear-gradient(142deg, transparent 36%, rgba(122, 139, 110, 0.22) 37% 40%, transparent 41%),
+        linear-gradient(90deg, transparent 20%, rgba(144, 73, 81, 0.30) 21% 24%, transparent 25% 48%, rgba(144, 73, 81, 0.40) 49% 53%, transparent 54%);
     filter: none;
     z-index: 1;
 }

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260503-591">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-592">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Refs #592

Changed files:
- css/search/tree-card.css
- css/search/responsive.css
- pages/search.html

LoveTree identity treatment:
- Add a subtle scrapbook-paper surface treatment to Browse cards.
- Add a quiet organic tree/branch/glow motif over representative media without hiding thumbnails.
- Polish fallback media so the tree silhouette reads more like a LoveTree visual rather than a generic placeholder.
- Tune the mobile motif sizing so the identity accent stays soft at 375px.
- Refresh the Search CSS cache key for the later fixed-slot verification path.

#591 text hierarchy preserved:
- Preserve the merged title/subtitle/meta grid slots from #591.
- Preserve two-line title clamp and two-line subtitle clamp.
- Preserve derived/fallback subtitle class behavior and copy.
- No Search card data, title, subtitle, or meta rendering logic changed.

Scope:
- API/data/backend/Auth unchanged.
- No selected hub redesign.
- No Search page layout rewrite.
- No JS runtime behavior changes.

Validation:
- git diff --check: PASS
- npm.cmd run verify: PASS, 139/139
- npm.cmd test: PASS, 191/191

Browser verification:
- NOT_PERFORMED
- Browser verification requires separate fixed-slot deployment and SHA-matched verification.
- Local/static checks only; browser PASS is not claimed in this PR.