### PR TITLE
fix(editor): center initial canvas viewport

### DIFF
--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -1,4 +1,61 @@
 window.LoveBudEditorCanvasViewport = {
+  readableCenter: {
+    x: 0.5,
+    y: 0.38
+  },
+
+  getViewportTargets(options) {
+    const { getTreeMemories, getCanonicalRootId, isRootMemory } = options;
+    const treeMemories = getTreeMemories();
+    if (!treeMemories.length) return [];
+
+    if (typeof getCanonicalRootId !== 'function' || typeof isRootMemory !== 'function') {
+      return treeMemories;
+    }
+
+    const canonicalRootId = getCanonicalRootId();
+    const visibleNodes = treeMemories.filter((memory) => !isRootMemory(memory, canonicalRootId));
+    if (visibleNodes.length) return visibleNodes;
+
+    const rootMemory = treeMemories.find((memory) => isRootMemory(memory, canonicalRootId));
+    return rootMemory ? [rootMemory] : [];
+  },
+
+  getReadableViewportOffset(options) {
+    const { getWorldPosition, getMetrics } = options;
+    const targets = this.getViewportTargets(options);
+    if (!targets.length) return null;
+
+    const points = targets.map((memory) => getWorldPosition(memory));
+    const minX = Math.min(...points.map((point) => point.x));
+    const maxX = Math.max(...points.map((point) => point.x));
+    const minY = Math.min(...points.map((point) => point.y));
+    const maxY = Math.max(...points.map((point) => point.y));
+    const metrics = getMetrics();
+
+    return {
+      offsetX: Math.round(metrics.width * this.readableCenter.x - ((minX + maxX) / 2)),
+      offsetY: Math.round(metrics.height * this.readableCenter.y - ((minY + maxY) / 2))
+    };
+  },
+
+  prepareInitialViewport(options) {
+    const { viewportState } = options;
+    if (viewportState.initialViewportApplied) return;
+
+    if (viewportState.hasStoredViewportOffset) {
+      viewportState.initialViewportApplied = true;
+      return;
+    }
+
+    const nextOffset = this.getReadableViewportOffset(options);
+    if (!nextOffset) return;
+
+    viewportState.offsetX = nextOffset.offsetX;
+    viewportState.offsetY = nextOffset.offsetY;
+    viewportState.initialViewportApplied = true;
+  },
+
   drawBranch(svg, startPos, endPos) {
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     const cp1x = startPos.x + (endPos.x - startPos.x) / 2;
@@ -28,7 +85,7 @@ window.LoveBudEditorCanvasViewport = {
   },
 
   recenterViewport(options) {
-    const { getTreeMemories, getWorldPosition, getMetrics, viewportState, initCanvas } = options;
+    const { getTreeMemories, viewportState, initCanvas } = options;
     const treeMemories = getTreeMemories();
     if (!treeMemories.length) {
       viewportState.offsetX = 0;
@@ -37,15 +94,11 @@ window.LoveBudEditorCanvasViewport = {
       return;
     }
 
-    const points = treeMemories.map((memory) => getWorldPosition(memory));
-    const minX = Math.min(...points.map((point) => point.x));
-    const maxX = Math.max(...points.map((point) => point.x));
-    const minY = Math.min(...points.map((point) => point.y));
-    const maxY = Math.max(...points.map((point) => point.y));
-    const metrics = getMetrics();
+    const nextOffset = this.getReadableViewportOffset(options);
+    if (!nextOffset) return;
 
-    viewportState.offsetX = Math.round(metrics.width * 0.5 - ((minX + maxX) / 2));
-    viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
+    viewportState.offsetX = nextOffset.offsetX;
+    viewportState.offsetY = nextOffset.offsetY;
     initCanvas();
   },
 

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -32,6 +32,7 @@ function createEditorCanvas(deps) {
         canvasLayout
     });
     const viewportState = canvasState.createViewportState();
+    viewportState.hasStoredViewportOffset = hasStoredViewportOffset();
 
     const ROOT_RIGHT_GUTTER = 300;
     const ROOT_BOTTOM_GUTTER = 180;
@@ -44,6 +45,18 @@ function createEditorCanvas(deps) {
 
     function persistStoredPositions() {
         canvasState.persistStoredPositions(viewportState);
+    }
+
+    function hasStoredViewportOffset() {
+        try {
+            const raw = localStorage.getItem(layoutStorageKey);
+            if (!raw || raw === 'null') return false;
+            const parsed = JSON.parse(raw);
+            return !!parsed && typeof parsed === 'object'
+                && (typeof parsed.offsetX === 'number' || typeof parsed.offsetY === 'number');
+        } catch (error) {
+            return false;
+        }
     }
 
     function getMetrics() {
@@ -335,6 +348,16 @@ function createEditorCanvas(deps) {
         const rootMemory = treeMemories.find((node) => isRootMemory(node, canonicalRootId)) || null;
         const shouldRenderRootNode = drawableMemories.length === 0 && !!rootMemory;
         const hasVisibleNodes = drawableMemories.length > 0 || shouldRenderRootNode;
+        if (hasVisibleNodes && typeof canvasViewport.prepareInitialViewport === 'function') {
+            canvasViewport.prepareInitialViewport({
+                getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
+                getWorldPosition,
+                getMetrics,
+                viewportState
+            });
+        }
         canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
 
         canvas.querySelectorAll('.memory-node').forEach((node) => node.remove());
@@ -382,6 +405,8 @@ function createEditorCanvas(deps) {
             canvasViewport.focusNodeById({
                 nodeId,
                 getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
                 getWorldPosition,
                 getMetrics,
                 viewportState,

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -246,11 +246,11 @@
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
-    <script src="../js/editor/editor-canvas-viewport.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-viewport.js?v=20260504-651"></script>
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-canvas.js?v=20260421-5"></script>
+    <script src="../js/editor/editor-canvas.js?v=20260504-651"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-628"></script>


### PR DESCRIPTION
Summary
- Centers the first readable Editor canvas viewport when no saved viewport offset exists.
- Updates the full-tree control to use the same visible-node bounds.
- Keeps root-only trees readable while populated trees are measured from rendered non-root nodes.

Changed files
- js/editor/editor-canvas-viewport.js
- js/editor/editor-canvas.js
- pages/editor.html

Scope review
- Editor canvas viewport behavior only.
- No Auth/API/backend/DB/package/workflow changes.
- No My Trees/Browse/Search/Detail route behavior changes.
- Existing Editor containment and spacing behavior remains in place.

Local checks
- git diff --check: PASS
- node --check js/editor/editor-canvas-viewport.js: PASS
- node --check js/editor/editor-canvas.js: PASS
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

Guardrails
- Browser verification deferred.
- Test slot deployment deferred.
- No secret/private payload exposure.
- No production deploy.

NOT_VERIFIED
- Desktop and mobile runtime viewport evidence.
- Test slot deployed SHA match.

Refs #651