### PR TITLE
docs(engineering): document Modal API service boundary plan

### DIFF
--- a/docs/engineering/MODAL_API_SERVICE_BOUNDARY_PLAN.md
+++ b/docs/engineering/MODAL_API_SERVICE_BOUNDARY_PLAN.md
@@ -1,0 +1,272 @@
+# Modal API Service Boundary Plan
+
+**Status:** Active staged-refactor boundary  
+**Owner:** CTO / Backend Lead  
+**Related issue:** #660  
+**Depends on:** #656 large-file audit, #423 owner route split boundary
+
+This document defines a staged, behavior-preserving plan for reducing `modal_compute/app.py` responsibility without changing the active Cloudflare Pages plus Modal runtime contract.
+
+The Modal app is a high-risk backend boundary. It handles route dispatch, authentication, ownership and visibility policy, database access, serialization, retry/error handling, and public/private read/write behavior. Any split must preserve current response shapes, status codes, auth semantics, and Cloudflare same-origin `/api/*` expectations.
+
+---
+
+## 1. Boundary principle
+
+The first implementation PRs should reduce responsibility without moving route decorators.
+
+Route decorators in `modal_compute/app.py` are part of the observable application surface and should remain in place until helper extraction and contract coverage are accepted. A safe split extracts pure or near-pure service/helper functions first, then leaves route handlers as thin orchestration wrappers.
+
+Do not combine route movement, database query changes, ownership policy changes, response shape changes, and retry/error behavior changes in a single PR.
+
+---
+
+## 2. Responsibility buckets
+
+`modal_compute/app.py` should be treated as multiple responsibility buckets, not one generic backend file.
+
+| Bucket | Examples | First safe action |
+| --- | --- | --- |
+| Route handler orchestration | FastAPI decorators, request parsing, response return | Keep decorators in app; make wrappers thinner later |
+| Auth identity bridge | Firebase token verification, user identity extraction | Preserve behavior; no first-step extraction unless tests exist |
+| Ownership/visibility guards | owner-only checks, public/private visibility checks | Extract only with contract coverage |
+| Public read services | browse/latest/growing/community/detail reads | Keep stable unless follow-up proves need |
+| Owner read services | private tree/memory list/detail reads | Candidate after owner-read contract tests |
+| Owner write services | create/update/delete/fork writes | Candidate after owner-write contract tests |
+| Serialization | camelCase response shape, safe public/private fields | Extract only with response-shape tests |
+| Retry/error handling | DB retry, not-found/denial mapping, degraded errors | Extract after current behavior map is documented |
+| Database query helpers | SQL/query assembly, row mapping | Extract one route family at a time |
+
+---
+
+## 3. Preserved contracts
+
+The following must remain equivalent unless a separate API-contract PR explicitly changes them:
+
+```text
+HTTP method and route path
+status code
+response shape and key casing
+public/private field exposure
+owner-only access behavior
+anonymous public-read behavior
+parent-tree visibility guard behavior
+error response shape
+retry/degraded behavior
+Cloudflare same-origin /api mapping
+request ID propagation expectations
+```
+
+Reports must not include raw private payloads, database rows, credentials, tokens, sessions, cookies, owner IDs, tree IDs, memory IDs, copied tree IDs, or DB row values.
+
+Use safe labels only:
+
+```text
+OWNER_GUARD: PASS/FAIL/NOT_VERIFIED
+VISIBILITY_GUARD: PASS/FAIL/NOT_VERIFIED
+RESPONSE_SHAPE: PASS/FAIL/NOT_VERIFIED
+STATUS_CODE: PASS/FAIL/NOT_VERIFIED
+PRIVATE_PAYLOAD_EXPOSURE: NO/YES
+```
+
+---
+
+## 4. Recommended implementation sequence
+
+### PR A — service boundary contract tests or test plan
+
+Goal:
+- Add or document contract coverage for the route family targeted by the first extraction.
+
+Preferred coverage:
+- route exists;
+- method accepted/rejected behavior;
+- status code compatibility;
+- response shape compatibility;
+- owner/non-owner behavior where relevant;
+- public/private visibility behavior;
+- no private payload exposure.
+
+No runtime behavior change.
+
+### PR B — owner read helper extraction
+
+Precondition:
+- owner read coverage exists or CTO accepts a documented test gap.
+
+Allowed:
+- extract owner tree/memory read query helpers;
+- keep decorators and route entrypoints in `modal_compute/app.py`;
+- preserve SQL semantics and response shape;
+- preserve denial/not-found mapping.
+
+Forbidden:
+- no writes;
+- no public route changes;
+- no Cloudflare gateway changes;
+- no response renaming.
+
+### PR C — owner write helper extraction
+
+Precondition:
+- owner write contract coverage exists or CTO accepts a documented test gap.
+
+Allowed:
+- extract one write family at a time, such as create tree or create memory;
+- preserve auth, ownership, validation, SQL, and response shape.
+
+Forbidden:
+- no multiple write families unless tightly coupled;
+- no schema change;
+- no entitlement or visibility policy redesign.
+
+### PR D — serialization helper extraction
+
+Precondition:
+- response-shape contract coverage exists.
+
+Allowed:
+- extract row-to-response serializers;
+- preserve camelCase shape and public/private field filtering.
+
+Forbidden:
+- no field additions/removals;
+- no private field exposure changes.
+
+### PR E — retry/error helper extraction
+
+Precondition:
+- current error/status behavior is documented for the route family.
+
+Allowed:
+- extract shared retry or error mapping helpers.
+
+Forbidden:
+- no new error codes or changed status mapping unless separately approved.
+
+### PR F — route decorator movement, only if still necessary
+
+Precondition:
+- helper extraction is complete for that route family;
+- contract coverage exists;
+- CTO explicitly approves route movement.
+
+Allowed:
+- move one route family at a time.
+
+Forbidden:
+- no broad Modal app rewrite.
+
+---
+
+## 5. Contract gate for each PR
+
+Every implementation PR touching Modal API behavior must include this matrix in the PR body or verification comment:
+
+```text
+[Modal API Contract Gate]
+Route family:
+Changed files:
+Route decorators moved: YES/NO
+Auth behavior changed: YES/NO
+Ownership behavior changed: YES/NO
+Visibility behavior changed: YES/NO
+DB schema changed: YES/NO
+Response shape changed: YES/NO
+Status code changed: YES/NO
+Cloudflare gateway changed: YES/NO
+Contract tests: PASS/FAIL/NOT_RUN
+Runtime smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
+Private payload exposure: NO
+Secret exposure: NO
+Final judgment: PASS/PARTIAL/BLOCKED/FAIL
+```
+
+If any behavior is intentionally changed, the PR is no longer a behavior-equivalent refactor and must be rescoped.
+
+---
+
+## 6. Runtime verification requirements
+
+Static checks are necessary but not sufficient for Modal API behavior changes.
+
+Minimum static checks:
+
+```text
+git diff --check
+relevant backend contract tests
+npm test
+npm run verify
+```
+
+Runtime/API smoke should use safe, non-production-mutation paths unless CTO explicitly approves a mutation test. If a write route must be tested, use approved disposable test data and report only status labels.
+
+Required safe observations:
+
+```text
+route reachable: YES/NO
+request authenticated where required: YES/NO/NOT_REQUIRED
+owner guard: PASS/FAIL/NOT_VERIFIED
+visibility guard: PASS/FAIL/NOT_VERIFIED
+response shape: PASS/FAIL/NOT_VERIFIED
+status code: PASS/FAIL/NOT_VERIFIED
+5xx regression: YES/NO
+private payload exposure: NO
+secret exposure: NO
+```
+
+---
+
+## 7. Cloudflare boundary
+
+Do not change Cloudflare Pages Functions gateway behavior as part of #660 unless explicitly approved.
+
+Out of scope for first Modal service extraction:
+
+```text
+functions/api/[[path]].js route mapping
+same-origin /api path contract
+request ID propagation
+upstream/degraded response headers
+Cloudflare cache behavior
+method-not-allowed behavior
+unhandled-route behavior
+```
+
+Any Cloudflare gateway change requires a separate gateway PR and fixed-slot API/browser verification.
+
+---
+
+## 8. Forbidden combinations
+
+Do not combine Modal API service extraction with:
+
+- frontend UI work;
+- Auth provider changes;
+- database schema changes;
+- visibility/product policy changes;
+- package/workflow changes;
+- Cloudflare gateway changes;
+- PR #7 or prototype/reference/demo/variant changes;
+- production data mutation;
+- broad route decorator movement.
+
+---
+
+## 9. First implementation recommendation
+
+The safest first code PR is not broad extraction. It should be one of:
+
+1. Add owner-read or owner-write contract tests for one route family.
+2. Extract a narrow owner-read query helper with route decorators left in `app.py`.
+3. Extract a pure serializer only after response-shape tests exist.
+
+Do not start with route decorator movement or write-route behavior changes.
+
+---
+
+## 10. Closure criteria for #660
+
+Issue #660 should remain open until one or more implementation PRs reduce `modal_compute/app.py` responsibility while preserving behavior and recording required contract/runtime evidence.
+
+A docs-only boundary PR can make the issue implementation-ready, but it does not complete the refactor by itself.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -21,26 +21,27 @@
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 4. [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) - #408 500+ line large-file candidate inventory, owner routing, extraction guardrails
 5. [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) - #423 Modal owner read/write route split boundary, implementation gates, verification requirements
-6. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
-7. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-8. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
-9. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, and #512 verification linkage
-10. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-11. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-12. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
-13. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-14. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-15. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-16. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-17. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-18. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-19. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
-20. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-21. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-22. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-23. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
-24. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-25. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+6. [MODAL_API_SERVICE_BOUNDARY_PLAN.md](./MODAL_API_SERVICE_BOUNDARY_PLAN.md) - #660 Modal API route/service split plan, contract gate, runtime verification requirements
+7. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
+8. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+9. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
+10. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, and #512 verification linkage
+11. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+12. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+13. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
+14. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+15. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+16. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+17. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+18. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+19. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+20. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
+21. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+22. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+23. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+24. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
+25. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+26. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -53,6 +54,7 @@
 | [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 정책 |
 | [LARGE_FILE_MODULARIZATION_CANDIDATES.md](./LARGE_FILE_MODULARIZATION_CANDIDATES.md) | Issue #408 large-file candidate inventory, owner-domain routing, extraction guardrails, verification requirements |
 | [MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md](./MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md) | Issue #423 Modal owner read/write route split boundary, implementation gates, Cloudflare boundary, verification expectations |
+| [MODAL_API_SERVICE_BOUNDARY_PLAN.md](./MODAL_API_SERVICE_BOUNDARY_PLAN.md) | Issue #660 Modal API route/service split plan, preserved contracts, staged extraction sequence, contract gate, and runtime verification requirements |
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
@@ -93,6 +95,7 @@
 - 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
 - #408 large-file candidate 판단은 `LARGE_FILE_MODULARIZATION_CANDIDATES.md`에서 owner routing and forbidden scope를 먼저 확인합니다.
 - #423 Modal owner-route split 판단은 `MODAL_OWNER_ROUTE_SPLIT_BOUNDARY.md`에서 completed public-read work, remaining owner read/write gates, and verification expectations를 먼저 확인합니다.
+- #660 Modal API service split 판단은 `MODAL_API_SERVICE_BOUNDARY_PLAN.md`에서 preserved contracts, implementation sequence, contract gate, and runtime verification requirements를 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
 - CSS import hub, global token/readiness selector ownership, and future readiness dedupe decisions start from `GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` and `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`.
 - Global focus/visibility hardening decisions start from `GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md` and must use `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` for implementation verification.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -27,21 +27,22 @@
 9. [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) - #510 global CSS token and readiness selector ownership audit, future PR split, #512 verification linkage
 10. [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) - #511 global focus and visibility selector audit, affected surfaces, allowed future PR shapes, and #512 verification linkage
 11. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-12. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-13. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
-14. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-15. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-16. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-17. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-18. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-19. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-20. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
-21. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-22. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-23. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-24. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
-25. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-26. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+12. [AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md](./AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md) - #705 auth bootstrap compatibility boundary, global/cache/script-order contract, staged extraction guardrails
+13. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+14. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, forbidden combinations, fixed slot smoke 기준
+15. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+16. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+17. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+18. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+19. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+20. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+21. [EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md](./EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md) - #518 editor detail UI responsibility buckets, future split candidates, and browser smoke gates
+22. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+23. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+24. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+25. [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) - #516 editor hidden/compatibility selector usage audit, disposition map, and future removal/relocation gates
+26. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+27. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -60,6 +61,7 @@
 | [GLOBAL_CSS_TOKEN_READINESS_AUDIT.md](./GLOBAL_CSS_TOKEN_READINESS_AUDIT.md) | Issue #510 global CSS token groups, readiness selector aliases, duplication candidates, future PR split, and #512 verification linkage |
 | [GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md](./GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md) | Issue #511 global focus and visibility selector groups, affected surfaces, forbidden combinations, future narrow PR shapes, and #512 verification linkage |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
+| [AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md](./AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md) | Issue #705 Auth bootstrap compatibility boundary, preserved globals, cache keys, script order, extraction guardrails, and runtime verification requirements |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, smoke checklist |
 | [SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md](./SEARCH_PREVIEW_CONTROLLER_SPLIT_AUDIT.md) | Search/Browse preview controller split 준비 audit와 종속 구현 guardrail |
 | [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) | #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit |
@@ -100,6 +102,7 @@
 - CSS import hub, global token/readiness selector ownership, and future readiness dedupe decisions start from `GLOBAL_CSS_TOKEN_READINESS_AUDIT.md` and `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md`.
 - Global focus/visibility hardening decisions start from `GLOBAL_FOCUS_VISIBILITY_HARDENING_AUDIT.md` and must use `../ops/GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md` for implementation verification.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
+- Auth bootstrap compatibility refactor 판단은 `AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md`에서 preserved globals, cache keys, script order, and runtime verification requirements를 먼저 확인합니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.
 - CSS import hub, split ownership, visual verification 판단은 `CSS_ARCHITECTURE.md`와 `../ops/BROWSER_VERIFICATION_URL_POLICY.md`를 함께 봅니다.
 - #223 repository structure follow-up closure 판단은 `REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md`에서 active blockers and closure conditions를 먼저 확인합니다.


### PR DESCRIPTION
Refs #660

Purpose:
- Document the staged Modal API service boundary plan before changing `modal_compute/app.py`.
- Preserve the active Cloudflare Pages + Modal runtime contract while planning route/service/helper extraction.
- Define responsibility buckets, preserved contracts, forbidden combinations, per-PR contract gate, and runtime verification requirements.

Changed files:
- `docs/engineering/MODAL_API_SERVICE_BOUNDARY_PLAN.md`
- `docs/engineering/engineering_index.md`

Scope:
- Docs-only engineering boundary note.
- No runtime Python/JS/CSS/HTML/API/Auth/backend behavior changes.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, DB URL, owner ID, tree ID, memory ID, copied tree ID, or DB row value included.

Verification:
- GitHub API changed-file scope check: PASS, docs/engineering only.
- Modal/runtime verification: NOT_REQUIRED for docs-only PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is part of the implementation batch and should remain draft until batch review policy is satisfied.
- Future Modal implementation PRs must still pass contract/runtime verification before merge judgment.
- Do not ready or merge without CTO approval.