### PR TITLE
ui(login): reduce auth card height

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -3,14 +3,14 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 120px 48px 80px;
+    padding: 80px 48px 48px;
 }
 
 .login-card {
     width: 100%;
     max-width: 480px;
     background: white;
-    padding: 64px;
+    padding: 48px;
     border-radius: 3rem;
     box-shadow: 0 40px 100px rgba(0,0,0,0.1);
     text-align: center;
@@ -48,7 +48,7 @@
     opacity: 0.6;
     font-size: 11px;
     font-weight: 800;
-    margin: 32px 0;
+    margin: 20px 0;
     letter-spacing: 1px;
     text-transform: uppercase;
 }
@@ -62,8 +62,8 @@
 }
 
 .badge-group {
-    margin-top: 48px;
-    padding-top: 32px;
+    margin-top: 32px;
+    padding-top: 20px;
     border-top: 1px solid var(--outline-variant);
     display: flex;
     flex-wrap: wrap;
@@ -233,7 +233,7 @@ input[type="password"]:focus {
 
 .login-desc {
     color: var(--on-surface-variant);
-    margin-bottom: 40px;
+    margin-bottom: 24px;
     font-size: 1rem;
     line-height: 1.6;
     font-weight: 400;
@@ -367,7 +367,7 @@ input[type="password"]:focus {
 
 .login-later-link {
     display: block;
-    margin-top: 40px;
+    margin-top: 24px;
     color: var(--on-surface-variant);
     font-size: 13px;
     text-decoration: none;
@@ -447,10 +447,10 @@ input[type="password"]:focus {
 
 @media (max-width: 768px) {
     .login-shell {
-        padding: 24px;
+        padding: 16px;
     }
 
     .login-card {
-        padding: 40px 24px;
+        padding: 32px 16px;
     }
 }


### PR DESCRIPTION
## Summary

Reduces login card height by tightening vertical spacing. Auth actions (Google/email buttons) now appear above the fold more quickly on common desktop and mobile viewports. First-time guidance remains compact per #642.

## Changes

| File | Change |
|------|--------|
| `css/login.css` | Reduced `.login-shell`, `.login-card`, `.login-desc`, `.login-divider`, `.badge-group`, `.login-later-link` padding/margin |

## Changed Files

- `css/login.css` (CSS-only, 9 spacing values adjusted)

## Scope Review

- ✅ #642 CTA hierarchy preserved (single Google + single email)
- ✅ No duplicate CTA regression
- ✅ No standalone signup form restoration
- ✅ Auth modal structure unchanged
- ✅ No JS/i18n changes
- ✅ No backend/API changes

## Verification

| Check | Status |
|-------|--------|
| `git diff --check` | PASS |
| `npm run build` | PASS |
| `npm test` (195 tests) | PASS |
| `npm run verify` | 138/140 (firebase-admin, pg skipped - server-only deps) |

## Browser Verification Required: YES

**NOT_VERIFIED:**
- Fixed slot deployment
- Desktop login screenshot
- Mobile 375px login screenshot  
- Primary auth actions above fold
- Email modal opens
- No duplicate CTA regression
- No fatal console errors
- No secret/private exposure

---

Refs #644