### PR TITLE
my-trees: keep create tree modal submit clickable

### DIFF
--- a/css/my-trees/create-modal.css
+++ b/css/my-trees/create-modal.css
@@ -1,5 +1,6 @@
-.create-tree-modal-backdrop { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; padding: 24px; background: rgba(53, 40, 38, 0.34); backdrop-filter: blur(8px); z-index: 1200; pointer-events: none; }
-.create-tree-modal-backdrop.show { display: flex; pointer-events: auto; }
+.create-tree-modal-backdrop { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; padding: 24px; z-index: 1200; pointer-events: none; isolation: isolate; }
+.create-tree-modal-backdrop::before { content: ""; position: absolute; inset: 0; background: rgba(53, 40, 38, 0.34); backdrop-filter: blur(8px); pointer-events: auto; z-index: 0; }
+.create-tree-modal-backdrop.show { display: flex; }
 .create-tree-modal { position: relative; z-index: 1; width: min(100%, 520px); background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(255,248,249,0.98)); border: 1px solid rgba(144, 73, 81, 0.12); border-radius: 28px; box-shadow: 0 30px 70px rgba(75, 64, 57, 0.18); padding: 28px; pointer-events: auto; }
 .create-tree-modal-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 22px; }
 .create-tree-modal-kicker { display: inline-flex; align-items: center; gap: 6px; min-height: 28px; padding: 0 12px; border-radius: 999px; background: rgba(144, 73, 81, 0.08); color: var(--primary); font-size: 12px; font-weight: 900; margin-bottom: 12px; }

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-  <link rel="stylesheet" href="../css/my-trees.css?v=20260427-1">
+  <link rel="stylesheet" href="../css/my-trees.css?v=20260504-1">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Root cause summary
- The dim backdrop owned pointer events on the same flex container that wraps the dialog, which left the modal action area vulnerable to backdrop hit-testing above the visible submit button.

Implementation summary
- Moved the dim/blur layer onto `.create-tree-modal-backdrop::before`.
- Kept the dialog at the higher layer with explicit pointer events so visible form controls remain targetable.
- Updated the My Trees stylesheet cache key only.

Changed files
- css/my-trees/create-modal.css
- pages/my-trees.html

Verification results
- git diff --check: PASS
- node --check: NOT_RUN, no JS changed
- targeted My Trees/page contract tests: PASS
- npm test: PASS
- npm run verify: PASS

Browser slot verification: NOT_PERFORMED
No API/Auth/backend/DB/package/workflow behavior changes.

Refs #678