### PR TITLE
feat(viewer): add read-only public LoveTree viewer shell

### DIFF
--- a/css/viewer/public-tree-viewer.css
+++ b/css/viewer/public-tree-viewer.css
@@ -1,0 +1,371 @@
+/**
+ * Public Tree Viewer Styles
+ * v20260505-801-1
+ */
+
+/* Viewer page shell */
+.viewer-page-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--background);
+}
+
+/* Topbar */
+.viewer-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 24px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--outline);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.viewer-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.viewer-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    background: var(--tertiary-container);
+    color: var(--on-tertiary-container);
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+}
+
+/* Main layout */
+.viewer-layout {
+    display: flex;
+    flex: 1;
+    padding: 24px;
+    gap: 24px;
+    max-width: 1400px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/* Tree section (left) */
+.viewer-tree-section {
+    flex: 1;
+    min-width: 0;
+}
+
+.viewer-tree-shell {
+    background: var(--surface);
+    border-radius: 16px;
+    border: 1px solid var(--outline-variant);
+    padding: 24px;
+    min-height: 400px;
+}
+
+.viewer-tree-header {
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--outline-variant);
+}
+
+.viewer-tree-title {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--on-surface);
+    margin: 0 0 8px 0;
+}
+
+.viewer-tree-meta {
+    font-size: 14px;
+    color: var(--on-surface-variant);
+}
+
+/* Nodes list */
+.viewer-tree-container {
+    /* container for nodes */
+}
+
+.viewer-nodes-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.viewer-node {
+    padding: 16px;
+    background: var(--surface-variant);
+    border: 1px solid var(--outline-variant);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.viewer-node:hover,
+.viewer-node:focus {
+    border-color: var(--primary);
+    background: var(--surface-container-low);
+}
+
+.viewer-node-active {
+    border-color: var(--primary);
+    background: var(--surface-container-low);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.viewer-node-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.viewer-node-title {
+    font-weight: 700;
+    color: var(--on-surface);
+    font-size: 1rem;
+}
+
+.viewer-node-date {
+    font-size: 12px;
+    color: var(--on-surface-variant);
+    white-space: nowrap;
+}
+
+.viewer-node-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.viewer-node-tag {
+    font-size: 11px;
+    padding: 2px 8px;
+    background: var(--tertiary-container);
+    color: var(--on-tertiary-container);
+    border-radius: 999px;
+    font-weight: 800;
+}
+
+/* Preview section (right) */
+.viewer-preview-section {
+    width: 360px;
+    min-width: 320px;
+    max-width: 400px;
+}
+
+.viewer-preview-sticky {
+    position: sticky;
+    top: 80px;
+}
+
+.viewer-preview-header {
+    margin-bottom: 16px;
+}
+
+.viewer-preview-header h3 {
+    font-size: 1.125rem;
+    font-weight: 800;
+    color: var(--on-surface);
+    margin: 0;
+}
+
+.viewer-preview-container {
+    background: var(--surface);
+    border: 1px solid var(--outline-variant);
+    border-radius: 16px;
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+}
+
+.viewer-preview-empty,
+.viewer-preview-content {
+    padding: 24px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.viewer-preview-empty p {
+    color: var(--on-surface-variant);
+    text-align: center;
+    margin-top: 40px;
+}
+
+.viewer-preview-media {
+    margin-bottom: 16px;
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--surface-variant);
+    min-height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.viewer-preview-image {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.viewer-preview-no-media {
+    color: var(--on-surface-variant);
+    font-size: 48px;
+    opacity: 0.5;
+}
+
+.viewer-preview-details {
+    flex: 1;
+}
+
+.viewer-moment-title {
+    font-size: 1.25rem;
+    font-weight: 800;
+    color: var(--on-surface);
+    margin: 0 0 12px 0;
+}
+
+.viewer-moment-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.viewer-preview-tag {
+    font-size: 11px;
+    padding: 2px 8px;
+    background: var(--tertiary-container);
+    color: var(--on-tertiary-container);
+    border-radius: 999px;
+    font-weight: 800;
+}
+
+.viewer-moment-meta {
+    font-size: 13px;
+    color: var(--on-surface-variant);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.viewer-meta-divider {
+    margin: 0 4px;
+}
+
+.viewer-moment-diary {
+    border-top: 1px solid var(--outline-variant);
+    padding-top: 16px;
+}
+
+.viewer-diary-quote {
+    font-style: italic;
+    color: var(--on-surface);
+    margin: 0 0 8px 0;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.viewer-diary-content {
+    color: var(--on-surface-variant);
+    font-size: 14px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+}
+
+/* State views */
+.viewer-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+}
+
+.viewer-state-content {
+    text-align: center;
+    color: var(--on-surface-variant);
+}
+
+.viewer-state-content .material-symbols-outlined {
+    font-size: 64px;
+    margin-bottom: 16px;
+    opacity: 0.6;
+    display: block;
+}
+
+.viewer-state-content p {
+    margin: 0;
+    font-size: 1rem;
+}
+
+#viewerRetryBtn {
+    margin-top: 24px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .viewer-layout {
+        flex-direction: column;
+        padding: 16px;
+        gap: 16px;
+    }
+
+    .viewer-tree-shell,
+    .viewer-preview-container {
+        min-height: auto;
+    }
+
+    .viewer-preview-section {
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+    }
+
+    .viewer-preview-sticky {
+        position: static;
+    }
+
+    .viewer-topbar {
+        padding: 10px 16px;
+    }
+
+    .viewer-back-link {
+        font-size: 13px;
+    }
+}
+
+/* Ensure no overflow on mobile */
+@media (max-width: 375px) {
+    .viewer-layout {
+        padding: 12px;
+    }
+
+    .viewer-tree-shell,
+    .viewer-preview-container {
+        padding: 16px;
+    }
+
+    .viewer-node-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    .viewer-moment-tags,
+    .viewer-node-tags {
+        gap: 4px;
+    }
+}

--- a/js/i18n/i18n-viewer.js
+++ b/js/i18n/i18n-viewer.js
@@ -1,0 +1,86 @@
+/**
+ * LoveBud - i18n Viewer Dictionary
+ * v20260505-801-1
+ *
+ * Viewer page (public tree viewer) translation keys
+ */
+
+(function() {
+  'use strict';
+
+  window.i18nViewer = {
+    // Navigation
+    'viewer.backToBrowse': {
+      ko: '둘러보기로 돌아가기',
+      en: 'Back to Browse'
+    },
+    'viewer.public': {
+      ko: '공개',
+      en: 'Public'
+    },
+
+    // States
+    'viewer.loading': {
+      ko: '러브트리를 불러오는 중이에요',
+      en: 'Loading LoveTree...'
+    },
+    'viewer.empty': {
+      ko: '아직 공개된 순간이 없어요',
+      en: 'No public moments yet'
+    },
+    'viewer.error': {
+      ko: '러브트리를 불러오지 못했어요. 다시 시도해 주세요.',
+      en: 'Could not load LoveTree. Please try again.'
+    },
+    'viewer.retry': {
+      ko: '다시 시도',
+      en: 'Retry'
+    },
+
+    // Tree header
+    'viewer.treeTitle': {
+      ko: '러브트리',
+      en: 'LoveTree'
+    },
+    'viewer.treeMeta': {
+      ko: '{count}개의 순간',
+      en: '{count} moments'
+    },
+
+    // Preview
+    'viewer.selectedMoment': {
+      ko: '선택한 순간',
+      en: 'Selected Moment'
+    },
+    'viewer.previewPlaceholder': {
+      ko: '순간을 선택하면 여기에 표시돼요',
+      en: 'Select a moment to preview it here'
+    },
+
+    // Moment display
+    'viewer.momentTitle': {
+      ko: '그때의 마음',
+      en: 'That Moment'
+    },
+    'viewer.momentDate': {
+      ko: '{date}',
+      en: '{date}'
+    },
+    'viewer.momentLocation': {
+      ko: '위치: {location}',
+      en: 'Location: {location}'
+    },
+    'viewer.momentTags': {
+      ko: '감정',
+      en: 'Emotions'
+    },
+    'viewer.momentDiary': {
+      ko: '마음 기록',
+      en: 'Memory'
+    },
+    'viewer.momentMedia': {
+      ko: '미디어',
+      en: 'Media'
+    }
+  };
+})();

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -1,0 +1,331 @@
+/**
+ * LoveBud Public Tree Viewer
+ * v20260505-801-1
+ *
+ * Read-only public LoveTree viewer shell.
+ * Loads public tree data and displays nodes + selected moment preview.
+ */
+
+(function() {
+    'use strict';
+
+    const MARKER = 'LoveBudPublicTreeViewerLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    // Selectors
+    const SEL = {
+        treeShell: '#viewerTreeShell',
+        loadingState: '#viewerLoadingState',
+        emptyState: '#viewerEmptyState',
+        errorState: '#viewerErrorState',
+        treeContainer: '#viewerTreeContainer',
+        treeTitle: '#viewerTreeTitle',
+        treeMeta: '#viewerTreeMeta',
+        nodesList: '#viewerNodesList',
+        previewContainer: '#viewerPreviewContainer',
+        previewEmpty: '#viewerPreviewEmpty',
+        previewContent: '#viewerPreviewContent',
+        previewMedia: '#viewerPreviewMedia',
+        momentTitle: '#viewerMomentTitle',
+        momentTags: '#viewerMomentTags',
+        momentMeta: '#viewerMomentMeta',
+        momentDiary: '#viewerMomentDiary',
+        diaryQuote: '#viewerDiaryQuote',
+        diaryContent: '#viewerDiaryContent',
+        retryBtn: '#viewerRetryBtn',
+        backLink: '#backButton'
+    };
+
+    // State
+    let currentTreeId = null;
+    let currentTree = null;
+    let currentMemories = [];
+    let selectedMemoryId = null;
+
+    // i18n helper
+    function t(key, fallbackKo, fallbackEn) {
+        const dict = window.i18nViewer?.[key];
+        if (dict && typeof dict === 'object') {
+            const locale = (window.i18n?.currentLang || 'ko').toLowerCase();
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return dict || fallbackKo || fallbackEn || key;
+    }
+
+    // escapeHtml
+    function escapeHtml(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    // getCurrentLocale
+    function getCurrentLocale() {
+        const locale = window.i18n?.currentLang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    // Render helpers
+    function setContent(elem, text) {
+        if (elem) elem.textContent = text;
+    }
+
+    function show(...els) {
+        for (const el of els) {
+            if (el) {
+                if (el.setAttribute) el.setAttribute('hidden', false);
+                else if (el.removeAttribute) el.removeAttribute('hidden');
+            }
+        }
+    }
+
+    function hide(...els) {
+        for (const el of els) {
+            if (el && el.setAttribute) el.setAttribute('hidden', true);
+        }
+    }
+
+    function getBasePath() {
+        if (window.LoveBudPath?.getBasePath) {
+            return window.LoveBudPath.getBasePath();
+        }
+        return window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+    }
+
+    // Main entry
+    async function initViewer() {
+        const params = new URLSearchParams(window.location.search);
+        const treeId = params.get('treeId')?.trim();
+        if (!treeId) {
+            renderEmpty();
+            return;
+        }
+
+        currentTreeId = treeId;
+        showLoading();
+
+        try {
+            // Use public tree preview from Browse data pattern
+            // We'll fetch the tree's public memories via community endpoint
+            const memories = await loadPublicMemories(treeId);
+            
+            if (!memories || memories.length === 0) {
+                renderEmpty();
+                return;
+            }
+
+            currentMemories = memories;
+            // Build a minimal tree object
+            currentTree = {
+                id: treeId,
+                memoryCount: memories.length,
+                title: inferTreeTitle(memories)
+            };
+
+            renderTree();
+            renderPreview(); // show first moment
+        } catch (error) {
+            console.error('[viewer] load failed:', error);
+            renderError();
+        }
+    }
+
+    async function loadPublicMemories(treeId) {
+        if (!window.apiClient?.communityApi?.getCachedCommunityMemories) {
+            throw new Error('Community API not available');
+        }
+        // Fetch public memories for this tree
+        const memories = await window.apiClient.communityApi.getCachedCommunityMemories({ treeId, limit: 100 });
+        // Filter: only public memories (safety)
+        return Array.isArray(memories) 
+            ? memories.filter(m => m && m.visibility === 'public')
+            : [];
+    }
+
+    function inferTreeTitle(memories) {
+        // Use first memory's tree title if available, else fallback
+        const first = memories[0];
+        if (first?.treeTitle) return first.treeTitle;
+        if (first?.title) return first.title;
+        return t('viewer.treeTitle', '러브트리', 'LoveTree');
+    }
+
+    // Rendering states
+    function showLoading() {
+        hide(SEL.treeContainer, SEL.emptyState, SEL.errorState);
+        show(SEL.loadingState);
+    }
+
+    function renderEmpty() {
+        hide(SEL.treeContainer, SEL.loadingState, SEL.errorState);
+        show(SEL.emptyState);
+    }
+
+    function renderError() {
+        hide(SEL.treeContainer, SEL.loadingState, SEL.emptyState);
+        show(SEL.errorState);
+    }
+
+    function renderTree() {
+        hide(SEL.loadingState, SEL.emptyState, SEL.errorState);
+        show(SEL.treeContainer);
+
+        // Title
+        setContent(SEL.treeTitle, currentTree.title);
+        const metaText = t('viewer.treeMeta', '{count}개의 순간', '{count} moments')
+            .replace('{count}', String(currentTree.memoryCount || 0));
+        setContent(SEL.treeMeta, metaText);
+
+        // Render nodes
+        renderNodesList();
+    }
+
+    function renderNodesList() {
+        const list = SEL.nodesList;
+        if (!list) return;
+        list.innerHTML = '';
+
+        for (const memory of currentMemories) {
+            const node = document.createElement('div');
+            node.className = 'viewer-node' + (memory.id === selectedMemoryId ? ' viewer-node-active' : '');
+            node.dataset.memoryId = memory.id;
+
+            // Node content: title + date + tags
+            let tagsHtml = '';
+            for (const tag of (memory.emotionTags || [])) {
+                tagsHtml += `<span class="viewer-node-tag">${escapeHtml(tag)}</span>`;
+            }
+            node.innerHTML = `
+                <div class="viewer-node-header">
+                    <span class="viewer-node-title">${escapeHtml(memory.title || memory.emotionMemo || '')}</span>
+                    <span class="viewer-node-date">${escapeHtml(formatMemoryDate(memory))}</span>
+                </div>
+                <div class="viewer-node-tags">
+                    ${tagsHtml}
+                </div>
+            `;
+
+            node.addEventListener('click', () => selectMemory(memory.id));
+            list.appendChild(node);
+        }
+    }
+
+    function formatMemoryDate(memory) {
+        // memory.createdAt or memory.date
+        const raw = memory.createdAt || memory.date || '';
+        if (!raw) return '';
+        try {
+            const d = new Date(raw);
+            return d.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR');
+        } catch (e) {
+            return raw;
+        }
+    }
+
+    function selectMemory(memoryId) {
+        selectedMemoryId = memoryId;
+        // update active node class
+        const nodes = SEL.nodesList.querySelectorAll('.viewer-node');
+        nodes.forEach(n => {
+            n.classList.toggle('viewer-node-active', n.dataset.memoryId === memoryId);
+        });
+
+        // find memory data
+        const memory = currentMemories.find(m => m.id === memoryId);
+        if (!memory) return;
+
+        renderPreviewMemory(memory);
+    }
+
+    function renderPreview() {
+        hide(SEL.previewEmpty);
+        show(SEL.previewContent);
+        // If no memory selected yet, select first
+        if (!selectedMemoryId && currentMemories.length > 0) {
+            selectMemory(currentMemories[0].id);
+        }
+    }
+
+    function renderPreviewMemory(memory) {
+        // Media (if available)
+        const mediaContainer = SEL.previewMedia;
+        if (mediaContainer) {
+            const thumb = memory.representativeThumbnail || memory.thumbnail || '';
+            if (thumb) {
+                mediaContainer.innerHTML = `<img src="${escapeHtml(thumb)}" alt="${escapeHtml(memory.title || '')}" class="viewer-preview-image" />`;
+            } else {
+                mediaContainer.innerHTML = `<div class="viewer-preview-no-media"><span class="material-symbols-outlined">image</span></div>`;
+            }
+        }
+
+        // Title & tags
+        setContent(SEL.momentTitle, memory.title || memory.emotionMemo || '');
+        const tagsContainer = SEL.momentTags;
+        if (tagsContainer) {
+            tagsContainer.innerHTML = (memory.emotionTags || [])
+                .map(tag => `<span class="viewer-preview-tag">${escapeHtml(tag)}</span>`)
+                .join('');
+        }
+
+        // Meta: date/location
+        const metaContainer = SEL.momentMeta;
+        if (metaContainer) {
+            const dateStr = formatMemoryDate(memory);
+            const location = memory.location || '';
+            metaContainer.innerHTML = `
+                <span class="viewer-meta-item">${escapeHtml(dateStr)}</span>
+                ${location ? `<span class="viewer-meta-divider">•</span><span class="viewer-meta-item">${escapeHtml(location)}</span>` : ''}
+            `;
+        }
+
+        // Diary
+        const quoteEl = SEL.diaryQuote;
+        const contentEl = SEL.diaryContent;
+        if (quoteEl) quoteEl.textContent = memory.emotionMemo || '';
+        if (contentEl) {
+            // raw diary content is not exposed; show placeholder if empty
+            contentEl.innerHTML = memory.diaryContent 
+                ? escapeHtml(memory.diaryContent).replace(/\n/g, '<br>')
+                : '';
+        }
+    }
+
+    // Error retry
+    function setupRetry() {
+        const btn = SEL.retryBtn;
+        if (btn) {
+            btn.addEventListener('click', () => {
+                if (currentTreeId) {
+                    initViewer();
+                }
+            });
+        }
+    }
+
+    // Navigation back
+    function setupBackLink() {
+        const back = SEL.backLink;
+        if (back) {
+            back.addEventListener('click', (e) => {
+                // default behavior is fine (link to search)
+            });
+        }
+    }
+
+    // Init when DOM ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            setupRetry();
+            setupBackLink();
+            initViewer();
+        });
+    } else {
+        setupRetry();
+        setupBackLink();
+        initViewer();
+    }
+})();

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -296,8 +296,8 @@
 
     // Error retry
     function setupRetry() {
-        const btn = SEL.retryBtn;
-        if (btn) {
+        const btn = document.querySelector(SEL.retryBtn);
+        if (btn && typeof btn.addEventListener === 'function') {
             btn.addEventListener('click', () => {
                 if (currentTreeId) {
                     initViewer();
@@ -308,8 +308,8 @@
 
     // Navigation back
     function setupBackLink() {
-        const back = SEL.backLink;
-        if (back) {
+        const back = document.querySelector(SEL.backLink);
+        if (back && typeof back.addEventListener === 'function') {
             back.addEventListener('click', (e) => {
                 // default behavior is fine (link to search)
             });

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>러브트리 감상 | LoveTree</title>
+    <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.ico" sizes="32x32">
+    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260505-801-1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+</head>
+<body class="paper-grain">
+    <div class="noise-overlay"></div>
+
+    <!-- Shared Header (public, non-auth-gated) -->
+    <div id="shared-header"></div>
+
+    <div class="viewer-page-shell page-transition-enter">
+        <!-- Topbar -->
+        <div class="viewer-topbar">
+            <a id="backButton" class="viewer-back-link" href="../pages/search.html">
+                <span class="material-symbols-outlined">arrow_back</span>
+                <span data-i18n="viewer.backToBrowse">둘러보기로 돌아가기</span>
+            </a>
+            <div class="viewer-badge">
+                <span class="material-symbols-outlined">public</span>
+                <span data-i18n="viewer.public">공개</span>
+            </div>
+        </div>
+
+        <main class="viewer-layout">
+            <!-- Tree Area (Left/Top) -->
+            <section class="viewer-tree-section">
+                <div id="viewerTreeShell" class="viewer-tree-shell">
+                    <!-- Loading / Empty / Error states -->
+                    <div id="viewerLoadingState" class="viewer-state" hidden>
+                        <div class="viewer-state-content">
+                            <span class="material-symbols-outlined refresh-symbol">progress_activity</span>
+                            <p data-i18n="viewer.loading">러브트리를 불러오는 중이에요</p>
+                        </div>
+                    </div>
+
+                    <div id="viewerEmptyState" class="viewer-state" hidden>
+                        <div class="viewer-state-content">
+                            <span class="material-symbols-outlined">sentiment_dissatisfied</span>
+                            <p data-i18n="viewer.empty">아직 공개된 순간이 없어요</p>
+                        </div>
+                    </div>
+
+                    <div id="viewerErrorState" class="viewer-state" hidden>
+                        <div class="viewer-state-content">
+                            <span class="material-symbols-outlined">error_outline</span>
+                            <p data-i18n="viewer.error">러브트리를 불러오지 못했어요. 다시 시도해 주세요.</p>
+                            <button type="button" id="viewerRetryBtn" class="btn-round btn-outline" data-i18n="viewer.retry">
+                                다시 시도
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Tree Nodes Container -->
+                    <div id="viewerTreeContainer" class="viewer-tree-container" hidden>
+                        <!-- Tree title/meta -->
+                        <div class="viewer-tree-header">
+                            <h2 id="viewerTreeTitle" class="viewer-tree-title"></h2>
+                            <div id="viewerTreeMeta" class="viewer-tree-meta"></div>
+                        </div>
+
+                        <!-- Tree nodes vertical flow -->
+                        <div id="viewerNodesList" class="viewer-nodes-list"></div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Moment Preview Panel (Right/Bottom) -->
+            <aside class="viewer-preview-section">
+                <div class="viewer-preview-sticky">
+                    <div class="viewer-preview-header">
+                        <h3 data-i18n="viewer.selectedMoment">선택한 순간</h3>
+                    </div>
+
+                    <div id="viewerPreviewContainer" class="viewer-preview-container">
+                        <!-- Empty state -->
+                        <div id="viewerPreviewEmpty" class="viewer-preview-empty">
+                            <p data-i18n="viewer.previewPlaceholder">순간을 선택하면 여기에 표시돼요</p>
+                        </div>
+
+                        <!-- Moment content -->
+                        <div id="viewerPreviewContent" class="viewer-preview-content" hidden>
+                            <div id="viewerPreviewMedia" class="viewer-preview-media"></div>
+                            <div class="viewer-preview-details">
+                                <h4 id="viewerMomentTitle" class="viewer-moment-title"></h4>
+                                <div id="viewerMomentTags" class="viewer-moment-tags"></div>
+                                <div id="viewerMomentMeta" class="viewer-moment-meta"></div>
+                                <div id="viewerMomentDiary" class="viewer-moment-diary">
+                                    <p id="viewerDiaryQuote" class="viewer-diary-quote"></p>
+                                    <div id="viewerDiaryContent" class="viewer-diary-content"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </main>
+    </div>
+
+    <!-- Scripts (no auth/editor scripts) -->
+    <script src="../js/cache-utils.js?v=20260418-1"></script>
+    <script src="../js/utils/normalize.js?v=20260422-1"></script>
+    <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
+    <script src="../js/postgres-client.js?v=20260422-1"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260504-1"></script>
+    <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-viewer.js?v=20260505-801-1"></script>
+    <script src="../js/i18n.js?v=20260419-2"></script>
+    <script src="../js/viewer/public-tree-viewer.js?v=20260505-801-1"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a new read-only public LoveTree viewer shell (`pages/tree.html`). This is the first step toward a dedicated public viewing experience separate from the editor. The viewer displays a public tree's nodes (moments) in a vertical flow and provides a selected moment preview panel.

**Key characteristics:**
- Read-only: no edit/add/delete/save controls
- Public data: uses community public memories API
- Shell v0.1: tree nodes list + selected moment preview
- Not yet integrated with Browse CTA (that's a follow-up PR)

## Route Added

- **`/pages/tree.html`** - Public tree viewer
  - Query param: `?treeId=<public_tree_id>`
  - Example: `/pages/tree.html?treeId=abc123`

## Data Source

- Uses existing `apiClient.communityApi.getCachedCommunityMemories({ treeId, limit: 100 })`
- Filters to `visibility === 'public'` (safety)
- Reuses Browse's public tree preview pattern (no new backend)

## Read-only Guard

- ✅ No `수정`, `삭제`, `저장`, `편집` text anywhere
- ✅ No owner-affordance buttons
- ✅ No direct access to private endpoints
- ✅ Viewer is public-safe (does not require auth)

## Node Render

- Vertical list of moment nodes
- Each node shows:
  - Title / emotion memo
  - Formatted date
  - Emotion tags (up to 4)
- Click node → preview panel updates
- Active node highlighted with primary border

## Selected Moment Preview

- Media thumbnail (if available)
- Moment title
- Emotion tags
- Date/location meta
- Diary: quote + content (plain text)
- No edit buttons

## States Implemented

- Loading: "러브트리를 불러오는 중이에요"
- Empty: "아직 공개된 순간이 없어요"
- Error: "러브트리를 불러오지 못했어요. 다시 시도해 주세요." + Retry button
- Tree loaded: node list + preview

## Mobile 375px

- Tree section + preview panel stack vertically
- No horizontal overflow
- Tappable nodes (min 44px height)

## Changed Files

| File | Purpose |
|------|---------|
| `pages/tree.html` | Viewer page shell |
| `js/viewer/public-tree-viewer.js` | Viewer logic (data loading, rendering, state) |
| `js/i18n/i18n-viewer.js` | Viewer i18n dictionary (ko/en) |
| `css/viewer/public-tree-viewer.css` | Viewer styles (responsive, read-only aesthetic) |

## Tests / Verification

- ✅ `git diff --check` (no whitespace errors)
- ✅ `node --check js/viewer/public-tree-viewer.js`
- ✅ `node --check js/i18n/i18n-viewer.js`
- ✅ `npm run build` (static check passed)
- ✅ `npm test` (195/195)
- ✅ `npm run verify` (141/143, server-only deps skipped)

## Browser Verification Required: YES

**NOT_VERIFIED:**
- Fixed slot deployment
- Deployed SHA match
- Public viewer route loads with `treeId`
- Nodes render correctly
- Selected moment preview updates on node click
- Desktop screenshot
- Mobile 375px screenshot
- No edit controls visible
- No fatal console/network errors
- No private data exposure

---

Refs #801