### PR TITLE
ui(search): test hybrid Browse card tree preview

### DIFF
--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -83,6 +83,46 @@
         opacity: 0.62;
     }
 
+    .tree-card-preview-strip-media {
+        left: 14px;
+        right: 14px;
+        bottom: 10px;
+        height: 34px;
+    }
+
+    .tree-card-preview-strip-fallback {
+        top: 28px;
+        width: 98px;
+        height: 36px;
+    }
+
+    .tree-card-preview-line-main {
+        top: 20px;
+    }
+
+    .tree-card-preview-line-branch {
+        top: 19px;
+        width: 28px;
+    }
+
+    .tree-card-preview-node {
+        width: 7px;
+        height: 7px;
+        box-shadow:
+            0 0 0 4px rgba(255, 248, 245, 0.14),
+            0 5px 10px rgba(50, 38, 35, 0.14);
+    }
+
+    .tree-card-preview-node-root,
+    .tree-card-preview-node-leaf,
+    .tree-card-preview-node-end {
+        top: 17px;
+    }
+
+    .tree-card-preview-node-branch {
+        top: 8px;
+    }
+
     .tree-card-media-fallback::before {
         top: 20px;
         width: 74px;

--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -124,6 +124,122 @@
     z-index: 2;
 }
 
+.tree-card-preview-strip {
+    position: absolute;
+    pointer-events: none;
+    z-index: 3;
+    height: 42px;
+    color: rgba(255, 248, 245, 0.92);
+}
+
+.tree-card-preview-strip[hidden] {
+    display: none !important;
+}
+
+.tree-card-preview-strip-media {
+    left: 18px;
+    right: 18px;
+    bottom: 13px;
+    color: rgba(255, 248, 245, 0.9);
+    filter: drop-shadow(0 7px 12px rgba(50, 38, 35, 0.26));
+}
+
+.tree-card-preview-strip-fallback {
+    left: 50%;
+    top: 32px;
+    width: 112px;
+    transform: translateX(-50%);
+    color: rgba(144, 73, 81, 0.72);
+    filter: none;
+}
+
+.tree-card-preview-line,
+.tree-card-preview-node {
+    position: absolute;
+    display: block;
+}
+
+.tree-card-preview-line {
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    opacity: 0.74;
+    transform-origin: left center;
+}
+
+.tree-card-preview-line-main {
+    left: 10px;
+    right: 10px;
+    top: 23px;
+}
+
+.tree-card-preview-line-branch {
+    left: 44%;
+    top: 22px;
+    width: 34px;
+    transform: rotate(-32deg);
+    opacity: 0.58;
+}
+
+.tree-card-preview-node {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow:
+        0 0 0 5px rgba(255, 248, 245, 0.15),
+        0 6px 14px rgba(50, 38, 35, 0.16);
+}
+
+.tree-card-preview-strip-fallback .tree-card-preview-node {
+    box-shadow: 0 0 0 5px rgba(144, 73, 81, 0.08);
+}
+
+.tree-card-preview-node-root {
+    left: 8px;
+    top: 18px;
+}
+
+.tree-card-preview-node-branch {
+    left: 45%;
+    top: 8px;
+    color: rgba(255, 222, 219, 0.92);
+}
+
+.tree-card-preview-strip-fallback .tree-card-preview-node-branch {
+    color: rgba(122, 139, 110, 0.68);
+}
+
+.tree-card-preview-node-leaf {
+    left: 58%;
+    top: 18px;
+    color: rgba(255, 232, 227, 0.94);
+}
+
+.tree-card-preview-strip-fallback .tree-card-preview-node-leaf {
+    color: rgba(200, 116, 128, 0.66);
+}
+
+.tree-card-preview-node-end {
+    right: 8px;
+    top: 18px;
+}
+
+.tree-card-preview-empty .tree-card-preview-node-branch,
+.tree-card-preview-empty .tree-card-preview-node-leaf,
+.tree-card-preview-empty .tree-card-preview-line-branch {
+    opacity: 0.28;
+}
+
+.tree-card-preview-sprout .tree-card-preview-node-end {
+    opacity: 0.38;
+}
+
+.tree-card-preview-full .tree-card-preview-line-branch,
+.tree-card-preview-full .tree-card-preview-node-branch {
+    opacity: 0.92;
+}
+
 .tree-card-media-fallback {
     position: absolute;
     inset: 0;

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260503-591
+ * v20260503-618
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -72,6 +72,10 @@
         if (fallback) {
             fallback.hidden = false;
         }
+        const mediaPreview = img.parentElement?.querySelector?.('.tree-card-preview-strip-media');
+        if (mediaPreview) {
+            mediaPreview.hidden = true;
+        }
     }
 
     let _resultsList = null;
@@ -130,6 +134,28 @@
         return Number.isFinite(count) && count > 0 ? count : 0;
     }
 
+    function getTreePreviewTone(tree) {
+        const memoryCount = getDisplayMemoryCount(tree?.memoryCount);
+        if (memoryCount >= 6) return 'full';
+        if (memoryCount >= 3) return 'growing';
+        if (memoryCount >= 1) return 'sprout';
+        return 'empty';
+    }
+
+    function renderCompactTreePreview(tree, variant) {
+        const tone = getTreePreviewTone(tree);
+        return `
+            <div class="tree-card-preview-strip tree-card-preview-strip-${variant} tree-card-preview-${tone}" aria-hidden="true">
+                <span class="tree-card-preview-line tree-card-preview-line-main"></span>
+                <span class="tree-card-preview-line tree-card-preview-line-branch"></span>
+                <span class="tree-card-preview-node tree-card-preview-node-root"></span>
+                <span class="tree-card-preview-node tree-card-preview-node-branch"></span>
+                <span class="tree-card-preview-node tree-card-preview-node-leaf"></span>
+                <span class="tree-card-preview-node tree-card-preview-node-end"></span>
+            </div>
+        `;
+    }
+
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
         const treeStage = tree?.stage || 'empty';
@@ -137,11 +163,7 @@
         return `
             <div class="tree-card-media-fallback">
                 <div class="fallback-title">${safeTitle}</div>
-                <div class="fallback-dots">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </div>
+                ${renderCompactTreePreview(tree, 'fallback')}
             </div>
         `;
     }
@@ -181,9 +203,12 @@
          );
          const firstMoment = escapeHtml(firstMem?.title || '대표 순간 준비 중');
 
+         const mediaPreview = mediaUrl ? renderCompactTreePreview(tree, 'media') : '';
+
          return `
              <div class="tree-card-media" aria-label="${firstMoment}" style="position:relative;overflow:hidden;">
                  ${renderRepresentativeImage(mediaUrl, firstMoment, tree, titleText)}
+                 ${mediaPreview}
              </div>
          `;
      }
@@ -385,5 +410,5 @@
         }
     };
 
-    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260503-591');
+    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260503-618');
  })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,11 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-<<<<<<< HEAD
-    <link rel="stylesheet" href="../css/search.css?v=20260503-618-merge1">
-=======
-    <link rel="stylesheet" href="../css/search.css?v=20260503-598">
->>>>>>> origin/main
+    <link rel="stylesheet" href="../css/search.css?v=20260503-618-merge2">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -135,11 +131,7 @@
     <script src="../js/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
-<<<<<<< HEAD
     <script src="../js/search/search-card-renderer.js?v=20260503-618"></script>
-=======
-    <script src="../js/search/search-card-renderer.js?v=20260503-591"></script>
->>>>>>> origin/main
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260503-592">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-618">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -131,7 +131,7 @@
     <script src="../js/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
-    <script src="../js/search/search-card-renderer.js?v=20260503-591"></script>
+    <script src="../js/search/search-card-renderer.js?v=20260503-618"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260503-618">
+    <link rel="stylesheet" href="../css/search.css?v=20260503-618-merge1">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -132,17 +132,17 @@
     <script src="../js/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search-shared-utils.js?v=20260428-1"></script>
     <script src="../js/search/search-card-renderer.js?v=20260503-618"></script>
-    <script src="../js/search/search-preview-media-helper.js?v=20260428-1"></script>
+    <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-action-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260501-1"></script>
+    <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260502-1"></script>
+    <script src="../js/search/search-ui.js?v=20260503-598"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
-     <script src="../js/search/data.js?v=20260429-1"></script>
+    <script src="../js/search/data.js?v=20260503-598-2"></script>
      <script src="../js/search/preview-controller.js?v=20260429-1"></script>
-     <script src="../js/search/index.js?v=20260429-2"></script>
+    <script src="../js/search/index.js?v=20260503-598-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>


### PR DESCRIPTION
Refs #618

## Changed files
- `js/search/search-card-renderer.js`
- `css/search/tree-card.css`
- `css/search/responsive.css`
- `pages/search.html`

## Hybrid visual model summary
- Adds a compact, non-interactive tree preview strip inside Browse card media.
- Keeps representative thumbnails recognizable while adding a branch/minimap signature so cards read as LoveTree discovery cards, not plain media tiles.
- Uses memory-count tone classes only for visual density; no API/data behavior changes.

## Media-backed/fallback grammar comparison
- Media-backed cards render the compact tree strip over the lower media area.
- No-thumbnail and image-error fallback cards render the same compact strip inside the fallback visual, sharing the same branch/node grammar.
- The previous fallback dot cluster is replaced by the shared compact tree preview markup.

## #591/#592 preservation note
- Preserves #591 title/subtitle/meta structure, clamps, and copy hierarchy.
- Preserves #592 warm card surface and media/fallback LoveTree polish, adding only a narrow shared preview strip.

## Click target / interaction decision
- No new button, CTA, or click target was added.
- Existing card selection/preview interaction remains the only interaction path.
- The tree preview strip is `aria-hidden` and `pointer-events: none` to avoid fake-button ambiguity.

## API/data/backend/Auth
- No Browse API, data adapter, backend, DB, Auth, package, or workflow changes.

## Verification
- Browser verification deferred to batch.
- Local/static checks only; browser PASS is not claimed.
- `git diff --check`: PASS
- `node --check js/search/search-card-renderer.js`: PASS
- `npm run verify`: PASS, 140/140
- `npm test`: PASS, 192/192