### PR TITLE
ui(browse): clamp long flow moment labels in preview sidebar

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -180,12 +180,19 @@
     max-width: 100%;
     min-height: 36px;
     justify-content: flex-start;
-    overflow-wrap: anywhere;
+    overflow: hidden;
 }
 
-.preview-flow-stage span:last-child {
+/* Issue #602: label text clamped to 2 lines with ellipsis; full label preserved in title attribute */
+.preview-flow-stage-label {
     min-width: 0;
-    overflow-wrap: anywhere;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: 1.35;
 }
 
 .preview-flow-controls {

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260428-1
+ * v20260504-1
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -421,8 +421,9 @@
         `;
     }
 
+    // Issue #602: full label preserved in title attribute; label text uses .preview-flow-stage-label for 2-line clamp.
     function renderPathStageBadge(index, title) {
-        return `<span class="preview-flow-stage" style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;background:var(--surface-container);border-radius:8px;font-size:13px;"><span style="color:var(--primary);font-weight:800;">${index}</span><span>${escapeHtml(title)}</span></span>`;
+        return `<span class="preview-flow-stage" style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;background:var(--surface-container);border-radius:8px;font-size:13px;"><span style="color:var(--primary);font-weight:800;flex:0 0 auto;">${index}</span><span class="preview-flow-stage-label" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}">${escapeHtml(title)}</span></span>`;
     }
 
     function renderPathStages(memories, startIndex = 0) {
@@ -795,5 +796,5 @@
         }
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260428-1');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260504-1');
 })();


### PR DESCRIPTION
Refs #602

Browse selected hub flow moment labels 길이 제한 처리.

Changed files:
- `css/search/preview-sidebar.css`
- `js/search/search-preview-renderer.js`

Scope:
- `.preview-flow-stage-label` CSS class 추가: `display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; text-overflow:ellipsis`으로 2줄 clamp.
- `.preview-flow-stage` 에서 `overflow-wrap:anywhere` 제거, `overflow:hidden` 추가.
- `renderPathStageBadge()`에서 label span에 `class="preview-flow-stage-label"`, `title` 및 `aria-label` 속성 추가 → 원본 full label 접근성/tooltip 보존.
- 인덱스 번호 span에 `flex:0 0 auto` 추가 → 번호가 clamp되지 않도록 보존.
- 원본 moment title/data 불변 (읽기 전용 표시 처리만).
- API/Auth/backend/DB/Editor/Settings/Login/My Trees 파일 미변경.
- PR #7/prototype/reference/demo/variant 미변경.
- secret/private ID 미노출.

Browser verification: NOT_PERFORMED — Browse runtime UI라 fixed slot + deployed SHA match 검증 필요.