### PR TITLE
ci(ops): add fixed test slot deploy workflow

### DIFF
--- a/.github/workflows/deploy-test-slot.yml
+++ b/.github/workflows/deploy-test-slot.yml
@@ -1,0 +1,165 @@
+name: Deploy fixed test slot
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to deploy to a fixed test slot"
+        required: true
+        type: string
+      expected_sha:
+        description: "Exact commit SHA expected after checkout"
+        required: true
+        type: string
+      slot:
+        description: "Fixed test slot branch/domain name: test1 through test10"
+        required: true
+        default: "test4"
+        type: choice
+        options:
+          - test1
+          - test2
+          - test3
+          - test4
+          - test5
+          - test6
+          - test7
+          - test8
+          - test9
+          - test10
+      marker_path:
+        description: "Optional path to fetch after deploy, for example js/app.js"
+        required: false
+        default: ""
+        type: string
+      marker_text:
+        description: "Optional marker text expected in marker_path response"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+jobs:
+  deploy-fixed-slot:
+    name: Deploy to ${{ inputs.slot }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Validate fixed slot input
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.slot }}" in
+            test1|test2|test3|test4|test5|test6|test7|test8|test9|test10)
+              echo "slot=${{ inputs.slot }}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Invalid slot. Allowed slots are test1 through test10." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - name: Verify checked-out SHA
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          expected_sha="${{ inputs.expected_sha }}"
+          echo "actual_sha=${actual_sha}" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=${expected_sha}" >> "$GITHUB_OUTPUT"
+          if [ "${actual_sha}" != "${expected_sha}" ]; then
+            echo "Checked-out SHA does not match expected SHA." >&2
+            echo "expected=${expected_sha}" >&2
+            echo "actual=${actual_sha}" >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run static verification
+        run: npm run verify
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify Cloudflare secrets are configured
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "CLOUDFLARE_API_TOKEN is missing." >&2
+            exit 1
+          fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "CLOUDFLARE_ACCOUNT_ID is missing." >&2
+            exit 1
+          fi
+          echo "Cloudflare credential names are configured. Values are not printed."
+
+      - name: Deploy to Cloudflare Pages fixed slot
+        shell: bash
+        run: |
+          set -euo pipefail
+          slot="${{ inputs.slot }}"
+          npx wrangler pages deploy . --project-name lovebud --branch "${slot}"
+
+      - name: Verify fixed slot URL and optional marker
+        shell: bash
+        run: |
+          set -euo pipefail
+          slot="${{ inputs.slot }}"
+          marker_path="${{ inputs.marker_path }}"
+          marker_text="${{ inputs.marker_text }}"
+          base_url="https://${slot}.lovebud.pages.dev"
+
+          echo "Checking ${base_url}/"
+          curl --fail --silent --show-error --location "${base_url}/" > /tmp/fixed-slot-index.html
+
+          if [ -n "${marker_path}" ]; then
+            clean_path="${marker_path#/}"
+            marker_url="${base_url}/${clean_path}"
+            echo "Checking marker path ${marker_url}"
+            curl --fail --silent --show-error --location "${marker_url}" > /tmp/fixed-slot-marker.txt
+            if [ -n "${marker_text}" ]; then
+              if ! grep -Fq "${marker_text}" /tmp/fixed-slot-marker.txt; then
+                echo "Marker text was not found in marker path response." >&2
+                exit 1
+              fi
+            fi
+          fi
+
+      - name: Write deployment summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Fixed test slot deployment"
+            echo ""
+            echo "- Slot: \`${{ inputs.slot }}\`"
+            echo "- URL: \`https://${{ inputs.slot }}.lovebud.pages.dev\`"
+            echo "- Requested ref: \`${{ inputs.ref }}\`"
+            echo "- Expected SHA: \`${{ steps.sha.outputs.expected_sha }}\`"
+            echo "- Actual SHA: \`${{ steps.sha.outputs.actual_sha }}\`"
+            echo "- SHA match: \`YES\`"
+            echo "- Static verification: \`PASS\`"
+            echo "- Tests: \`PASS\`"
+            echo "- Production deploy: \`NO\`"
+            echo "- Secret values printed: \`NO\`"
+            echo ""
+            echo "Browser verification must still be performed separately when required."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Refs #684

Purpose:
- Add a manual GitHub Actions workflow for deploying a chosen ref to a fixed Cloudflare Pages test slot.
- Reduce repeated manual slot deployment/SHA mismatch work before browser verification.

Changed files:
- `.github/workflows/deploy-test-slot.yml`

Workflow behavior:
- Manual `workflow_dispatch` only.
- Inputs: `ref`, `expected_sha`, `slot`, optional `marker_path`, optional `marker_text`.
- Restricts slot selection to `test1` through `test10`.
- Checks out the requested ref.
- Verifies checked-out `HEAD` exactly matches `expected_sha` before deploy.
- Runs `npm run verify` and `npm test` before deploy.
- Requires Cloudflare secret names to be configured without printing values.
- Deploys to Cloudflare Pages using the selected fixed slot as the Pages branch.
- Checks the fixed slot URL and optional marker path/text.
- Writes a safe deployment summary.

Guardrails:
- No production deployment.
- No runtime UI/API/Auth/backend code changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret/token/session/cookie/password/private ID output.
- Browser verification remains separate after slot deployment.

Verification:
- GitHub API scope check: changed files limited to workflow file only.
- Runtime execution of the workflow: NOT_STARTED, requires GitHub Actions run with repository Cloudflare secrets present.

Status:
- Draft PR for workflow review and first manual workflow test.