### PR TITLE
fix(browse): prevent first card footer clipping

### DIFF
--- a/css/search/tree-card.css
+++ b/css/search/tree-card.css
@@ -58,9 +58,10 @@
     opacity: 1;
 }
 
+/* Issue #778: keep the first/featured card media within the same vertical budget as other cards so the footer row is not clipped. */
 .tree-card-featured .tree-card-media {
-    height: 150px;
-    min-height: 150px;
+    height: 136px;
+    min-height: 136px;
 }
 
 .tree-card-media {

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260504-601">
+    <link rel="stylesheet" href="../css/search.css?v=20260504-778">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Refs #778

## Summary

Fixes the narrow Browse card layout issue where the first visible card can clip its footer metadata row.

The current first card receives `tree-card-featured`, which previously gave its media area a taller 150px height while the card itself remained fixed at 336px. That reduced the remaining vertical budget for the title/subtitle/footer grid and could crop the bottom metadata row on the first card only.

## Changed files

- `css/search/tree-card.css`
- `pages/search.html`

## Scope

- Browse card layout only.
- Keeps card height, grid behavior, card renderer, selected hub behavior, and Browse data loading unchanged.
- Makes the first/featured card media height use the same 136px vertical budget as other cards so footer metadata has sufficient room.
- Refreshes the `search.css` cache key in `pages/search.html`.

## Out of scope

- Browse infinite-scroll behavior tracked separately in #777.
- PR #774 selected-hub flow label clamp behavior.
- Search/Browse renderer logic.
- Editor, Settings/Auth, My Trees, Detail, Login, API/backend/DB, package, workflow changes.
- PR #7 or prototype/reference/demo/variant paths.

## Verification needed

Runtime/browser verification is required before merge because this is visible Browse UI.

Required checks:

- Browse page access.
- First card footer clipping: ABSENT.
- Neighboring card footer clipping: ABSENT.
- Selected/active state tested.
- Desktop result.
- Mobile 375px result.
- No fatal console/page errors.
- No secret/private payload exposure.

No issue close keyword used.