### PR TITLE
fix(browse): add recovery for copy failure state

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -133,6 +133,18 @@
       ko: '가져오지 못했어요',
       en: 'Copy failed'
     },
+    'search.previewCopyToMyTreesFailedBody': {
+      ko: '가져오지 못했어요. 다시 시도해 주세요.',
+      en: 'Copy failed. Please try again.'
+    },
+    'search.previewCopyToMyTreesRetry': {
+      ko: '다시 시도',
+      en: 'Try again'
+    },
+    'search.previewCopyToMyTreesLoginRequired': {
+      ko: '로그인이 필요해요',
+      en: 'Login required'
+    },
     'search.previewOpenCopiedTree': {
       ko: '복사된 트리 열기',
       en: 'Open copied tree'

--- a/js/search-copy-ui.js
+++ b/js/search-copy-ui.js
@@ -9,6 +9,7 @@
     'use strict';
 
     const COPY_BUTTON_SELECTOR = '[data-copy-public-tree]';
+    const COPY_STATUS_SELECTOR = '[data-copy-public-tree-status]';
     const SHARE_BUTTON_SELECTOR = '[data-share-tree-link]';
     const SCRIPT_MARK = 'lovebudSearchCopyUiLoaded';
 
@@ -100,6 +101,7 @@
                 <span class="material-symbols-outlined" style="font-size:16px;">content_copy</span>
                 <span data-copy-public-tree-label>${safeLabel}</span>
             </button>
+            <div data-copy-public-tree-status class="copy-status-text" style="font-size:12px;color:var(--on-surface-variant);margin-top:6px;min-height:18px;"></div>
         `;
     }
 
@@ -130,6 +132,20 @@
         button.disabled = Boolean(disabled);
     }
 
+    function setStatusText(button, key, fallbackKo, fallbackEn) {
+        const statusEl = button.parentElement?.querySelector(COPY_STATUS_SELECTOR);
+        if (statusEl) {
+            statusEl.textContent = getCopy(key, fallbackKo, fallbackEn);
+        }
+    }
+
+    function clearStatusText(button) {
+        const statusEl = button.parentElement?.querySelector(COPY_STATUS_SELECTOR);
+        if (statusEl) {
+            statusEl.textContent = '';
+        }
+    }
+
     async function handleCopyClick(event) {
         const button = event.target.closest(COPY_BUTTON_SELECTOR);
         if (!button) return;
@@ -145,22 +161,30 @@
         if (!treeId) return;
 
         if (!hasAuthSession()) {
+            const loginMsg = getCopy('search.previewCopyToMyTreesLoginRequired', '로그인이 필요해요', 'Login required');
+            setStatusText(button, 'search.previewCopyToMyTreesLoginRequired', '로그인이 필요해요', 'Login required');
+            setButtonState(button, 'search.previewCopyToMyTrees', '내 러브트리로 가져오기', 'Copy to my LoveTrees', false);
             window.location.href = buildLoginHref(treeId);
             return;
         }
 
         setButtonState(button, 'search.previewCopyingToMyTrees', '가져오는 중이에요', 'Copying...', true);
+        clearStatusText(button);
         try {
             const result = await forkPublicTree(treeId);
             button.dataset.copiedTreeId = result.treeId;
             setButtonState(button, 'search.previewOpenCopiedTree', '복사된 트리 열기', 'Open copied tree', false);
+            setStatusText(button, 'search.previewCopyToMyTreesDone', '내 러브트리로 복사됐어요', 'Copied to my LoveTrees');
         } catch (error) {
-            console.warn('[search-copy-ui] public tree fork failed:', error.message);
             if (error.status === 401 || error.status === 403) {
+                setStatusText(button, 'search.previewCopyToMyTreesLoginRequired', '로그인이 필요해요', 'Login required');
                 window.location.href = buildLoginHref(treeId);
                 return;
             }
-            setButtonState(button, 'search.previewCopyToMyTreesFailed', '가져오지 못했어요', 'Copy failed', false);
+            const retryMsg = getCopy('search.previewCopyToMyTreesRetry', '다시 시도', 'Try again');
+            const failedBody = getCopy('search.previewCopyToMyTreesFailedBody', '가져오지 못했어요. 다시 시도해 주세요.', 'Copy failed. Please try again.');
+            setButtonState(button, 'search.previewCopyToMyTrees', '내 러브트리로 가져오기', 'Copy to my LoveTrees', false);
+            setStatusText(button, 'search.previewCopyToMyTreesFailedBody', '가져오지 못했어요. 다시 시도해 주세요.', 'Copy failed. Please try again.');
         }
     }
 


### PR DESCRIPTION
## Summary

Adds recovery state for Browse selected hub \"Copy to My Trees\" (내 러브트리로 가져오기) action failure. Previously, failure resulted in a dead-end state with no retry option. Now users can retry the action after failure.

## Changes

| File | Change |
|------|--------|
| `js/search-copy-ui.js` | Added status element, `setStatusText()`, `clearStatusText()`, failure recovery with retry, status messaging |
| `js/i18n/i18n-search.js` | Added keys: `previewCopyToMyTreesFailedBody`, `previewCopyToMyTreesRetry`, `previewCopyToMyTreesLoginRequired` |

## Scope Review

- ✅ Backend/API behavior unchanged
- ✅ Ownership/visibility/fork policy unchanged
- ✅ Browse card grid unchanged
- ✅ Selected hub layout unchanged
- ✅ Search/filter placement unchanged
- ✅ Detail/Editor/Auth provider unchanged

## Failure/Retry Behavior

| State | Button Label | Status Text | Action |
|-------|--------------|-------------|--------|
| Idle | 내 러브트리로 가져오기 | - | Trigger copy |
| Loading | 가져오는 중이에요 | - | Disabled |
| Success | 복사된 트리 열기 | 내 러브트리로 복사됐어요 | Open copied tree |
| Failed | 내 러브트리로 가져오기 | 가져오지 못했어요. 다시 시도해 주세요. | Retry available |
| Login Required | 내 러브트리로 가져오기 | 로그인이 필요해요 | Redirect to login |

## Success Path Preservation

- ✅ `copiedTreeId` stored in `button.dataset.copiedTreeId`
- ✅ Success button shows "복사된 트리 열기"
- ✅ Clicking success button navigates to `editor.html?treeId=<copiedTreeId>`

## Privacy/Security

- ✅ No raw IDs/tree IDs exposed in console.warn or logs
- ✅ No private payload values output
- ✅ Safe generic error messages used

## Verification

| Check | Status |
|-------|--------|
| `git diff --check` | PASS |
| `node --check js/search-copy-ui.js` | PASS |
| `node --check js/i18n/i18n-search.js` | PASS |
| `npm run build` | PASS |
| `npm test` (195 tests) | PASS |
| `npm run verify` | 138/140 (server-only deps skipped) |

## Browser Verification Required: YES

**NOT_VERIFIED:**
- Fixed slot deployment
- Deployed SHA match
- Browse selected hub populated state
- Logged-out behavior
- Logged-in copy attempt
- Success path if safely possible
- Forced/observed failure path
- Retry behavior
- Existing copied-tree open path
- Desktop screenshot
- Mobile 375px screenshot
- Fatal console/network errors
- Secret/private exposure

---

Refs #604