### PR TITLE
docs(product): add v0.1 CTA exposure policy

### DIFF
--- a/docs/product/V01_CTA_EXPOSURE_POLICY.md
+++ b/docs/product/V01_CTA_EXPOSURE_POLICY.md
@@ -1,0 +1,232 @@
+# v0.1 CTA exposure policy
+
+**Status:** Product readiness policy  
+**Owner:** CTO / Product  
+**Related issue:** #683
+
+This document defines how LoveBud v0.1 should expose actions that lead to complete, partial, unavailable, or intentionally deferred flows.
+
+The goal is to protect product trust. A polished screen should not present a strong primary action that routes users into an unfinished, unverified, or unrecoverable experience.
+
+This is not an implementation PR. It does not change UI, copy, routing, Auth, API, backend, database, packages, workflows, or provider settings.
+
+---
+
+## 1. Core rule
+
+A strong primary CTA requires a `Ready` classification.
+
+If a flow is not ready, the action must be softened, disabled with explanation, or hidden/deferred.
+
+```text
+Primary CTA allowed: Ready only
+Secondary CTA allowed: Ready or Soft exposure
+Disabled CTA allowed: Not ready but useful to explain expectation
+Hidden/deferred: Not ready and likely to confuse or erode trust
+```
+
+---
+
+## 2. Readiness classifications
+
+### Ready
+
+Use for actions that are:
+
+- implemented;
+- runtime verified in an appropriate environment;
+- connected to the intended route or behavior;
+- supported by acceptable loading states;
+- supported by acceptable error/recovery states;
+- safe with Auth/API/DB boundaries;
+- not known to expose restricted data.
+
+Ready actions may be primary, secondary, or contextual.
+
+### Soft exposure
+
+Use for actions that are partially ready but not stable enough to own the screen.
+
+Soft exposure actions:
+
+- should be visually secondary;
+- should use cautious copy;
+- should not promise more than they can deliver;
+- should not be the only route to a critical flow;
+- must not hide known failure or incomplete state.
+
+### Disabled with explanation
+
+Use when users benefit from knowing the feature is planned or intentionally unavailable.
+
+Disabled actions should:
+
+- state that the feature is not available yet;
+- avoid implying a bug;
+- avoid a dead click;
+- not require users to discover failure by trying the action.
+
+### Hidden / deferred
+
+Use when exposing the action creates more confusion than value.
+
+Hide or defer actions that:
+
+- route to missing or placeholder pages;
+- cannot recover from failure;
+- require unavailable Auth/API/backend support;
+- represent v0.2 or later behavior;
+- are likely to be interpreted as complete when they are not.
+
+---
+
+## 3. Verification standard before promotion
+
+Before an action can be promoted to primary, the responsible PR or review must verify:
+
+- the click/tap target is wired;
+- the target route or behavior exists;
+- the intended state loads;
+- loading and empty states are acceptable;
+- failure states are safe and recoverable;
+- Auth/session behavior is correct when applicable;
+- API/database behavior is verified when applicable;
+- no restricted values are exposed in reports;
+- desktop and mobile behavior are acceptable when the action is user-facing.
+
+Runtime-sensitive actions require a valid deployed environment. Localhost-only or production-only pre-merge proof is not sufficient for Auth/API/My Trees/Editor/Browse-dependent flows.
+
+---
+
+## 4. Screen-specific v0.1 decision template
+
+Use this template for each active screen or component:
+
+```text
+Screen:
+Action label:
+Action type: PRIMARY / SECONDARY / DESTRUCTIVE / CONTEXTUAL
+Target behavior:
+Readiness classification: READY / SOFT_EXPOSURE / DISABLED_WITH_EXPLANATION / HIDDEN_DEFERRED
+Runtime verification: PASS / NOT_VERIFIED / BLOCKED / NOT_REQUIRED
+Failure/recovery state: PRESENT / MISSING / NOT_APPLICABLE / UNKNOWN
+Decision: KEEP_PRIMARY / MAKE_SECONDARY / DISABLE_WITH_COPY / HIDE / SPLIT_FOLLOWUP
+Follow-up issue/PR:
+Restricted values exposed: NO
+```
+
+Do not include tree IDs, owner IDs, memory IDs, copied tree IDs, user IDs, tokens, sessions, cookies, private keys, DB URLs, raw payloads, or DB rows.
+
+---
+
+## 5. Initial v0.1 screen recommendations
+
+These are policy-level recommendations, not implementation changes.
+
+### Browse selected hub
+
+Actions to classify:
+
+- open selected tree / viewing route;
+- copy/import to My Trees;
+- share or copy link;
+- selected hub preview interactions.
+
+Policy:
+
+- Do not make a route-opening action primary unless the target viewing experience is implemented and runtime verified.
+- If import/copy lacks reliable recovery, keep it secondary or disabled with explanation.
+- If the selected hub is the only verified experience, favor preview-safe actions over route promises.
+
+### Login/account entry
+
+Actions to classify:
+
+- Google continuation;
+- email continuation;
+- signup/account creation messaging;
+- account/settings links.
+
+Policy:
+
+- Do not duplicate equivalent auth methods as separate strong CTAs.
+- If account/settings routes are not implemented, avoid sending users to a generic login screen without explanation.
+- Preserve working auth methods when simplifying hierarchy.
+
+### My Trees
+
+Actions to classify:
+
+- open owned tree;
+- create tree;
+- manage/overflow actions;
+- visibility-related controls;
+- empty-state actions.
+
+Policy:
+
+- The primary action should match the product role of a personal LoveTree gallery.
+- Management actions should be quiet unless needed.
+- Destructive or unavailable actions should not compete with open/create flows.
+
+### Editor
+
+Actions to classify:
+
+- save/cancel for title, moment, and memo edits;
+- delete/destructive actions;
+- source/video replacement;
+- add moment or branch placement.
+
+Policy:
+
+- Save actions should be clear and recoverable.
+- Destructive actions should be visually and semantically separated.
+- Unverified edit paths should not be presented as complete.
+- Auth/owner-write behavior must be runtime verified before calling an edit flow ready.
+
+---
+
+## 6. Copy guidance for unavailable actions
+
+Use concise copy that sets expectation without making the screen feel broken.
+
+Preferred patterns:
+
+- `준비 중입니다`
+- `곧 사용할 수 있어요`
+- `아직 열 수 없는 기능입니다`
+- `저장할 수 없는 상태입니다`
+- `다시 시도해 주세요`
+
+Avoid:
+
+- strong action labels that imply completion;
+- silent no-op buttons;
+- disabled buttons without explanation;
+- vague error-only copy when the feature is intentionally deferred.
+
+---
+
+## 7. Follow-up split rules
+
+Do not bundle broad CTA cleanup into one implementation PR.
+
+Split by screen or action family:
+
+1. Browse selected hub route/readiness actions.
+2. Login/account CTA hierarchy.
+3. My Trees primary/secondary action hierarchy.
+4. Editor edit/save/destructive action readiness.
+5. Settings/account unavailable action handling.
+6. Cross-screen audit-only decision map.
+
+Each runtime-sensitive follow-up needs its own verification plan and deployed target when applicable.
+
+---
+
+## 8. Current disposition
+
+This document satisfies the policy-definition layer for #683. It defines Ready / Soft exposure / Disabled with explanation / Hidden-deferred classifications, promotion gates, screen-specific recommendation areas, unavailable-action copy guidance, and follow-up split rules.
+
+#683 should remain open until screen-specific action decisions are audited and linked follow-up PRs or explicit deferrals exist.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -21,6 +21,7 @@
 | [PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md](PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md) | public-by-default 정책과 private entitlement 이전 visibility mismatch를 안전하게 audit/backfill 판단하기 위한 count-only 계획 |
 | [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
 | [TREE_MOMENT_SOCIAL_MODEL.md](TREE_MOMENT_SOCIAL_MODEL.md) | public LoveTree의 tree-level / moment-level comments, reactions, permissions, moderation, phased implementation 모델 |
+| [V01_CTA_EXPOSURE_POLICY.md](V01_CTA_EXPOSURE_POLICY.md) | v0.1 unfinished/partial action 노출 기준과 Ready/Soft/Disabled/Hidden CTA 분류 정책 |
 | [MOMENT_TIMELINE_PLAN.md](MOMENT_TIMELINE_PLAN.md) | cue-based YouTube Moment Timeline 제품/기술 계획 |
 | [YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md](YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md) | cue-based YouTube segment player PoC scope and Go/No-Go criteria |
 | [YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md](YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md) | YouTube segment player PoC test matrix and browser verification requirements |
@@ -30,7 +31,7 @@
 | [MOMENT_TIMELINE_REORDER_DESIGN.md](MOMENT_TIMELINE_REORDER_DESIGN.md) | Moment Timeline reorder / sequence editor design |
 | [UI_COPY_DIET_GUIDE.md](UI_COPY_DIET_GUIDE.md) | 전역 UI 카피 다이어트 기준 |
 | [MVP_SCOPE.md](MVP_SCOPE.md) | MVP 범위 및 포함/제외 항목 |
-| [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 플로우 |
+| [USER_FLOW.md](USER_FLOW.md) | 주요 사용자 여정 및 핵심 플로우 |
 | [PRODUCT_BRIEF.md](PRODUCT_BRIEF.md) | 현재 실행 기준 제품 개요 |
 | [DATA_NAMING_RULE.md](DATA_NAMING_RULE.md) | 데이터 명명 규칙 |
 | [READONLY_SHARE_SCOPE.md](READONLY_SHARE_SCOPE.md) | 읽기 전용 공유 범위 |
@@ -62,6 +63,17 @@ public LoveTree social surfaces are planned as two distinct scopes:
 
 The two scopes should not be merged into one ambiguous count or comment surface. Public reads must inherit parent tree and target moment visibility boundaries.
 
+## CTA readiness highlights
+
+v0.1 action exposure uses four readiness classifications:
+
+- Ready;
+- Soft exposure;
+- Disabled with explanation;
+- Hidden / deferred.
+
+Strong primary CTAs require Ready status and valid runtime verification when Auth/API/data-loaded behavior is involved.
+
 ## 원천 자료 (Identity Source)
 
 제품 정체성의 기반이 된 인터뷰 및 콘셉트 원본 문서:
@@ -81,18 +93,19 @@ The two scopes should not be merged into one ambiguous count or comment surface.
 4. **PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md** — public-by-default 정책 alignment와 private entitlement 이전 visibility mismatch audit/backfill gate
 5. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
 6. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
-7.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-8.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-9.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-10.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-11.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-12.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-13. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-14. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-15. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-16. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-17. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-18. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
+7. **V01_CTA_EXPOSURE_POLICY.md** — v0.1 unfinished/partial action 노출 기준과 CTA readiness 분류 정책
+8.  **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+9.  **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+10.  **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+11.  **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+12.  **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+13.  **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+14. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+15. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+16. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+17. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+18. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+19. 필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
Refs #683

Purpose:
- Define v0.1 policy for exposing Ready, Soft exposure, Disabled with explanation, and Hidden/deferred actions.
- Document promotion gates before an action can become a strong primary CTA.
- Provide a screen/action decision template and initial policy-level recommendations for Browse, Login/account, My Trees, and Editor without changing any UI.

Changed files:
- `docs/product/V01_CTA_EXPOSURE_POLICY.md`
- `docs/product/product_index.md`

Scope:
- Docs-only product policy update.
- No UI implementation or copy changes.
- No route implementation.
- No Auth/API/backend/DB behavior changes.
- No package/workflow changes.
- No Browser verification required for this docs-only PR.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret, token, session, cookie, password, private key, DB URL, owner ID, tree ID, memory ID, copied tree ID, raw payload, or DB row value included.

Current finding:
- Direct PR coverage for #683 was not found in recent PR search.
- #683 asks for a policy note/checklist before screen-specific implementation; this PR provides that policy without touching screens or runtime behavior.

Verification:
- GitHub API compare: branch is ahead of current `main` by 2 and behind by 0.
- GitHub API changed-file scope check: docs/product only.
- Browser/runtime verification: NOT_REQUIRED for docs-only PR.
- UI/API/database implementation: NOT_PERFORMED in this PR.
- Local markdown/static checks: NOT_RUN in this Web/GitHub-only pass.

Guardrails:
- Issue #683 remains open until screen-specific action decisions are audited and linked follow-up PRs or explicit deferrals exist.
- Do not ready or merge without CTO approval.
- No issue close keyword used.