### PR TITLE
ui(search): refine Browse selected hub states

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -138,7 +138,7 @@
     background: linear-gradient(135deg, rgba(144, 73, 81, 0.08), rgba(122, 139, 110, 0.08));
     border-radius: 1.55rem;
     overflow: hidden;
-    margin-bottom: 24px;
+    margin-bottom: 20px;
     border: 1px solid rgba(144,73,81,0.06);
     box-shadow: none;
 }
@@ -148,6 +148,8 @@
     margin-bottom: 12px;
     font-weight: 800;
     color: var(--on-surface);
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .preview-panel-desc {
@@ -177,6 +179,7 @@
     color: var(--on-surface-variant);
     font-size: 13px;
     line-height: 1.6;
+    min-width: 0;
 }
 
 /* Issue #455 PR C: selected-tree hub preview polish. */
@@ -235,6 +238,37 @@
     box-shadow: 0 16px 38px rgba(75, 64, 57, 0.10);
 }
 
+.video-container.preview-state-empty,
+.video-container.preview-state-loading,
+.video-container.preview-state-no-moments {
+    background:
+        radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0.72), transparent 58%),
+        linear-gradient(135deg, rgba(144, 73, 81, 0.08), rgba(122, 139, 110, 0.09));
+    border-color: rgba(144, 73, 81, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+.video-container.preview-state-loading::before {
+    opacity: 0.45;
+}
+
+.video-container.preview-state-media,
+.video-container.preview-state-thumbnail {
+    box-shadow: 0 14px 30px rgba(75, 64, 57, 0.10);
+}
+
+.preview-media-frame {
+    background: var(--surface-container-low);
+}
+
+.preview-media-frame-iframe iframe {
+    background: #201917;
+}
+
+.preview-media-fallback {
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
 .video-container::before {
     content: '';
     position: absolute;
@@ -270,10 +304,29 @@
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.58);
     font-weight: 700;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .preview-panel-emotion-tags span {
     box-shadow: 0 8px 16px rgba(75, 64, 57, 0.06);
+    max-width: 100%;
+    overflow-wrap: anywhere;
+}
+
+.preview-primary-action,
+.preview-share-action {
+    box-shadow: 0 12px 24px rgba(75, 64, 57, 0.08);
+}
+
+.preview-share-action {
+    box-shadow: none;
+}
+
+.preview-sidebar.preview-state-empty .preview-badge,
+.preview-sidebar.preview-state-loading .preview-badge {
+    background: rgba(122, 139, 110, 0.10);
+    color: #6f7c61;
 }
 
 /* Mobile bottom sheet: body scroll lock when sheet is open */

--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -169,7 +169,7 @@
         overscroll-behavior: contain;
         /* Appearance */
         border-radius: 2rem 2rem 0 0;
-        padding: 22px 18px env(safe-area-inset-bottom, 0px);
+        padding: 22px 18px calc(18px + env(safe-area-inset-bottom, 0px));
         /* Preserve desktop gradient bg from preview-sidebar.css — override position only */
         /* Reset sticky/grid props from tablet breakpoint */
         align-self: auto;
@@ -230,6 +230,7 @@
     .preview-panel-header {
         align-items: flex-start;
         gap: 8px;
+        margin-bottom: 14px;
     }
 
     .preview-panel-title-group {
@@ -239,6 +240,53 @@
 
     .preview-panel-header h3 {
         font-size: 1.42rem;
+    }
+
+    .preview-sidebar .video-container {
+        margin-bottom: 16px;
+        border-radius: 1.35rem;
+    }
+
+    .preview-sidebar .preview-panel-title {
+        font-size: 1.04rem;
+        margin-bottom: 10px;
+    }
+
+    .preview-sidebar .preview-panel-desc {
+        font-size: 13px;
+        line-height: 1.55;
+    }
+
+    .preview-sidebar .tree-meta {
+        gap: 8px;
+        margin: 14px 0;
+        padding: 10px;
+    }
+
+    .preview-sidebar .tree-meta-item {
+        flex: 1 1 140px;
+        justify-content: center;
+        min-height: 34px;
+        padding: 0 8px;
+        font-size: 12px;
+    }
+
+    .preview-sidebar .emotion-tags-label {
+        margin-bottom: 10px;
+    }
+
+    .preview-sidebar .preview-panel-emotion-tags {
+        gap: 6px;
+    }
+
+    .preview-sidebar .preview-primary-action {
+        margin-top: 14px !important;
+        min-height: 46px !important;
+    }
+
+    .preview-sidebar .preview-share-action {
+        margin-top: 8px !important;
+        min-height: 42px !important;
     }
 
     .preview-mobile-close {

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -101,7 +101,7 @@
             'Open this tree'
         );
         return `
-            <a href="${escapeHtml(href)}" class="btn-round btn-primary" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
+            <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
                 <span class="material-symbols-outlined" style="font-size:18px;">play_circle</span>
                 ${escapeHtml(label)}
             </a>
@@ -121,7 +121,7 @@
             'Copy view link'
         );
         return `
-            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
+            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round preview-share-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
                 <span class="material-symbols-outlined" style="font-size:16px;">link</span>
                 <span data-share-tree-link-label>${escapeHtml(label)}</span>
             </button>

--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -84,7 +84,7 @@
      */
     function renderPreviewThumbnailFallback(title, subtitle) {
         return `
-            <div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
+            <div class="preview-media-fallback" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
                 <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">movie</span>
                 <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${escapeHtml(title)}</div>
                 <p style="margin:0;font-size:13px;line-height:1.6;">${escapeHtml(subtitle)}</p>
@@ -102,7 +102,7 @@
         );
 
         return `
-            <div style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
+            <div class="preview-media-frame preview-media-frame-thumbnail" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                 <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
                 <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
@@ -170,7 +170,7 @@
         if (!iframeSrc) return '';
 
         return `
-            <div style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
+            <div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                 <iframe width="100%" height="100%"
                     src="${iframeSrc}"
                     title="${escapeHtml(treeTitle)}" frameborder="0"

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -139,7 +139,7 @@
             'Open this tree'
         );
         return `
-            <a href="${escapeHtml(href)}" class="btn-round btn-primary" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
+            <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
                 <span class="material-symbols-outlined" style="font-size:18px;">play_circle</span>
                 ${escapeHtml(label)}
             </a>
@@ -158,7 +158,7 @@
             'Copy view link'
         );
         return `
-            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
+            <button type="button" data-share-tree-link="${escapeHtml(tree.id)}" class="btn-round preview-share-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">
                 <span class="material-symbols-outlined" style="font-size:16px;">link</span>
                 <span data-share-tree-link-label>${escapeHtml(label)}</span>
             </button>
@@ -169,6 +169,25 @@
 
     function init(domRefs) {
         _dom = domRefs;
+    }
+
+    function setPreviewState(state) {
+        const previewContainer = _dom?.previewContainer;
+        const previewSidebar = document.getElementById('previewSidebar');
+        const stateClassNames = [
+            'preview-state-empty',
+            'preview-state-loading',
+            'preview-state-no-moments',
+            'preview-state-media',
+            'preview-state-thumbnail'
+        ];
+
+        [previewContainer, previewSidebar].forEach((element) => {
+            if (!element) return;
+            element.classList.remove(...stateClassNames);
+            element.classList.add(`preview-state-${state}`);
+            element.dataset.previewState = state;
+        });
     }
 
     function getTreeIcon(stage) {
@@ -358,6 +377,7 @@
             : (String(tree?.title || '').trim() || getDefaultTreeName());
         const safeTreeTitle = escapeHtml(previewDisplayTitle);
         const previewStats = getPreviewStatsElement();
+        setPreviewState('loading');
 
         if (_dom.previewContainer) {
             _dom.previewContainer.innerHTML = `
@@ -398,7 +418,7 @@
             return helper.renderPreviewThumbnailFallback(title, subtitle);
         }
         return `
-            <div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
+            <div class="preview-media-fallback" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
                 <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">movie</span>
                 <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${escapeHtml(title)}</div>
                 <p style="margin:0;font-size:13px;line-height:1.6;">${escapeHtml(subtitle)}</p>
@@ -418,7 +438,7 @@
         );
 
         return `
-            <div style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
+            <div class="preview-media-frame preview-media-frame-thumbnail" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                 <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
                 <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
@@ -468,9 +488,11 @@
             ? titleHelper.getBrowseDisplayTitle(tree)
             : (String(tree?.title || '').trim() || getDefaultTreeName());
         const safeTreeTitle = escapeHtml(previewDisplayTitle);
+        let previewState = 'empty';
 
         if (_dom.previewContainer) {
             if (!hasMemories) {
+                previewState = 'no-moments';
                 _dom.previewContainer.innerHTML = `
                     <div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
                         <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">psychiatry</span>
@@ -486,6 +508,7 @@
                 const safeSourceUrl = sanitizeUrl(mediaMem?.sourceUrl || '');
                 const safeThumbnail = sanitizeUrl(mediaMem?.thumbnail || '');
                 const safeMediaMemTitle = escapeHtml(getMomentLabel(mediaMem || firstMem));
+                previewState = safeSourceUrl ? 'media' : (safeThumbnail ? 'thumbnail' : 'empty');
 
                 const mediaHelper = window.LoveBudSearchPreviewMediaHelper;
                 if (mediaHelper?.renderPreviewIframe && safeSourceUrl) {
@@ -495,7 +518,7 @@
                         ? safeSourceUrl + (safeSourceUrl.includes('?') ? '&' : '?') + 'autoplay=0&mute=1'
                         : '';
                     _dom.previewContainer.innerHTML = iframeSrc ? `
-                        <div style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
+                        <div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                             <iframe width="100%" height="100%"
                                 src="${iframeSrc}"
                                 title="${safeTreeTitle}" frameborder="0"
@@ -509,6 +532,7 @@
                     ` : (safeThumbnail ? renderPreviewThumbnailMedia(safeThumbnail, safeMediaMemTitle, safeTreeTitle) : renderPlaceholder());
                 }
             }
+            setPreviewState(previewState);
         }
 
         if (_dom.previewTitle) {
@@ -632,7 +656,8 @@
             '트리를 고르면 대표 순간과 이어진 감정이 이곳에 열립니다.',
             'Choose a tree to open the featured moment and connected feelings here.'
         );
-        
+        setPreviewState('empty');
+
         if (_dom.previewContainer) {
             _dom.previewContainer.innerHTML = renderPlaceholder();
         }

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260503-592">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-594">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -132,10 +132,10 @@
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
     <script src="../js/search/search-card-renderer.js?v=20260503-591"></script>
-    <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
+    <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
+    <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260502-1"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>


### PR DESCRIPTION
Refs #594

## Changed files
- css/search/preview-sidebar.css
- css/search/responsive.css
- js/search/search-preview-renderer.js
- js/search/search-preview-media-helper.js
- js/search/search-preview-action-helper.js
- pages/search.html

## State coverage summary
- No selected tree: preview container/sidebar now carry an explicit empty state hook.
- Selected tree loading: loading state hook is applied before hydrated preview content renders.
- Selected tree with representative media: iframe/media state receives a dedicated hook and calmer frame styling.
- Selected tree with thumbnail fallback: thumbnail state receives a dedicated hook and fallback styling hook.
- Selected tree without moments: no-moments state is separated from generic empty so it can read as a waiting appreciation flow.
- Emotion tags present/missing: tags are allowed to wrap safely without horizontal overflow.
- Action/share button state: primary/share actions now have preview-specific hooks for hierarchy and mobile spacing.

## Selected/loading/empty/fallback handling
- Added narrow renderer state classes on the selected preview hub without changing API, hydration, URL, or share-link contracts.
- Added media/action class hooks in existing preview helpers while preserving existing data attributes.
- Tuned desktop selected hub spacing, media frame softness, meta wrapping, tag wrapping, and action hierarchy.
- Tuned mobile bottom-sheet density so close/header/media/text/actions have safer spacing and less overflow risk.

## Preservation notes
- #591 card text hierarchy preserved: no Browse card renderer or tree-card CSS changes.
- #592 Browse card LoveTree identity polish preserved: card media/fallback styles were not changed.
- API/data/backend/Auth behavior unchanged.
- Browser verification deferred to batch; local/static checks only, browser PASS not claimed.