### PR TITLE
docs(product): document Browse popular sort semantics

### DIFF
--- a/docs/product/BROWSE_POPULAR_SORT_SEMANTICS.md
+++ b/docs/product/BROWSE_POPULAR_SORT_SEMANTICS.md
@@ -1,0 +1,209 @@
+# Browse Popular Sort Semantics
+
+**Status:** Active product/API semantics note  
+**Owner:** CTO / Product + Backend  
+**Related issue:** #608
+
+This document defines the current meaning and risk of the Browse `popular` sort option.
+
+The important conclusion is that the current backend implementation does not measure popularity in the engagement sense. It sorts public Browse-eligible trees by public memory count, then by creation time. This is a useful completeness/activity proxy, but it is not yet a true popularity signal.
+
+---
+
+## 1. Current implementation finding
+
+The public Browse route accepts `sort=popular` as an allowed value and passes it to the Modal public-read helper.
+
+Current Modal route behavior:
+
+```text
+if sort is latest or popular:
+  pass through
+else:
+  fallback to latest
+```
+
+Current public-read behavior:
+
+```text
+latest:
+  ORDER BY tree.created_at DESC
+
+popular:
+  ORDER BY public_memory_count DESC, tree.created_at DESC
+```
+
+The query only includes public trees with at least three public memories. Therefore `popular` currently means:
+
+```text
+public Browse-eligible trees with more public memories first,
+then newer trees first when public memory count ties.
+```
+
+---
+
+## 2. Product interpretation
+
+The current behavior should not be described as real popularity unless the product explicitly accepts memory count as the public definition of popularity.
+
+Memory count may correlate with richer or more complete trees, but it does not prove:
+
+- views;
+- opens;
+- likes/reactions;
+- comments;
+- shares;
+- copy/import count;
+- recent engagement;
+- editorial curation;
+- user retention or dwell time.
+
+A user who sees `인기순` can reasonably assume other users made the tree popular. The current implementation does not have that evidence.
+
+---
+
+## 3. Recommended v0.1 decision
+
+For v0.1, LoveBud should avoid overclaiming popularity.
+
+Recommended decision:
+
+```text
+Do not present memory-count ordering as “인기순” unless UI copy or help text clearly defines it.
+Prefer renaming to an honest proxy label such as “기록 많은 순” or “풍성한 순,” or hide/disable “인기순” until engagement signals exist.
+```
+
+The exact copy should be decided in a later UI/copy PR because this document is not a UI implementation PR.
+
+---
+
+## 4. Acceptable product states
+
+### Option A — Rename the sort
+
+Use a label that matches current behavior.
+
+Candidate Korean labels:
+
+```text
+기록 많은 순
+순간 많은 순
+풍성한 순
+```
+
+Pros:
+- honest about current implementation;
+- no backend work required;
+- keeps useful ordering.
+
+Cons:
+- less emotionally familiar than `인기순`;
+- needs copy and screenshot verification.
+
+### Option B — Keep `인기순` with explicit definition
+
+Keep the label but define it in UI/help text as memory-count based.
+
+Pros:
+- smallest visible change if the team prefers current wording;
+- keeps sort recognizable.
+
+Cons:
+- still risks misleading users;
+- “popular” normally implies engagement from other people.
+
+### Option C — Hide or disable popular sort
+
+Remove or disable the visible popular option until real engagement signals exist.
+
+Pros:
+- avoids misleading ranking;
+- preserves product trust.
+
+Cons:
+- removes a discoverability control;
+- later reintroduction requires UI regression review.
+
+### Option D — Implement real popularity later
+
+Define a true score based on engagement signals.
+
+Possible future signals:
+
+```text
+view/open count
+copy/import count
+share-link copy count
+likes/reactions
+comments
+recent engagement window
+editorial/curation score
+```
+
+This requires data-model, event tracking, privacy, abuse, and ranking policy work. It is out of scope for this semantics note.
+
+---
+
+## 5. Engineering contract
+
+Until a real popularity score is implemented, backend and frontend work should treat current `sort=popular` as a proxy sort.
+
+Current backend contract:
+
+```text
+sort=latest  => created_at DESC
+sort=popular => public_memory_count DESC, created_at DESC
+invalid sort => latest fallback
+eligibility  => public tree + at least 3 public memories
+```
+
+Do not change this behavior casually. If a PR changes the backend sort formula, it must update this document or a successor semantics document.
+
+---
+
+## 6. Verification requirements for future implementation PRs
+
+If a future PR changes the visible sort label, available sort options, or backend popular formula, verify:
+
+```text
+latest ordering: PASS/FAIL/NOT_VERIFIED
+popular/proxy ordering: PASS/FAIL/NOT_VERIFIED
+invalid sort fallback: PASS/FAIL/NOT_VERIFIED
+Browse eligibility threshold remains public_memory_count >= 3: PASS/FAIL/NOT_VERIFIED
+search/filter interaction with sort: PASS/FAIL/NOT_VERIFIED
+URL state or selected sort state, if applicable: PASS/FAIL/NOT_VERIFIED
+desktop Browse smoke: PASS/FAIL/NOT_VERIFIED
+mobile 375px Browse smoke: PASS/FAIL/NOT_VERIFIED
+private payload exposure: NO
+secret exposure: NO
+```
+
+Runtime-sensitive UI changes require Cloudflare Preview or fixed test slot verification with deployed SHA confirmation.
+
+---
+
+## 7. Non-goals for this document
+
+This document does not:
+
+- rename the Browse UI label;
+- change frontend sort controls;
+- change Modal SQL;
+- add engagement tracking;
+- add analytics tables;
+- change Browse card layout;
+- change Search/Browse visual behavior;
+- close #608 by itself.
+
+---
+
+## 8. Closure criteria for #608
+
+Issue #608 can move toward closure when one of these decisions is implemented or explicitly accepted:
+
+1. the visible label is renamed to match the current memory-count proxy;
+2. `인기순` is hidden/disabled until real popularity exists;
+3. the product explicitly accepts memory-count as the v0.1 definition and documents it in user-facing copy;
+4. a real engagement-based popularity score is implemented and verified.
+
+This document establishes the current semantics and recommended direction. It does not complete the UI/product decision by itself.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -9,6 +9,7 @@
 - 팬페이지 기반 감성 UX / 페이지 경험 기준 정리
 - 전역 UI 카피 운영 기준 정리
 - public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책 정리
+- Browse sort semantics and public discovery language 정리
 
 ## 파일 목록
 
@@ -17,6 +18,7 @@
 | [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 public-first 감상 공간 원칙 |
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
+| [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
 | [YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md](YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md) | YouTube segment player PoC test matrix and browser verification requirements |
@@ -45,6 +47,7 @@
 - anonymous public read는 `memory.visibility = public`과 `parent tree.visibility = public`을 모두 요구합니다.
 - public visibility와 Browse/Search eligibility는 별개입니다.
 - Browse/Search introduction은 `publicMomentCount >= 3`이 필요합니다.
+- Browse `popular` sort는 현재 true engagement popularity가 아니라 `publicMemoryCount DESC, createdAt DESC` proxy입니다.
 - private tree 아래 public memory가 가능하더라도 Browse/Search, community memories list, public memory detail read 노출은 parent tree visibility guard를 함께 봅니다.
 - owner/private read는 private access policy에 따라 private tree 아래 public/private memory를 조회할 수 있습니다.
 
@@ -64,18 +67,19 @@
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
-4.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-5.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-6.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-7.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-8.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-9.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-10. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-11. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-12. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-13. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-14. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-15. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+4. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
+5.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+6.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+7.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+8.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+9.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+10.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+11. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+12. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+13. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+14. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+15. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+16. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
Refs #608

Purpose:
- Document the current backend meaning of Browse `sort=popular` before any UI/copy or ranking implementation change.
- Clarify that the current implementation is a public-memory-count proxy, not true engagement popularity.
- Define v0.1 product options for renaming, hiding, defining, or replacing the popular sort.

Current finding:
- Modal accepts `sort=popular` for the public Browse route.
- Public-read query orders `popular` by `public_memory_count DESC, created_at DESC`.
- This does not measure views, copies, shares, reactions, comments, or recent engagement.

Changed files:
- `docs/product/BROWSE_POPULAR_SORT_SEMANTICS.md`
- `docs/product/product_index.md`

Scope:
- Docs-only product/API semantics note.
- No runtime JS/CSS/HTML/API/Auth/backend behavior changes.
- No Modal SQL changes.
- No Browse UI label/copy changes.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, DB URL, owner ID, tree ID, memory ID, copied tree ID, or DB row value included.

Verification:
- GitHub API source inspection: `modal_compute/app.py` allows `latest`/`popular` and passes safe sort to public read helper.
- GitHub API source inspection: `modal_compute/public_reads.py` maps `popular` to `memory_count DESC, created_at DESC`.
- GitHub API changed-file scope check: PASS, docs/product only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is batch item 1/5 for the new batch and should remain draft until batch review policy is satisfied.
- Issue #608 should remain open until the UI/product decision is accepted or implemented.
- Do not ready or merge without CTO approval.