### PR TITLE
fix(editor): stabilize new-tree empty-state layout

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -9,7 +9,7 @@
  * verification across desktop, tablet, and mobile viewports.
  */
 @import url("./editor/base.css");
-@import url("./editor/layout.css");
+@import url("./editor/layout.css?v=20260504-775");
 @import url("./editor/sidebar.css");
 @import url("./editor/canvas.css");
 @import url("./editor/canvas-toolbar.css");

--- a/css/editor/layout.css
+++ b/css/editor/layout.css
@@ -1,6 +1,29 @@
 .editor-layout {
     display: flex;
-    height: calc(100vh - var(--header-height));
+    height: calc(100dvh - var(--header-height));
+    width: 100%;
+    max-width: 100vw;
+    min-height: 0;
+    overflow: hidden;
     position: relative;
     background: var(--background);
+    box-sizing: border-box;
+}
+
+.editor-layout > .sidebar,
+.editor-layout > .detail-panel,
+.editor-layout > .canvas-area {
+    box-sizing: border-box;
+    min-height: 0;
+}
+
+.editor-layout > .canvas-area {
+    min-width: 0;
+}
+
+@media (max-width: 1024px) {
+    .editor-layout {
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
 }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260503-626-2">
+    <link rel="stylesheet" href="../css/editor.css?v=20260504-775">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Summary
- Stabilizes the Editor flex shell for the new-tree landing state.
- Keeps the page body policy unchanged while the Editor layout owns viewport containment.
- Preserves My Trees create-tree submit and redirect behavior.

Changed files
- css/editor/layout.css
- css/editor.css
- pages/editor.html

Local checks
- git diff --check: PASS
- relevant Editor route/contract tests: PASS
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

No Editor JS/Auth/API changes.
No API/Auth/backend/DB/package/workflow changes.
No prototype/reference/demo/variant changes.

Refs #775