### PR TITLE
docs(ops): add Cloudflare preview provenance runbook

### DIFF
--- a/docs/ops/CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md
+++ b/docs/ops/CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md
@@ -1,0 +1,266 @@
+# Cloudflare Preview Provenance Runbook
+
+**Status:** Active ops runbook  
+**Owner:** CTO / Ops Lead  
+**Related issue:** #668
+
+This runbook defines how operators should identify valid Cloudflare Preview URLs and fixed test slot URLs for LoveBud browser verification.
+
+The goal is to prevent browser reports from using guessed branch-name URLs, stale preview URLs, malformed/truncated preview URLs, production `/pull/<number>` paths, or fixed slots whose deployed SHA does not match the target PR.
+
+---
+
+## 1. Core rule
+
+A browser verification URL is valid only when the operator can prove where it came from and what commit it serves.
+
+Allowed provenance:
+
+```text
+CTO-provided URL
+GitHub PR check/deployment URL tied to the current PR
+Cloudflare deployment metadata tied to the current PR/ref
+CTO-assigned fixed test slot with deployed SHA confirmation
+```
+
+Forbidden provenance:
+
+```text
+branch-name URL guessed by the operator
+truncated or ellipsized URL copied from UI text
+preview URL from another PR
+closed or superseded PR preview URL
+production URL used as pre-merge PR proof
+fixed slot with unknown or mismatched SHA
+```
+
+---
+
+## 2. URL classes
+
+### 2.1 PR Preview URL
+
+A PR Preview URL is acceptable only when GitHub or Cloudflare metadata ties the URL to the current PR and head SHA.
+
+Required report fields:
+
+```text
+URL type: PR Preview
+URL source: GitHub PR check / Cloudflare deployment metadata / CTO-provided
+PR number matched: YES
+PR head SHA:
+Deployed SHA:
+SHA match: YES/NO
+```
+
+### 2.2 Branch Preview URL
+
+A Branch Preview URL is acceptable only when metadata confirms the branch and deployed SHA. Do not derive it from the branch name.
+
+Required report fields:
+
+```text
+URL type: Branch Preview
+URL source: Cloudflare deployment metadata / CTO-provided
+Branch matched: YES
+Branch name:
+Expected SHA:
+Deployed SHA:
+SHA match: YES/NO
+Guessed URL used: NO
+```
+
+### 2.3 Deployment ID URL
+
+A deployment-specific URL can be useful for static/public smoke only if the deployment metadata proves the SHA. It is not a fixed slot.
+
+Required report fields:
+
+```text
+URL type: Deployment ID URL
+Deployment metadata available: YES
+Expected SHA:
+Deployed SHA:
+SHA match: YES/NO
+Fixed slot: NO
+```
+
+### 2.4 Fixed test slot URL
+
+A fixed test slot is acceptable only when CTO assigns it to the target PR/ref and the deployed SHA or marker evidence matches.
+
+Required report fields:
+
+```text
+URL type: fixed test slot
+Slot name: test1/test2/test3/test4/test5/test6/test7/test8/test9/test10
+Slot URL:
+Assigned by CTO: YES
+Expected SHA:
+Deployed SHA:
+SHA match: YES/NO
+Fresh asset or marker check: PASS/FAIL/NOT_RUN
+```
+
+---
+
+## 3. How to handle malformed or truncated URLs
+
+Do not repair truncated UI text by guessing the missing suffix.
+
+If a Cloudflare Pages comment, UI chip, or screenshot shows an ellipsized URL, report:
+
+```text
+PREVIEW_URL_MALFORMED_OR_TRUNCATED
+Browser verification: BLOCKED
+Guessed URL used: NO
+```
+
+Then use one of these paths:
+
+1. open the full link target from the GitHub check/deployment details;
+2. ask a browser-capable executor to copy the link href, not the visible text;
+3. use Cloudflare deployment metadata;
+4. deploy to a CTO-assigned fixed test slot.
+
+---
+
+## 4. Fixed slot binding inventory
+
+For a fixed slot verification, record this inventory before opening the browser:
+
+```text
+[Fixed Slot Binding]
+Slot:
+Slot URL:
+Target PR:
+Target branch:
+Expected PR head SHA:
+Current slot branch/ref:
+Deployed SHA:
+SHA match: YES/NO
+Cloudflare deployment status: SUCCESS/FAILED/UNKNOWN
+Fresh marker path:
+Fresh marker expected text:
+Fresh marker result: PASS/FAIL/NOT_RUN
+Login-capable: YES/NO/NOT_REQUIRED
+Browser verification allowed: YES/NO
+```
+
+If `SHA match` is not `YES`, do not run final browser verification.
+
+---
+
+## 5. Valid fixed slot deployment methods
+
+Allowed methods:
+
+```text
+Deploy fixed test slot workflow
+Wrangler direct deploy runbook
+CTO-approved Cloudflare dashboard operation
+```
+
+For each method, the operator must still verify the served content after deployment.
+
+A successful branch push alone is not final proof. A successful Cloudflare build alone is not final proof. Final proof requires slot URL content or metadata evidence tied to the expected SHA.
+
+---
+
+## 6. Browser verification separation
+
+Slot deployment and browser verification are separate tasks.
+
+Deployment task result examples:
+
+```text
+FIXED_SLOT_DEPLOYED
+FIXED_SLOT_DEPLOY_BLOCKED
+SHA_MATCH_CONFIRMED
+FRESH_ASSET_PRESENT
+```
+
+Browser task result examples:
+
+```text
+BROWSER_RUNTIME_VERIFIED
+BROWSER_PARTIAL
+BROWSER_BLOCKED_AUTH
+BROWSER_BLOCKED_NO_TEST_DATA
+BROWSER_FAIL
+```
+
+Do not combine them into one unreviewable report unless CTO explicitly asks for a combined run.
+
+---
+
+## 7. Auth/API-dependent surfaces
+
+The following surfaces require fixed slot or otherwise CTO-approved deployed runtime verification before final PASS:
+
+```text
+Login/Auth
+My Trees
+Browse/Search with API-backed selected hub or copy/import behavior
+Editor
+Detail when API-backed route/data behavior is under review
+Modal/API-backed reads or writes
+create/update/delete flows
+user-specific state
+```
+
+Localhost and production are not valid pre-merge final proof for those surfaces.
+
+---
+
+## 8. Safe status labels
+
+Use status labels, not private values:
+
+```text
+URL_PROVENANCE_CONFIRMED
+URL_PROVENANCE_BLOCKED
+SHA_MATCH_CONFIRMED
+SHA_MISMATCH
+FRESH_ASSET_PRESENT
+FRESH_ASSET_MISSING
+PREVIEW_URL_MALFORMED_OR_TRUNCATED
+FIXED_SLOT_DEPLOYED
+BROWSER_VERIFICATION_NOT_STARTED
+BROWSER_RUNTIME_VERIFIED
+BROWSER_BLOCKED
+```
+
+Never print credentials, tokens, sessions, cookies, account IDs, DB URLs, tree IDs, owner IDs, memory IDs, copied tree IDs, raw API payloads, or DB row values.
+
+---
+
+## 9. Report template
+
+```text
+[Cloudflare Preview / Fixed Slot Provenance Report]
+1. Target PR:
+2. Target branch:
+3. Expected head SHA:
+4. URL used:
+5. URL type:
+6. URL source:
+7. URL guessed from branch name: NO
+8. PR/branch matched to URL: YES/NO
+9. Deployed SHA:
+10. SHA match:
+11. Fixed slot assigned by CTO: YES/NO/NOT_APPLICABLE
+12. Fixed slot name:
+13. Fresh marker path/text:
+14. Fresh marker result:
+15. Login required:
+16. Browser verification allowed:
+17. Secret/private ID exposure: NO
+18. Final judgment: URL_PROVENANCE_CONFIRMED / URL_PROVENANCE_BLOCKED
+```
+
+---
+
+## 10. Relationship to Issue #668
+
+Issue #668 should remain open until the team can consistently produce verified URLs or fixed slots for active UI/runtime PRs without guessing. This runbook defines the provenance rules and reporting format, but does not itself fix Cloudflare comment publication or configure any fixed slot.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -20,31 +20,32 @@
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
 4. [BROWSER_VERIFICATION_SLOT_GATE.md](BROWSER_VERIFICATION_SLOT_GATE.md) - 브라우저/network 검증 전 final PASS target 및 fixed slot 배정 gate
-5. [OPERATOR_WRITING_AND_VERIFICATION_POLICY.md](OPERATOR_WRITING_AND_VERIFICATION_POLICY.md) - prose-first Issue/PR 작성, valid runtime verification, QA credential safe reporting, batch verification 운영 기준
-6. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
-7. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
-8. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
-9. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-10. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-11. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
-12. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
-13. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-14. [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) - Issue #684 Deploy fixed test slot workflow의 Cloudflare GitHub Actions secret setup 및 post-secret runtime verification 절차
-15. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-16. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-17. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-18. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-19. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-20. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-21. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-22. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-23. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-24. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-25. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-26. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-27. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-28. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
-29. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+5. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+6. [CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md](CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md) - Cloudflare Preview/Branch Preview/fixed slot URL provenance, SHA match, malformed URL handling 기준
+7. [OPERATOR_WRITING_AND_VERIFICATION_POLICY.md](OPERATOR_WRITING_AND_VERIFICATION_POLICY.md) - prose-first Issue/PR 작성, valid runtime verification, QA credential safe reporting, batch verification 운영 기준
+8. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
+9. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+10. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+11. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+12. [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) - Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements
+13. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
+14. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+15. [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) - Issue #684 Deploy fixed test slot workflow의 Cloudflare GitHub Actions secret setup 및 post-secret runtime verification 절차
+16. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+17. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+18. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+19. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+20. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+21. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+22. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+23. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+24. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+25. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+26. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+27. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+28. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+29. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
+30. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -75,6 +76,7 @@
 | [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |
 | [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) | GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준 |
 | [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) | 브라우저 smoke URL provenance, PR Preview, Branch Preview, fixed test slot 검증 기준 |
+| [CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md](CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md) | Cloudflare Preview/Branch Preview/fixed slot URL provenance, SHA match, malformed/truncated URL handling, safe report template |
 | [GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md](GLOBAL_CSS_BROWSER_SMOKE_CHECKLIST.md) | Issue #512 global CSS desktop/mobile smoke matrix, PASS/NOT_VERIFIED/BLOCKED reporting, fixed-slot requirements |
 | [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) | Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |


### PR DESCRIPTION
Refs #668

Purpose:
- Document how operators should prove Cloudflare PR Preview, Branch Preview, deployment ID URL, and fixed test slot provenance before browser verification.
- Prevent guessed branch-name URLs, malformed/truncated URLs, stale PR previews, production pre-merge proof, and SHA-mismatch fixed slots from being reported as PASS.
- Add safe status labels and a provenance report template for future verification reports.

Changed files:
- `docs/ops/CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md`
- `docs/ops/ops_index.md`

Scope:
- Docs-only ops runbook update.
- No workflow changes.
- No runtime JS/CSS/HTML/API/Auth/backend changes.
- No package changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, account ID value, DB URL, owner ID, tree ID, memory ID, copied tree ID, or DB row value included.

Verification:
- GitHub API branch reconstruction check: branch is based on current main and is ahead-only.
- GitHub API changed-file scope check: docs/ops only.
- Required ops index entries preserved:
  - `FIXED_SLOT_WORKFLOW_SECRET_SETUP.md`
  - `CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md`
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Batch policy note:
- This PR replaces closed/unmerged PR #744 after the original PR was closed during conflict handling.
- Issue #668 should remain open until verified URL/fixed-slot publication can be consistently produced for active runtime PRs.
- Do not ready or merge without CTO approval.