### PR TITLE
ui(editor): stabilize tree title loading and edit placement

### DIFF
--- a/css/editor/overrides.css
+++ b/css/editor/overrides.css
@@ -318,7 +318,12 @@ body .editor-canvas-title h2 {
 }
 
 .editor-rename-btn {
+    align-self: flex-start;
     display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: auto;
     min-height: 32px;
     padding: 0 11px;
     margin-top: 2px;
@@ -327,6 +332,9 @@ body .editor-canvas-title h2 {
     border-color: rgba(197,146,128,0.30);
     color: #9b5f58;
     font-size: 11px;
+    font-weight: 900;
+    line-height: 1;
+    white-space: nowrap;
     box-shadow: 0 8px 18px rgba(165,124,101,0.08);
 }
 
@@ -339,11 +347,19 @@ body .editor-canvas-title h2 {
 }
 
 .editor-title-settings-panel {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
     gap: 10px;
     margin-top: 14px;
+    width: 100% !important;
+    align-items: stretch !important;
+    justify-content: stretch !important;
+    pointer-events: auto !important;
 }
 
 .editor-mini-setting-btn {
+    display: inline-flex !important;
+    width: 100%;
     min-height: 48px;
     border-radius: 999px;
     background: rgba(255,255,255,0.70);
@@ -351,6 +367,10 @@ body .editor-canvas-title h2 {
     color: #7f6258;
     font-weight: 800;
     box-shadow: 0 8px 16px rgba(165,124,101,0.06);
+}
+
+.editor-status-card #sidebarVisibilityToggleBtn.editor-mini-setting-btn {
+    display: inline-flex !important;
 }
 
 .editor-tree-quiet-note {

--- a/css/editor/overrides.css
+++ b/css/editor/overrides.css
@@ -318,7 +318,16 @@ body .editor-canvas-title h2 {
 }
 
 .editor-rename-btn {
-    display: none !important;
+    display: inline-flex !important;
+    min-height: 32px;
+    padding: 0 11px;
+    margin-top: 2px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.78);
+    border-color: rgba(197,146,128,0.30);
+    color: #9b5f58;
+    font-size: 11px;
+    box-shadow: 0 8px 18px rgba(165,124,101,0.08);
 }
 
 .editor-tree-visibility-pill {
@@ -331,7 +340,7 @@ body .editor-canvas-title h2 {
 
 .editor-title-settings-panel {
     gap: 10px;
-    margin-top: 20px;
+    margin-top: 14px;
 }
 
 .editor-mini-setting-btn {

--- a/css/editor/status-settings.css
+++ b/css/editor/status-settings.css
@@ -30,13 +30,15 @@
 
 .editor-space-between-row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 12px;
 }
 
 .editor-status-card strong {
     display: block;
+    flex: 1 1 auto;
+    min-width: 0;
     font-size: 1.42rem;
     font-weight: 900;
     line-height: 1.24;
@@ -59,6 +61,9 @@
 
 .editor-rename-btn {
     flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     min-height: 34px;
     padding: 0 12px;
     border-radius: 999px;
@@ -67,6 +72,7 @@
     color: var(--primary);
     font-size: 12px;
     font-weight: 800;
+    line-height: 1;
     box-shadow: 0 6px 16px rgba(75,64,57,0.05);
 }
 
@@ -98,7 +104,7 @@
 
 .editor-title-settings-panel {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: 8px;
     margin-top: 10px;
 }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260503-624">
+    <link rel="stylesheet" href="../css/editor.css?v=20260503-624-2">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260423-1">
+    <link rel="stylesheet" href="../css/editor.css?v=20260503-624">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -29,15 +29,11 @@
                 <div class="editor-status-card">
                     <div class="editor-reference-kicker" aria-hidden="true">✿ Our LoveTree</div>
                     <div class="editor-space-between-row">
-                        <strong id="sidebarTreeTitle">LoveTree</strong>
+                        <strong id="sidebarTreeTitle">러브트리</strong>
                         <button type="button" id="renameTreeBtn" class="icon-menu-btn editor-rename-btn" aria-label="트리 제목 변경" title="트리 제목 변경">편집</button>
                     </div>
                     <span id="sidebarTreeVisibility" class="editor-tree-visibility-pill is-private">비공개</span>
-                    <div class="editor-title-settings-panel" aria-label="트리 핵심 설정">
-                        <button type="button" class="editor-mini-setting-btn" id="sidebarTitleEditBtn" aria-label="제목 수정">
-                            <span class="material-symbols-outlined" aria-hidden="true">edit</span>
-                            <span id="sidebarTitleEditBtnLabel">제목 수정</span>
-                        </button>
+                    <div class="editor-title-settings-panel" aria-label="트리 공개 설정">
                         <button type="button" class="editor-mini-setting-btn" id="sidebarVisibilityToggleBtn">
                             <span class="material-symbols-outlined" id="sidebarVisibilityToggleBtnIcon" aria-hidden="true">public</span>
                             <span id="sidebarVisibilityToggleBtnLabel">이 트리 공개하기</span>


### PR DESCRIPTION
Refs #624

## Changed files
- `pages/editor.html`
- `css/editor/status-settings.css`
- `css/editor/overrides.css`

## Title loading fallback fix summary
- Changed the initial left summary title fallback from English `LoveTree` to Korean-safe `러브트리`.
- Refreshed the Editor stylesheet cache key so the corrected first-paint title and layout styling are picked up.

## Title edit placement decision
- Reinstated the existing `#renameTreeBtn` in the title row as the primary compact title-edit affordance.
- Styled it as a small title-adjacent chip so the edit action stays visually connected to the title/badge area.

## Duplicated edit affordance handling
- Removed the lower `#sidebarTitleEditBtn` markup from the settings panel.
- Kept the visibility toggle in the lower settings panel and changed that panel to a single-column layout.
- Existing JS binding remains tolerant because it already no-ops when `#sidebarTitleEditBtn` is absent.

## Title edit behavior
- Title edit behavior is preserved through the existing `#renameTreeBtn` binding and rename handler.
- No title-edit flow rewrite was included.

## Auth/API/backend/data
- No Auth, API, backend, DB, package, workflow, editor canvas/detail/memory CRUD, Browse/Search, My Trees, Intro, Home, or Detail behavior changes.

## Verification
- Browser verification deferred to batch.
- Local/static checks only; browser PASS is not claimed.
- `git diff --check`: PASS
- JS changed: NO, so no changed-JS `node --check` target
- Editor targeted tests: PASS, 16/16
- `npm run verify`: PASS, 140/140
- `npm test`: PASS, 192/192