### PR TITLE
fix(editor): clarify moment count and current identity

### DIFF
--- a/js/editor/editor-detail-sidebar-status-boundary.js
+++ b/js/editor/editor-detail-sidebar-status-boundary.js
@@ -9,6 +9,22 @@
             getTreeState
         } = deps;
 
+        const formatCountLabel = (treeState) => {
+            const total = treeState.totalMomentCount;
+            const visible = treeState.visibleMomentCount;
+            if (!treeState.hasMoments) {
+                return formatI18nText('sidebar_moment_count_empty_short', '첫 순간 준비 중');
+            }
+            if (total !== visible) {
+                return formatI18nText(
+                    'sidebar_moment_count_with_visible_short',
+                    '총 {total}개의 저장된 순간 · 캔버스 {visible}개 표시',
+                    { total, visible }
+                );
+            }
+            return formatI18nText('sidebar_moment_count_short', '총 {count}개의 저장된 순간', { count: total });
+        };
+
         const updateSidebarStatus = () => {
             const treeTitleEl = document.getElementById('sidebarTreeTitle');
             const visibilityEl = document.getElementById('sidebarTreeVisibility');
@@ -18,7 +34,6 @@
             const currentTreeData = getCurrentTreeData();
             const selectedNodeId = getSelectedNodeId();
             const treeState = getTreeState();
-            const count = treeState.visibleMomentCount;
             const selected = treeState.treeMemories.find(m => m.id === selectedNodeId);
             const visibility = currentTreeData?.visibility || 'public';
             const isPublic = visibility === 'public';
@@ -34,21 +49,19 @@
                 visibilityEl.classList.toggle('is-private', !isPublic);
             }
             if (momentCountEl) {
-                momentCountEl.textContent = treeState.hasVisibleMoments
-                    ? formatI18nText('sidebar_moment_count_short', `총 ${count}개의 순간`, { count })
-                    : formatI18nText('sidebar_moment_count_empty_short', '첫 순간 준비 중');
+                momentCountEl.textContent = formatCountLabel(treeState);
             }
             if (flowSummaryEl) {
                 flowSummaryEl.textContent = selected?.title
-                    ? formatI18nText('sidebar_flow_summary_selected_short', `지금은 "{title}"에 마음이 머물러 있어요.`, { title: selected.title })
-                    : treeState.hasVisibleMoments
-                        ? formatI18nText('sidebar_flow_summary_connected_short', `이 트리에 {count}개의 순간이 이어져 있어요.`, { count })
+                    ? formatI18nText('sidebar_flow_summary_selected_short', '지금은 "{title}" 순간을 보고 있어요', { title: selected.title })
+                    : treeState.hasMoments
+                        ? formatI18nText('sidebar_flow_summary_connected_short', '이 트리에 {count}개의 순간이 저장되어 있어요', { count: treeState.totalMomentCount })
                         : formatI18nText('sidebar_flow_summary_empty_short', '첫 순간을 심으면 감정의 흐름이 여기서 시작됩니다.');
             }
             if (hintEl) {
                 hintEl.textContent = selected?.title
-                    ? formatI18nText('sidebar_canvas_hint_selected', '빈 공간을 드래그해 이동하고, “트리 한눈에 보기”로 전체 흐름을 다시 볼 수 있어요.')
-                    : formatI18nText('sidebar_canvas_hint_empty', '트리가 화면 밖으로 밀리면 “트리 한눈에 보기”로 다시 가운데에 맞출 수 있어요.');
+                    ? formatI18nText('sidebar_canvas_hint_selected', '선택한 순간을 중심으로 트리를 둘러보세요.')
+                    : formatI18nText('sidebar_canvas_hint_empty', '첫 순간을 심으면 감정이 여기서 시작돼요.');
                 hintEl.style.fontStyle = 'normal';
                 hintEl.style.color = 'var(--on-surface-variant)';
             }
@@ -65,13 +78,13 @@
             }
             if (addMemoryEyebrow) {
                 addMemoryEyebrow.textContent = isEmptyTree
-                    ? formatI18nText('editor_add_first_memory_eyebrow', '첫 순간 심기')
+                    ? formatI18nText('editor_add_first_memory_eyebrow', '첫 순간에서')
                     : i18n('editor_add_memory_eyebrow');
             }
             if (addMemoryIntro) {
                 addMemoryIntro.textContent = isEmptyTree
-                    ? formatI18nText('editor_empty_tree_hint_short', '이 트리의 첫 장면을 남기면 가운데 캔버스에 감정의 흐름이 열립니다.')
-                    : formatI18nText('editor_next_memory_hint_short', '지금 머문 장면 다음에 새로운 순간을 이어 심어 보세요.');
+                    ? formatI18nText('editor_empty_tree_hint_short', '첫 순간이 여기서 시작돼요.')
+                    : formatI18nText('editor_next_memory_hint_short', '다음 순간을 이어가 보세요.');
             }
         };
 

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -39,7 +39,9 @@
 
     var momentCountEl = document.getElementById('sidebarMomentCount');
     if (momentCountEl) {
-      momentCountEl.textContent = tText('sidebar_moment_count', '순간 {count}개가 이어지고 있어요').replace('{count}', String(count));
+      momentCountEl.textContent = count === 0
+        ? tText('sidebar_moment_count_empty_short', '첫 순간 준비 중')
+        : tText('sidebar_moment_count_short', '총 {count}개의 순간', '{count}').replace('{count}', String(count));
     }
 
     var flowSummaryEl = document.getElementById('sidebarFlowSummary');

--- a/js/i18n/i18n-editor.js
+++ b/js/i18n/i18n-editor.js
@@ -113,3 +113,10 @@ Object.assign(window.i18nEditor, {
     editor_add_first_memory_eyebrow: { ko: '첫 순간에서', en: 'From first moment' },
     editor_empty_tree_hint_short: { ko: '첫 순간이 여기에 시작돼요.', en: 'The first moment starts here.' }
 });
+Object.assign(window.i18nEditor, {
+    start_moment: { ko: '현재 선택 · 시작 순간', en: 'Current selection · starting moment' },
+    selected_moment: { ko: '현재 선택한 순간', en: 'Current selected moment' },
+    sidebar_moment_count_short: { ko: '총 {count}개의 저장된 순간', en: '{count} saved moments total' },
+    sidebar_moment_count_with_visible_short: { ko: '총 {total}개의 저장된 순간 · 캔버스 {visible}개 표시', en: '{total} saved moments · {visible} shown on canvas' },
+    sidebar_flow_summary_connected_short: { ko: '이 트리에 {count}개의 순간이 저장되어 있어요', en: '{count} moments are saved in this tree' }
+});

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -254,7 +254,7 @@
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
-    <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260504-628"></script>
@@ -284,7 +284,7 @@
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
-    <script src="../js/i18n/i18n-editor.js?v=20260423-1"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260504-772"></script>
     <script>
         window.i18nEditor = Object.assign(window.i18nEditor || {}, {
             editor_sidebar_public_tree: { ko: '공개', en: 'Public' },


### PR DESCRIPTION
Summary
- Clarifies how the Editor sidebar reports saved moment count versus canvas-visible moments.
- Clarifies the current moment badge copy so root and selected moments read as the active selection.
- Keeps the change in the Editor display layer.

Investigation findings
- My Trees card count is derived from the full memories array length or the tree memoryCount fields.
- Editor canvas renders non-root memories when they exist; root-only trees render the root/start memory.
- Editor detail state already tracks both total saved memories and canvas-visible memories.
- The confusing part was display copy: the sidebar used the canvas-visible count while reading like a total, and the current moment badge did not explicitly say it was the active selection.

Changed files
- js/editor/editor-detail-sidebar-status-boundary.js
- js/i18n/i18n-editor.js
- pages/editor.html

Scope review
- Editor UI/data display only.
- No My Trees count calculation changes.
- No Editor canvas layout or mobile viewport changes.
- No memory save/delete/persistence changes.
- No Auth/API/backend/DB/package/workflow changes.

What changed
- Sidebar moment count now says total saved moments.
- When total saved and canvas-visible counts differ, the sidebar shows both values.
- Current moment badge copy now distinguishes the current selection and the starting moment.
- Editor script cache keys were updated for the changed files.

What did not change
- My Trees card data source and count calculation.
- Editor memory filtering, loading, save, delete, and memo persistence behavior.
- Browse/Search/Detail routes.

Local checks
- git diff --check: PASS
- node --check js/editor/editor-detail-sidebar-status-boundary.js: PASS
- node --check js/i18n/i18n-editor.js: PASS
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

NOT_VERIFIED
- My Trees count compared with Editor sidebar count in a logged-in browser.
- Current/root/selected moment badge rendering in runtime.
- New moment creation selection state in runtime.
- Desktop populated tree runtime evidence.
- Mobile runtime evidence, separate from the mobile viewport follow-up.
- Fatal console/page/network errors.

Refs #772