### PR TITLE
docs(engineering): document auth bootstrap compatibility boundary

### DIFF
--- a/docs/engineering/AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md
+++ b/docs/engineering/AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md
@@ -1,0 +1,204 @@
+# Auth Bootstrap Compatibility Boundary
+
+**Status:** Active staged-refactor boundary  
+**Owner:** CTO / Engineering Lead  
+**Related issue:** #705  
+**Source tracker:** #78
+
+This document defines the compatibility boundary that must be preserved while `js/auth.js` is reduced toward a thinner bootstrap/orchestration file.
+
+The first Auth refactor steps must be behavior-equivalent. They must not change Firebase provider behavior, login/signup semantics, protected-route behavior, API token handling, cache key names, or user-facing Auth UI. The goal is to make the large Auth entrypoint easier to review without changing the runtime contract.
+
+---
+
+## 1. Current boundary summary
+
+`js/auth.js` currently behaves as the browser-global Auth entrypoint. It coordinates modules under `js/auth/` while preserving legacy global exports expected by pages and older runtime code.
+
+Current main already has several helper modules loaded before `js/auth.js`, including:
+
+- `js/auth/auth-state.js`
+- `js/auth/auth-callbacks.js`
+- `js/auth/auth-cache.js`
+- `js/auth/auth-ui.js`
+- `js/auth/auth-session.js`
+- `js/auth/auth-firebase.js`
+- `js/auth/auth-login-page.js`
+
+The entrypoint should continue to be a classic script. Do not convert it or any Auth helper to ES modules unless a separate architecture decision explicitly approves that loading model change.
+
+---
+
+## 2. Globals that must remain stable
+
+The first staged extraction must preserve these public browser globals:
+
+```text
+window.signInWithGoogle
+window.signOut
+window.initAuth
+window.getEnvironmentCheckError
+window.getFriendlyErrorMessage
+window.getConfirmedAuthUser
+window.hasConfirmedAuthSession
+window.getCachedAuthToken
+window.registerOnAuthReady
+window.getBasePath
+```
+
+The following shared runtime flags and callback containers must remain compatible:
+
+```text
+window.__onAuthReadyCallbacks
+window.__lastAuthUser
+window.__lovebudAuthInitialized
+window.__lovebudAuthReady
+window.LoveBudAuthBootstrap
+```
+
+If a future PR believes any global can be removed, that PR must first add an audit proving it is unused across all active pages and tests. Do not remove globals opportunistically during a file-size refactor.
+
+---
+
+## 3. Cache and token key contract
+
+These key names are part of the Auth compatibility boundary and must not change in the first refactor PR:
+
+```text
+lovebud_auth_cache
+lovebud_auth_confirmed
+lovebud_auth_token
+```
+
+Logout and invalid-session cleanup must keep clearing confirmed private Auth state. Public Browse cache handling must remain separate from private Auth/My Trees/Editor caches.
+
+Do not alter token lifetime, token refresh behavior, confirmed-session semantics, or localStorage/sessionStorage key names as part of the first split.
+
+---
+
+## 4. Allowed first extraction candidates
+
+A narrow implementation PR may move one of these responsibilities out of `js/auth.js` when the helper already exists or can be added as a browser-global helper:
+
+1. Bootstrap compatibility resolver wiring.
+2. Auth ready callback registration/fire bridge.
+3. Confirmed Auth cache wrapper functions.
+4. Protected-route bridge construction arguments.
+5. Legacy alias/global export setup.
+
+The recommended first code PR is the smallest extraction that removes responsibility from `js/auth.js` without altering behavior. Avoid mixing multiple areas in one PR unless the same helper boundary requires them to move together.
+
+---
+
+## 5. Forbidden combinations
+
+Do not combine Auth bootstrap refactor work with:
+
+- login page copy or layout changes;
+- signup policy changes;
+- Firebase provider changes;
+- password policy changes;
+- token/cache security behavior changes;
+- protected-route policy changes;
+- API endpoint or payload changes;
+- Browse/Search, Editor, My Trees, or Detail UI changes;
+- package, workflow, or dependency changes;
+- PR #7 or prototype/reference/demo/variant path changes.
+
+A refactor PR must be behavior-equivalent and narrow enough to review by changed responsibility boundary.
+
+---
+
+## 6. Script order contract
+
+Pages that use Auth must continue loading helper modules before `js/auth.js`. The Auth entrypoint may depend on existing helper globals but must keep fallback behavior where active runtime still requires it.
+
+Minimum order expectation:
+
+```text
+firebase SDK / firebase-config
+shared i18n and shared header dependencies as needed
+js/auth/auth-state.js
+js/auth/auth-callbacks.js
+js/auth/auth-cache.js
+js/auth/auth-ui.js
+js/auth/auth-session.js
+js/auth/auth-firebase.js
+login helper modules where login page requires them
+js/auth/auth-login-page.js where login page requires it
+js/auth.js
+page-specific login/auth script where present
+```
+
+Any script order change requires a focused contract test or manual page inventory explaining why the order remains safe.
+
+---
+
+## 7. Required verification per implementation PR
+
+Static verification:
+
+```text
+git diff --check
+node --check changed JS files
+npm test
+npm run verify
+```
+
+Auth/browser verification for runtime-sensitive PRs:
+
+```text
+Login page opens in login mode: PASS/FAIL
+Login page opens in signup mode: PASS/FAIL
+Google login button remains wired: PASS/FAIL
+Email login/signup flow remains wired: PASS/FAIL
+Logged-out protected pages redirect/block as before: PASS/FAIL
+Logged-in header/nav auth state renders: PASS/FAIL
+Logout clears confirmed auth state and redirects/reloads as before: PASS/FAIL
+My Trees protected load after login: PASS/FAIL
+Editor protected load after login: PASS/FAIL
+Console fatal errors: NONE/PRESENT
+Network fatal errors: NONE/PRESENT
+```
+
+Because Auth behavior is runtime-sensitive, final PASS must use Cloudflare Preview or an assigned fixed test slot with deployed SHA confirmation. Local-only checks are not final PASS.
+
+---
+
+## 8. Batch verification handling
+
+Auth refactor PRs may be accumulated as draft PRs under the batch verification policy only when they are independent and do not block other work. However, Auth is high-risk. If a PR changes login/session/protected-route behavior, verify it immediately rather than waiting for the batch.
+
+For draft batch PRs, use this status language:
+
+```text
+Status: DRAFT_IMPLEMENTED / AUTH_RUNTIME_VERIFICATION_NOT_STARTED
+Static checks: PASS or NOT_RUN
+Browser verification: NOT_STARTED
+Merge candidate: NO
+```
+
+---
+
+## 9. First implementation recommendation
+
+The safest next code PR after this boundary note is one of:
+
+1. Move legacy Auth global export setup into a focused helper while preserving all exported names.
+2. Move protected-route bridge argument construction into a focused helper without changing any callback function references.
+3. Move callback bridge fallback wiring into `auth-callbacks.js` while preserving `window.registerOnAuthReady` behavior.
+
+Do not start with Firebase sign-in/sign-out behavior or token/cache semantics. Those are higher-risk and require immediate fixed-slot Auth verification.
+
+---
+
+## 10. Completion criteria for #705
+
+Issue #705 can move toward completion only after one or more narrow PRs:
+
+- reduce `js/auth.js` responsibility;
+- preserve the listed global contracts;
+- preserve cache key and token behavior;
+- pass static checks;
+- pass fixed-slot or Cloudflare runtime Auth verification;
+- document remaining Auth cleanup as follow-up rather than hiding it in one broad PR.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -26,21 +26,22 @@
 8. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
 9. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, and #512 verification linkage
 10. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-11. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-12. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
-13. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-14. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-15. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-16. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-17. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-18. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-19. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
-20. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-21. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-22. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-23. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
-24. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-25. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+11. [AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md](./AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md) - #705 auth bootstrap compatibility boundary, global/cache/script-order contract, staged extraction guardrails
+12. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+13. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
+14. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+15. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+16. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+17. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+18. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+19. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+20. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
+21. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+22. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+23. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+24. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
+25. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+26. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -58,6 +59,7 @@
 | [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
 | [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) | Issue #511 global focus and visibility selector groups, affected surfaces, forbidden combinations, future narrow PR shapes, and #512 verification linkage |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
+| [AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md](./AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md) | Issue #705 Auth bootstrap compatibility boundary, preserved globals, cache keys, script order, extraction guardrails, and runtime verification requirements |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, smoke checklist |
 | [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
 | [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) | #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit |
@@ -97,6 +99,7 @@
 - CSS import hub, global token/readiness selector ownership, and future readiness dedupe decisions start from `GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` and `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`.
 - Global focus/visibility hardening decisions start from `GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md` and must use `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` for implementation verification.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
+- Auth bootstrap compatibility refactor 판단은 `AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md`에서 preserved globals, cache keys, script order, and runtime verification requirements를 먼저 확인합니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 - #223 repository structure follow-up closure 판단은 `REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md`에서 active blockers and closure conditions를 먼저 확인합니다.


### PR DESCRIPTION
Refs #705

Purpose:
- Document the compatibility boundary for staged `js/auth.js` refactoring before changing Auth runtime code.
- Preserve current Auth/Login/protected-route/Firebase/API token behavior while planning narrower future extractions.
- Define the globals, cache keys, script order, forbidden combinations, and verification matrix that implementation PRs must preserve.

Changed files:
- `docs/engineering/AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md`
- `docs/engineering/engineering_index.md`

Scope:
- Docs-only engineering boundary note.
- No runtime JS/CSS/HTML/API/Auth/backend changes.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.

Verification:
- GitHub API changed-file scope check: PASS, docs/engineering only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is part of the implementation batch and should remain draft until batch review/verification policy is satisfied.
- Future Auth runtime implementation PRs must still pass fixed-slot/Auth verification before merge judgment.
- Do not ready or merge without CTO approval.