### PR TITLE
docs(project): define agent operation guardrails

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -37,10 +37,11 @@
 2. `./doc_index.md`
 3. `./ops/PARALLEL_WORKTREE_AGENT_POLICY.md`
 4. `./ops/AGENT_STARTUP_VERIFICATION_RULES.md`
-5. `./product/PRODUCT_IDENTITY.md`
-6. `./product/BRAND_EXPERIENCE.md`
-7. `./design/UI_DESIGN_SYSTEM.md`
-8. 요청 범위에 맞는 문서군 인덱스
+5. `./project/AGENT_OPERATION_GUARDRAILS.md`
+6. `./product/PRODUCT_IDENTITY.md`
+7. `./product/BRAND_EXPERIENCE.md`
+8. `./design/UI_DESIGN_SYSTEM.md`
+9. 요청 범위에 맞는 문서군 인덱스
 
 Visibility, private storage, anonymous public exposure, Browse/Search eligibility 판단이 필요하면 아래를 추가로 읽습니다.
 
@@ -197,6 +198,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [PROJECT_OPERATING_MODEL.md](./project/PROJECT_OPERATING_MODEL.md) - 역할, 책임, 승인권, 세션 시작 프로토콜
 - [BRANCHING_AND_REVIEW.md](./project/BRANCHING_AND_REVIEW.md) - main 우선 확인, 브랜치 작업, 리뷰/검증/완료 보고 원칙
 - [LOCAL_MODEL_WORKFLOW.md](./project/LOCAL_MODEL_WORKFLOW.md) - 로컬 실행 모델 작업 기준
+- [AGENT_OPERATION_GUARDRAILS.md](./project/AGENT_OPERATION_GUARDRAILS.md) - 파일 inspection과 secret 노출의 경계, fixed-slot browser verification, test account handling, 병렬 프롬프트 중복 방지, 범위 밖 입력 확인, implementation handoff 기준
 - [TASK_STATUS.md](./project/TASK_STATUS.md) - 작업 상태 추적 문서
 - [VERIFICATION_AND_EVIDENCE.md](./project/VERIFICATION_AND_EVIDENCE.md) - 검증 및 증빙 기준
 - [VERIFICATION_WARNING_CATALOG.md](./project/VERIFICATION_WARNING_CATALOG.md) - UI/production/test preview 검증 warning과 blocker 분류 기준

--- a/docs/project/AGENT_OPERATION_GUARDRAILS.md
+++ b/docs/project/AGENT_OPERATION_GUARDRAILS.md
@@ -1,0 +1,166 @@
+# Agent Operation Guardrails
+
+This document defines operational guidance for LoveBud agents when a broad `AGENTS.md` rule can be misread as a reason to avoid required work.
+
+`AGENTS.md` should remain the entrypoint and index. Detailed behavior rules should live in focused project/ops/engineering documents like this one.
+
+## Purpose
+
+Agents must be safe, but safety must not block legitimate repository inspection, implementation, and browser verification.
+
+The intended model is:
+
+- inspect the files needed for the authorized task;
+- do not print, paste, commit, screenshot, or summarize restricted values;
+- report only redacted status labels;
+- stop only when actual exposure or out-of-scope risk occurs.
+
+## File inspection versus secret exposure
+
+Security rules must not be interpreted as "do not open files".
+
+Allowed:
+
+- Reading repository files needed for the task.
+- Reading local configuration files when required to understand file structure, key names, expected environment variables, or tool configuration.
+- Checking whether required files exist.
+- Checking whether required key names are present.
+- Loading approved local secret files into a process environment for authorized commands.
+- Using secrets through approved tools such as `gh`, `wrangler`, Firebase tooling, npm scripts, Playwright, or local test runners.
+- Reporting redacted statuses only, for example:
+  - `FILE_READ: YES`
+  - `SECRET_FILE_EXISTS: YES`
+  - `REQUIRED_KEYS_PRESENT: YES`
+  - `TOKEN_VALUE_PRINTED: NO`
+
+Forbidden:
+
+- Printing raw secret values.
+- Printing partial secret values, prefixes, suffixes, or last characters.
+- Printing session, cookie, authorization header, private key, credential, database URL, or private identifier values.
+- Copying secret values into chat, logs, PR comments, issue comments, screenshots, docs, or commits.
+- Running commands whose purpose is to dump all environment variables or secret file contents to visible output.
+- Committing secret files or generated files that contain secret values.
+
+Clarification:
+
+- An agent may inspect files and commands to do the work.
+- The forbidden action is exposing restricted values, not reading ordinary source files or configuration structure.
+- If a file contains secrets, the agent should avoid displaying the value and report only presence/status.
+- If a secret is accidentally displayed, stop and report `SECURITY_INCIDENT_SECRET_EXPOSURE` without repeating the value.
+
+## Browser verification and fixed test slots
+
+Runtime-sensitive UI work must use the current fixed-slot verification policy.
+
+This applies especially to:
+
+- Browse / Search
+- Editor
+- My Trees
+- Auth / Login
+- `/api/*` dependent pages
+- Cloudflare Pages Functions dependent pages
+- Modal-dependent flows
+- Firebase session dependent flows
+
+Required before final browser PASS:
+
+1. Deploy the exact PR head SHA or current-main target SHA to a fixed test slot.
+2. Confirm the slot URL.
+3. Confirm deployed SHA prefix match.
+4. Use a login-capable browser path when the page requires auth/session state.
+5. Report PASS / FAIL / NOT_VERIFIED / BLOCKED separately.
+6. Do not treat production or localhost-only verification as final pre-merge proof for these flows.
+
+## Test account handling
+
+For browser verification that requires login, agents should use the latest approved test account source.
+
+Rules:
+
+- Use the current approved QA/test credential source before assuming auth is blocked.
+- Do not print credential values.
+- Report only `APPROVED_QA_CREDENTIAL_SOURCE_USED: YES/NO`.
+- If the approved test account no longer works, attempt the approved signup or test-account refresh path if that is in scope.
+- If a new test account is created, record it only in the approved local test-account file or approved secret store.
+- Never commit test credential values.
+- Never write test credential values into PR comments, issue comments, docs, screenshots, logs, or chat.
+- Report only redacted state:
+  - `TEST_ACCOUNT_LOGIN: PASS`
+  - `TEST_ACCOUNT_LOGIN: FAIL`
+  - `TEST_ACCOUNT_REFRESHED: YES`
+  - `TEST_ACCOUNT_FILE_UPDATED: YES`
+
+If the test account file path is provided, agents may use that file locally. They must not print its contents.
+
+## Parallel model and prompt hygiene
+
+LoveBud often uses multiple models or executors in parallel. Agents must avoid duplicate or conflicting prompts.
+
+Rules:
+
+- Before issuing a new executor prompt, check whether the same PR/issue already has an active prompt or recent report.
+- Do not send two different agents the same implementation task unless the user explicitly asks for parallel execution.
+- Do not give a verification executor a coding prompt.
+- Do not give a coding executor a merge/finalization prompt.
+- If another executor is already working on the same PR/issue, report that status instead of generating another overlapping prompt.
+- If parallel work is intentional, split by non-overlapping files, surfaces, or responsibilities.
+
+Recommended report labels:
+
+- `NO_ACTIVE_DUPLICATE_PROMPT_FOUND`
+- `ACTIVE_EXECUTOR_ALREADY_ASSIGNED`
+- `PROMPT_WITHHELD_DUPLICATE_RISK`
+- `PARALLEL_SAFE_SPLIT_DEFINED`
+
+## Out-of-scope user input handling
+
+When the user provides content that does not match the active PR/issue/task, do not silently switch scope.
+
+Rules:
+
+- If the active task is PR-specific and the user provides unrelated work, ask once for confirmation before changing task.
+- If the user clearly says "next", "switch", "do this instead", or gives an explicit new target, proceed with the new target after recording the switch.
+- If the pasted report appears to belong to a different PR/issue than the active one, call out the mismatch and ask whether to treat it as a task switch.
+- Do not merge, close, ready, deploy, or create PRs for a different scope without explicit confirmation.
+
+Standard confirmation:
+
+> This appears to be about PR/Issue X, while the active task is PR/Issue Y. Should I switch scope to X?
+
+## Implementation handoff guidance
+
+For coding tasks, the lead/CTO agent should provide enough implementation shape that a lower-capability local executor can implement safely.
+
+Include when useful:
+
+- target files;
+- files not to touch;
+- existing DOM IDs/classes/functions/event handlers to preserve;
+- expected DOM structure or expected implementation shape;
+- pseudo diff or patch draft;
+- required cache-key or script-order changes;
+- verification commands;
+- fixed-slot/browser verification requirement;
+- explicit non-goals and stop conditions.
+
+Do not use a pseudo diff as permission for broad rewrites. The implementation executor must still inspect the latest current file state and apply the smallest safe change.
+
+Standard handoff language:
+
+> Provide an expected implementation shape before coding. Reuse existing IDs, handlers, and DOM contracts whenever possible. Do not create parallel controls or duplicate event paths unless explicitly required. Treat pseudo diff as guidance, not as permission for broad rewrites.
+
+## Completion standard
+
+A task is not complete merely because a local command passed.
+
+Completion reports must separate:
+
+- code changed versus already present on main;
+- local checks versus browser/fixed-slot checks;
+- verified versus not verified;
+- implementation done versus merge candidate;
+- merge done versus issue closure disposition.
+
+For runtime-sensitive work, final PASS requires the required fixed-slot/SHA-match evidence unless a user or CTO explicitly downgrades the task to static-only review.

--- a/docs/project/project_index.md
+++ b/docs/project/project_index.md
@@ -10,6 +10,7 @@
 - 3TF 구조, TF별 보고선, project 운영 문서 진입 경로
 - 상태 추적 문서 위치
 - 검증 warning / blocker 분류 기준
+- 에이전트 운영 가드레일과 구현 handoff 기준
 
 장문 정책 본문은 이 인덱스에 두지 않습니다. 상세 기준은 아래 하위 문서로 이동합니다.
 
@@ -19,9 +20,10 @@
 2. [PROJECT_OPERATING_MODEL.md](./PROJECT_OPERATING_MODEL.md)
 3. [BRANCHING_AND_REVIEW.md](./BRANCHING_AND_REVIEW.md)
 4. [LOCAL_MODEL_WORKFLOW.md](./LOCAL_MODEL_WORKFLOW.md)
-5. [TASK_STATUS.md](./TASK_STATUS.md)
-6. [VERIFICATION_AND_EVIDENCE.md](./VERIFICATION_AND_EVIDENCE.md)
-7. [VERIFICATION_WARNING_CATALOG.md](./VERIFICATION_WARNING_CATALOG.md)
+5. [AGENT_OPERATION_GUARDRAILS.md](./AGENT_OPERATION_GUARDRAILS.md)
+6. [TASK_STATUS.md](./TASK_STATUS.md)
+7. [VERIFICATION_AND_EVIDENCE.md](./VERIFICATION_AND_EVIDENCE.md)
+8. [VERIFICATION_WARNING_CATALOG.md](./VERIFICATION_WARNING_CATALOG.md)
 
 ## 하위 문서 안내
 
@@ -36,6 +38,9 @@
 
 - [LOCAL_MODEL_WORKFLOW.md](./LOCAL_MODEL_WORKFLOW.md)  
   프로젝트 공통 로컬 실행 규칙과 로컬 실행 모델이 따라야 할 작업 기준을 정리합니다.
+
+- [AGENT_OPERATION_GUARDRAILS.md](./AGENT_OPERATION_GUARDRAILS.md)  
+  파일 inspection과 secret 노출의 경계, fixed-slot browser verification, test account handling, 병렬 프롬프트 중복 방지, 범위 밖 입력 확인, implementation handoff 기준을 정리합니다.
 
 - [TASK_STATUS.md](./TASK_STATUS.md)  
   작업 상태를 추적하기 위한 상태 필드, 템플릿, 항목 관리 기준을 제공합니다.


### PR DESCRIPTION
## Summary

- Adds `docs/project/AGENT_OPERATION_GUARDRAILS.md` as a focused policy document for agent operation edge cases.
- Clarifies that agents may inspect files needed for work; the restriction is exposing restricted values, not reading files.
- Documents fixed-slot browser verification, test account handling, parallel prompt hygiene, out-of-scope input confirmation, and implementation handoff guidance.
- Registers the new document in `docs/project/project_index.md` and `docs/doc_index.md`.

## Scope

Changed files:
- `docs/project/AGENT_OPERATION_GUARDRAILS.md`
- `docs/project/project_index.md`
- `docs/doc_index.md`

Docs-only change. No runtime code, UI, Auth, API, backend, DB, package, workflow, PR #7, prototype/reference/demo/variant changes.

## Key policy clarifications

- Agents should inspect files required for authorized tasks, including configuration structure, while never printing or committing secret values.
- Browser verification for Browse/Search/Editor/My Trees/Auth/API-dependent flows must use fixed test slots with deployed SHA match when required.
- Agents should use the latest approved QA/test credential source and may refresh test accounts through approved local storage without exposing credential values.
- Parallel model prompts should avoid duplicate overlapping assignments.
- If user-provided content appears to belong to a different active PR/issue, the agent should ask once before switching scope.
- Coding handoffs should include expected implementation shape, preserved IDs/handlers, pseudo diff when useful, and stop conditions.

## Verification

- GitHub API write completed for docs-only files.
- Secret/private values included: NO
- Runtime/browser verification required: NO

No issue reference.
No issue close keyword.