### PR TITLE
docs(ops): add Firebase console posture runbook

### DIFF
--- a/docs/ops/FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md
+++ b/docs/ops/FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md
@@ -1,0 +1,274 @@
+# Firebase Console and deployment secret posture runbook
+
+**Status:** External-console verification guide  
+**Owner:** CTO / Ops / Security  
+**Related issue:** #266
+
+This runbook defines how LoveBud should verify Firebase Console, Google Cloud, Modal, Cloudflare, and legacy deployment-secret posture without exposing secret values or treating repository source review as sufficient proof.
+
+Issue #124 established that committed source does not contain an obvious hardcoded Firebase service-account credential, and later security planning covered Firestore Rules hardening. This document covers the remaining external-console and deployment-secret checks from #266.
+
+---
+
+## 1. Scope
+
+In scope:
+
+- Firebase Authorized Domains review;
+- Firebase API key restriction posture review;
+- Firestore Rules deployment posture check;
+- Storage Rules active/inactive posture check;
+- Modal Firebase Admin/service-account secret presence check;
+- legacy Netlify Firebase service-account environment posture check;
+- Cloudflare/Vercel/Netlify deployment-secret inventory status labels;
+- owner and rotation cadence documentation.
+
+Out of scope:
+
+- printing, pasting, or summarizing secret values;
+- committing service-account JSON;
+- changing runtime code;
+- changing Firestore Rules from this runbook alone;
+- production mutation;
+- reactivating Netlify runtime;
+- PR #7 or prototype/reference/demo/variant changes.
+
+---
+
+## 2. Safe reporting rules
+
+Reports must use presence and posture labels only.
+
+Allowed labels:
+
+```text
+PRESENT / MISSING / NOT_APPLICABLE / NOT_CHECKED
+RESTRICTED / UNRESTRICTED / UNKNOWN
+EXPECTED / UNEXPECTED / NEEDS_REVIEW
+ACTIVE / LEGACY_ONLY / DISABLED / UNKNOWN
+ROTATION_OWNER_PRESENT / ROTATION_OWNER_MISSING
+SECRET_VALUE_EXPOSED: NO
+```
+
+Forbidden in reports, screenshots, PRs, issue comments, commits, or chat:
+
+- Firebase service-account JSON values;
+- private keys;
+- API keys beyond public-by-design Firebase Web config names;
+- OAuth client secrets;
+- Cloudflare API tokens;
+- Modal secrets;
+- Vercel/Netlify environment variable values;
+- cookies, sessions, tokens, passwords, DB URLs;
+- project-private account identifiers when not required for safe status reporting.
+
+If a restricted value is exposed, stop the task and report `SECURITY_INCIDENT_SECRET_EXPOSURE` without repeating the value.
+
+---
+
+## 3. Firebase Authorized Domains checklist
+
+Verify in Firebase Console:
+
+- Authorized domains contain intended LoveBud production domain(s).
+- Authorized domains contain intended Cloudflare Pages domains.
+- Local development domains are limited to expected localhost/dev entries.
+- Unexpected staging, legacy, or abandoned domains are flagged for review.
+- Production domain ownership and active routing are still valid.
+
+Report format:
+
+```text
+Firebase Authorized Domains:
+- intended production domains: PRESENT / MISSING / NOT_CHECKED
+- intended Cloudflare Pages domains: PRESENT / MISSING / NOT_CHECKED
+- local dev domains: EXPECTED / UNEXPECTED / NOT_CHECKED
+- unexpected domains: PRESENT / ABSENT / NOT_CHECKED
+- action required: YES / NO / UNKNOWN
+```
+
+Do not paste the full domain list if it includes private or internal hostnames. Use category labels and count-only summaries when needed.
+
+---
+
+## 4. Firebase API key restrictions checklist
+
+Firebase Web API keys are public-by-design browser initialization values, but their Google Cloud restriction posture still needs review.
+
+Verify in Google Cloud Console or Firebase-linked API credential settings:
+
+- API key restrictions are configured where appropriate.
+- Allowed APIs are limited to intended Firebase services where possible.
+- Application restrictions match the intended web domains.
+- Legacy unrestricted keys are flagged.
+- Rotation owner and review cadence are documented.
+
+Report format:
+
+```text
+Firebase API key restrictions:
+- key inventory checked: YES / NO
+- application restrictions: RESTRICTED / UNRESTRICTED / UNKNOWN
+- API restrictions: RESTRICTED / UNRESTRICTED / UNKNOWN
+- legacy unrestricted key present: YES / NO / UNKNOWN
+- rotation owner: ROTATION_OWNER_PRESENT / ROTATION_OWNER_MISSING
+- action required: YES / NO / UNKNOWN
+```
+
+Do not print key values, prefixes, suffixes, or screenshots showing key values.
+
+---
+
+## 5. Firestore Rules posture checklist
+
+This checklist does not replace the Firestore Rules hardening plan. It verifies current external-console posture.
+
+Verify:
+
+- active Firestore Rules are known and attributable to an approved deployment path;
+- public/private tree read boundaries are reviewed against the current policy;
+- owner write boundaries are reviewed;
+- comments read/write boundaries are reviewed;
+- any repository-tracked rules source is identified, or absence is reported as a source-of-truth gap;
+- deployment and rollback procedures are known.
+
+Report format:
+
+```text
+Firestore Rules posture:
+- active rules reviewed: YES / NO
+- repository source of truth: PRESENT / MISSING / UNKNOWN
+- private tree read boundary: ENFORCED / NOT_ENFORCED / UNKNOWN
+- owner write boundary: ENFORCED / NOT_ENFORCED / UNKNOWN
+- comments visibility inheritance: ENFORCED / NOT_ENFORCED / UNKNOWN
+- rollback path known: YES / NO / UNKNOWN
+- action required: YES / NO / UNKNOWN
+```
+
+Do not paste full rules if they include environment-specific private identifiers. Link to repository-tracked rules only if they exist and are safe.
+
+---
+
+## 6. Storage Rules posture checklist
+
+Verify whether Firebase Storage is active for LoveBud.
+
+If inactive:
+
+```text
+Firebase Storage usage: INACTIVE
+Storage Rules review: NOT_APPLICABLE
+```
+
+If active:
+
+- identify allowed read paths by category only;
+- identify write paths by category only;
+- verify authenticated/owner/admin boundaries;
+- verify upload size/content-type constraints where applicable;
+- verify no public write rule exists unintentionally.
+
+Report format:
+
+```text
+Firebase Storage posture:
+- usage: ACTIVE / INACTIVE / UNKNOWN
+- rules reviewed: YES / NO / NOT_APPLICABLE
+- public read paths: EXPECTED / UNEXPECTED / UNKNOWN
+- public write paths: ABSENT / PRESENT / UNKNOWN
+- owner/admin write boundary: ENFORCED / NOT_ENFORCED / UNKNOWN
+- action required: YES / NO / UNKNOWN
+```
+
+---
+
+## 7. Modal Firebase Admin secret posture
+
+LoveBud's active backend target is Modal. Firebase Admin/service-account credentials should be environment-secret based, not committed.
+
+Verify through approved Modal secret inspection paths only:
+
+- required Modal secret name is present;
+- secret owner/rotation owner is documented;
+- secret value is not printed;
+- deployment environment using the secret is the intended active runtime;
+- stale or duplicate Firebase Admin secrets are flagged by name/status only.
+
+Report format:
+
+```text
+Modal Firebase Admin posture:
+- required secret presence: PRESENT / MISSING / NOT_CHECKED
+- active runtime binding: EXPECTED / UNEXPECTED / UNKNOWN
+- rotation owner: ROTATION_OWNER_PRESENT / ROTATION_OWNER_MISSING
+- duplicate/stale secret names: PRESENT / ABSENT / UNKNOWN
+- secret value exposed: NO
+- action required: YES / NO / UNKNOWN
+```
+
+Do not use commands that dump full environment variables.
+
+---
+
+## 8. Legacy Netlify secret posture
+
+Netlify is a legacy artifact / removal candidate, not the active production fallback. Its Firebase service-account environment posture should be documented as legacy-only, disabled, absent, or needing removal.
+
+Verify:
+
+- whether legacy Netlify environment variables still exist;
+- whether any Netlify deploy/runtime is active for LoveBud;
+- whether Firebase service-account secrets exist in Netlify;
+- whether those secrets are disabled, removed, or documented as legacy-only.
+
+Report format:
+
+```text
+Legacy Netlify Firebase secret posture:
+- Netlify runtime role: LEGACY_ONLY / ACTIVE / UNKNOWN
+- Firebase service-account env present: PRESENT / MISSING / NOT_CHECKED
+- legacy-only documentation: PRESENT / MISSING / NOT_APPLICABLE
+- removal candidate: YES / NO / UNKNOWN
+- secret value exposed: NO
+- action required: YES / NO / UNKNOWN
+```
+
+Do not reactivate Netlify while performing this review.
+
+---
+
+## 9. Deployment secret inventory summary
+
+Use this summary table after external-console checks.
+
+```text
+[Deployment secret posture summary]
+Firebase Authorized Domains: PASS / NEEDS_REVIEW / NOT_CHECKED
+Firebase API key restrictions: PASS / NEEDS_REVIEW / NOT_CHECKED
+Firestore Rules posture: PASS / NEEDS_REVIEW / NOT_CHECKED
+Storage Rules posture: PASS / NEEDS_REVIEW / NOT_APPLICABLE / NOT_CHECKED
+Modal Firebase Admin secret: PASS / NEEDS_REVIEW / NOT_CHECKED
+Legacy Netlify Firebase secret: PASS / NEEDS_REVIEW / NOT_APPLICABLE / NOT_CHECKED
+Rotation owner documented: YES / NO / PARTIAL
+Secret value exposed: NO
+Production mutation performed: NO
+Runtime code changed: NO
+Recommended next step: NO_ACTION / CONSOLE_HARDENING / RULES_PR / SECRET_ROTATION / LEGACY_SECRET_REMOVAL / ADDITIONAL_AUDIT
+```
+
+---
+
+## 10. Completion boundary for #266
+
+This runbook is a documentation prerequisite, not final proof that #266 is complete.
+
+#266 still requires an actual external-console posture review using the safe labels above. After that review, follow-up work may include:
+
+- Firebase Console domain cleanup;
+- Google Cloud API key restriction hardening;
+- repository-tracked Firestore Rules source-of-truth work;
+- Storage Rules hardening or inactive confirmation;
+- Modal secret rotation/ownership documentation;
+- legacy Netlify secret removal or legacy-only documentation.
+
+Any provider-console mutation, rule deployment, or secret rotation requires explicit CTO approval before execution.

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -31,21 +31,22 @@
 13. [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) - Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준
 14. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
 15. [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) - Issue #684 Deploy fixed test slot workflow의 Cloudflare GitHub Actions secret setup 및 post-secret runtime verification 절차
-16. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-17. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-18. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-19. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-20. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-21. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-22. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
-23. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-24. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-25. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-26. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-27. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-28. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-29. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
-30. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+16. [FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md](FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md) - Issue #266 Firebase Console, API key restriction, Modal secret, legacy Netlify secret posture 점검 기준
+17. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+18. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+19. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+20. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+21. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+22. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+23. [SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md](SOURCE_OF_TRUTH_HYGIENE_DISPOSITION.md) - Issue #425 docs source-of-truth hierarchy, stale-doc classification, update routing, archive and index maintenance rules
+24. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+25. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+26. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+27. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+28. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+29. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+30. [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) - Issue #694 fixed slot Wrangler direct deploy 표준 경로 및 stale asset guardrail
+31. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -81,6 +82,7 @@
 | [EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md](EDITOR_DETAIL_UI_BROWSER_SMOKE_CHECKLIST.md) | Issue #521 editor detail UI smoke matrix, fixed-slot/SHA provenance, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) | 고정 테스트 Preview 슬롯 운영 기준 |
 | [FIXED_SLOT_WORKFLOW_SECRET_SETUP.md](FIXED_SLOT_WORKFLOW_SECRET_SETUP.md) | `Deploy fixed test slot` workflow의 required GitHub Actions secret names, rerun 절차, safe report template, blocked-state 분류 |
+| [FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md](FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md) | Firebase Console authorized domains, API key restriction, Firestore/Storage rules, Modal secret, legacy Netlify secret posture 점검 기준 |
 | [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) | Fixed slot 수동 E2E gate 런북 — slot 배정·SHA provenance·evidence 양식·page 분류·제한 사항 (Issue #136 manual gate 단계) |
 | [FIXED_SLOT_DEPLOY_WITH_WRANGLER.md](FIXED_SLOT_DEPLOY_WITH_WRANGLER.md) | Fixed slot Wrangler direct deploy 표준 경로 — `test/slot-X` 배포, `test-slot-X` URL, stale asset guardrail |
 | [CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md](CLOUDFLARE_PAGES_E2E_SMOKE_REPLACEMENT.md) | Cloudflare Pages + Modal 기반 E2E smoke replacement 제안 — Phase 1 supplied URL smoke, Phase 2 manual workflow, Phase 3 preview URL discovery 기준 |


### PR DESCRIPTION
Refs #266

Purpose:
- Add an external-console verification runbook for Firebase Authorized Domains, Firebase API key restrictions, Firestore Rules posture, Storage Rules posture, Modal Firebase Admin secret posture, and legacy Netlify Firebase secret posture.
- Turn #266's checklist into a safe status-label workflow that avoids printing provider secret values or private identifiers.
- Separate repository source review from provider-console posture verification and future hardening actions.

Changed files:
- `docs/ops/FIREBASE_CONSOLE_AND_DEPLOYMENT_SECRET_POSTURE.md`
- `docs/ops/ops_index.md`

Scope:
- Docs-only ops/security runbook update.
- No Firebase Console, Google Cloud, Modal, Cloudflare, Vercel, or Netlify settings changed.
- No Firestore/Storage Rules deployment.
- No runtime JS/CSS/HTML/API/Auth/backend/Modal behavior changes.
- No database query, migration, production mutation, package change, or workflow change.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, private key, service-account JSON, DB URL, owner ID, tree ID, memory ID, copied tree ID, raw payload, or DB row value included.

Current finding:
- Direct PR coverage for #266 was not found in recent PR search.
- Related security docs cover repository posture and Firestore hardening, but not the provider-console/deployment-secret posture procedure itself.
- This PR adds the missing safe runbook; it does not claim the external-console audit is complete.

Verification:
- GitHub API compare: branch is ahead of current `main` by 2 and behind by 0.
- GitHub API changed-file scope check: docs/ops only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- Provider-console verification: NOT_PERFORMED in this PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Guardrails:
- Issue #266 remains open until actual external-console posture review is completed or explicitly deferred.
- Do not ready or merge without CTO approval.
- No issue close keyword used.