### PR TITLE
fix(intro): restore English language switch

### DIFF
--- a/pages/intro.html
+++ b/pages/intro.html
@@ -280,6 +280,15 @@
 
      // i18n 초기화
      document.addEventListener('DOMContentLoaded', function() {
+       // URL param에서 언어 확인 (?lang=en 또는 ?lang=ko)
+       var urlParams = new URLSearchParams(window.location.search);
+       var langParam = urlParams.get('lang');
+
+       if (langParam && (langParam === 'en' || langParam === 'ko')) {
+         // URL param이 있으면 해당 언어로 설정
+         if (window.setCurrentLang) window.setCurrentLang(langParam);
+       }
+
        if (window.applyI18n) window.applyI18n();
 
        // 저장된 언어로 드롭다운 상태 동기화


### PR DESCRIPTION
## Summary
Fix English language switch not working on Intro page with ?lang=en URL param.

## Scope
- pages/intro.html: Add URL param language handling in DOMContentLoaded

## Changes
- Check for ?lang=en or ?lang=ko on page load
- Apply i18n with the URL-specified language before rendering
- Ensure language dropdown syncs with current language

## Verification Required
- [ ] Browser: /pages/intro.html Korean default render PASS
- [ ] Browser: /pages/intro.html?lang=en English render PASS
- [ ] Browser: language switch Korean  English toggle PASS
- [ ] Desktop layout overflow check
- [ ] Mobile 375px overflow check
- [ ] Console errors check

## Deployment
- Cloudflare Pages branch deployment required
- Fixed test slot verification required before ready

Refs #672