### PR TITLE
ui(search): add scroll-based Browse incremental loading

### DIFF
--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -76,3 +76,30 @@
     margin: 0 0 22px;
     min-width: 0;
 }
+
+.browse-scroll-load-sentinel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 54px;
+    margin: 18px 0 4px;
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.browse-scroll-load-sentinel[hidden] {
+    display: none;
+}
+
+.browse-scroll-load-sentinel .material-symbols-outlined {
+    font-size: 18px;
+    color: var(--primary);
+    opacity: 0.72;
+}
+
+.browse-scroll-load-sentinel.is-loading .material-symbols-outlined {
+    animation: spin 1s linear infinite;
+}

--- a/js/search/data.js
+++ b/js/search/data.js
@@ -48,7 +48,20 @@
         // ── Load public trees (main browse) ────────────────────────────────────
         async function loadPublicTrees(options = {}) {
             const { resetSelection = false } = options;
+
+            // Prevent duplicate concurrent requests
+            if (state.isLoadingMore && !resetSelection) {
+                return;
+            }
+
             const cacheKey = `${PUBLIC_TREES_CACHE_KEY}_${state.currentSort}_${state.currentLimit}`;
+            const requestId = (state.currentPublicTreeRequestId || 0) + 1;
+            const requestSort = state.currentSort;
+            const requestLimit = state.currentLimit;
+            state.currentPublicTreeRequestId = requestId;
+            const isCurrentRequest = () => state.currentPublicTreeRequestId === requestId
+                && state.currentSort === requestSort
+                && state.currentLimit === requestLimit;
 
             ui.syncBrowseHead();
 
@@ -56,14 +69,10 @@
                 ui.clearSelectedPreview();
             }
 
-            // Prevent duplicate concurrent requests
-            if (state.isLoadingMore && !resetSelection) {
-                return;
-            }
-
             // Set loading state for incremental loading
             if (!resetSelection) {
                 state.isLoadingMore = true;
+                ui.syncControlsFromState();
             }
 
             // Serve from cache first (stale-while-revalidate)
@@ -91,6 +100,9 @@
                                 : 'API 응답 형식 오류'
                         );
                     }
+                    if (!isCurrentRequest()) {
+                        return;
+                    }
 
                     if (cache) {
                         cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
@@ -110,6 +122,9 @@
                     );
                 }
             } catch (error) {
+                if (!isCurrentRequest()) {
+                    return;
+                }
                 state.loadError = error;
                 console.warn('[search/data] API 로드 실패:', error.message);
                 if (!state.allTrees || state.allTrees.length === 0) {
@@ -117,7 +132,10 @@
                 }
                 callbacks.renderResults();
             } finally {
-                state.isLoadingMore = false;
+                if (isCurrentRequest()) {
+                    state.isLoadingMore = false;
+                    ui.syncControlsFromState();
+                }
             }
         }
 

--- a/js/search/data.js
+++ b/js/search/data.js
@@ -15,6 +15,26 @@
  * CSS, HTML, preview renderer, card renderer, url-state are untouched.
  */
 (function () {
+    function dedupeTreesById(trees) {
+        if (!Array.isArray(trees)) return [];
+
+        const seenIds = new Set();
+        return trees.filter((tree) => {
+            const rawId = tree?.id ?? tree?.treeId ?? tree?.tree_id;
+            if (rawId === null || rawId === undefined || rawId === '') {
+                return true;
+            }
+
+            const key = String(rawId);
+            if (seenIds.has(key)) {
+                return false;
+            }
+
+            seenIds.add(key);
+            return true;
+        });
+    }
+
     function createSearchData({ refs, state, previewCacheApi, ui, CardRenderer, PreviewRenderer, callbacks, cache, PUBLIC_TREES_CACHE_KEY, PREVIEW_CACHE_TTL_MS, getPreviewCacheKey }) {
 
         // ── Hydrate selected tree preview ──────────────────────────────────────
@@ -80,7 +100,7 @@
             if (cache) {
                 cachedTrees = cache.get(cacheKey);
                 if (cachedTrees && Array.isArray(cachedTrees) && cachedTrees.length > 0) {
-                    state.allTrees = cachedTrees;
+                    state.allTrees = dedupeTreesById(cachedTrees);
                     state.isFromCache = true;
                     callbacks.renderResults();
                 }
@@ -103,16 +123,17 @@
                     if (!isCurrentRequest()) {
                         return;
                     }
+                    const uniqueApiTrees = dedupeTreesById(apiTrees);
 
                     if (cache) {
-                        cache.set(cacheKey, apiTrees, 5 * 60 * 1000);
+                        cache.set(cacheKey, uniqueApiTrees, 5 * 60 * 1000);
                     }
-                    if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, apiTrees)) {
-                        state.allTrees = apiTrees;
+                    if (!previewCacheApi.areTreesEffectivelySame(state.allTrees, uniqueApiTrees)) {
+                        state.allTrees = uniqueApiTrees;
                     }
                     state.loadError = null;
                     state.apiTreesLoaded = true;
-                    state.hasMoreTrees = apiTrees.length === state.currentLimit;
+                    state.hasMoreTrees = apiTrees.length >= requestLimit && requestLimit < 60;
                     callbacks.renderResults();
                 } else {
                     throw new Error(
@@ -169,6 +190,7 @@
         }
 
         return {
+            dedupeTreesById,
             hydrateSelectedTreePreview,
             loadPublicTrees,
             loadGrowingTrees

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -65,7 +65,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         urlStateReady: false,
         initialTreeDeepLinkApplied: false,
         isLoadingMore: false,
-        hasMoreTrees: true
+        hasMoreTrees: true,
+        currentPublicTreeRequestId: 0
     };
     const previewCache = new Map();
     const callbacks = {};
@@ -245,6 +246,24 @@ document.addEventListener('DOMContentLoaded', async () => {
     callbacks.renderResults = renderResults;
     callbacks.renderGrowingResults = renderGrowingResults;
     callbacks.updateUrlState = urlState.updateUrlState;
+
+    callbacks.loadMorePublicTrees = async () => {
+        if (!state.apiTreesLoaded || state.isLoadingMore || !state.hasMoreTrees || state.currentLimit >= 60) {
+            return false;
+        }
+
+        const nextLimit = Math.min(state.currentLimit + 10, 60);
+        if (nextLimit === state.currentLimit) return false;
+
+        state.currentLimit = nextLimit;
+        ui.syncControlsFromState();
+        ui.syncBrowseHead();
+        urlState.updateUrlState();
+
+        await dataApi.loadPublicTrees({ resetSelection: false });
+        ui.syncControlsFromState();
+        return true;
+    };
 
     const controls = window.LoveBudSearchControls.createSearchControls({
         refs,

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
     const previewCache = new Map();
     const callbacks = {};
+    let loadMoreRequestInFlight = false;
 
     const ui = window.LoveBudSearchUI.createSearchUI({
         refs,
@@ -178,7 +179,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         })
         : createInlinePreviewController();
 
-    const getFilteredTrees = () => Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory);
+    const getFilteredTrees = () => dataApi.dedupeTreesById(
+        Adapter.filterTrees(state.allTrees, state.currentQuery, state.currentCategory)
+    );
 
     function renderResults(resetPreviewWhenNoSelection = true) {
         const filtered = getFilteredTrees();
@@ -248,21 +251,27 @@ document.addEventListener('DOMContentLoaded', async () => {
     callbacks.updateUrlState = urlState.updateUrlState;
 
     callbacks.loadMorePublicTrees = async () => {
-        if (!state.apiTreesLoaded || state.isLoadingMore || !state.hasMoreTrees || state.currentLimit >= 60) {
+        if (loadMoreRequestInFlight || !state.apiTreesLoaded || state.isLoadingMore || !state.hasMoreTrees || state.currentLimit >= 60) {
             return false;
         }
 
         const nextLimit = Math.min(state.currentLimit + 10, 60);
         if (nextLimit === state.currentLimit) return false;
 
-        state.currentLimit = nextLimit;
-        ui.syncControlsFromState();
-        ui.syncBrowseHead();
-        urlState.updateUrlState();
+        loadMoreRequestInFlight = true;
 
-        await dataApi.loadPublicTrees({ resetSelection: false });
-        ui.syncControlsFromState();
-        return true;
+        try {
+            state.currentLimit = nextLimit;
+            ui.syncControlsFromState();
+            ui.syncBrowseHead();
+            urlState.updateUrlState();
+
+            await dataApi.loadPublicTrees({ resetSelection: false });
+            return true;
+        } finally {
+            loadMoreRequestInFlight = false;
+            ui.syncControlsFromState();
+        }
     };
 
     const controls = window.LoveBudSearchControls.createSearchControls({

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -19,6 +19,11 @@
         // overlay element reference + saved scroll position for lock/restore
         let sheetOverlay = null;
         let savedScrollY = 0;
+        let scrollLoadSentinel = null;
+        let scrollLoadObserver = null;
+        let scrollCheckRaf = 0;
+        let isScrollLoadQueued = false;
+        let hasUserScrolledTowardFeed = false;
 
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
@@ -196,7 +201,7 @@
             }
             const loadMoreBtn = document.getElementById('browseLoadMoreBtn');
             if (loadMoreBtn) {
-                const shouldDisable = state.currentLimit >= 60 || !state.hasMoreTrees || state.isLoadingMore;
+                const shouldDisable = !state.apiTreesLoaded || state.currentLimit >= 60 || !state.hasMoreTrees || state.isLoadingMore;
                 loadMoreBtn.disabled = shouldDisable;
 
                 if (state.isLoadingMore) {
@@ -255,17 +260,107 @@
                         ${getCurrentLocale() === 'en' ? 'Loading...' : '로딩 중...'}
                     `;
                 } else {
-                    loadMoreBtn.disabled = false;
+                    loadMoreBtn.disabled = !state.apiTreesLoaded;
                     loadMoreBtn.textContent = state.currentLimit >= 60
                         ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
                         : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
                 }
             }
+            syncScrollLoadSentinel();
+        }
+
+        function canLoadMorePublicTrees() {
+            return Boolean(
+                callbacks.loadMorePublicTrees
+                && state.apiTreesLoaded
+                && state.hasMoreTrees
+                && !state.isLoadingMore
+                && !isScrollLoadQueued
+                && state.currentLimit < 60
+            );
+        }
+
+        function syncScrollLoadSentinel() {
+            if (!scrollLoadSentinel) return;
+
+            const isDone = !state.apiTreesLoaded || state.currentLimit >= 60 || !state.hasMoreTrees;
+            scrollLoadSentinel.hidden = isDone;
+            scrollLoadSentinel.classList.toggle('is-loading', Boolean(state.isLoadingMore));
+            scrollLoadSentinel.setAttribute('aria-hidden', isDone ? 'true' : 'false');
+
+            const text = scrollLoadSentinel.querySelector('[data-scroll-load-label]');
+            if (!text) return;
+            text.textContent = state.isLoadingMore
+                ? 'Loading more LoveTrees...'
+                : 'More LoveTrees will appear as you scroll.';
+        }
+
+        function isSentinelNearViewport() {
+            if (!scrollLoadSentinel || scrollLoadSentinel.hidden) return false;
+            const rect = scrollLoadSentinel.getBoundingClientRect();
+            return rect.top <= window.innerHeight + 520 && rect.bottom >= -160;
+        }
+
+        async function requestScrollLoadMore() {
+            if (!hasUserScrolledTowardFeed || !isSentinelNearViewport() || !canLoadMorePublicTrees()) return;
+
+            isScrollLoadQueued = true;
+            syncScrollLoadSentinel();
+            try {
+                await callbacks.loadMorePublicTrees({ source: 'scroll' });
+            } finally {
+                isScrollLoadQueued = false;
+                syncScrollLoadSentinel();
+            }
+        }
+
+        function scheduleScrollLoadCheck() {
+            if (scrollCheckRaf) return;
+            scrollCheckRaf = window.requestAnimationFrame(() => {
+                scrollCheckRaf = 0;
+                if ((window.scrollY || window.pageYOffset || 0) > 80) {
+                    hasUserScrolledTowardFeed = true;
+                }
+                requestScrollLoadMore();
+            });
+        }
+
+        function ensureScrollLoadSentinel() {
+            if (!resultsList || scrollLoadSentinel) return;
+
+            scrollLoadSentinel = document.createElement('div');
+            scrollLoadSentinel.id = 'browseScrollLoadSentinel';
+            scrollLoadSentinel.className = 'browse-scroll-load-sentinel';
+            scrollLoadSentinel.innerHTML = `
+                <span class="material-symbols-outlined" aria-hidden="true">progress_activity</span>
+                <span data-scroll-load-label></span>
+            `;
+
+            resultsList.insertAdjacentElement('afterend', scrollLoadSentinel);
+            syncScrollLoadSentinel();
+
+            if ('IntersectionObserver' in window) {
+                scrollLoadObserver = new IntersectionObserver((entries) => {
+                    if (entries.some(entry => entry.isIntersecting)) {
+                        scheduleScrollLoadCheck();
+                    }
+                }, {
+                    root: null,
+                    rootMargin: '520px 0px 520px 0px',
+                    threshold: 0
+                });
+                scrollLoadObserver.observe(scrollLoadSentinel);
+            }
+
+            window.addEventListener('scroll', scheduleScrollLoadCheck, { passive: true });
         }
 
         function ensureBrowseControls() {
             ensureResultsHead();
-            if (document.getElementById('browseSortControls')) return;
+            if (document.getElementById('browseSortControls')) {
+                ensureScrollLoadSentinel();
+                return;
+            }
 
             const controls = document.createElement('div');
             controls.id = 'browseSortControls';
@@ -311,14 +406,10 @@
             });
 
             controls.querySelector('#browseLoadMoreBtn')?.addEventListener('click', async () => {
-                if (state.isLoadingMore || !state.hasMoreTrees) return;
-
-                state.currentLimit = Math.min(state.currentLimit + 10, 60);
-                syncControlsFromState();
-                callbacks.updateUrlState();
-                await callbacks.loadPublicTrees({ resetSelection: false });
+                await callbacks.loadMorePublicTrees?.({ source: 'button' });
             });
 
+            ensureScrollLoadSentinel();
             syncControlsFromState();
         }
 

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260503-592">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-598">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -137,12 +137,12 @@
     <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260502-1"></script>
+    <script src="../js/search/search-ui.js?v=20260503-598"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
-     <script src="../js/search/data.js?v=20260429-1"></script>
+     <script src="../js/search/data.js?v=20260503-598"></script>
      <script src="../js/search/preview-controller.js?v=20260429-1"></script>
-     <script src="../js/search/index.js?v=20260429-2"></script>
+     <script src="../js/search/index.js?v=20260503-598"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -140,9 +140,9 @@
     <script src="../js/search/search-ui.js?v=20260503-598"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
-     <script src="../js/search/data.js?v=20260503-598"></script>
+    <script src="../js/search/data.js?v=20260503-598-2"></script>
      <script src="../js/search/preview-controller.js?v=20260429-1"></script>
-     <script src="../js/search/index.js?v=20260503-598"></script>
+    <script src="../js/search/index.js?v=20260503-598-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>


### PR DESCRIPTION
Refs #598

## Changed files
- css/search/controls.css
- js/search/index.js
- js/search/data.js
- js/search/search-ui.js
- pages/search.html

## Current behavior finding
- Current main preserved the first Browse batch at `currentLimit: 6`.
- PR #535 added button-based incremental loading through `browseLoadMoreBtn`, `state.isLoadingMore`, and `state.hasMoreTrees`.
- Current main did not have an IntersectionObserver or scroll-near-bottom trigger for the Browse card feed.
- PR #537 remains a Home prefetch path for the initial `limit=6` Browse summary cache and does not provide Browse page scroll loading.

## Final interaction model
- Browse still starts with the existing 6-card public LoveTree batch.
- A results-list sentinel is inserted below the card grid.
- After the user scrolls toward the feed bottom, IntersectionObserver plus a guarded scroll check requests the next batch automatically.
- The existing Load more button remains as the explicit fallback/manual path.
- Both automatic scroll loading and the fallback button use the same `loadMorePublicTrees` callback.

## Scroll trigger guard
- Auto loading requires `apiTreesLoaded`, `hasMoreTrees`, `currentLimit < 60`, no active `isLoadingMore`, and no queued scroll load.
- The sentinel only triggers after actual user scroll intent, so the initial 6-card batch is not immediately expanded just because the sentinel is near the viewport.
- The sentinel is hidden before initial API load, after max limit, or when `hasMoreTrees` is false.

## Duplicate request/card prevention
- `state.isLoadingMore` and local scroll queue state prevent repeated concurrent batch requests.
- `state.currentPublicTreeRequestId` ignores stale public-tree responses if sort/limit changed while a request was in flight.
- Existing API refresh behavior replaces the rendered result set for the expanded limit, so cards are not appended twice.

## Search/filter/sort behavior
- Search and category filtering remain client-side over `state.allTrees` and keep the current pagination policy.
- Sort still uses the existing sort control path and reloads public trees through the same API contract.
- URL `limit` sync remains unchanged through the existing URL state helper.

## Runtime boundaries
- API/data/backend/Auth unchanged.
- No DB, package, workflow, card redesign, selected hub redesign, or search/filter placement changes.
- Browser verification deferred to batch; local/static checks only, browser PASS not claimed.

## Local/static checks
- `git diff --check`
- `node --check js/search/index.js`
- `node --check js/search/data.js`
- `node --check js/search/search-ui.js`
- `node --test tests/routes/search-runtime-modules.test.js tests/contracts/api-route-mapping.test.js`
- `npm run verify`
- `npm test`