### PR TITLE
fix(browse): improve scroll load trigger reliability

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -24,6 +24,7 @@
         let scrollCheckRaf = 0;
         let isScrollLoadQueued = false;
         let hasUserScrolledTowardFeed = false;
+        let scrollLoadIntentBound = false;
 
         function getCurrentLocale() {
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
@@ -298,7 +299,7 @@
         function isSentinelNearViewport() {
             if (!scrollLoadSentinel || scrollLoadSentinel.hidden) return false;
             const rect = scrollLoadSentinel.getBoundingClientRect();
-            return rect.top <= window.innerHeight + 520 && rect.bottom >= -160;
+            return rect.top <= window.innerHeight + 720 && rect.bottom >= -240;
         }
 
         async function requestScrollLoadMore() {
@@ -325,6 +326,30 @@
             });
         }
 
+        function markScrollLoadIntent() {
+            hasUserScrolledTowardFeed = true;
+            scheduleScrollLoadCheck();
+        }
+
+        function handleScrollLoadKeydown(event) {
+            const scrollingKeys = [' ', 'PageDown', 'End', 'ArrowDown'];
+            if (scrollingKeys.includes(event.key)) {
+                markScrollLoadIntent();
+            }
+        }
+
+        function bindScrollLoadIntentHandlers() {
+            if (scrollLoadIntentBound) return;
+            scrollLoadIntentBound = true;
+
+            window.addEventListener('scroll', scheduleScrollLoadCheck, { passive: true });
+            window.addEventListener('wheel', markScrollLoadIntent, { passive: true });
+            window.addEventListener('touchmove', markScrollLoadIntent, { passive: true });
+            window.addEventListener('keydown', handleScrollLoadKeydown);
+            window.addEventListener('resize', scheduleScrollLoadCheck, { passive: true });
+            window.addEventListener('pageshow', scheduleScrollLoadCheck);
+        }
+
         function ensureScrollLoadSentinel() {
             if (!resultsList || scrollLoadSentinel) return;
 
@@ -346,13 +371,14 @@
                     }
                 }, {
                     root: null,
-                    rootMargin: '520px 0px 520px 0px',
+                    rootMargin: '720px 0px 720px 0px',
                     threshold: 0
                 });
                 scrollLoadObserver.observe(scrollLoadSentinel);
             }
 
-            window.addEventListener('scroll', scheduleScrollLoadCheck, { passive: true });
+            bindScrollLoadIntentHandlers();
+            scheduleScrollLoadCheck();
         }
 
         function ensureBrowseControls() {

--- a/pages/search.html
+++ b/pages/search.html
@@ -137,7 +137,7 @@
     <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260504-601"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260504-777"></script>
+    <script src="../js/search/search-ui.js?v=20260504-777-2"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
     <script src="../js/search/data.js?v=20260503-598-2"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -137,7 +137,7 @@
     <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260504-601"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260503-598"></script>
+    <script src="../js/search/search-ui.js?v=20260504-777"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
      <script src="../js/search/controls.js?v=20260429-1"></script>
     <script src="../js/search/data.js?v=20260503-598-2"></script>


### PR DESCRIPTION
Refs #777

## Summary

Improves Browse infinite-scroll trigger reliability with a narrow client-side trigger update.

Observed behavior from #777 indicated that normal manual scrolling could fail to trigger additional LoveTree loading, while programmatic full-page screenshot scrolling could cause remaining items to appear. The existing code already had a sentinel and `IntersectionObserver`, but the load path depended heavily on a window `scroll` check and required user-scroll state plus sentinel proximity at the same time.

## Changed files

- `js/search/search-ui.js`
- `pages/search.html`

## What changed

- Broadened the sentinel prefetch distance from `520px` to `720px`.
- Added explicit user scroll intent handling for:
  - wheel
  - touchmove
  - keyboard scroll keys
- Added resize and pageshow re-checks.
- Added a one-time binding guard for scroll intent handlers.
- Runs an initial scroll-load check after sentinel setup.
- Refreshes the `search-ui.js` cache key in `pages/search.html`.

## Scope

- Browse infinite-scroll trigger reliability only.
- No Browse API request shape changes.
- No card renderer changes.
- No selected hub preview renderer changes.
- No PR #774 label clamp changes.
- No PR #780 first-card footer layout changes.
- No Auth/API/backend/DB/package/workflow changes.
- No PR #7 or prototype/reference/demo/variant paths.

## Verification needed

Runtime/browser verification is required before merge.

Required checks:

- Browse page access: PASS/FAIL.
- Initial tree list visible: PASS/FAIL.
- Manual scroll triggers additional load: PASS/FAIL.
- Screenshot/programmatic scroll trigger comparison: PASS/FAIL/NOT_TESTED.
- Load-more request sent: SENT/NOT_SENT/UNKNOWN.
- New trees rendered after manual scroll: PASS/FAIL.
- Loading indicator clears: PASS/FAIL/NOT_APPLICABLE.
- Desktop result: PASS/FAIL.
- Mobile 375px result: PASS/FAIL/NOT_TESTED.
- Fatal console/page/network errors: NONE/PRESENT.
- Secret/private payload exposure: NO.

No issue close keyword used.