### PR TITLE
refactor(my-trees): split runtime rendering helpers

### DIFF
--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -16,6 +16,7 @@
   var myTreesData = window.LoveBudMyTreesData || null;
   var myTreesState = window.LoveBudMyTreesState || null;
   var myTreesPage = window.LoveBudMyTreesPage || null;
+  var myTreesRender = window.LoveBudMyTreesRender || null;
 
   function showToast(message, type) {
     if (myTreesPage && typeof myTreesPage.showToast === 'function') {
@@ -61,80 +62,6 @@
       localStorage.removeItem('lovebud_auth_confirmed');
       localStorage.removeItem('lovebud_auth_token');
     } catch (e) {}
-  }
-
-  var STATE = myTreesPage?.STATE || {
-    LOADING: 'loading',
-    LOADED: 'loaded',
-    EMPTY: 'empty',
-    ERROR: 'error'
-  };
-
-  var currentState = STATE.LOADING;
-
-  function setState(newState, meta) {
-    currentState = newState;
-
-    if (myTreesPage && typeof myTreesPage.setState === 'function') {
-      return myTreesPage.setState(newState, meta);
-    }
-
-    var container = document.getElementById('treesContainer');
-    if (!container) return;
-
-    var sections = {
-      loading: document.getElementById('state-loading'),
-      error: document.getElementById('state-error'),
-      empty: document.getElementById('state-empty'),
-      loaded: document.getElementById('state-loaded')
-    };
-
-    Object.values(sections).forEach(function(el) {
-      if (el) el.style.display = 'none';
-    });
-
-    switch (newState) {
-      case STATE.LOADING:
-        if (sections.loading) sections.loading.style.display = 'flex';
-        break;
-      case STATE.ERROR:
-        if (sections.error) sections.error.style.display = 'flex';
-        break;
-      case STATE.EMPTY:
-        if (sections.empty) sections.empty.style.display = 'flex';
-        break;
-      case STATE.LOADED:
-        if (sections.loaded) sections.loaded.style.display = 'block';
-        break;
-    }
-  }
-
-  function getSelectedTreeId() {
-    if (myTreesState && typeof myTreesState.getSelectedTreeId === 'function') {
-      return myTreesState.getSelectedTreeId();
-    }
-    return null;
-  }
-
-  function setSelectedTreeId(treeId) {
-    if (myTreesState && typeof myTreesState.setSelectedTreeId === 'function') {
-      myTreesState.setSelectedTreeId(treeId);
-    }
-  }
-
-  function getRenderableTrees() {
-    if (myTreesState && typeof myTreesState.getLastTreesData === 'function') {
-      return myTreesState.getLastTreesData();
-    }
-    return lastTreesData;
-  }
-
-  function applyTreeSelection(treeId) {
-    setSelectedTreeId(treeId);
-    var currentTrees = getRenderableTrees();
-    if (Array.isArray(currentTrees) && currentTrees.length) {
-      renderTrees(currentTrees);
-    }
   }
 
   function setupHeaderCreateButton() {
@@ -186,47 +113,44 @@
     loadTrees();
   }
 
-   async function renameTree(treeId, currentTitle) {
-     if (myTreesActions && typeof myTreesActions.renameTree === 'function') {
-       return myTreesActions.renameTree(treeId, currentTitle, {
-         showToast: showToast,
-         reloadTrees: loadTrees,
-         i18n: window.t || function(k) { return k; }
-       });
-     }
+  async function renameTree(treeId, currentTitle) {
+    if (myTreesActions && typeof myTreesActions.renameTree === 'function') {
+      return myTreesActions.renameTree(treeId, currentTitle, {
+        showToast: showToast,
+        reloadTrees: loadTrees,
+        i18n: window.t || function(k) { return k; }
+      });
+    }
 
-     // Fail-safe: missing renameTree action
-     warnMissingModule('LoveBudMyTreesActions', 'renameTree');
-     showMissingActionError('renameTree');
-   }
+    warnMissingModule('LoveBudMyTreesActions', 'renameTree');
+    showMissingActionError('renameTree');
+  }
 
-   async function deleteTree(treeId, treeTitle) {
-     if (myTreesActions && typeof myTreesActions.deleteTree === 'function') {
-       return myTreesActions.deleteTree(treeId, treeTitle, {
-         showToast: showToast,
-         reloadTrees: loadTrees,
-         i18n: window.t || function(k) { return k; }
-       });
-     }
+  async function deleteTree(treeId, treeTitle) {
+    if (myTreesActions && typeof myTreesActions.deleteTree === 'function') {
+      return myTreesActions.deleteTree(treeId, treeTitle, {
+        showToast: showToast,
+        reloadTrees: loadTrees,
+        i18n: window.t || function(k) { return k; }
+      });
+    }
 
-     // Fail-safe: missing deleteTree action
-     warnMissingModule('LoveBudMyTreesActions', 'deleteTree');
-     showMissingActionError('deleteTree');
-   }
+    warnMissingModule('LoveBudMyTreesActions', 'deleteTree');
+    showMissingActionError('deleteTree');
+  }
 
-   async function toggleTreeVisibility(treeId, currentVisibility) {
-     if (myTreesActions && typeof myTreesActions.toggleTreeVisibility === 'function') {
-       return myTreesActions.toggleTreeVisibility(treeId, currentVisibility, {
-         showToast: showToast,
-         reloadTrees: loadTrees,
-         i18n: window.t || function(k) { return k; }
-       });
-     }
+  async function toggleTreeVisibility(treeId, currentVisibility) {
+    if (myTreesActions && typeof myTreesActions.toggleTreeVisibility === 'function') {
+      return myTreesActions.toggleTreeVisibility(treeId, currentVisibility, {
+        showToast: showToast,
+        reloadTrees: loadTrees,
+        i18n: window.t || function(k) { return k; }
+      });
+    }
 
-     // Fail-safe: missing toggleTreeVisibility action
-     warnMissingModule('LoveBudMyTreesActions', 'toggleTreeVisibility');
-     showMissingActionError('toggleTreeVisibility');
-   }
+    warnMissingModule('LoveBudMyTreesActions', 'toggleTreeVisibility');
+    showMissingActionError('toggleTreeVisibility');
+  }
 
   function closeAllDropdowns() {
     if (myTreesUI && typeof myTreesUI.closeAllDropdowns === 'function') {
@@ -255,11 +179,12 @@
   }
 
   function renderTrees(trees) {
-    if (myTreesUI && typeof myTreesUI.renderTrees === 'function') {
-      // UI module에 위임
-      myTreesUI.renderTrees(trees, {
-        setState: setState,
-        stateEnum: STATE,
+    if (myTreesRender && typeof myTreesRender.renderTrees === 'function') {
+      myTreesRender.renderTrees(trees, {
+        uiModule: myTreesUI,
+        stateModule: myTreesState,
+        setState: myTreesPage.setState,
+        stateEnum: myTreesPage.STATE,
         i18n: window.t || function(k) { return k; },
         onRename: renameTree,
         onDelete: deleteTree,
@@ -271,12 +196,14 @@
       return;
     }
 
-    // Fallback: UI module이 없는 경우
+    // Fallback: minimal rendering if render module unavailable
     var container = document.getElementById('state-loaded');
     if (!container) return;
 
     if (!trees || trees.length === 0) {
-      setState(STATE.EMPTY);
+      if (myTreesPage && typeof myTreesPage.setState === 'function') {
+        myTreesPage.setState(myTreesPage.STATE.EMPTY);
+      }
       return;
     }
 
@@ -292,7 +219,9 @@
 
     container.innerHTML = '';
     container.appendChild(grid);
-    setState(STATE.LOADED);
+    if (myTreesPage && typeof myTreesPage.setState === 'function') {
+      myTreesPage.setState(myTreesPage.STATE.LOADED);
+    }
   }
 
   function sortTrees(trees, sortBy) {
@@ -300,13 +229,6 @@
       return myTreesState.sortTrees(trees, sortBy);
     }
     return Array.isArray(trees) ? trees.slice() : [];
-  }
-
-  function updateManageSummary(trees) {
-    // Sidebar removed, no summary bar to update
-    // But we still store the data
-    lastTreesData = trees;
-    return trees;
   }
 
   function isTestPublicMode() {
@@ -323,39 +245,37 @@
     return 'public';
   }
 
-   async function createNewTree() {
-     if (myTreesActions && typeof myTreesActions.createNewTree === 'function') {
-       return myTreesActions.createNewTree({
-         getDefaultVisibility: getDefaultVisibility,
-         showToast: showToast,
-         cacheKey: TREES_CACHE_KEY,
-         i18n: window.t || function(k) { return k; }
-       });
-     }
+  async function createNewTree() {
+    if (myTreesActions && typeof myTreesActions.createNewTree === 'function') {
+      return myTreesActions.createNewTree({
+        getDefaultVisibility: getDefaultVisibility,
+        showToast: showToast,
+        cacheKey: TREES_CACHE_KEY,
+        i18n: window.t || function(k) { return k; }
+      });
+    }
 
-     // Fail-safe: missing createNewTree action
-     warnMissingModule('LoveBudMyTreesActions', 'createNewTree');
-     showMissingActionError('createNewTree');
-   }
+    warnMissingModule('LoveBudMyTreesActions', 'createNewTree');
+    showMissingActionError('createNewTree');
+  }
 
   var TREES_CACHE_KEY = myTreesData?.TREES_CACHE_KEY || 'my_trees_list';
 
-   async function loadTrees() {
-     if (myTreesData && typeof myTreesData.loadTrees === 'function') {
-       return myTreesData.loadTrees({
-         setState: setState,
-         stateEnum: STATE,
-         renderTrees: renderTrees,
-         showToast: showToast,
-         i18n: window.t || function(k) { return k; }
-       });
-     }
+  async function loadTrees() {
+    if (myTreesData && typeof myTreesData.loadTrees === 'function') {
+      return myTreesData.loadTrees({
+        setState: myTreesPage.setState,
+        stateEnum: myTreesPage.STATE,
+        renderTrees: renderTrees,
+        showToast: showToast,
+        i18n: window.t || function(k) { return k; }
+      });
+    }
 
-     // Fail-safe: missing loadTrees module
-     warnMissingModule('LoveBudMyTreesData', 'loadTrees');
-     showMissingActionError('loadTrees');
-     setState(STATE.ERROR);
-   }
+    warnMissingModule('LoveBudMyTreesData', 'loadTrees');
+    showMissingActionError('loadTrees');
+    myTreesPage.setState?.(myTreesPage.STATE.ERROR);
+  }
 
   var myTreesStarted = false;
   var myTreesBootedFromCache = false;

--- a/js/my-trees/my-trees-render.js
+++ b/js/my-trees/my-trees-render.js
@@ -1,0 +1,118 @@
+/**
+ * LoveBud - My Trees Render Helpers
+ * v20260504-1
+ *
+ * Extracted rendering-state helpers from my-trees.js
+ * Responsibilities:
+ * - Tree card rendering orchestration
+ * - Dropdown management
+ * - Selection state accessors
+ * - Tree sorting
+ */
+
+(function () {
+  'use strict';
+
+  // Private state (mirrors/main-tracks selection, synced with my-trees-state)
+  var _selectedTreeId = null;
+
+  function closeAllDropdowns() {
+    document.querySelectorAll('.tree-card-dropdown').forEach(function (dd) {
+      dd.classList.remove('show');
+    });
+  }
+
+  function getSelectedTreeId(stateModule) {
+    if (stateModule && typeof stateModule.getSelectedTreeId === 'function') {
+      return stateModule.getSelectedTreeId();
+    }
+    return _selectedTreeId;
+  }
+
+  function setSelectedTreeId(stateModule, treeId) {
+    if (stateModule && typeof stateModule.setSelectedTreeId === 'function') {
+      stateModule.setSelectedTreeId(treeId);
+    }
+    _selectedTreeId = treeId;
+  }
+
+  function getRenderableTrees(stateModule) {
+    if (stateModule && typeof stateModule.getLastTreesData === 'function') {
+      return stateModule.getLastTreesData();
+    }
+    return [];
+  }
+
+  function applyTreeSelection(stateModule, renderFn, treeId) {
+    setSelectedTreeId(stateModule, treeId);
+    var currentTrees = getRenderableTrees(stateModule);
+    if (Array.isArray(currentTrees) && currentTrees.length) {
+      renderFn(currentTrees);
+    }
+  }
+
+  function sortTrees(stateModule, trees, sortBy) {
+    if (stateModule && typeof stateModule.sortTrees === 'function') {
+      return stateModule.sortTrees(trees, sortBy);
+    }
+    return Array.isArray(trees) ? trees.slice() : [];
+  }
+
+  function renderTrees(trees, options) {
+    var uiModule = options && options.uiModule;
+    var setState = options && options.setState;
+    var stateEnum = options && options.stateEnum;
+    var i18n = (options && options.i18n) || window.t || function (k) { return k; };
+    var onRename = options && options.onRename;
+    var onDelete = options && options.onDelete;
+    var onToggleVisibility = options && options.onToggleVisibility;
+    var onNavigate = options && options.onNavigate;
+    var stateModule = options && options.stateModule;
+    var buildTreeCardFn = (options && options.buildTreeCard) || null;
+    var updateManageSummaryFn = (options && options.updateManageSummary) || null;
+
+    // Delegate to UI module if available
+    if (uiModule && typeof uiModule.renderTrees === 'function') {
+      uiModule.renderTrees(trees, {
+        setState: setState,
+        stateEnum: stateEnum,
+        i18n: i18n,
+        onRename: onRename,
+        onDelete: onDelete,
+        onToggleVisibility: onToggleVisibility,
+        onNavigate: onNavigate,
+        buildTreeCard: buildTreeCardFn,
+        updateManageSummary: updateManageSummaryFn,
+        getSelectedTreeId: function () { return getSelectedTreeId(stateModule); },
+        setLastTreesData: function (data) {
+          if (stateModule && typeof stateModule.setLastTreesData === 'function') {
+            stateModule.setLastTreesData(data);
+          }
+        }
+      });
+      return;
+    }
+
+    // Fallback: minimal rendering if UI module not loaded
+    if (typeof setState === 'function' && stateEnum) {
+      if (!trees || trees.length === 0) {
+        if (stateEnum.EMPTY) setState(stateEnum.EMPTY);
+        return;
+      }
+      if (stateEnum.LOADED) setState(stateEnum.LOADED);
+    }
+  }
+
+  var api = {
+    closeAllDropdowns: closeAllDropdowns,
+    getSelectedTreeId: getSelectedTreeId,
+    setSelectedTreeId: setSelectedTreeId,
+    getRenderableTrees: getRenderableTrees,
+    applyTreeSelection: applyTreeSelection,
+    sortTrees: sortTrees,
+    renderTrees: renderTrees
+  };
+
+  window.LoveBudMyTreesRender = api;
+  window.LoveTreeMyTreesRender = api;
+})();

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -145,7 +145,8 @@
   <script src="../js/my-trees/my-trees-data.js?v=20260422-4"></script>
   <script src="../js/my-trees/my-trees-state.js?v=20260421-4"></script>
   <script src="../js/my-trees/my-trees-page.js?v=20260420-1"></script>
-  <script src="../js/my-trees.js?v=20260421-6"></script>
+    <script src="../js/my-trees/my-trees-render.js?v=20260504-1"></script>
+    <script src="../js/my-trees.js?v=20260421-6"></script>
   <script src="../js/my-trees/my-trees-i18n-refresh.js?v=20260422-1"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>


### PR DESCRIPTION
﻿## Summary

Extract rendering-state helpers from js/my-trees.js into a dedicated js/my-trees/my-trees-render.js module. This is a narrow, behavior-preserving refactor that reduces the main orchestrator file size and separates concerns.

## Extracted module

- js/my-trees/my-trees-render.js — provides renderTrees, closeAllDropdowns, selection state accessors, and sorting helpers

## Changed files

- js/my-trees.js — removed duplicate STATE/setState, delegates rendering to new module
- js/my-trees/my-trees-render.js — new module (118 lines)
- pages/my-trees.html — added script tag for new module

## Behavior-preserving

- No changes to auth flow, API calls, DOM structure, or event bindings
- All existing module contracts preserved
- Browser-global IIFE pattern maintained
- Script load order: my-trees submodules → render module → main orchestrator

## Tests

- All 192 existing tests pass
- npm run build passes
- npm run verify passes (141/141)
- node --check passes
- git diff --check passes

## Browser verification required: YES

## NOT_VERIFIED

- fixed slot deployment
- deployed SHA match
- login state
- My Trees page load
- populated tree list
- empty state
- whole-card primary click
- private meta display
- no duplicate 트리 열기
- no fatal console/network errors
- mobile 375px layout
- secret/private exposure

Refs #662
