### PR TITLE
ui(login): simplify auth CTA hierarchy

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -252,8 +252,8 @@ input[type="password"]:focus {
 }
 
 .login-signup-section {
-    margin-top: 28px;
-    padding: 24px 20px 0;
+    margin-top: 22px;
+    padding: 18px 18px 2px;
     border-top: 1px solid var(--outline-variant);
     background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 247, 244, 0.36));
     border-radius: 1.5rem;
@@ -264,7 +264,7 @@ input[type="password"]:focus {
     flex-direction: column;
     align-items: center;
     gap: 10px;
-    margin-bottom: 18px;
+    margin-bottom: 0;
     text-align: center;
 }
 
@@ -295,32 +295,10 @@ input[type="password"]:focus {
 
 .login-signup-desc {
     margin: 0;
-    color: var(--primary);
-    font-size: 13px;
-    font-weight: 800;
-    line-height: 1.5;
-}
-
-.login-signup-google-btn {
-    margin-bottom: 12px;
-    box-shadow: 0 10px 24px rgba(75, 64, 57, 0.04);
-}
-
-.login-signup-helper {
-    text-align: center;
     color: var(--on-surface-variant);
-    font-size: 12px;
-    margin: 8px 0 0;
+    font-size: 13px;
     font-weight: 700;
     line-height: 1.55;
-}
-
-.login-signup-divider {
-    margin: 18px 0 16px;
-}
-
-.login-signup-divider-text {
-    font-size: 12px;
 }
 
 .login-form {

--- a/js/i18n/i18n-login.js
+++ b/js/i18n/i18n-login.js
@@ -29,21 +29,21 @@
 
     // 소셜 로그인
     'google_login': {
-      ko: 'Google로 시작하기',
+      ko: 'Google로 계속하기',
       en: 'Continue with Google'
     },
     'google_signup': {
-      ko: 'Google로 바로 시작하기',
-      en: 'Start with Google'
+      ko: 'Google로 계속하기',
+      en: 'Continue with Google'
     },
 
     // 구분선
     'or_email': {
-      ko: '또는 이메일로 시작하기',
+      ko: '또는 이메일로 계속하기',
       en: 'Or continue with email'
     },
     'email_login': {
-      ko: '이메일로 시작하기',
+      ko: '이메일로 계속하기',
       en: 'Continue with email'
     },
 
@@ -53,12 +53,12 @@
       en: 'New here?'
     },
     'signup_intro_title': {
-      ko: '계정만 만들면 바로 첫 순간을 남길 수 있어요',
-      en: 'Create an account and save your first moment right away'
+      ko: '처음이어도 같은 버튼으로 바로 시작할 수 있어요',
+      en: 'New here? The same buttons get you started.'
     },
     'signup_intro_desc': {
-      ko: '아래에서 Google 또는 이메일로 바로 시작해보세요',
-      en: 'Start right away with Google or email below'
+      ko: 'Google 또는 이메일로 계속하면 필요한 경우 계정 생성까지 같은 흐름에서 이어집니다.',
+      en: 'Continue with Google or email; account creation is included in the same flow when needed.'
     },
     'google_signup_helper': {
       ko: 'Google 계정으로 로그인만 하면 별도 가입 없이 바로 시작됩니다',

--- a/pages/login.html
+++ b/pages/login.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/login.css?v=20260427-1">
+    <link rel="stylesheet" href="../css/login.css?v=20260504-642">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -68,54 +68,6 @@
                     </p>
                 </div>
 
-                <!-- Google 회원가입 -->
-                <button id="signup-btn-google" class="login-btn-google login-signup-google-btn">
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" class="login-google-icon">
-                        <path fill="#4285F4" d="M45.12,24.5c0-2.46-0.2-4.84-0.64-7.12l-14.54,0c0.24,1.08,0.4,2.2,0.4,3.4c0,5.6-3.8,10.8-10.8,10.8l-8.72,0c-6.48,0-11.76-5.28-11.76-11.76c0-6.4,5.2-11.64,11.64-11.64c2.96,0,5.56,1.12,7.6,2.96l6.24-6.16C29.32,6.56,24.36,5.72,19.04,5.72c-9.36,0-17.52,6.76-17.52,16.08c0,9.28,8.16,16.08,17.52,16.08c6.8,0,11.52-3.28,14.36-7.96c0.76,0.08,1.56,0.12,2.4,0.12C42.4,29.92,45.12,27.56,45.12,24.5z"/>
-                        <path fill="#34A853" d="M19.12,44.36c6.56,0,12.16-2.44,16.24-6.56l-7.68-5.92C25.24,34.8,22.52,36,19.12,36c-6.08,0-10.8-4.16-12.48-9.76l-7.76,0C3.48,31.96,10.64,44.36,19.12,44.36z"/>
-                        <path fill="#FBBC05" d="M9.84,26.68c-1.56-2.92-2.4-6.08-2.4-9.48c0-3.4,0.84-6.56,2.4-9.48L3.2,12.08C1.24,16.52,0.04,21.48,0.04,26.32C0.04,31.16,1.24,36.12,3.2,40.56L9.84,26.68z"/>
-                        <path fill="#EA4335" d="M19.12,12.32c4.76,0,8.24,1.92,10.04,3.56l7.24-7.16C34.76,5.92,29.32,4.8,23.72,4.8c-7.4,0-14,4.4-17.6,10.96l7.76,6.44C15.48,16.84,18.32,12.32,19.12,12.32z"/>
-                    </svg>
-                    <span data-i18n="google_signup">Google로 바로 시작하기</span>
-                </button>
-
-                <p class="login-signup-helper" data-i18n="google_signup_helper">
-                    Google 계정으로 로그인만 하면 별도 가입 없이 바로 시작됩니다
-                </p>
-
-                <div class="login-divider login-signup-divider">
-                    <span class="login-signup-divider-text" data-i18n="or_create_with_email">또는 이메일로 계정 만들기</span>
-                </div>
-
-                <!-- 이메일 회원가입 폼 -->
-                <form id="signup-form" class="login-form" novalidate>
-                    <div class="login-form-group">
-                        <label for="signup-display-name" class="login-form-label" data-i18n="display_name_label">닉네임</label>
-                        <input
-                            type="text"
-                            id="signup-display-name"
-                            name="displayName"
-                            required
-                            maxlength="30"
-                            placeholder="예: XG Alpha"
-                            data-i18n-placeholder="display_name_placeholder"
-                            class="login-form-input"
-                        >
-                    </div>
-                    <div class="login-form-group">
-                        <label for="signup-email" class="login-form-label" data-i18n="email_label">이메일</label>
-                        <input type="email" id="signup-email" name="email" required placeholder="your@email.com"
-                            class="login-form-input">
-                    </div>
-                    <div class="login-form-group-large">
-                        <label for="signup-password" class="login-form-label" data-i18n="password_label">비밀번호</label>
-                        <input type="password" id="signup-password" name="password" required placeholder="8자 이상 입력" minlength="8"
-                            class="login-form-input">
-                    </div>
-                    <button type="submit" id="signup-submit" class="login-submit-button" data-i18n="signup_btn">
-                        회원가입 완료
-                    </button>
-                </form>
             </div>
 
             <div class="badge-group">
@@ -174,7 +126,7 @@
 
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
-    <script src="../js/i18n/i18n-login.js?v=20260422-1"></script>
+    <script src="../js/i18n/i18n-login.js?v=20260504-642"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>


### PR DESCRIPTION
## Summary
- Kept one visible Google action and one visible email action in the login card.
- Converted the first-time section into compact guidance copy only.
- Routed email signup through the existing email auth modal toggle instead of the standalone signup form.

## Changed files
- pages/login.html
- css/login.css
- js/i18n/i18n-login.js

## Scope review
- Login page CTA hierarchy only.
- No Auth provider, Firebase, redirect, session, or cache behavior changes.
- No Browse/Search/My Trees/Editor/Detail/backend/API/package/workflow changes.
- No PR #7/prototype/reference/demo/variant changes.

## Auth capability preservation
- Google auth capability preserved through #login-btn-google.
- Email login capability preserved through #login-btn-email and #email-auth-modal.
- Email signup capability preserved through #email-auth-toggle inside the existing email modal.

## Verification
- git diff --check: PASS
- node --check js/i18n/i18n-login.js: PASS
- targeted login/auth tests: PASS via npm test login/auth contract coverage
- npm run build: PASS
- npm test: PASS
- npm run verify: PASS

## Browser verification required: YES

## NOT_VERIFIED fixed-slot browser checks
- Fixed test slot deployment.
- Desktop login page CTA hierarchy.
- Mobile 375px login page CTA hierarchy.
- Google button visible/clickable.
- Email button visible/clickable.
- Email modal opens.
- Email modal login/signup toggle works.
- No duplicate Google/email start flows visible.
- No fatal console errors.
- No secret/private exposure.

Refs #642