### PR TITLE
fix(editor): improve moment edit form spacing

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -14,7 +14,7 @@
 @import url("./editor/canvas.css?v=20260504-787");
 @import url("./editor/canvas-toolbar.css");
 @import url("./editor/memory-form.css");
-@import url("./editor/detail-panel.css");
+@import url("./editor/detail-panel.css?v=20260504-636");
 @import url("./editor/responsive.css");
 @import url("./editor/mode-selection.css");
 @import url("./editor/status-settings.css");

--- a/css/editor/detail-panel.css
+++ b/css/editor/detail-panel.css
@@ -184,6 +184,35 @@
     background: rgba(158,81,88,0.08);
 }
 
+#detailEditMode .detail-info-group {
+    margin: 0;
+}
+
+#detailEditMode .detail-info-group + .detail-info-group {
+    margin-top: 18px;
+}
+
+#detailEditMode .detail-info-group:nth-of-type(3) {
+    margin-top: 20px;
+}
+
+.editor-edit-actions-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 24px;
+    padding-top: 18px;
+    border-top: 1px solid rgba(144,73,81,0.10);
+}
+
+.editor-edit-actions-row .editor-edit-action-btn,
+.editor-edit-actions-row .editor-edit-danger-action {
+    min-height: 42px;
+    padding-inline: 16px;
+}
+
 .editor-memory-delete-btn {
     color: #a87b80;
     border-color: rgba(158,81,88,0.08);
@@ -421,5 +450,28 @@
         min-height: 30px;
         padding: 0 10px;
         font-size: 10.5px;
+    }
+
+    .editor-edit-actions-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+        margin-top: 22px;
+        padding-top: 16px;
+    }
+
+    .editor-edit-actions-row .editor-edit-action-btn,
+    .editor-edit-actions-row .editor-edit-danger-action {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .editor-edit-actions-row .editor-edit-action-btn {
+        order: 1;
+    }
+
+    .editor-edit-actions-row .editor-edit-danger-action {
+        order: 2;
+        margin: 8px 0 0;
     }
 }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260504-787">
+    <link rel="stylesheet" href="../css/editor.css?v=20260504-636">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Summary
- Improves vertical rhythm in the Editor moment edit form.
- Separates the destructive moment delete action from normal cancel/save actions visually.
- Keeps behavior and handlers unchanged.

Changed files
- css/editor/detail-panel.css
- css/editor.css
- pages/editor.html

Scope review
- Editor moment edit form spacing only.
- CSS-only behavior change; HTML only updates the stylesheet cache key.
- No save, cancel, or delete handler changes.
- No moment persistence, delete semantics, Auth/API/backend/DB/package/workflow changes.
- No Browse/Search/My Trees/Detail route changes.

What changed
- Added consistent spacing between edit title, memo, and tag field groups.
- Added breathing room and a subtle divider above the edit action row.
- Kept delete visually separated from cancel/save on desktop by using the existing destructive button class.
- On narrow mobile widths, action buttons stack full-width and the destructive action is separated below the normal actions.
- Updated CSS cache keys for the changed stylesheet.

What did not change
- Button labels and copy.
- Delete, cancel, and save click handlers.
- Editor memory save/delete data behavior.
- Source URL editing or unrelated Editor issues.

Local checks
- git diff --check: PASS
- node --check changed JS: NOT_RUN, no JS changed
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

NOT_VERIFIED
- Desktop moment edit form screenshot review.
- Mobile 375px moment edit form screenshot review.
- Runtime spacing between title, memo, tag, and action rows.
- Runtime destructive action hierarchy.
- Fatal console/page/network errors.

Refs #636