### PR TITLE
copy(editor): clarify current moment detail CTA

### DIFF
--- a/js/i18n/i18n-editor.js
+++ b/js/i18n/i18n-editor.js
@@ -77,7 +77,7 @@ Object.assign(window.i18nEditor, {
     editor_visibility_loading_private: { ko: '비공개로 전환하는 중...', en: 'Switching to private...' },
     editor_visibility_loading_public: { ko: '공개로 전환하는 중...', en: 'Switching to public...' },
     editor_visibility_guard_failed: { ko: '공개 순간이 3개 이상일 때만 이 트리를 공개할 수 있어요.', en: 'This tree can be made public only when it has at least 3 public moments.' },
-    editor_open_detail: { ko: '상세로 보기', en: 'View details' },
+    editor_open_detail: { ko: '현재 순간 감상하기', en: 'View current moment' },
     editor_focus_current_moment: { ko: '현재 순간 위치 보기', en: 'Locate current moment' },
     editor_visibility_updated_private: { ko: '이 트리를 비공개로 전환했어요.', en: 'This tree has been set to private.' },
     editor_visibility_updated_public: { ko: '이 트리를 공개로 전환했어요.', en: 'This tree has been set to public.' },

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -140,7 +140,7 @@
         <aside class="detail-panel memory-detail-section reveal-fade" id="detailPanel">
             <div class="panel-header">
                 <h3 class="headline editor-panel-headline"></h3>
-                <button type="button" class="icon-menu-btn editor-hidden-initial editor-detail-more-btn" aria-label="상세로 보기" id="detailMoreBtn">상세로 보기</button>
+                <button type="button" class="icon-menu-btn editor-hidden-initial editor-detail-more-btn" aria-label="현재 순간 감상하기" id="detailMoreBtn">현재 순간 감상하기</button>
             </div>
 
             <div class="detail-content" id="detailContent">
@@ -284,7 +284,7 @@
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
-    <script src="../js/i18n/i18n-editor.js?v=20260504-772"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
     <script>
         window.i18nEditor = Object.assign(window.i18nEditor || {}, {
             editor_sidebar_public_tree: { ko: '공개', en: 'Public' },


### PR DESCRIPTION
## Summary

Update the current-moment panel "상세로 보기" CTA to match its actual destination – the dedicated detail page for the selected moment.

- Korean label: "현재 순간 감상하기"
- English label: "View current moment"

**Target:** Issue #633
**Base:** latest main

## Changed files

| File | Change |
|------|--------|
| `pages/editor.html` | `#detailMoreBtn` visible text & `aria-label` updated; i18n-editor.js cache key bumped (`20260504-772` → `20260504-633`) |
| `js/i18n/i18n-editor.js` | `editor_open_detail` copy updated (ko: "현재 순간 감상하기", en: "View current moment") |

## Scope review

- **Scope**: Editor UI copy only (i18n string + button label)
- **Preserved**: `#detailMoreBtn` ID, click binding, `openCurrentMomentDetail()` routing, `detail.html?id=…&tree=…&from=editor` navigation, button classes, styles/layout
- **No changes**: `js/editor.js`, `pages/detail.html`, Browse/Search/My Trees/Auth/API/backend/DB/package/workflow
- **No impact**: PR #7 / prototype / reference / demo / variant

## Verification

- `git diff --check`: PASS
- `node --check js/i18n/i18n-editor.js`: PASS
- `npm run build`: PASS
- `npm run test`: PASS (195/195)
- `npm run verify`: PASS (138/140 – backend deps firebase-admin, pg absent as expected)

## Browser verification required

- Desktop: `#detailMoreBtn` label "현재 순간 감상하기" visible; click navigates to `detail.html` with correct query params
- Mobile 375px: same label; no horizontal overflow; navigation works
- Back navigation from detail page returns to editor correctly
- No fatal console/page/network errors
- No secret/private payload exposure

Refs #633
