### PR TITLE
Fix Browse hub summary missing time range fallback

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -225,6 +225,14 @@
       ko: '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 <strong>{range}</strong>에 걸쳐 이어졌어요.',
       en: '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> continued across <strong>{range}</strong>.'
     },
+    'search.previewSummaryThemeNoRange': {
+      ko: '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+      en: '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> are connected.'
+    },
+    'search.previewSummaryNoRange': {
+      ko: '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+      en: '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> are connected.'
+    },
     'search.previewLoadingLead': {
       ko: '대표 순간을 불러오는 중이에요.',
       en: 'Loading the featured moment.'

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -315,6 +315,24 @@
         return getSearchCopy('search.previewDefaultTreeName', '러브트리', 'LoveTree');
     }
 
+    function getPreviewTimeRange(tree) {
+        const raw = String(tree?.timeRange || '').trim();
+        const missingRangeLabels = [
+            '기록 없음',
+            'no records',
+            'no record',
+            'unknown',
+            'n/a',
+            getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')
+        ].map(label => String(label || '').trim().toLowerCase()).filter(Boolean);
+
+        if (!raw) {
+            return '';
+        }
+
+        return missingRangeLabels.includes(raw.toLowerCase()) ? '' : raw;
+    }
+
     function getPreviewSummaryCopy(tree, memories) {
         const titleHelper = getSearchTitleHelper();
         const displayTitle = titleHelper?.getBrowseDisplayTitle
@@ -323,7 +341,7 @@
         const themeLabel = titleHelper?.getThemeLabel
             ? titleHelper.getThemeLabel(tree)
             : '';
-        const timeRange = String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')).trim();
+        const timeRange = getPreviewTimeRange(tree);
         const memoryCount = Number(tree?.memoryCount || 0);
         const safeTitle = escapeHtml(displayTitle);
         const safeTheme = escapeHtml(themeLabel);
@@ -343,6 +361,24 @@
                 { title: safeTitle },
                 '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 공개 러브트리예요.',
                 '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.'
+            );
+        }
+
+        if (!timeRange) {
+            if (themeLabel) {
+                return formatSearchCopy(
+                    'search.previewSummaryThemeNoRange',
+                    { theme: safeTheme, count: memoryCount },
+                    '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+                    '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> are connected.'
+                );
+            }
+
+            return formatSearchCopy(
+                'search.previewSummaryNoRange',
+                { title: safeTitle, count: memoryCount },
+                '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+                '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> are connected.'
             );
         }
 

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -60,3 +60,19 @@ test('search UI module implements card accessibility and event delegation', () =
   assert.match(uiModule, /container\.addEventListener\(['"]keydown['"]/);
   assert.match(uiModule, /event\.target\.closest\(['"]\.tree-card\[data-tree-id\]['"]\)/);
 });
+
+test('search preview summary omits range phrase for missing time range labels', () => {
+  const previewRenderer = read('js/search/search-preview-renderer.js');
+  const i18nSearch = read('js/i18n/i18n-search.js');
+
+  assert.match(previewRenderer, /function getPreviewTimeRange\(tree\)/);
+  assert.match(previewRenderer, /'기록 없음'/);
+  assert.match(previewRenderer, /getSearchCopy\('search\.previewUnknownRange'/);
+  assert.match(previewRenderer, /if \(!timeRange\)/);
+  assert.match(previewRenderer, /search\.previewSummaryThemeNoRange/);
+  assert.match(previewRenderer, /search\.previewSummaryNoRange/);
+
+  assert.match(i18nSearch, /'search\.previewSummaryThemeNoRange'/);
+  assert.match(i18nSearch, /'search\.previewSummaryNoRange'/);
+  assert.match(i18nSearch, /span style="color:var\(--primary\);font-weight:700;">\{count\}개의 순간<\/span>이 이어졌어요/);
+});


### PR DESCRIPTION
Refs #767

## Root cause summary
The selected Browse hub summary always used the period-based sentence after substituting missing `timeRange` values with fallback labels. When the summary data carried the missing-data label, that label was inserted into the range phrase.

## Implementation summary
- Added display-layer normalization for unavailable preview time ranges.
- Added no-range summary copy for themed and non-themed selected hub summaries.
- Preserved the moment count in both range and no-range summary paths.
- Added a route contract test for the missing-range summary behavior.

## Browser/fixed-slot verification deferred
Browser and fixed-slot verification are deferred to the later verification executor after deployment.

## Scope notes
No API/Auth/backend/DB behavior changes.
No secret/private payload exposure.