### PR TITLE
docs(ops): document fixed slot workflow secret setup

### DIFF
--- a/docs/ops/FIXED_SLOT_WORKFLOW_SECRET_SETUP.md
+++ b/docs/ops/FIXED_SLOT_WORKFLOW_SECRET_SETUP.md
@@ -1,0 +1,170 @@
+# Fixed Slot Workflow Secret Setup
+
+**Status:** Active ops runbook  
+**Owner:** CTO / Ops Lead  
+**Related issue:** #684  
+**Related workflow:** `.github/workflows/deploy-test-slot.yml`
+
+This runbook explains the repository secret setup and safe verification process for the `Deploy fixed test slot` workflow.
+
+The workflow exists on `main` and can be manually dispatched. A post-merge smoke run already proved that the workflow can dispatch, validate input, check out the requested SHA, run `npm run verify`, run `npm test`, and fail safely when Cloudflare deployment secrets are missing.
+
+The remaining blocker is secret configuration, not workflow syntax.
+
+---
+
+## 1. Required GitHub Actions secrets
+
+The workflow expects these repository secrets by name:
+
+```text
+CLOUDFLARE_API_TOKEN
+CLOUDFLARE_ACCOUNT_ID
+```
+
+Only the names may be reported. Never print, paste, screenshot, or echo the secret values.
+
+### 1.1 Required token capability
+
+The token must be able to deploy to the LoveBud Cloudflare Pages project used by fixed slots.
+
+Minimum expected capability:
+
+```text
+Cloudflare Pages deployment write access for the LoveBud Pages project
+Account/project access sufficient for wrangler pages deploy
+```
+
+Prefer least privilege. Do not use a broad personal/global token if a narrower Cloudflare API token can deploy the Pages project.
+
+---
+
+## 2. Secret setup path
+
+Use GitHub repository settings or GitHub CLI with value entry through a secure local environment.
+
+Allowed reporting:
+
+```text
+CLOUDFLARE_API_TOKEN: PRESENT/MISSING
+CLOUDFLARE_ACCOUNT_ID: PRESENT/MISSING
+Secret value exposed: NO
+```
+
+Forbidden reporting:
+
+```text
+actual token value
+partial token prefix/suffix
+account id value
+copied CLI command that includes a secret literal
+terminal output that prints the secret
+screenshot containing a secret value
+```
+
+---
+
+## 3. First rerun after secrets are configured
+
+After the required secrets are configured, rerun the workflow manually.
+
+Recommended safe input:
+
+```text
+ref: main
+expected_sha: <current main commit SHA>
+slot: test10
+marker_path: .github/workflows/deploy-test-slot.yml
+marker_text: Deploy fixed test slot
+```
+
+Use the current `main` SHA at the time of the run. Do not reuse an old SHA unless the workflow is intentionally testing an old ref.
+
+Expected successful flow:
+
+```text
+manual dispatch: YES
+fixed slot validation: PASS
+checked-out SHA equals expected SHA: YES
+npm run verify: PASS
+npm test: PASS
+Cloudflare secrets configured: PRESENT
+wrangler pages deploy: PASS
+fixed slot URL check: PASS
+marker check: PASS
+production deploy performed: NO
+secret values exposed: NO
+```
+
+---
+
+## 4. Failure classification
+
+Use these states precisely:
+
+```text
+WORKFLOW_RUNTIME_VERIFIED
+PARTIAL_RUNTIME_VERIFIED / BLOCKED_BY_MISSING_CLOUDFLARE_SECRET
+BLOCKED_BY_CLOUDFLARE_TOKEN_SCOPE
+BLOCKED_BY_SHA_MISMATCH
+BLOCKED_BY_STATIC_CHECK_FAILURE
+BLOCKED_BY_TEST_FAILURE
+BLOCKED_BY_DEPLOY_FAILURE
+BLOCKED_BY_MARKER_MISMATCH
+```
+
+Do not call the workflow fully verified unless deploy and marker verification both run successfully.
+
+---
+
+## 5. Safe report template
+
+Use this after each workflow run:
+
+```text
+[Fixed Slot Workflow Run Report]
+1. Workflow:
+2. Run URL:
+3. Ref input:
+4. Expected SHA input:
+5. Checked-out SHA:
+6. SHA match: YES/NO
+7. Slot input:
+8. Marker path/text:
+9. npm run verify: PASS/FAIL/NOT_RUN
+10. npm test: PASS/FAIL/NOT_RUN
+11. Cloudflare secrets configured: PRESENT/MISSING
+12. Deploy step: PASS/FAIL/NOT_RUN
+13. Fixed slot URL:
+14. Fixed slot URL check: PASS/FAIL/NOT_RUN
+15. Marker check: PASS/FAIL/NOT_RUN
+16. Production deploy performed: NO
+17. Secret exposure: NO
+18. Final judgment: WORKFLOW_RUNTIME_VERIFIED / PARTIAL / BLOCKED
+```
+
+---
+
+## 6. Operational guardrails
+
+- Manual dispatch only.
+- Do not use the workflow to deploy production.
+- Do not change production branch settings.
+- Do not use the workflow for ready, merge, or issue close actions.
+- Do not expose Cloudflare values, account IDs, tokens, cookies, sessions, credentials, DB URLs, tree IDs, owner IDs, memory IDs, copied tree IDs, or DB row values.
+- Do not modify PR #7 or prototype/reference/demo/variant paths.
+- Browser verification still remains separate after slot deployment.
+
+---
+
+## 7. Relationship to Issue #684
+
+Issue #684 is not fully complete until:
+
+- required Cloudflare secrets are configured;
+- the workflow completes a real fixed slot deploy;
+- the fixed slot URL check passes;
+- marker verification passes;
+- a safe workflow run report records the result.
+
+The merged workflow plus this runbook establish the automation path. The remaining work is environment secret configuration and one successful deploy run.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -29,21 +29,22 @@
 11. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
 12. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
 13. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-14. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-15. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-16. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-17. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-18. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-19. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-20. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-21. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-22. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-23. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-24. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-25. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-26. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-27. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
-28. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+14. [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) - Issue #684 Deploy fixed test slot workflow의 Cloudflare GitHub Actions secret setup 및 post-secret runtime verification 절차
+15. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+16. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+17. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+18. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+19. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+20. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+21. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+22. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+23. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+24. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+25. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+26. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+27. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+28. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
+29. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -77,6 +78,7 @@
 | [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) | Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements |
 | [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) | Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
+| [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) | `Deploy fixed test slot` workflow의 required GitHub Actions secret names, rerun 절차, safe report template, blocked-state 분류 |
 | [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) | Fixed slot 수동 E2E gate 런북 — slot 배정·SHA provenance·evidence 양식·page 분류·제한 사항 (Issue #136 manual gate 단계) |
 | [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) | Fixed slot Wrangler direct deploy 표준 경로 — `test/slot-X` 배포, `test-slot-X` URL, stale asset guardrail |
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |


### PR DESCRIPTION
Refs #684

Purpose:
- Document the required GitHub Actions secret setup for the merged `Deploy fixed test slot` workflow.
- Record that the post-merge workflow run verified dispatch/SHA/static/test behavior but stopped safely because Cloudflare secrets were missing.
- Define the safe rerun procedure and report template for completing workflow runtime verification after secrets are configured.

Changed files:
- `docs/ops/FIXED_SLOT_WORKFLOW_SECRET_SETUP.md`
- `docs/ops/ops_index.md`

Scope:
- Docs-only ops runbook update.
- No workflow changes.
- No runtime JS/CSS/HTML/API/Auth/backend changes.
- No package changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, account ID value, DB URL, owner ID, tree ID, memory ID, copied tree ID, or DB row value included.

Verification:
- GitHub API changed-file scope check: PASS, docs/ops only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Workflow runtime verification: NOT_PERFORMED in this PR; #684 remains blocked until Cloudflare secrets are configured and a deploy+marker run passes.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is batch item 2/5 for the current batch and should remain draft until batch review policy is satisfied.
- Issue #684 should remain open until actual fixed-slot workflow deploy and marker verification complete.
- Do not ready or merge without CTO approval.