### PR TITLE
editor: persist inline emotion memo saves

### DIFF
--- a/js/editor/editor-detail-inline-edit.js
+++ b/js/editor/editor-detail-inline-edit.js
@@ -127,6 +127,10 @@ function createEditorDetailInlineEditBoundary(deps) {
             hintDiv.className = 'memory-edit-hint';
             hintDiv.textContent = formatI18nText('noteSaveHint', 'Ctrl+Enter로 저장할 수 있어요.');
 
+            const errorMsg = document.createElement('div');
+            errorMsg.className = 'memory-edit-error';
+            errorMsg.setAttribute('role', 'status');
+
             const actions = document.createElement('div');
             actions.className = 'memory-edit-actions';
 
@@ -143,6 +147,7 @@ function createEditorDetailInlineEditBoundary(deps) {
 
             memoContainer.appendChild(textarea);
             memoContainer.appendChild(hintDiv);
+            memoContainer.appendChild(errorMsg);
             memoContainer.appendChild(actions);
 
             textarea.focus();
@@ -155,12 +160,14 @@ function createEditorDetailInlineEditBoundary(deps) {
 
             const saveEdit = async () => {
                 const newMemo = textarea.value.trim();
+                errorMsg.textContent = '';
                 saveBtn.disabled = true;
                 cancelBtn.disabled = true;
                 if (await updateSelectedMemoryFields({ memo: newMemo })) {
                     if (showToast) showToast(formatI18nText('memoryUpdateSaved', '순간을 수정했어요.'), 'success');
                     endEdit();
                 } else {
+                    errorMsg.textContent = formatI18nText('memoryUpdateFailed', '순간을 수정하지 못했어요.');
                     if (showToast) showToast(formatI18nText('memoryUpdateFailed', '순간을 수정하지 못했어요.'), 'error');
                     saveBtn.disabled = false;
                     cancelBtn.disabled = false;

--- a/js/editor/editor-memory-actions.js
+++ b/js/editor/editor-memory-actions.js
@@ -24,6 +24,7 @@ function createEditorMemoryActions(deps) {
     } = deps;
 
     let isEditMode = false;
+    let isInlineMemorySaveInFlight = false;
 
     const enterEditMode = () => {
         const currentEditingMemory = getCurrentEditingMemory();
@@ -103,52 +104,77 @@ function createEditorMemoryActions(deps) {
     };
 
     const updateSelectedMemoryFields = async (updates) => {
-        const selectedNodeId = getSelectedNodeId();
-        if (!selectedNodeId) return false;
+        const currentEditingMemory = getCurrentEditingMemory();
+        const selectedNodeId = getSelectedNodeId() || currentEditingMemory?.id;
+        if (!selectedNodeId) {
+            updateSaveStatus('failed', i18n('save_failed'));
+            return false;
+        }
+        if (isInlineMemorySaveInFlight) return false;
+
         const allowedUpdates = {};
         if (Object.prototype.hasOwnProperty.call(updates || {}, 'title')) allowedUpdates.title = updates.title;
         if (Object.prototype.hasOwnProperty.call(updates || {}, 'memo')) allowedUpdates.memo = updates.memo;
         if (Object.keys(allowedUpdates).length === 0) return false;
 
-        const memories = getTreeMemories();
+        const memories = Array.isArray(getTreeMemories()) ? getTreeMemories().slice() : [];
         const idx = memories.findIndex(m => m.id === selectedNodeId);
-        if (idx === -1) return false;
-
-        if (window.apiClient && typeof window.apiClient.updateMemory === 'function' && !isLocalSaveMode()) {
-            updateSaveStatus('saving', i18n('save_saving'));
-            try {
-                await window.apiClient.updateMemory(selectedNodeId, allowedUpdates);
-            } catch (error) {
-                console.error('[editor] Failed to update selected memory:', error);
-                updateSaveStatus('failed', i18n('save_failed'));
-                return false;
-            }
+        if (idx === -1) {
+            updateSaveStatus('failed', i18n('save_failed'));
+            return false;
         }
 
-        if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'title')) memories[idx].title = allowedUpdates.title;
-        if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'memo')) memories[idx].memo = allowedUpdates.memo;
+        const localSaveMode = typeof isLocalSaveMode === 'function' ? isLocalSaveMode() : false;
+        let savedMemory = null;
+
+        updateSaveStatus('saving', i18n('save_saving'));
+        isInlineMemorySaveInFlight = true;
+        try {
+            if (!localSaveMode) {
+                if (!window.apiClient || typeof window.apiClient.updateMemory !== 'function') {
+                    throw new Error('updateMemory not available');
+                }
+                savedMemory = await window.apiClient.updateMemory(selectedNodeId, allowedUpdates);
+            }
+        } catch (error) {
+            console.error('[editor] Failed to update selected memory:', error);
+            updateSaveStatus('failed', i18n('save_failed'));
+            return false;
+        } finally {
+            isInlineMemorySaveInFlight = false;
+        }
+
+        const nextMemory = {
+            ...memories[idx],
+            ...allowedUpdates,
+            ...(savedMemory && typeof savedMemory === 'object' ? savedMemory : {})
+        };
+        memories[idx] = nextMemory;
+        setTreeMemories(memories);
 
         const currentTreeData = getCurrentTreeData();
         if (currentTreeData && currentTreeData.memories) {
             const dataIdx = currentTreeData.memories.findIndex(m => m.id === selectedNodeId);
             if (dataIdx !== -1) {
-                if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'title')) currentTreeData.memories[dataIdx].title = allowedUpdates.title;
-                if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'memo')) currentTreeData.memories[dataIdx].memo = allowedUpdates.memo;
+                currentTreeData.memories[dataIdx] = {
+                    ...currentTreeData.memories[dataIdx],
+                    ...nextMemory
+                };
             }
         }
 
         if (window.LoveBudCache) {
-            const treeId = (currentTreeData && currentTreeData.id) ? currentTreeData.id : 'default';
+            const treeId = (currentTreeData && currentTreeData.id) || nextMemory.treeId || 'default';
             const cacheKey = 'memories_' + treeId;
             window.LoveBudCache.set(cacheKey, memories, 2 * 60 * 1000);
         }
 
-        const currentEditingMemory = getCurrentEditingMemory();
         if (currentEditingMemory && currentEditingMemory.id === selectedNodeId) {
-            const updatedMemory = { ...currentEditingMemory };
-            if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'title')) updatedMemory.title = allowedUpdates.title;
-            if (Object.prototype.hasOwnProperty.call(allowedUpdates, 'memo')) updatedMemory.memo = allowedUpdates.memo;
+            const updatedMemory = { ...currentEditingMemory, ...nextMemory };
             setCurrentEditingMemory(updatedMemory);
+            if (typeof updateDetailPanel === 'function') updateDetailPanel(updatedMemory);
+        } else if (typeof updateDetailPanel === 'function') {
+            updateDetailPanel(nextMemory);
         }
 
         if (typeof rerenderCanvas === 'function') rerenderCanvas();

--- a/js/editor/editor-save-status.js
+++ b/js/editor/editor-save-status.js
@@ -28,6 +28,13 @@
     return Math.floor(diff / 86400) + '일 전';
   }
 
+  function setStatusIcon(iconEl, token) {
+    if (!iconEl) return;
+    iconEl.textContent = '';
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.dataset.statusIcon = token || '';
+  }
+
   function updateSaveStatus(saveStatusData, options) {
     var status = options && options.status;
     var message = options && options.message;
@@ -49,7 +56,7 @@
 
     switch (status) {
       case 'saving':
-        iconEl.textContent = 'hourglass_empty';
+        setStatusIcon(iconEl, 'hourglass_empty');
         textEl.textContent = message || (typeof i18n === 'function' ? i18n('save_saving') : '저장 중...');
         indicator.className = 'save-status-indicator saving';
         indicator.style.display = 'flex';
@@ -57,7 +64,7 @@
         break;
 
       case 'saved':
-        iconEl.textContent = 'check_circle';
+        setStatusIcon(iconEl, 'check_circle');
         textEl.textContent = message || (typeof i18n === 'function' ? i18n('save_saved') : '저장됨');
         indicator.className = 'save-status-indicator saved';
         saveStatusData.lastSaved = new Date();
@@ -71,7 +78,7 @@
         break;
 
       case 'failed':
-        iconEl.textContent = 'error';
+        setStatusIcon(iconEl, 'error');
         textEl.textContent = message || (typeof i18n === 'function' ? i18n('save_failed') : '저장 실패');
         indicator.className = 'save-status-indicator failed';
         if (timeEl) timeEl.style.display = 'none';

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -253,11 +253,11 @@
     <script src="../js/editor/editor-canvas.js?v=20260421-5"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-detail-inline-edit.js?v=20260502-2"></script>
+    <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-628"></script>
     <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260422-2"></script>
-    <script src="../js/editor/editor-memory-actions.js?v=20260419-1"></script>
+    <script src="../js/editor/editor-memory-actions.js?v=20260504-628"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260422-3"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>

--- a/tests/routes/editor-memory-actions-save.test.js
+++ b/tests/routes/editor-memory-actions-save.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function createMemoryActionsWithStubs(overrides = {}) {
+  const context = {
+    console: { ...console, error: () => {} },
+    window: {
+      apiClient: {
+        updateMemory: async () => ({})
+      },
+      LoveBudCache: {
+        set: () => {}
+      }
+    }
+  };
+  vm.createContext(context);
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-memory-actions.js'), 'utf8');
+  vm.runInContext(source, context);
+
+  let currentEditingMemory = { id: 'memory-1', treeId: 'tree-1', title: 'Before', memo: 'before' };
+  let treeMemories = [{ ...currentEditingMemory }];
+  const currentTreeData = { id: 'tree-1', memories: [{ ...currentEditingMemory }] };
+  const statuses = [];
+  const detailUpdates = [];
+  const cacheWrites = [];
+
+  context.window.apiClient.updateMemory = overrides.updateMemory || (async (memoryId, payload) => ({
+    id: memoryId,
+    ...payload,
+    updatedAt: 'updated'
+  }));
+  context.window.LoveBudCache.set = (key, value) => cacheWrites.push({ key, value });
+
+  const actions = context.window.createEditorMemoryActions({
+    i18n: (key) => key,
+    updateSaveStatus: (status) => statuses.push(status),
+    updateDetailPanel: (memory) => detailUpdates.push(memory),
+    updateSidebarStatus: () => {},
+    showToast: () => {},
+    getCurrentEditingMemory: () => currentEditingMemory,
+    setCurrentEditingMemory: (value) => { currentEditingMemory = value; },
+    getTreeMemories: () => treeMemories,
+    setTreeMemories: (value) => { treeMemories = value; },
+    getSelectedNodeId: () => 'memory-1',
+    setSelectedNodeId: () => {},
+    getCanonicalRootId: () => 'memory-1',
+    isRootMemory: () => false,
+    findRootMemory: () => null,
+    detailPanel: null,
+    svg: null,
+    calcPosition: () => ({ x: 0, y: 0 }),
+    setDetailEmptyState: () => {},
+    rerenderCanvas: () => {},
+    getCurrentTreeData: () => currentTreeData,
+    isLocalSaveMode: () => false
+  });
+
+  return {
+    actions,
+    get currentEditingMemory() { return currentEditingMemory; },
+    get treeMemories() { return treeMemories; },
+    currentTreeData,
+    statuses,
+    detailUpdates,
+    cacheWrites
+  };
+}
+
+test('editor inline memo save persists through API and refreshes current moment UI state', async () => {
+  let sentRequest = null;
+  const harness = createMemoryActionsWithStubs({
+    updateMemory: async (memoryId, payload) => {
+      sentRequest = { memoryId, payload };
+      return { id: memoryId, memo: payload.memo, title: 'Before', updatedAt: 'server-time' };
+    }
+  });
+
+  const result = await harness.actions.updateSelectedMemoryFields({ memo: 'after' });
+
+  assert.equal(result, true);
+  assert.equal(sentRequest.memoryId, 'memory-1');
+  assert.equal(sentRequest.payload.memo, 'after');
+  assert.equal(harness.treeMemories[0].memo, 'after');
+  assert.equal(harness.currentTreeData.memories[0].memo, 'after');
+  assert.equal(harness.currentEditingMemory.memo, 'after');
+  assert.equal(harness.detailUpdates.at(-1).memo, 'after');
+  assert.equal(harness.cacheWrites.at(-1).key, 'memories_tree-1');
+  assert.deepEqual(harness.statuses, ['saving', 'saved']);
+});
+
+test('editor inline memo save failure keeps existing state and reports failed status', async () => {
+  const harness = createMemoryActionsWithStubs({
+    updateMemory: async () => {
+      throw new Error('update failed');
+    }
+  });
+
+  const result = await harness.actions.updateSelectedMemoryFields({ memo: 'after' });
+
+  assert.equal(result, false);
+  assert.equal(harness.treeMemories[0].memo, 'before');
+  assert.equal(harness.currentEditingMemory.memo, 'before');
+  assert.equal(harness.detailUpdates.length, 0);
+  assert.deepEqual(harness.statuses, ['saving', 'failed']);
+});


### PR DESCRIPTION
Refs #628

Root cause summary:
The inline current moment memo save path updated memory data but did not refresh the current detail panel from the saved memory, so the textarea flow could look like it did not persist. The memo inline path also lacked a local error message area for retry feedback.

Implementation summary:
The inline selected-memory update now sends the existing private memory update request when not in local-save mode, applies the returned memory data to current memory state, tree memory state, current tree data, cache, canvas/sidebar state, and the current detail panel. Memo inline edit now shows a retry-safe error message while keeping the typed textarea value in place.

Auth/API/backend/DB ownership boundary unchanged.

Browser slot verification deferred.

No Browse/Search/My Trees/Detail route behavior changes.

No secret/private payload exposure.