### PR TITLE
docs(ops): document operator writing and verification policy

### DIFF
--- a/docs/ops/OPERATOR_WRITING_AND_VERIFICATION_POLICY.md
+++ b/docs/ops/OPERATOR_WRITING_AND_VERIFICATION_POLICY.md
@@ -1,0 +1,269 @@
+# Operator Writing and Verification Policy
+
+**Status:** Active draft for operators  
+**Owner:** CTO / Ops Lead  
+**Related issue:** #676
+
+This document defines how LoveBud operators should write issues and PR bodies, how they should classify browser/runtime verification, and how verification may be batched without weakening merge standards.
+
+The goal is to keep execution reports useful for future operators. A checklist can say what to do, but the issue or PR body must also explain why the work exists, what user or operator risk it reduces, and what evidence is required before a runtime-sensitive change can be treated as complete.
+
+---
+
+## 1. Prose-first issue and PR writing
+
+Issues and PR bodies should be prose-first. They should not be only a command list or a terse checklist.
+
+A good issue or PR body explains:
+
+- the product or engineering problem;
+- why the problem matters to users, reviewers, or operators;
+- the intended direction;
+- what is in scope;
+- what is explicitly out of scope;
+- how verification should happen;
+- which guardrails apply.
+
+Lists are still appropriate for changed files, acceptance criteria, safety constraints, and verification checklists. The rule is not anti-structure. The rule is that future operators must be able to understand context without reading the full conversation that created the task.
+
+### 1.1 Minimum issue body shape
+
+Use this shape when creating or rewriting operational issues:
+
+```text
+## Purpose
+
+Explain what problem this issue exists to solve and why it matters.
+
+## Current problem
+
+Describe the observed failure, ambiguity, or risk.
+
+## Desired outcome
+
+Describe the intended result without over-prescribing implementation.
+
+## Scope
+
+List likely files, systems, or behavior areas.
+
+## Non-goals
+
+List what must not be changed.
+
+## Verification requirements
+
+State which checks, browser targets, fixed slots, runtime environments, or safe status labels are required.
+
+## Acceptance criteria
+
+Use a checklist or bullets for completion criteria.
+
+## Guardrails
+
+List security, privacy, branch, merge, and prototype/reference/demo/variant restrictions.
+```
+
+### 1.2 Minimum PR body shape
+
+A PR body should include:
+
+- `Refs #...` links, not close keywords unless explicitly approved;
+- a short purpose summary;
+- exact changed files or intended file scope;
+- behavior-equivalence intent when the PR is a refactor;
+- verification already performed;
+- verification not performed;
+- runtime/browser verification requirements if still pending;
+- guardrails such as no production mutation and no secret exposure.
+
+Do not claim runtime PASS from a static PR body.
+
+---
+
+## 2. Valid browser/runtime verification targets
+
+Runtime-sensitive work needs a deployed environment whose source can be tied to the PR or target commit.
+
+Final runtime PASS requires one of these:
+
+1. a valid Cloudflare PR/branch deployment with deployed SHA confirmed;
+2. a CTO-assigned fixed test slot with deployed SHA confirmed;
+3. production only after the relevant PR is merged and deployed.
+
+Production is not valid pre-merge proof for a PR. Localhost or a local static server may be used for triage, but it is not final PASS for Auth/API/data-loaded behavior.
+
+### 2.1 Runtime-sensitive surfaces
+
+Use Cloudflare deployment or fixed-slot verification for:
+
+- Login/Auth flows;
+- My Trees;
+- Browse/Search with API data or selected hub interaction;
+- Editor;
+- Detail when it loads API-backed content;
+- Modal/API-backed behavior;
+- DB-backed display or mutation paths;
+- user-specific state;
+- create/edit/save/delete flows;
+- loading, flicker, routing, and runtime-state investigations.
+
+### 2.2 Invalid final verification targets
+
+Do not report final PASS from:
+
+- localhost static server output;
+- production as pre-merge PR proof;
+- arbitrary `/pull/<number>/` paths on production;
+- fixed slots with unknown or mismatched SHA;
+- text-only/code-only review for browser-dependent behavior;
+- screenshots whose URL or deployed SHA is not identified.
+
+If target provenance is unclear, report `PARTIAL` or `BLOCKED`, not PASS.
+
+---
+
+## 3. Fixed-slot browser verification preflight
+
+Before fixed-slot browser verification, record:
+
+- PR number or task name;
+- PR head branch;
+- PR head SHA;
+- assigned fixed slot;
+- slot URL;
+- slot branch or deployment source;
+- deployed SHA or content marker evidence;
+- login requirement;
+- test-data requirement;
+- desktop and mobile 375px screenshot requirement, when UI judgment is involved.
+
+Auth/API/data-loaded verification must use a login-capable environment when login is part of the flow. If login cannot be completed, report `BLOCKED_AUTH` or `PARTIAL`, not PASS.
+
+---
+
+## 4. QA credential and secret reporting
+
+Reports must never include raw credential, token, cookie, session, private key, database URL, owner id, tree id, memory id, copied tree id, or database row values.
+
+Allowed safe labels:
+
+```text
+QA_CREDENTIAL: PRESENT / MISSING
+LOGIN: PASS / FAIL / BLOCKED
+SESSION_VALUE_EXPOSED: NO
+TOKEN_VALUE_EXPOSED: NO
+TREE_ID_PRESENT: YES / NO
+MEMORY_ID_PRESENT: YES / NO
+COPIED_TREE_ID_PRESENT: YES / NO
+DATA_MUTATION: NO_MUTATIONS / APPROVED_DISPOSABLE_MUTATION_ONLY
+```
+
+Use presence/status labels only. Do not print partial prefixes, suffixes, or last characters of restricted values.
+
+If restricted values are exposed, stop the task and report `SECURITY_INCIDENT_SECRET_EXPOSURE` without repeating the value.
+
+---
+
+## 5. Batch verification policy
+
+Implementation work may proceed in batches before browser/runtime verification, but this is verification scheduling, not a relaxation of merge standards.
+
+Default policy:
+
+- Up to roughly five independent implementation PRs may be accumulated as draft PRs before running a fixed-slot/browser verification batch.
+- Each PR still needs per-PR scope review, changed-file review, PR hygiene, and secret-safety review.
+- Static checks should still be run when available.
+- Runtime-sensitive PRs must remain draft or otherwise blocked from merge-ready judgment until required verification exists.
+- Ready and merge decisions require the same evidence as before.
+
+### 5.1 When not to batch
+
+Do not delay verification when the PR is:
+
+- foundational for the next PR;
+- high-risk Auth/API/DB/Modal behavior;
+- a workflow/deployment change whose correctness affects other verification;
+- touching overlapping files with another in-flight PR;
+- likely to create a conflict if merged late;
+- needed to unblock a current browser/runtime investigation.
+
+In these cases, verify immediately or stop and sequence the work.
+
+### 5.2 Batch report format
+
+When a batch is ready, report:
+
+```text
+[Batch Verification Plan]
+- Batch size:
+- PRs included:
+- Shared runtime surfaces:
+- Overlapping files: YES/NO
+- Assigned slot(s):
+- Required logins:
+- Required test data:
+- Desktop screenshots required: YES/NO
+- Mobile 375px screenshots required: YES/NO
+- Network/API checks:
+- Console checks:
+- Final status per PR: PASS / PARTIAL / BLOCKED / FAIL
+```
+
+Batch verification should still produce per-PR conclusions. A batch PASS must not hide a failure in one PR.
+
+---
+
+## 6. PASS / PARTIAL / BLOCKED / NOT_VERIFIED language
+
+Use these states precisely:
+
+- `PASS`: required observations completed and no blocking regression found.
+- `PARTIAL`: some material observations were completed, but one or more required checks are missing.
+- `BLOCKED`: verification cannot proceed because of auth, deployment, secret, data, infra, or runtime blockers.
+- `FAIL`: observed behavior does not meet expected behavior.
+- `NOT_VERIFIED`: no meaningful verification was performed for that requirement.
+
+Do not convert `PARTIAL`, `BLOCKED`, or `NOT_VERIFIED` into PASS for merge convenience.
+
+---
+
+## 7. Safe PR status examples
+
+### Draft implementation awaiting batch verification
+
+```text
+Status: DRAFT_IMPLEMENTED / AWAITING_BATCH_RUNTIME_VERIFICATION
+Static checks: PASS
+Browser verification: NOT_STARTED
+Merge candidate: NO
+```
+
+### Runtime-sensitive PR blocked by test data
+
+```text
+Status: BROWSER_RUNTIME_BLOCKED
+Reason: BLOCKED_BY_NO_EDITOR_TEST_DATA
+Merge candidate: NO
+```
+
+### Workflow that can only run after merge
+
+```text
+Status: STRUCTURE_VERIFIED / POST_MERGE_RUNTIME_REQUIRED
+Reason: workflow_dispatch is only available after the workflow exists on the default branch
+```
+
+---
+
+## 8. Relationship to existing ops docs
+
+This policy complements, but does not replace:
+
+- `TEST_PREVIEW_SLOTS.md` for fixed test slot mechanics;
+- `BROWSER_VERIFICATION_URL_POLICY.md` for URL provenance;
+- `LOCAL_BROWSER_VERIFICATION_STARTUP.md` for browser startup preflight;
+- `GITHUB_AUTH_TOKEN_USAGE.md` for GitHub CLI and token-safe operation;
+- `AGENT_SECURITY.md` for secret handling.
+
+When this document and a more specific runbook conflict, use the stricter rule or escalate to CTO before proceeding.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -20,29 +20,30 @@
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
 4. [BROWSER_VERIFICATION_SLOT_GATE.md](BROWSER_VERIFICATION_SLOT_GATE.md) - 브라우저/network 검증 전 final PASS target 및 fixed slot 배정 gate
-5. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
-6. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
-7. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
-8. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-9. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-10. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
-11. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
-12. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-13. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-14. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-15. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-16. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-17. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-18. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-19. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-20. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-21. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-22. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-23. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-24. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-25. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-26. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
-27. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+5. [OPERATOR_WRITING_AND_VERIFICATION_POLICY.md](OPERATOR_WRITING_AND_VERIFICATION_POLICY.md) - prose-first Issue/PR 작성, valid runtime verification, QA credential safe reporting, batch verification 운영 기준
+6. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
+7. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+8. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+9. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+10. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+11. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
+12. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
+13. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+14. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+15. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+16. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+17. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+18. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+19. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+20. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+21. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+22. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+23. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+24. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+25. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+26. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+27. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
+28. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -52,6 +53,7 @@
 |--------|------|
 | [DOC_WORKFLOW.md](DOC_WORKFLOW.md) | 문서 작업 흐름 및 문서군 역할 정의 |
 | [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) | 병렬 모델, worktree, 검증 모델, PR 통합 운영 기준 |
+| [OPERATOR_WRITING_AND_VERIFICATION_POLICY.md](OPERATOR_WRITING_AND_VERIFICATION_POLICY.md) | prose-first Issue/PR 작성, valid runtime verification, QA credential safe reporting, batch verification 운영 기준 |
 | [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token/secret-safe reporting 기준 |
 | [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) | Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules |
 | [PATHS_AND_SHELLS.md](PATHS_AND_SHELLS.md) | 경로 / 셸 기준 |


### PR DESCRIPTION
Refs #676

Purpose:
- Document prose-first Issue/PR writing rules for LoveBud operators.
- Document valid browser/runtime verification targets and invalid final PASS environments.
- Add safe QA credential/secret reporting labels.
- Record the batch verification policy for accumulating draft implementation PRs before fixed-slot/browser verification.

Changed files:
- `docs/ops/OPERATOR_WRITING_AND_VERIFICATION_POLICY.md`
- `docs/ops/ops_index.md`

Scope:
- Docs-only ops/runbook update.
- No runtime JS/CSS/HTML/API/Auth/backend changes.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.

Verification:
- GitHub API changed-file scope check: PASS, docs/ops only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is part of the implementation batch and should remain draft until batch review/verification policy is satisfied.
- Do not ready or merge without CTO approval.