### PR TITLE
fix(editor): add spacing below tree overview control

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -11,7 +11,7 @@
 @import url("./editor/base.css");
 @import url("./editor/layout.css?v=20260504-775");
 @import url("./editor/sidebar.css");
-@import url("./editor/canvas.css");
+@import url("./editor/canvas.css?v=20260504-787");
 @import url("./editor/canvas-toolbar.css");
 @import url("./editor/memory-form.css");
 @import url("./editor/detail-panel.css");

--- a/css/editor/canvas.css
+++ b/css/editor/canvas.css
@@ -89,3 +89,15 @@
     margin-top: 4px;
     min-width: 170px;
 }
+
+@media (max-width: 1024px) {
+    .editor-canvas-empty-guide {
+        top: calc(50% + 32px);
+    }
+}
+
+@media (max-width: 768px) {
+    .editor-canvas-empty-guide {
+        top: calc(50% + 40px);
+    }
+}

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260504-775">
+    <link rel="stylesheet" href="../css/editor.css?v=20260504-787">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Summary
- Adds compact Editor empty-state breathing room below the tree overview control.
- Keeps the containment behavior from PR #786 intact.
- Limits changes to Editor CSS and stylesheet cache keys.

Changed files
- css/editor/canvas.css
- css/editor.css
- pages/editor.html

Local checks
- git diff --check: PASS
- relevant Editor route/contract tests: PASS
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

Refs #787