### PR TITLE
docs(product): add public-default visibility audit plan

### DIFF
--- a/docs/product/PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md
+++ b/docs/product/PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md
@@ -1,0 +1,159 @@
+# Public-default visibility audit plan
+
+**Status:** Planning and audit guide  
+**Owner:** CTO / Product / Ops  
+**Related issue:** #674
+
+This document defines the safe read-only audit path for aligning LoveBud tree visibility with the current public-by-default product policy until a paid or entitled private-storage model is intentionally available.
+
+The goal is not to mutate production data from this document. The goal is to make the next implementation or data-disposition step explicit, count-only, and safe.
+
+---
+
+## 1. Current policy
+
+LoveBud's current v0.1 policy is:
+
+- new default/free trees should be public;
+- private trees are a future paid or entitled feature;
+- private visibility should not be created or saved as the normal free/default state;
+- public visibility and Browse/Search eligibility are separate concepts;
+- anonymous public exposure must still respect parent tree visibility and public-read guards;
+- no production data mutation may occur without explicit CTO approval.
+
+This policy is consistent with the existing product docs that describe public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, and Browse/Search eligibility as separate decisions.
+
+---
+
+## 2. Existing related coverage
+
+Related historical coverage exists, but it does not replace the read-only audit required by #674.
+
+Existing coverage includes:
+
+- policy direction for public-first plus private storage;
+- Modal public-first create behavior and private entitlement guard documentation;
+- parent-tree visibility guard documentation for anonymous public memory reads;
+- product-index highlights for public visibility versus Browse/Search eligibility.
+
+Remaining #674 gap:
+
+- current safe counts of public/private/default rows are not recorded here;
+- current create-tree client and backend defaults need a fresh current-main audit;
+- any currently exposed UI path that can save private visibility before entitlement needs current confirmation;
+- any production backfill must be planned separately and explicitly approved.
+
+---
+
+## 3. Read-only audit scope
+
+The first audit pass should be read-only.
+
+Inspect and report only safe aggregate/status values for:
+
+1. tree visibility schema and accepted values;
+2. current default create-tree behavior when visibility is omitted;
+3. current frontend create-tree payload behavior;
+4. current backend/Modal create-tree default behavior;
+5. current private visibility entitlement guard behavior;
+6. whether the UI exposes a private toggle or save path before entitlement exists;
+7. whether Browse/Search public listing still separates public visibility from eligibility;
+8. count-only visibility distribution.
+
+Reports must not include tree IDs, owner IDs, memory IDs, copied tree IDs, raw DB rows, raw payloads, tokens, sessions, cookies, passwords, private keys, or DB URLs.
+
+---
+
+## 4. Safe count-only report template
+
+Use safe labels and aggregate counts only.
+
+```text
+[Public-default visibility audit]
+Repository SHA:
+Runtime target:
+Database target category: PRODUCTION / STAGING / LOCAL / NOT_QUERIED
+Schema visibility field: PRESENT / MISSING / UNKNOWN
+Accepted visibility values: PUBLIC_PRIVATE / OTHER / UNKNOWN
+Create-tree frontend default: PUBLIC / PRIVATE / OMITTED / UNKNOWN
+Create-tree backend omitted default: PUBLIC / PRIVATE / UNKNOWN
+Private entitlement guard: PRESENT / MISSING / UNKNOWN
+Pre-entitlement private UI path exposed: YES / NO / UNKNOWN
+Browse/Search eligibility separate from visibility: YES / NO / UNKNOWN
+Public tree count: <number or NOT_QUERIED>
+Private tree count: <number or NOT_QUERIED>
+Unknown/null visibility count: <number or NOT_QUERIED>
+Production mutation performed: NO
+Restricted values exposed: NO
+Recommended next step: NO_ACTION / BACKFILL_PLAN / DEFAULT_FIX_PR / UI_GUARD_PR / ADDITIONAL_AUDIT
+```
+
+If counts are unavailable because the executor lacks safe database access, report `NOT_QUERIED` rather than guessing.
+
+---
+
+## 5. Backfill planning gate
+
+If the audit finds non-entitled private/default rows that should become public, prepare a separate backfill plan before any mutation.
+
+A backfill plan must include:
+
+- target environment;
+- exact inclusion criteria described without exposing row identifiers;
+- exclusion criteria for deleted, archived, paid, entitled, or intentionally private rows;
+- before-count and after-count verification plan;
+- rollback or restore approach;
+- whether `updated_at` is preserved or intentionally changed;
+- explicit CTO approval line for production mutation.
+
+No production mutation should be performed from a docs-only PR.
+
+---
+
+## 6. Default creation enforcement gate
+
+If new default/free trees can still be created as private, create a narrow implementation PR after the read-only audit.
+
+The implementation PR should be scoped to the smallest responsible layer:
+
+- frontend payload default if the client sends private by default;
+- backend/Modal omitted visibility default if the server stores private when omitted;
+- backend entitlement rejection if private is accepted without entitlement;
+- UI toggle hide/disable if private selection is exposed before entitlement.
+
+Do not combine this with My Trees visual redesign, Browse visual work, Editor work, paid entitlement implementation, billing, or data backfill.
+
+---
+
+## 7. Verification requirements for follow-up PRs
+
+Read-only audit PRs:
+
+- changed files limited to docs/product or docs/engineering index files;
+- no runtime code changes;
+- no database mutation;
+- no restricted values;
+- issue body and PR body use `Refs #674` only.
+
+Implementation PRs:
+
+- `git diff --check`;
+- relevant JS/Python syntax checks for changed runtime files;
+- `npm test` and `npm run verify` when applicable;
+- fixed slot or Cloudflare runtime verification for UI/Auth/API behavior;
+- safe status labels only.
+
+Backfill or production mutation:
+
+- explicit CTO approval required before execution;
+- count-only before/after report;
+- no row identifiers in reports;
+- rollback or restore path recorded.
+
+---
+
+## 8. Current disposition
+
+This document covers the planning and safe audit shape for #674. It does not claim that existing data is already aligned. It does not perform a backfill. It does not change runtime creation defaults. It does not implement paid/private entitlement.
+
+#674 should remain open until the read-only audit is performed and any required backfill/default-enforcement follow-up is either completed or explicitly deferred.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -18,6 +18,7 @@
 | [PRODUCT_IDENTITY.md](PRODUCT_IDENTITY.md) | LoveBud의 핵심 정체성과 public-first 감상 공간 원칙 |
 | [BRAND_EXPERIENCE.md](BRAND_EXPERIENCE.md) | 팬 경험 중심 브랜드/UX 톤앤매너와 페이지별 감성 기준 |
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
+| [PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md](PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md) | public-by-default 정책과 private entitlement 이전 visibility mismatch를 안전하게 audit/backfill 판단하기 위한 count-only 계획 |
 | [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
@@ -67,19 +68,20 @@
 1. **PRODUCT_IDENTITY.md** — 제품 철학과 핵심 가치
 2. **BRAND_EXPERIENCE.md** — 팬 감성 UX / 톤앤매너 / 페이지별 표현 원칙
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
-4. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
-5.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-6.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-7.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-8.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-9.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-10.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-11. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-12. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-13. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-14. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-15. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-16. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+4. **PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md** — public-by-default 정책 alignment와 private entitlement 이전 visibility mismatch audit/backfill gate
+5. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
+6.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+7.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+8.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+9.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+10.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+11.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+12. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+13. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+14. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+15. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+16. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+17. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
Refs #674

Purpose:
- Document the safe read-only audit path for aligning current tree visibility data and defaults with the public-by-default policy before paid/private entitlement is available.
- Separate existing public-first policy coverage from the remaining #674 gaps: safe count-only audit, current-main default confirmation, exposed private UI path check, and explicit backfill/default-enforcement gates.
- Define report templates and guardrails so future audit/backfill work does not expose restricted identifiers or mutate production without explicit CTO approval.

Changed files:
- `docs/product/PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md`
- `docs/product/product_index.md`

Scope:
- Docs-only product/ops planning update.
- No runtime JS/CSS/HTML/API/Auth/backend/Modal behavior changes.
- No database query, migration, or production mutation.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, private key, DB URL, owner ID, tree ID, memory ID, copied tree ID, raw payload, or DB row value included.

Current finding:
- Earlier PRs cover public-first policy direction and runtime documentation, but #674 still needs a fresh read-only audit and any backfill/default-enforcement decision must remain separate.
- This PR adds the missing audit/backfill gate document; it does not claim data alignment is complete.

Verification:
- GitHub API compare: branch is ahead of current `main` by 2 and behind by 0.
- GitHub API changed-file scope check: docs/product only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Database audit/backfill: NOT_PERFORMED in this PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Guardrails:
- Issue #674 remains open until read-only audit and any required follow-up are completed or explicitly deferred.
- Do not ready or merge without CTO approval.
- No issue close keyword used.