### PR TITLE
docs(product): define tree and moment social model

### DIFF
--- a/docs/product/TREE_MOMENT_SOCIAL_MODEL.md
+++ b/docs/product/TREE_MOMENT_SOCIAL_MODEL.md
@@ -1,0 +1,241 @@
+# Tree and moment social model
+
+**Status:** Product and data model planning  
+**Owner:** CTO / Product  
+**Related issue:** #622
+
+This document defines the first product model for public LoveTree social spaces at two scopes: tree-level discussion and moment-level discussion.
+
+This is not an implementation PR. It does not add comments, reactions, API routes, database tables, UI surfaces, moderation tooling, or browser behavior. It records the product, permission, and data-model boundaries that future implementation PRs must follow.
+
+---
+
+## 1. Product intent
+
+Public LoveTrees should eventually support social response without turning the product into a generic feed.
+
+The intended model is:
+
+1. **Tree-level discussion** for the full public LoveTree.
+2. **Moment-level discussion** for a specific public moment/node inside that tree.
+
+The two scopes must remain distinct. A response to the whole emotional path is not the same as a response to one moment. Future UI can place these surfaces in different panels, drawers, sections, or pages, but implementation must preserve the scope distinction.
+
+---
+
+## 2. Scope definitions
+
+### Tree-level social scope
+
+Tree-level comments/reactions belong to the public LoveTree as a whole.
+
+They may discuss:
+
+- the overall emotional path;
+- the creator's curation;
+- the artist/story represented by the tree;
+- the general feeling of the full public tree;
+- the viewer's overall response.
+
+Tree-level social data should be keyed to the tree as a whole and should not be attached to a specific memory/moment.
+
+### Moment-level social scope
+
+Moment-level comments/reactions belong to one selected moment/node.
+
+They may discuss:
+
+- a specific media source;
+- a specific scene, lyric, image, or memory;
+- the memo or emotion tag attached to that moment;
+- a viewer's response to that exact point in the tree.
+
+Moment-level social data should be keyed to the moment/memory and must remain associated with its parent tree boundary.
+
+---
+
+## 3. Permission model direction
+
+Baseline direction for v0.1 planning:
+
+- Logged-out users may read public comments only if the parent tree is public and the target moment is publicly readable.
+- Logged-out users should not write comments in the first write-enabled version unless a separate anti-abuse plan is approved.
+- Authenticated users may write comments on public trees/moments if product policy permits.
+- Tree owners may moderate comments on their own public trees.
+- Comment authors may delete or edit their own comments, subject to future policy.
+- Private trees should not expose tree-level or moment-level social surfaces to anonymous users.
+- If a tree changes from public to private, public comment reads should be blocked or hidden according to the parent tree visibility boundary.
+- If a moment is deleted or becomes non-public, moment-level comments should no longer be publicly readable.
+
+Any write-enabled implementation must enforce permissions on the server/runtime boundary. Client-only hiding is not sufficient.
+
+---
+
+## 4. Data model direction
+
+A future implementation may use separate tables/collections or a shared polymorphic model. The product contract should preserve these logical fields regardless of storage shape.
+
+Required logical fields for both scopes:
+
+- comment identifier;
+- target scope: `tree` or `moment`;
+- target tree reference;
+- target moment reference only for moment-level comments;
+- author reference;
+- body text;
+- created timestamp;
+- updated timestamp if edits are supported;
+- deleted or moderated state;
+- visibility/read state derived from parent tree and target moment policy.
+
+Recommended separation:
+
+```text
+Tree comment:
+- target_scope: tree
+- target_tree: required
+- target_moment: absent
+
+Moment comment:
+- target_scope: moment
+- target_tree: required
+- target_moment: required
+```
+
+Do not rely on a moment identifier alone for public read decisions. Moment-level reads must also verify the parent tree boundary.
+
+---
+
+## 5. Reactions and counts
+
+Reactions should also preserve scope.
+
+Tree-level reaction counts answer:
+
+- how viewers responded to this whole tree.
+
+Moment-level reaction counts answer:
+
+- how viewers responded to this particular moment.
+
+Do not merge these counts into one ambiguous popularity number without a separate Browse/popular semantics decision.
+
+Future count surfaces should specify whether a number is:
+
+- tree comments;
+- moment comments;
+- total comments across all moments;
+- tree reactions;
+- moment reactions;
+- total reactions across all moments.
+
+---
+
+## 6. Moderation and abuse baseline
+
+A first implementation must not add public write comments without a moderation baseline.
+
+Minimum moderation questions:
+
+- Can the tree owner hide or delete comments?
+- Can a comment author delete their own comment?
+- Is edit history needed?
+- Is report/flag required before launch?
+- Are blocked users or abuse controls needed?
+- Are rate limits needed?
+- Are profanity/spam filters needed?
+- What audit trail is retained for deleted/moderated comments?
+
+If the answer is unknown, ship read-only placeholders or read-only seeded comments first rather than public write.
+
+---
+
+## 7. Public/private visibility boundaries
+
+Social data must inherit public exposure constraints from the parent tree and target moment.
+
+Required public read checks:
+
+```text
+Tree-level comment public read:
+- parent tree visibility is public
+- comment is not deleted/moderated/hidden
+
+Moment-level comment public read:
+- parent tree visibility is public
+- target moment is publicly readable under current policy
+- comment is not deleted/moderated/hidden
+```
+
+Owner/private reads may follow owner access policy, but public endpoints must not expose private tree or private moment social data.
+
+Reports and logs must use safe status labels. Do not print owner IDs, user IDs, tree IDs, memory IDs, raw payloads, tokens, sessions, cookies, private DB rows, or private response bodies.
+
+---
+
+## 8. Suggested implementation phases
+
+### Phase 1 — Planning and contract docs
+
+Document scope, permission model, moderation baseline, and API/data contract. This document is that first step.
+
+### Phase 2 — Read-only viewer placeholders
+
+Reserve tree-level and moment-level social surfaces in the future public viewer without enabling writes. This may be a UI/design task and should be tracked separately.
+
+### Phase 3 — Read-only comments
+
+Add read-only comment loading for public trees/moments if backend data exists. Verify public/private boundaries and empty states.
+
+### Phase 4 — Authenticated comment writing
+
+Allow authenticated write for one scope at a time. Start with either tree-level comments or moment-level comments, not both, unless separately approved.
+
+### Phase 5 — Reactions and counts
+
+Add scoped reaction counts after comment scope and moderation policies are stable.
+
+### Phase 6 — Moderation/reporting
+
+Add owner moderation, report flow, abuse handling, and administrative review if needed.
+
+---
+
+## 9. Follow-up issue split
+
+Recommended follow-up issues/PR tracks:
+
+1. Tree-level comments contract and read API.
+2. Moment-level comments contract and read API.
+3. Public viewer social placeholder design.
+4. Authenticated tree-level comment write path.
+5. Authenticated moment-level comment write path.
+6. Reaction model and scoped count policy.
+7. Moderation/reporting baseline.
+
+Do not combine all social behavior into one PR.
+
+---
+
+## 10. Verification requirements for future implementation
+
+Any future runtime PR must verify:
+
+- tree-level and moment-level scopes are separate;
+- logged-out reads respect parent public visibility;
+- authenticated writes require auth when enabled;
+- private trees do not expose public social data;
+- moment-level comments respect parent tree and target moment boundaries;
+- deleted/moderated comments are not publicly readable;
+- owner and author permissions are enforced;
+- no restricted identifiers or raw payloads are exposed;
+- desktop/mobile behavior is verified only on valid deployed environments when UI is involved;
+- Auth/API dependent behavior uses Cloudflare Preview or fixed test slot with SHA match.
+
+---
+
+## 11. Current disposition
+
+This document satisfies the first planning layer for #622: social scope separation, permission direction, data model direction, moderation baseline, phased implementation, and follow-up split.
+
+#622 should remain open until implementation follow-up issues/PRs are created or explicitly deferred.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -20,6 +20,7 @@
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md](PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md) | public-by-default 정책과 private entitlement 이전 visibility mismatch를 안전하게 audit/backfill 판단하기 위한 count-only 계획 |
 | [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
+| [TREE_MOMENT_SOCIAL_MODEL.md](TREE_MOMENT_SOCIAL_MODEL.md) | public LoveTree의 tree-level / moment-level comments, reactions, permissions, moderation, phased implementation 모델 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
 | [YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md](YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md) | YouTube segment player PoC test matrix and browser verification requirements |
@@ -27,7 +28,7 @@
 | [YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md](YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md) | Browser verification evidence and feasibility decision for the YouTube segment player PoC |
 | [MOMENT_CAPTURE_UI_DESIGN.md](MOMENT_CAPTURE_UI_DESIGN.md) | Moment capture UI flow design |
 | [MOMENT_TIMELINE_REORDER_DESIGN.md](MOMENT_TIMELINE_REORDER_DESIGN.md) | Moment Timeline reorder / sequence editor design |
-| [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 운영 기준 |
+| [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
 | [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
 | [PRODUCT_BRIEF.md](PRODUCT_BRIEF.md) | 현재 실행 기준 제품 개요 |
@@ -52,6 +53,15 @@
 - private tree 아래 public memory가 가능하더라도 Browse/Search, community memories list, public memory detail read 노출은 parent tree visibility guard를 함께 봅니다.
 - owner/private read는 private access policy에 따라 private tree 아래 public/private memory를 조회할 수 있습니다.
 
+## Social model highlights
+
+public LoveTree social surfaces are planned as two distinct scopes:
+
+- tree-level discussion/reactions for the full public LoveTree;
+- moment-level discussion/reactions for a specific public moment/node.
+
+The two scopes should not be merged into one ambiguous count or comment surface. Public reads must inherit parent tree and target moment visibility boundaries.
+
 ## 원천 자료 (Identity Source)
 
 제품 정체성의 기반이 된 인터뷰 및 콘셉트 원본 문서:
@@ -70,18 +80,19 @@
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
 4. **PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md** — public-by-default 정책 alignment와 private entitlement 이전 visibility mismatch audit/backfill gate
 5. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
-6.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-7.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-8.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-9.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-10.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-11.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-12. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-13. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-14. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-15. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-16. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-17. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+6. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
+7.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+8.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+9.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+10.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+11.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+12.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+13. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+14. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+15. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+16. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+17. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+18. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
Refs #622

Purpose:
- Define LoveBud's first product model for public LoveTree social spaces at two distinct scopes: tree-level discussion and moment-level discussion.
- Document permission direction, data-model direction, reactions/count semantics, moderation baseline, public/private visibility boundaries, phased implementation, and follow-up issue split.
- Keep future implementation narrow by separating planning from UI/API/runtime work.

Changed files:
- `docs/product/TREE_MOMENT_SOCIAL_MODEL.md`
- `docs/product/product_index.md`

Scope:
- Docs-only product planning update.
- No UI implementation.
- No comments/reactions API routes.
- No database schema or migration.
- No runtime JS/CSS/HTML/API/Auth/backend/Modal behavior changes.
- No package/workflow changes.
- No Browser verification required.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, private key, DB URL, owner ID, tree ID, memory ID, copied tree ID, raw payload, or DB row value included.

Current finding:
- Direct PR coverage for #622 was not found in recent PR search.
- #622 requests a planning model before implementation; this PR provides that model without adding UI or runtime behavior.

Verification:
- GitHub API compare: branch is ahead of current `main` by 2 and behind by 0.
- GitHub API changed-file scope check: docs/product only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- API/database implementation: NOT_PERFORMED in this PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Guardrails:
- Issue #622 remains open until implementation follow-up issues/PRs are created or explicitly deferred.
- Do not ready or merge without CTO approval.
- No issue close keyword used.