### PR TITLE
fix: add auth-gating to settings menu and page

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -92,6 +92,34 @@
     return Object.assign({}, DEFAULT_SETTINGS);
   }
 
+  function getConfirmedSessionUser() {
+    try {
+      if (window.getConfirmedAuthUser) {
+        return window.getConfirmedAuthUser();
+      }
+      if (localStorage.getItem('lovebud_auth_confirmed') === 'true') {
+        var raw = localStorage.getItem('lovebud_auth_cache');
+        if (raw && raw !== 'null') {
+          return JSON.parse(raw);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function isAuthenticatedUser(user) {
+    return !!(user && user.uid);
+  }
+
+  function getLoginRedirectHref() {
+    var target = window.location.pathname + (window.location.search || '') + (window.location.hash || '');
+    return 'login.html?redirect=' + encodeURIComponent(target);
+  }
+
+  function redirectToLogin() {
+    window.location.replace(getLoginRedirectHref());
+  }
+
   function applyHeaderNavFallbacks() {
     var t = window.t || function(key) { return key; };
     var navMap = [
@@ -198,8 +226,12 @@
 
   var settingsStarted = false;
 
-  function startSettings() {
+  function startSettings(user) {
     if (settingsStarted) return;
+    if (!isAuthenticatedUser(user)) {
+      redirectToLogin();
+      return;
+    }
     settingsStarted = true;
     document.body.classList.remove('settings-auth-pending');
 
@@ -216,31 +248,29 @@
   }
 
   function initSettings() {
-    startSettings();
-
-    // Early auth check: redirect to login if not authenticated (except on login page)
-    const isLoginPage = window.location.pathname.endsWith('login.html') || window.location.pathname.endsWith('/') || window.location.pathname === '' || window.location.pathname.endsWith('index.html');
-    const confirmedAuthUser = window.getConfirmedAuthUser ? window.getConfirmedAuthUser() : null;
-    const storedAuth = localStorage.getItem('lovebud_auth_confirmed');
-    const isAuthenticated = !!confirmedAuthUser || !!storedAuth;
-    if (!isAuthenticated && !isLoginPage) {
-      const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
-      window.location.href = 'login.html?redirect=' + returnTo;
-      return;
-    }
+    var cachedUser = getConfirmedSessionUser();
 
     if (window.LoveBudAuthBootstrap && typeof window.LoveBudAuthBootstrap.whenReady === 'function') {
       try {
-        window.LoveBudAuthBootstrap.whenReady().then(startSettings).catch(startSettings);
+        window.LoveBudAuthBootstrap.whenReady().then(function(user) {
+          startSettings(user);
+        }).catch(function() {
+          startSettings(cachedUser);
+        });
       } catch (e) {
-        startSettings();
+        startSettings(cachedUser);
       }
       return;
     }
 
     if (typeof window.registerOnAuthReady === 'function') {
-      window.registerOnAuthReady(startSettings);
+      window.registerOnAuthReady(function(user) {
+        startSettings(user);
+      });
+      return;
     }
+
+    startSettings(cachedUser);
   }
 
   function redirectAfterLogout() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -218,6 +218,17 @@
   function initSettings() {
     startSettings();
 
+    // Early auth check: redirect to login if not authenticated (except on login page)
+    const isLoginPage = window.location.pathname.endsWith('login.html') || window.location.pathname.endsWith('/') || window.location.pathname === '' || window.location.pathname.endsWith('index.html');
+    const confirmedAuthUser = window.getConfirmedAuthUser ? window.getConfirmedAuthUser() : null;
+    const storedAuth = localStorage.getItem('lovebud_auth_confirmed');
+    const isAuthenticated = !!confirmedAuthUser || !!storedAuth;
+    if (!isAuthenticated && !isLoginPage) {
+      const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.href = 'login.html?redirect=' + returnTo;
+      return;
+    }
+
     if (window.LoveBudAuthBootstrap && typeof window.LoveBudAuthBootstrap.whenReady === 'function') {
       try {
         window.LoveBudAuthBootstrap.whenReady().then(startSettings).catch(startSettings);

--- a/js/settings.js
+++ b/js/settings.js
@@ -111,8 +111,24 @@
     return !!(user && user.uid);
   }
 
+  function resolveEffectiveUser(user) {
+    if (isAuthenticatedUser(user)) return user;
+    var cachedUser = getConfirmedSessionUser();
+    if (isAuthenticatedUser(cachedUser)) return cachedUser;
+    return null;
+  }
+
   function getLoginRedirectHref() {
-    var target = window.location.pathname + (window.location.search || '') + (window.location.hash || '');
+    var target = window.location.pathname;
+
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      var returnTo = params.get('returnTo');
+      if (returnTo && isSafeReturnTarget(returnTo)) {
+        target += '?returnTo=' + encodeURIComponent(normalizeReturnTarget(returnTo));
+      }
+    } catch (e) {}
+
     return 'login.html?redirect=' + encodeURIComponent(target);
   }
 
@@ -228,7 +244,8 @@
 
   function startSettings(user) {
     if (settingsStarted) return;
-    if (!isAuthenticatedUser(user)) {
+    var effectiveUser = resolveEffectiveUser(user);
+    if (!isAuthenticatedUser(effectiveUser)) {
       redirectToLogin();
       return;
     }
@@ -253,24 +270,24 @@
     if (window.LoveBudAuthBootstrap && typeof window.LoveBudAuthBootstrap.whenReady === 'function') {
       try {
         window.LoveBudAuthBootstrap.whenReady().then(function(user) {
-          startSettings(user);
+          startSettings(user || cachedUser || getConfirmedSessionUser());
         }).catch(function() {
-          startSettings(cachedUser);
+          startSettings(cachedUser || getConfirmedSessionUser());
         });
       } catch (e) {
-        startSettings(cachedUser);
+        startSettings(cachedUser || getConfirmedSessionUser());
       }
       return;
     }
 
     if (typeof window.registerOnAuthReady === 'function') {
       window.registerOnAuthReady(function(user) {
-        startSettings(user);
+        startSettings(user || getConfirmedSessionUser());
       });
       return;
     }
 
-    startSettings(cachedUser);
+    startSettings(cachedUser || getConfirmedSessionUser());
   }
 
   function redirectAfterLogout() {

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -290,6 +290,20 @@
 
         // 에디터 페이지에서는 "편집하기" 메뉴 숨김 (이미 편집 화면 안에 있음)
 
+        // Settings (auth gated)
+        if (menuConfig.settings) {
+            var settingsClasses = [];
+            if (activeKey === 'settings') settingsClasses.unshift('active');
+
+            var settingsHref = cachedUser
+                ? menuConfig.settings.href
+                : getLoginRedirectHref(menuConfig.settings.href);
+
+            navLinksHTML += '<a href="' + settingsHref + '"' +
+                (settingsClasses.length ? ' class="' + settingsClasses.join(' ') + '"' : '') +
+                '>' + t(menuConfig.settings.textKey) + '</a>';
+        }
+
         return [
             '<header class="nav-bar">',
                 '<a href="' + logoHref + '" class="headline header-logo" aria-label="LoveTree 홈으로 이동">LoveTree</a>',

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -295,9 +295,10 @@
             var settingsClasses = [];
             if (activeKey === 'settings') settingsClasses.unshift('active');
 
+            var settingsReturnHref = appendSettingsReturnTo(menuConfig.settings.href);
             var settingsHref = cachedUser
-                ? menuConfig.settings.href
-                : getLoginRedirectHref(menuConfig.settings.href);
+                ? settingsReturnHref
+                : getLoginRedirectHref(settingsReturnHref);
 
             navLinksHTML += '<a href="' + settingsHref + '"' +
                 (settingsClasses.length ? ' class="' + settingsClasses.join(' ') + '"' : '') +

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -10,10 +10,10 @@
 </head>
 <body>
   <div class="noise-overlay"></div>
-  
+
   <div class="settings-layout">
     <div id="shared-header"></div>
-    
+
     <main class="settings-content" id="settingsContent">
       <div class="settings-card" id="settingsCard" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
         <button type="button" class="settings-close-btn" id="settingsCloseBtn" aria-label="설정 닫기" title="닫기">
@@ -21,7 +21,7 @@
         </button>
         <h1 id="settingsTitle">설정</h1>
         <p class="settings-subtitle">러브트리를 어떻게 소개할지 살펴봅니다</p>
-        
+
         <div class="settings-section">
           <div class="settings-section-title" id="settingsBrowseIntroTitle">
             <span class="material-symbols-outlined">travel_explore</span>
@@ -42,9 +42,9 @@
             </span>
           </div>
         </div>
-        
+
         <div class="settings-divider"></div>
-        
+
         <div class="settings-section">
           <button class="logout-btn" onclick="handleLogout()">
             <span class="material-symbols-outlined">logout</span>

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -59,6 +59,9 @@
     <script src="../js/i18n/i18n-shared.js?v=20260425-1"></script>
     <script src="../js/i18n/i18n-index.js?v=20260421-1"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+    <script src="../js/firebase-config.js?v=20260417-31"></script>
     <script src="../js/shared-header.js?v=20260421-2"></script>
      <script src="../js/auth/auth-state.js?v=20260417-31"></script>
      <script src="../js/auth/auth-callbacks.js?v=20260417-31"></script>


### PR DESCRIPTION
Refs #639

Applies the same auth-gating pattern as myTrees to the Settings navigation link, and adds a minimal auth check in settings.js to prevent unauthorized access to the settings page.

## Changes

- **js/shared-header.js**: Settings nav link now uses  when user is not authenticated (matching myTrees behavior)
- **js/settings.js**: Early auth check redirects unauthenticated users to login page with  parameter

## Verification

- git diff --check: PASS
- node --check: PASS (both files)
- npm run verify: 142/144 (2 unrelated missing deps)
- npm test: 195/195 PASS

## Notes

- Draft PR (per instructions, no merge/ready/issue close)
- No secret/token/private data exposure
- No backend/auth/DB/API changes
- Consistent with existing codebase patterns (redirect=, getConfirmedAuthUser)