### PR TITLE
docs(security): expand Firestore rules hardening plan

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -153,7 +153,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, 금지 조합, fixed test slot 검증 기준
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-- [RECENT_REFACTORING.md](./engineering/RECENT_REFACTORING.md) - 최근 리팩터링 기록
+- [RECENT_REFACTORING.md](./engineering/RECENT_REFACTORING.md) - 최근 코드 구조 정리 이력
  - [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./engineering/PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ## security 문서군
@@ -161,6 +161,8 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 보안 관련 문서는 `docs/security/` 아래에 정리됩니다.
 
 - [FIREBASE_CLIENT_CONFIG_POLICY.md](./security/FIREBASE_CLIENT_CONFIG_POLICY.md) - Firebase 클라이언트 설정 노출 정책 및 보안 모델
+- [FIREBASE_DEPLOYMENT_SECRET_POSTURE_RUNBOOK.md](./security/FIREBASE_DEPLOYMENT_SECRET_POSTURE_RUNBOOK.md) - Firebase Console, Google Cloud, Modal, Cloudflare, legacy deployment secret posture 검증 런북
+- [FIRESTORE_RULES_HARDENING_PLAN.md](./security/FIRESTORE_RULES_HARDENING_PLAN.md) - Firestore owner/visibility/comment rule hardening staged plan and deployment gate
 
 ## ops 문서군
 

--- a/docs/security/FIRESTORE_RULES_HARDENING_PLAN.md
+++ b/docs/security/FIRESTORE_RULES_HARDENING_PLAN.md
@@ -1,130 +1,291 @@
-# Firestore Rules Hardening Rollout Plan
+# Firestore Rules Hardening Plan
 
-> **Version:** 1.0
-> **Last updated:** 2026-04-29
-> **Related issue:** #281
+**Status:** Active security plan  
+**Owner:** CTO / Security-Ops  
+**Related issue:** #281  
+**Related posture issue:** #266
 
----
+This document defines a staged plan for hardening Firebase Firestore Security Rules for LoveBud without exposing restricted values or weakening the current Cloudflare Pages plus Modal runtime model.
 
-## 1. Problem
-
-Private tree/comment access boundary needs reinforcement at the Firestore Rules layer. Current implementation has gaps that could allow unauthorized access.
-
----
-
-## 2. Current Known Gaps
-
-| Gap | Current State | Risk |
-|-----|---------------|------|
-| Tree read | Unrestricted | Private trees potentially exposed |
-| Tree create | Missing ownerId validation | Unauthorized ownership assignment |
-| Comment read | Unrestricted | Comments inherit parent tree visibility incorrectly |
-| Comment create | Missing userId validation | Unauthorized authorship attribution |
-| Rules tracking | Not in repository | No version control, manual disaster recovery |
+Issue #281 identified that Firestore Rules need explicit owner and visibility boundaries. This plan is a security planning document. It does not apply console rules, deploy rules, mutate data, or change client/backend runtime behavior.
 
 ---
 
-## 3. Desired Policy
+## 1. Security boundary
 
-### 3.1 Tree Access
+Reports, PR bodies, issues, logs, and screenshots must never include:
 
-- **Public tree read**: Allowed without auth (maintains browse/search)
-- **Private tree read**: Owner or admin only (authentication required)
-- **Tree create**: Validate `ownerId` matches authenticated user
-- **Tree update/delete**: Owner validation enforced
+```text
+Firebase service account JSON
+private key
+API token
+session token
+cookie
+authorization header
+password
+DB URL
+owner id
+tree id
+memory id
+comment id
+copied tree id
+raw Firestore document path containing private IDs
+raw DB row value
+```
 
-### 3.2 Comment Access
+Use safe aggregate labels only:
 
-- **Comment read**: Inherit parent tree visibility
-  - If parent tree is public → comment readable
-  - If parent tree is private → comment readable by owner/admin only
-- **Comment create**: Validate `userId` matches authenticated user
-- **Comment update/delete**: Author validation enforced
+```text
+RULES_REVIEWED: YES/NO
+OWNER_BOUNDARY_PRESENT: YES/NO/UNKNOWN
+VISIBILITY_BOUNDARY_PRESENT: YES/NO/UNKNOWN
+ANONYMOUS_BROAD_READ: YES/NO/UNKNOWN
+ANONYMOUS_BROAD_WRITE: YES/NO/UNKNOWN
+CREATE_OWNER_VALIDATION: YES/NO/UNKNOWN
+COMMENT_AUTHOR_VALIDATION: YES/NO/UNKNOWN
+RESTRICTED_VALUES_EXPOSED: NO/YES
+```
 
-### 3.3 Repository-Tracked Rules
-
-- Rules stored in `firestore.rules`
-- Changes require PR review
-- Emulator tests required before deployment
-
----
-
-## 4. Rollout Phases
-
-### Phase 0: Docs/Plan Only (Current)
-- Document gaps and policy
-- Define verification requirements
-- No code/rules changes
-
-### Phase 1: Repository Rules Snapshot + Tests
-- Add `firestore.rules` to repository
-- Document current production rules
-- Add emulator-based rules tests
-- **Non-breaking**: Rules not yet deployed
-
-### Phase 2: Create-Time Validation
-- Add `ownerId` validation on tree create
-- Add `userId` validation on comment create
-- **Risk**: Client create flows must pass auth token
-
-### Phase 3: Private Tree Read Boundary
-- Enforce owner/admin read on private trees
-- **Risk**: Non-owner read queries will fail
-
-### Phase 4: Comment Visibility Inheritance
-- Read rules check parent tree visibility
-- **Risk**: Comment read queries may break for non-owners
-
-### Phase 5: Production Rollout
-- Staging validation on fixed test slot
-- Gradual production deployment
-- Monitor for unauthorized access errors
+If a restricted value is exposed, stop and report `SECURITY_INCIDENT_SECRET_OR_PRIVATE_ID_EXPOSURE` without repeating the value.
 
 ---
 
-## 5. Migration Risks
+## 2. Current known gaps
+
+The original #281 finding identified these Firestore Rules risks:
+
+| Gap | Current concern | Risk |
+| --- | --- | --- |
+| Tree read | Broad/unrestricted read may exist | Private trees may be exposed |
+| Tree create | Missing owner validation may exist | Ownership spoofing or inconsistent data |
+| Comment read | Broad/unrestricted read may exist | Comments may ignore parent tree visibility |
+| Comment create | Missing author validation may exist | Authorship spoofing |
+| Rules tracking | Rules may be console-only | No version control or rollback source |
+
+These findings must be re-verified against the current Firebase Console/rules state before any production change. Do not assume stale rule content is still current.
+
+---
+
+## 3. Desired policy
+
+The target Firestore policy should align with LoveBud's public/private model.
+
+Expected tree access:
+
+```text
+public tree read: allowed for public tree data intended for anonymous read
+private tree read: owner/admin only
+create tree: authenticated user must be owner
+update tree: owner/admin only, except narrowly constrained public counters if explicitly approved
+delete tree: owner/admin only
+```
+
+Expected comment access, if comments are active:
+
+```text
+comment read: inherits parent tree visibility
+create comment: authenticated user must be author
+update/delete comment: author/admin or owner-moderation path, depending on final product policy
+```
+
+Current active runtime may proxy many operations through Cloudflare/Modal rather than direct browser Firestore reads. That does not remove the need for Firestore Rules. Rules remain a defense-in-depth boundary and must not allow unrestricted private data access.
+
+---
+
+## 4. Phase 0 — source and console inventory
+
+Before writing or deploying rules, record source-of-truth status:
+
+```text
+[Firestore Rules Inventory]
+Rules tracked in repository: YES/NO
+Console rules reviewed: YES/NO
+Active client direct Firestore reads: YES/NO/UNKNOWN
+Active client direct Firestore writes: YES/NO/UNKNOWN
+Active Cloudflare/Modal proxy path: YES/NO/UNKNOWN
+Restricted values exposed: NO
+```
+
+If rules are console-only, the first implementation should add a tracked source file or explicit export process before broad policy changes.
+
+---
+
+## 5. Phase 1 — repository rules snapshot and tests
+
+First implementation should create a durable source-of-truth workflow before changing production rules.
+
+Expected outputs:
+
+```text
+firestore.rules source file or documented export path
+rules test fixture strategy
+emulator/staging validation command
+rollback procedure
+production deployment approval gate
+```
+
+Rules snapshot work must avoid printing production private document paths or IDs. Use synthetic fixtures for tests.
+
+---
+
+## 6. Phase 2 — create-time validation
+
+Next hardening target should be create-time author/owner validation because it reduces future data integrity drift.
+
+Expected checks:
+
+```text
+trees create requires authenticated user
+request.resource.data.ownerId matches authenticated user
+comments create requires authenticated user
+request.resource.data.userId or authorId matches authenticated user
+```
+
+Risks:
+
+- existing clients may use a different owner/author field name;
+- backend service-account paths may bypass rules and need separate server-side validation;
+- old data may be missing expected fields.
+
+Verification should use emulator/staging where possible before production rules update.
+
+---
+
+## 7. Phase 3 — private tree read boundary
+
+Next hardening target should enforce visibility-aware read access.
+
+Expected behavior:
+
+```text
+public tree: anonymous public read allowed for fields intended to be public
+private tree: owner/admin read only
+missing visibility: handled by product-approved default or migration plan
+```
+
+Important policy dependency:
+
+- LoveBud current product policy is public-by-default until private entitlement exists.
+- Private rows must be audited under #674 before rules assume a stable private entitlement model.
+
+Do not deploy a rule that makes existing owner data inaccessible because a legacy visibility field is missing.
+
+---
+
+## 8. Phase 4 — comments visibility inheritance
+
+Comments should not be public if their parent tree is private.
+
+Expected behavior:
+
+```text
+comment read allowed only when parent tree is public or requester has owner/admin access
+comment create allowed only for authenticated author on an allowed parent tree
+comment update/delete allowed only by author/admin or a separately approved owner moderation path
+```
+
+If comments are not active, record status as `INACTIVE` rather than inventing behavior.
+
+---
+
+## 9. Phase 5 — production deployment gate
+
+Before production rules deployment, record:
+
+```text
+[Firestore Rules Deploy Gate]
+Rules source tracked: YES/NO
+Emulator/staging validation: PASS/FAIL/NOT_RUN
+Production deployment approved by CTO: YES/NO
+Previous rules version captured: YES/NO
+Rollback path documented: YES/NO
+Expected affected collections: trees/comments/other
+Public read smoke path: READY/NOT_READY
+Owner read/write smoke path: READY/NOT_READY
+Monitoring path: READY/NOT_READY
+Secret/private ID exposure: NO
+Final judgment: PASS/PARTIAL/BLOCKED
+```
+
+Do not deploy rules from local console changes without a recoverable source-of-truth path.
+
+Rollback should restore the prior known-good rules version. It must not require printing service-account credentials or private document IDs.
+
+---
+
+## 10. Test matrix
+
+Minimum hardening test matrix:
+
+```text
+anonymous reads public tree: ALLOW/DENY/NOT_VERIFIED
+anonymous reads private tree: DENY/ALLOW/NOT_VERIFIED
+owner reads own private tree: ALLOW/DENY/NOT_VERIFIED
+non-owner reads private tree: DENY/ALLOW/NOT_VERIFIED
+authenticated user creates tree for self: ALLOW/DENY/NOT_VERIFIED
+authenticated user creates tree for another owner: DENY/ALLOW/NOT_VERIFIED
+anonymous creates tree: DENY/ALLOW/NOT_VERIFIED
+comment read on public tree: ALLOW/DENY/NOT_VERIFIED
+comment read on private tree by anonymous: DENY/ALLOW/NOT_VERIFIED
+comment create by authenticated author: ALLOW/DENY/NOT_VERIFIED
+comment create spoofing another author: DENY/ALLOW/NOT_VERIFIED
+```
+
+Use synthetic IDs in tests or emulator fixtures. Do not report real production IDs.
+
+---
+
+## 11. Migration risks
 
 | Risk | Mitigation |
-|------|------------|
-| Missing visibility field | Audit existing data, backfill defaults |
-| Existing private/grandfathered data | Grandfathered exception handling |
-| Client query failures | Update client queries to handle 403 |
-| Admin operations | Admin SDK bypasses rules |
-| Public tree browse/search compatibility | Public read paths unchanged |
+| --- | --- |
+| Missing visibility field | Audit existing data, backfill defaults only with approval |
+| Existing private/grandfathered data | Coordinate with #674 before enforcing private entitlement assumptions |
+| Client query failures | Verify active client direct Firestore usage and 403 handling |
+| Admin operations | Confirm Admin SDK/service-account paths remain server-side and not client-exposed |
+| Public Browse/Search compatibility | Keep public read paths explicitly tested |
+| Console-only rules | Add tracked source and rollback procedure before production change |
 
 ---
 
-## 6. Verification Requirements
+## 12. Non-goals for this planning PR
 
-### 6.1 Emulator/Rules Tests
-- Unauthorized read/write denial
-- Public read pass
-- Owner private read pass
-- Non-owner private read deny
-- Comment read inheritance verification
+This document does not:
 
-### 6.2 Fixed Test Slot Smoke
-- Deploy to `test6` slot
-- Verify public tree browse works
-- Verify private tree owner read works
-- Verify non-owner private read denied
-- Verify comment visibility inheritance
-- Verify create-time validation
+- deploy Firestore Rules;
+- change Firebase Console settings;
+- add service-account credentials;
+- change Cloudflare/Modal runtime code;
+- change client Auth behavior;
+- mutate production data;
+- implement private entitlement;
+- implement comments;
+- close #281.
 
 ---
 
-## 7. Explicit Non-Goals
+## 13. Closure criteria for #281
 
-- No client-only security boundary
-- No Firebase Console ad hoc change
-- No Storage Rules change
-- No auth provider/config change
-- No product policy change without review
+Issue #281 can move toward closure only after:
+
+1. Firestore Rules source-of-truth is tracked or the console-only process is replaced by a durable export/deploy workflow.
+2. Owner and visibility boundaries are implemented in rules.
+3. Comment visibility inheritance is implemented or comments are explicitly inactive/not applicable.
+4. Create-time owner/author validation is implemented.
+5. Emulator/staging or equivalent rules validation passes.
+6. Production deployment, if needed, is explicitly approved and safely reported.
+7. No restricted values or private identifiers are exposed.
+
+A docs-only planning PR can make the issue implementation-ready, but it is not a security fix by itself.
 
 ---
 
-## 8. Related
+## 14. Related documents
 
-- `docs/security/FIREBASE_CLIENT_CONFIG_POLICY.md` - Client config security policy
-- `js/firebase-config.js` - Firebase client configuration
-- Issue #281 - Firestore rules hardening tracker
+- `docs/security/FIREBASE_CLIENT_CONFIG_POLICY.md`
+- `docs/security/FIREBASE_DEPLOYMENT_SECRET_POSTURE_RUNBOOK.md`
+- `docs/product/PUBLICATION_AND_PRIVACY_UX_POLICY.md`
+- `docs/engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md`
+- Issue #266
+- Issue #281
+- Issue #674


### PR DESCRIPTION
Refs #281

Purpose:
- Expand the Firestore Rules hardening plan with current LoveBud security guardrails, staged rollout phases, test matrix, deployment gate, and safe reporting labels.
- Clarify that this is planning only and does not deploy Firebase Console rules, mutate data, or change runtime behavior.
- Link the security plan from the top-level docs index.

Changed files:
- `docs/security/FIRESTORE_RULES_HARDENING_PLAN.md`
- `docs/doc_index.md`

Scope:
- Docs-only security plan update.
- No Firebase Console/rules deployment.
- No runtime JS/CSS/HTML/API/Auth/backend behavior changes.
- No package/workflow changes.
- No production mutation.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, DB URL, owner ID, tree ID, memory ID, comment ID, copied tree ID, raw Firestore path, or DB row value included.

Verification:
- GitHub API changed-file scope check: PASS, docs/security + docs index only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Firebase/Firestore rules deployment verification: NOT_PERFORMED in this PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR is batch item 5/5 for the current batch and should remain draft until batch review policy is satisfied.
- Issue #281 should remain open until actual rules source tracking, validation, deployment gate, and safe verification complete.
- Do not ready or merge without CTO approval.