### PR TITLE
ui(viewer): add selected moment detail panel with YouTube embed support

### DIFF
--- a/css/viewer/public-tree-viewer.css
+++ b/css/viewer/public-tree-viewer.css
@@ -1,6 +1,6 @@
 /**
  * Public Tree Viewer Styles
- * v20260505-801-1
+ * v20260505-802-1
  */
 
 /* Viewer page shell */
@@ -217,6 +217,15 @@
 .viewer-preview-image {
     width: 100%;
     height: auto;
+    display: block;
+}
+
+.viewer-preview-video {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border: none;
+    border-radius: 12px;
+    background: #000;
     display: block;
 }
 

--- a/js/i18n/i18n-viewer.js
+++ b/js/i18n/i18n-viewer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - i18n Viewer Dictionary
- * v20260505-801-1
+ * v20260505-802-1
  *
  * Viewer page (public tree viewer) translation keys
  */
@@ -81,6 +81,18 @@
     'viewer.momentMedia': {
       ko: '미디어',
       en: 'Media'
+    },
+    'viewer.videoPlayer': {
+      ko: '영상 재생',
+      en: 'Video Player'
+    },
+    'viewer.noMedia': {
+      ko: '표시할 미디어가 없어요',
+      en: 'No media to display'
+    },
+    'viewer.momentPosition': {
+      ko: '순간 {index}번째',
+      en: 'Moment {index}'
     }
   };
 })();

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -71,22 +71,30 @@
     }
 
     // Render helpers
-    function setContent(elem, text) {
-        if (elem) elem.textContent = text;
+    function resolveElement(sel) {
+        if (!sel) return null;
+        if (typeof sel === 'string') {
+            return document.querySelector(sel);
+        }
+        return sel; // already an element
     }
 
-    function show(...els) {
-        for (const el of els) {
-            if (el) {
-                if (el.setAttribute) el.setAttribute('hidden', false);
-                else if (el.removeAttribute) el.removeAttribute('hidden');
-            }
+    function setContent(sel, text) {
+        const el = resolveElement(sel);
+        if (el) el.textContent = text;
+    }
+
+    function show(...sels) {
+        for (const sel of sels) {
+            const el = resolveElement(sel);
+            if (el) el.removeAttribute('hidden');
         }
     }
 
-    function hide(...els) {
-        for (const el of els) {
-            if (el && el.setAttribute) el.setAttribute('hidden', true);
+    function hide(...sels) {
+        for (const sel of sels) {
+            const el = resolveElement(sel);
+            if (el) el.setAttribute('hidden', '');
         }
     }
 
@@ -190,7 +198,7 @@
     }
 
     function renderNodesList() {
-        const list = SEL.nodesList;
+        const list = resolveElement(SEL.nodesList);
         if (!list) return;
         list.innerHTML = '';
 
@@ -255,7 +263,8 @@
     function selectMemory(memoryId) {
         selectedMemoryId = memoryId;
         // update active node class
-        const nodes = SEL.nodesList.querySelectorAll('.viewer-node');
+        const list = resolveElement(SEL.nodesList);
+        const nodes = list ? list.querySelectorAll('.viewer-node') : [];
         nodes.forEach(n => {
             n.classList.toggle('viewer-node-active', n.dataset.memoryId === memoryId);
         });
@@ -278,7 +287,7 @@
 
     function renderPreviewMemory(memory) {
         // Media (video embed or thumbnail)
-        const mediaContainer = SEL.previewMedia;
+        const mediaContainer = resolveElement(SEL.previewMedia);
         if (mediaContainer) {
             const sourceUrl = memory.sourceUrl || memory.originalUrl || '';
             const thumb = memory.representativeThumbnail || memory.thumbnail || '';
@@ -298,7 +307,7 @@
 
         // Title & tags
         setContent(SEL.momentTitle, memory.title || memory.emotionMemo || '');
-        const tagsContainer = SEL.momentTags;
+        const tagsContainer = resolveElement(SEL.momentTags);
         if (tagsContainer) {
             tagsContainer.innerHTML = (memory.emotionTags || [])
                 .map(tag => `<span class="viewer-preview-tag">${escapeHtml(tag)}</span>`)
@@ -306,7 +315,7 @@
         }
 
         // Meta: date/location
-        const metaContainer = SEL.momentMeta;
+        const metaContainer = resolveElement(SEL.momentMeta);
         if (metaContainer) {
             const dateStr = formatMemoryDate(memory);
             const location = memory.location || '';
@@ -317,8 +326,8 @@
         }
 
         // Diary
-        const quoteEl = SEL.diaryQuote;
-        const contentEl = SEL.diaryContent;
+        const quoteEl = resolveElement(SEL.diaryQuote);
+        const contentEl = resolveElement(SEL.diaryContent);
         if (quoteEl) quoteEl.textContent = memory.emotionMemo || '';
         if (contentEl) {
             // raw diary content is not exposed; show placeholder if empty
@@ -330,7 +339,7 @@
 
     // Error retry
     function setupRetry() {
-        const btn = document.querySelector(SEL.retryBtn);
+        const btn = resolveElement(SEL.retryBtn);
         if (btn && typeof btn.addEventListener === 'function') {
             btn.addEventListener('click', () => {
                 if (currentTreeId) {
@@ -342,7 +351,7 @@
 
     // Navigation back
     function setupBackLink() {
-        const back = document.querySelector(SEL.backLink);
+        const back = resolveElement(SEL.backLink);
         if (back && typeof back.addEventListener === 'function') {
             back.addEventListener('click', (e) => {
                 // default behavior is fine (link to search)

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -136,13 +136,17 @@
     }
 
     async function loadPublicMemories(treeId) {
-        if (!window.apiClient?.communityApi?.getCachedCommunityMemories) {
+        // Defensive: community methods may be on apiClient.communityApi or flattened onto apiClient
+        const getCachedCommunityMemories =
+            window.apiClient?.communityApi?.getCachedCommunityMemories ||
+            window.apiClient?.getCachedCommunityMemories;
+
+        if (typeof getCachedCommunityMemories !== 'function') {
             throw new Error('Community API not available');
         }
-        // Fetch public memories for this tree
-        const memories = await window.apiClient.communityApi.getCachedCommunityMemories({ treeId, limit: 100 });
-        // Filter: only public memories (safety)
-        return Array.isArray(memories) 
+
+        const memories = await getCachedCommunityMemories({ treeId, limit: 100 });
+        return Array.isArray(memories)
             ? memories.filter(m => m && m.visibility === 'public')
             : [];
     }

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -1,9 +1,10 @@
 /**
  * LoveBud Public Tree Viewer
- * v20260505-801-1
+ * v20260505-802-1
  *
  * Read-only public LoveTree viewer shell.
  * Loads public tree data and displays nodes + selected moment preview.
+ * Enhanced: YouTube embed support, improved accessibility.
  */
 
 (function() {
@@ -193,6 +194,9 @@
             const node = document.createElement('div');
             node.className = 'viewer-node' + (memory.id === selectedMemoryId ? ' viewer-node-active' : '');
             node.dataset.memoryId = memory.id;
+            node.setAttribute('role', 'button');
+            node.setAttribute('tabindex', '0');
+            node.setAttribute('aria-label', escapeHtml(memory.title || memory.emotionMemo || t('viewer.momentTitle', '그때의 마음', 'That Moment')));
 
             // Node content: title + date + tags
             let tagsHtml = '';
@@ -210,6 +214,12 @@
             `;
 
             node.addEventListener('click', () => selectMemory(memory.id));
+            node.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    selectMemory(memory.id);
+                }
+            });
             list.appendChild(node);
         }
     }
@@ -224,6 +234,18 @@
         } catch (e) {
             return raw;
         }
+    }
+
+    function extractYouTubeVideoId(url) {
+        if (!url) return null;
+        const s = String(url);
+        // Standard watch URL with v= parameter
+        const vMatch = s.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
+        if (vMatch) return vMatch[1];
+        // youtu.be/ID, shorts/ID, embed/ID, live/ID, v/ID
+        const pathMatch = s.match(/(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts\/|live\/))([a-zA-Z0-9_-]{11})/);
+        if (pathMatch) return pathMatch[1];
+        return null;
     }
 
     function selectMemory(memoryId) {
@@ -251,12 +273,20 @@
     }
 
     function renderPreviewMemory(memory) {
-        // Media (if available)
+        // Media (video embed or thumbnail)
         const mediaContainer = SEL.previewMedia;
         if (mediaContainer) {
+            const sourceUrl = memory.sourceUrl || memory.originalUrl || '';
             const thumb = memory.representativeThumbnail || memory.thumbnail || '';
-            if (thumb) {
-                mediaContainer.innerHTML = `<img src="${escapeHtml(thumb)}" alt="${escapeHtml(memory.title || '')}" class="viewer-preview-image" />`;
+
+            // Check for YouTube embed URL
+            const ytVideoId = extractYouTubeVideoId(sourceUrl);
+            if (ytVideoId) {
+                const embedUrl = `https://www.youtube.com/embed/${ytVideoId}?rel=0&modestbranding=1`;
+                const safeTitle = escapeHtml(memory.title || 'moment video');
+                mediaContainer.innerHTML = `<iframe src="${escapeHtml(embedUrl)}" class="viewer-preview-video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" title="${safeTitle}"></iframe>`;
+            } else if (thumb) {
+                mediaContainer.innerHTML = `<img src="${escapeHtml(thumb)}" alt="${escapeHtml(memory.title || '')}" class="viewer-preview-image" loading="lazy" />`;
             } else {
                 mediaContainer.innerHTML = `<div class="viewer-preview-no-media"><span class="material-symbols-outlined">image</span></div>`;
             }

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -104,9 +104,10 @@
         </main>
     </div>
 
-    <!-- Scripts (no auth/editor scripts) -->
+    <!-- Scripts (minimal auth policy for base-api-fetch) -->
     <script src="../js/cache-utils.js?v=20260418-1"></script>
     <script src="../js/utils/normalize.js?v=20260422-1"></script>
+    <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260504-1"></script>

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260505-801-1">
+    <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260505-802-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="paper-grain">
@@ -112,8 +112,8 @@
     <script src="../js/search/search-preview-renderer.js?v=20260504-1"></script>
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
-    <script src="../js/i18n/i18n-viewer.js?v=20260505-801-1"></script>
+    <script src="../js/i18n/i18n-viewer.js?v=20260505-802-1"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
-    <script src="../js/viewer/public-tree-viewer.js?v=20260505-801-1"></script>
+    <script src="../js/viewer/public-tree-viewer.js?v=20260505-802-1"></script>
 </body>
 </html>


### PR DESCRIPTION
Refs #802

## Summary
- Refreshed the public viewer moment detail panel branch on latest `main`.
- Rebased `ui/public-viewer-moment-detail-802` from old head `9386eb248ad0efc63e0a99f027b72f585ef52ab9` to new head `cdee5b2960c22e9b5bdf6be645264220e7b68772`.
- Preserved the existing viewer/detail-panel scope.

## Base refresh
- Base `origin/main` used: `8c82a20f0a166c83fd8e6b5e3217ea66af8d98b6`
- Rebase/update result: PASS
- Conflicts encountered: NO
- Scope after rebase: viewer files only

## Changed files
- `pages/tree.html`
- `js/viewer/public-tree-viewer.js`
- `js/i18n/i18n-viewer.js`
- `css/viewer/public-tree-viewer.css`

## What changed
- No new functional changes were added in this refresh.
- Existing PR #806 changes were replayed on top of latest `main`.
- Main-side changes from recent Detail/Browse work were preserved.

## What did not change
- No Browse CTA bridge changes.
- No Detail page changes.
- No Editor/My Trees/Auth/API/backend/DB changes.
- No package or workflow changes.
- No PR #7/prototype/reference/demo/variant changes.
- No browser verification or fixed-slot deployment in this step.
- Draft state should remain unchanged.

## Local checks
- `git diff --check origin/main...HEAD`: PASS
- `node --check js/viewer/public-tree-viewer.js`: PASS
- `node --check js/i18n/i18n-viewer.js`: PASS
- `node --test tests/routes/static-page-aliases.test.js tests/routes/search-runtime-modules.test.js tests/routes/detail-alias-consistency.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser verification required: YES

## Fixed slot deployment required: YES

## NOT_VERIFIED
- Fixed-slot deployed SHA match: NOT_VERIFIED
- Populated public viewer state: NOT_VERIFIED
- Node click/tap → detail panel population: NOT_VERIFIED
- YouTube embed or fallback rendering: NOT_VERIFIED
- Desktop screenshot: NOT_VERIFIED
- Mobile 375px screenshot: NOT_VERIFIED
- Fatal console/network errors: NOT_VERIFIED

## Secret/private data exposure
NO