### PR TITLE
fix(editor): move memo edit action to memo heading

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -14,7 +14,7 @@
 @import url("./editor/canvas.css?v=20260504-787");
 @import url("./editor/canvas-toolbar.css");
 @import url("./editor/memory-form.css");
-@import url("./editor/detail-panel.css?v=20260504-636");
+@import url("./editor/detail-panel.css?v=20260504-627");
 @import url("./editor/responsive.css");
 @import url("./editor/mode-selection.css");
 @import url("./editor/status-settings.css");

--- a/css/editor/detail-panel.css
+++ b/css/editor/detail-panel.css
@@ -245,6 +245,45 @@
     display: block;
 }
 
+.editor-memo-heading-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 7px;
+}
+
+.editor-memo-heading-row #detailMemoLabel {
+    margin-bottom: 0;
+}
+
+.editor-memo-heading-action-slot {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+}
+
+.editor-memo-heading-edit-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    min-height: 30px;
+    margin-left: 0;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(144,73,81,0.12);
+    background: rgba(255,255,255,0.72);
+    color: var(--primary);
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.editor-memo-heading-edit-button:hover {
+    background: rgba(144,73,81,0.08);
+}
+
 .detail-info-group p {
     font-size: 15px;
     font-weight: 700;
@@ -473,5 +512,15 @@
     .editor-edit-actions-row .editor-edit-danger-action {
         order: 2;
         margin: 8px 0 0;
+    }
+
+    .editor-memo-heading-row {
+        align-items: flex-start;
+    }
+
+    .editor-memo-heading-edit-button {
+        min-height: 28px;
+        padding: 4px 8px;
+        font-size: 10.5px;
     }
 }

--- a/js/editor/editor-detail-inline-edit.js
+++ b/js/editor/editor-detail-inline-edit.js
@@ -95,8 +95,9 @@ function createEditorDetailInlineEditBoundary(deps) {
     // ── Memo edit boundary helper ────────────────────────────────────────────
     // Responsible: encapsulate inline memo edit textarea, buttons, and state binding.
     // Does not affect title edit or current memory actions.
-    const createMemoEditBoundary = (memoContainer, data, { updateSelectedMemoryFields, showToast, formatI18nText, getMemoFallbackText, isEmptyState }) => {
+    const createMemoEditBoundary = (memoContainer, data, { updateSelectedMemoryFields, showToast, formatI18nText, getMemoFallbackText, isEmptyState, editButtonMount }) => {
         memoContainer.innerHTML = '';
+        if (editButtonMount) editButtonMount.innerHTML = '';
 
         const memoBody = document.createElement('div');
         memoBody.style.lineHeight = '1.8';
@@ -111,13 +112,12 @@ function createEditorDetailInlineEditBoundary(deps) {
         if (isEmptyState || typeof updateSelectedMemoryFields !== 'function') return;
 
         const editBtn = document.createElement('button');
-        editBtn.className = 'memory-edit-button';
-        editBtn.style.marginTop = '10px';
-        editBtn.style.marginLeft = '0';
+        editBtn.className = 'memory-edit-button editor-memo-heading-edit-button';
         editBtn.innerHTML = '<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:2px;">edit</span>' + formatI18nText('editMemoryNote', '메모 수정');
 
         editBtn.onclick = () => {
             memoContainer.innerHTML = '';
+            if (editButtonMount) editButtonMount.innerHTML = '';
 
             const textarea = document.createElement('textarea');
             textarea.className = 'memory-edit-textarea';
@@ -183,7 +183,7 @@ function createEditorDetailInlineEditBoundary(deps) {
             });
         };
 
-        memoContainer.appendChild(editBtn);
+        (editButtonMount || memoContainer).appendChild(editBtn);
     };
 
     return {

--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -231,6 +231,37 @@ function createEditorDetailUI(deps) {
     });
     const { updateSidebarStatus } = sidebarStatusBoundary;
 
+    const prepareMemoHeadingActionSlot = () => {
+        const memoLabel = document.getElementById('detailMemoLabel');
+        if (!memoLabel) return null;
+
+        const memoGroup = memoLabel.closest('.detail-info-group');
+        if (!memoGroup) return null;
+
+        memoGroup.classList.add('editor-memo-section-group');
+
+        let headingRow = memoGroup.querySelector('.editor-memo-heading-row');
+        if (!headingRow) {
+            headingRow = document.createElement('div');
+            headingRow.className = 'editor-memo-heading-row';
+            memoGroup.insertBefore(headingRow, memoLabel);
+        }
+
+        if (memoLabel.parentElement !== headingRow) {
+            headingRow.insertBefore(memoLabel, headingRow.firstChild);
+        }
+
+        let actionSlot = headingRow.querySelector('.editor-memo-heading-action-slot');
+        if (!actionSlot) {
+            actionSlot = document.createElement('div');
+            actionSlot.className = 'editor-memo-heading-action-slot';
+            headingRow.appendChild(actionSlot);
+        }
+
+        actionSlot.innerHTML = '';
+        return actionSlot;
+    };
+
      const updateDetailPanel = (data) => {
          const currentTree = getCurrentTreeData() || {};
          const treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
@@ -253,6 +284,7 @@ function createEditorDetailUI(deps) {
          const dateEl = document.getElementById('detailDateText');
          const tagsContainer = detailPanel.querySelector('.tags-container');
          const noteEl = document.querySelector('.diary-note');
+         const memoEditButtonMount = prepareMemoHeadingActionSlot();
          const memoryActions = detailPanel.querySelector('.memory-actions');
 
          const treeMetaModel = buildTreeMetaRenderModel({
@@ -356,7 +388,8 @@ function createEditorDetailUI(deps) {
                 showToast,
                 formatI18nText,
                 getMemoFallbackText,
-                isEmptyState
+                isEmptyState,
+                editButtonMount: memoEditButtonMount
             });
 
             noteEl.appendChild(memoContainer);

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260504-636">
+    <link rel="stylesheet" href="../css/editor.css?v=20260504-627">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -253,10 +253,10 @@
     <script src="../js/editor/editor-canvas.js?v=20260504-651"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-628"></script>
+    <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
     <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-detail-ui.js?v=20260422-2"></script>
+    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260504-628"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260422-3"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>


### PR DESCRIPTION
Summary
- Move the Editor emotion memo edit action into the memo section heading row.
- Keep the memo body focused on memo content, empty-state copy, or the active edit form.

Changed files
- css/editor.css
- css/editor/detail-panel.css
- js/editor/editor-detail-inline-edit.js
- js/editor/editor-detail-ui.js
- pages/editor.html

Scope review
- Editor memo section renderer/CSS only.
- No memo persistence, save, cancel, or delete behavior changes.
- No Auth/API/backend/DB/package/workflow changes.
- No Browse/Search/My Trees/Detail unrelated changes.

What changed
- Added a memo heading action slot beside detailMemoLabel.
- Reused the existing memo edit button and handler, mounting it in the heading slot.
- Added compact heading-row styling and mobile-width sizing.
- Bumped Editor CSS/JS cache keys for changed assets.

What did not change
- Memo edit open/close/save behavior.
- Current moment edit placement.
- Title edit placement.
- Delete/cancel/save handlers.
- Data model, API, auth, ownership, or persistence boundaries.

Local checks
- git diff --check: PASS
- node --check js/editor/editor-detail-inline-edit.js: PASS
- node --check js/editor/editor-detail-ui.js: PASS
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

Browser verification required: YES
Test slot deployment required: YES

NOT_VERIFIED
- Desktop memo display placement in real authenticated Editor runtime.
- Mobile 375px memo heading readability and horizontal overflow.
- Memo edit form open/close/save smoke in browser.

Refs #627