### PR TITLE
docs(ops): correct fixed slot URL source of truth

### DIFF
--- a/docs/ops/AGENTS.md
+++ b/docs/ops/AGENTS.md
@@ -78,7 +78,7 @@ Required safe reporting status values include:
 
 Agents must not use empty commits, version bumps, unrelated source edits, or workflow changes merely to trigger fixed slot deployment. If the deploy output indicates stale asset risk, such as `Uploaded 0 files`, report `BLOCKED_BY_STALE_ASSET` instead of final PASS.
 
-For fixed slot URLs, agents must distinguish `https://test-slot-X.lovebud.pages.dev` from `https://testX.lovebud.pages.dev` and report the exact URL used.
+For fixed slot URLs, agents must use the `test1` through `test10` domain format defined in [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md). Example: slot `test4` must use `https://test4.lovebud.pages.dev`. Do not use `https://test-slot-4.lovebud.pages.dev` for LoveBud fixed slot verification. Always report the exact URL used.
 
 ## Forbidden actions
 

--- a/docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md
+++ b/docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md
@@ -4,7 +4,7 @@
 
 This document defines the standard manual deployment path for LoveBud fixed test slots before browser verification.
 
-Use this procedure when a PR or issue requires a deployed fixed slot such as `test/slot-4`, `test/slot-5`, or another assigned slot branch before Browse, Search, Editor, My Trees, Auth, or API-dependent browser verification.
+Use this procedure when a PR or issue requires a deployed fixed slot such as `test4`, `test5`, or another CTO-assigned fixed test slot before Browse, Search, Editor, My Trees, Auth, or API-dependent browser verification.
 
 This is a docs-only operational procedure. It does not implement a GitHub workflow and does not change runtime behavior.
 
@@ -13,6 +13,7 @@ This is a docs-only operational procedure. It does not implement a GitHub workfl
 - PR #696 and PR #698 documented the need to separate fixed slot verification from stale slot artifacts.
 - Issue #694 tracks the fixed slot deployment procedure and stale asset guardrail.
 - [FIXED_SLOT_MANUAL_E2E_GATE.md](FIXED_SLOT_MANUAL_E2E_GATE.md) remains the assignment, SHA provenance, and evidence gate.
+- [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) is the source of truth for the LoveBud fixed slot domain format.
 
 ## Standard deployment path
 
@@ -23,35 +24,37 @@ Do not rely on a normal `git push` to a slot branch as the only deployment signa
 Use Wrangler direct deploy after the slot assignment and before browser verification.
 
 ```bash
-npx wrangler pages deploy . --project-name lovebud --branch test/slot-X
+npx wrangler pages deploy . --project-name lovebud --branch testX
 ```
 
-Replace `test/slot-X` with the assigned fixed slot branch, for example:
+Replace `testX` with the assigned fixed slot branch, for example:
 
 ```bash
-npx wrangler pages deploy . --project-name lovebud --branch test/slot-4
+npx wrangler pages deploy . --project-name lovebud --branch test4
 ```
 
 ## Slot URL format
 
-For a fixed slot branch named `test/slot-X`, the expected Cloudflare Pages URL is:
+LoveBud fixed test slots use the `test1` through `test10` domain format defined in [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md).
+
+For a fixed slot named `testX`, the expected Cloudflare Pages URL is:
 
 ```text
-https://test-slot-X.lovebud.pages.dev
+https://testX.lovebud.pages.dev
 ```
 
 Examples:
 
 | Slot branch | Expected URL |
 | --- | --- |
-| `test/slot-4` | `https://test-slot-4.lovebud.pages.dev` |
-| `test/slot-5` | `https://test-slot-5.lovebud.pages.dev` |
+| `test4` | `https://test4.lovebud.pages.dev` |
+| `test5` | `https://test5.lovebud.pages.dev` |
 
-Do not confuse these URLs with `testX.lovebud.pages.dev`.
+Do not introduce or use `test-slot-X.lovebud.pages.dev` URLs for LoveBud fixed slot verification.
 
 ```text
-Correct:   https://test-slot-4.lovebud.pages.dev
-Incorrect: https://test4.lovebud.pages.dev
+Correct:   https://test4.lovebud.pages.dev
+Incorrect: https://test-slot-4.lovebud.pages.dev
 ```
 
 Browser verification evidence must report the exact URL that was actually loaded.
@@ -59,18 +62,18 @@ Browser verification evidence must report the exact URL that was actually loaded
 ## Required sequence
 
 1. Confirm the PR or task requires fixed slot browser verification.
-2. Confirm the assigned slot branch, such as `test/slot-4`.
+2. Confirm the assigned fixed slot, such as `test4`.
 3. Confirm the source branch and source head SHA that should be deployed.
 4. Check out the intended source tree locally.
 5. Run the expected local static checks for the PR scope.
 6. Run Wrangler direct deploy:
 
    ```bash
-   npx wrangler pages deploy . --project-name lovebud --branch test/slot-X
+   npx wrangler pages deploy . --project-name lovebud --branch testX
    ```
 
 7. Confirm the Wrangler output reports a successful deploy.
-8. Open the expected fixed slot URL, such as `https://test-slot-X.lovebud.pages.dev`.
+8. Open the expected fixed slot URL, such as `https://testX.lovebud.pages.dev`.
 9. Perform the browser verification only after the Wrangler deployment succeeds.
 10. Report the deployed SHA/source branch, exact URL, viewport, browser, console/pageerror status, and final status.
 
@@ -127,7 +130,7 @@ Do not claim Browse browser PASS from:
 - an unassigned slot;
 - a stale slot;
 - a URL whose branch/SHA/source provenance is unclear;
-- `testX.lovebud.pages.dev` when the expected fixed slot URL is `test-slot-X.lovebud.pages.dev`.
+- `test-slot-X.lovebud.pages.dev` when the expected fixed slot URL is `testX.lovebud.pages.dev`.
 
 ## Security and reporting restrictions
 

--- a/docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md
+++ b/docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md
@@ -35,16 +35,16 @@ The current fixed slot pool is `test1` through `test10`.
 
 | Slot | Cloudflare Pages Branch | Status |
 |------|------------------------|--------|
-| test1 | `test/slot-1` | Available for assignment when no active assignment exists |
-| test2 | `test/slot-2` | Available for assignment when no active assignment exists |
-| test3 | `test/slot-3` | Available for assignment when no active assignment exists |
-| test4 | `test/slot-4` | Available for assignment when no active assignment exists |
-| test5 | `test/slot-5` | Available for assignment when no active assignment exists |
-| test6 | `test/slot-6` | Available for assignment when no active assignment exists |
-| test7 | `test/slot-7` | Available for assignment when no active assignment exists |
-| test8 | `test/slot-8` | Available for assignment when no active assignment exists |
-| test9 | `test/slot-9` | Available for assignment when no active assignment exists |
-| test10 | `test/slot-10` | Available for assignment when no active assignment exists |
+| test1 | `test1` | Available for assignment when no active assignment exists |
+| test2 | `test2` | Available for assignment when no active assignment exists |
+| test3 | `test3` | Available for assignment when no active assignment exists |
+| test4 | `test4` | Available for assignment when no active assignment exists |
+| test5 | `test5` | Available for assignment when no active assignment exists |
+| test6 | `test6` | Available for assignment when no active assignment exists |
+| test7 | `test7` | Available for assignment when no active assignment exists |
+| test8 | `test8` | Available for assignment when no active assignment exists |
+| test9 | `test9` | Available for assignment when no active assignment exists |
+| test10 | `test10` | Available for assignment when no active assignment exists |
 
 ### Slot Assignment Rules
 
@@ -82,7 +82,7 @@ Before reporting any E2E result against a fixed slot, the verifier **must** conf
 ```text
 1. Identify the slot's current branch head SHA:
    - Check the Cloudflare Pages deployment dashboard, OR
-   - Check the slot branch tip: git log test/slot-N --oneline -1
+   - Check the slot branch tip: git log testN --oneline -1
 
 2. Identify the PR head SHA:
    - GitHub PR page → head commit SHA, OR
@@ -251,3 +251,51 @@ Based on Issue #136 suggested minimal smoke targets:
 - [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) — 브라우저 검증 시작 전 공통 preflight
 - [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) — 반복 CI/E2E blocker 원인 분리
 - Issue [#136](https://github.com/skerishKang/LoveBud/issues/136) — CI gap: Cloudflare Pages E2E smoke replacement
+
+---
+
+## 11. Cloudflare Pages URL source of truth
+
+The LoveBud fixed slot URL format is defined by [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md):
+
+```text
+https://test1.lovebud.pages.dev
+https://test2.lovebud.pages.dev
+...
+https://test10.lovebud.pages.dev
+```
+
+Do not use `test-slot-1`, `test-slot-2`, or `test-slot-X` URLs for LoveBud fixed slot verification unless the CTO explicitly changes the fixed slot domain map.
+
+---
+
+## 12. Guardrails
+
+- main direct commit/push/force-push is prohibited.
+- PR branch modification is prohibited during slot verification.
+- plain `--force` is prohibited.
+- Fixed slot assignment must be explicit.
+- Available fixed slots are `test1` through `test10`.
+- PR Preview URLs are not sufficient for final PASS on login/auth/API/domain-sensitive UI flows.
+- A verifier must not silently choose a slot when no slot has been assigned.
+- A verifier must not claim final UI PASS from PR Preview when the CTO requested fixed slot verification.
+- production data write/delete is prohibited unless separately approved.
+- token/password/cookie/raw credential logging is prohibited.
+- PR #7 prototype and prototype/reference/demo folders are not slot cleanup targets.
+- API/backend code changes are not part of slot verification.
+- Browser-only verification must not be replaced by GitHub metadata when the task requires rendered UI proof.
+
+---
+
+## 13. Reference docs
+
+- [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - deployment verification checklist
+- [RUNBOOK.md](RUNBOOK.md) - operations runbook
+- [PR_CHECKLIST.md](PR_CHECKLIST.md) - PR review checklist
+- [../engineering/API_CONTRACT.md](../engineering/API_CONTRACT.md) - API contract
+- [../product/PRODUCT_IDENTITY.md](../product/PRODUCT_IDENTITY.md) - product identity
+
+---
+
+Document version: 1.5  
+Next review: CTO approval after next fixed-slot verification cycle


### PR DESCRIPTION
Refs #694

## Summary
- Correct the fixed slot Wrangler runbook to use the LoveBud fixed slot URL format from `TEST_PREVIEW_SLOTS.md`: `test1` through `test10`.
- Remove the incorrect `test-slot-X.lovebud.pages.dev` guidance from agent-facing fixed slot rules.
- Align the manual E2E gate slot branch names with the existing `test1` through `test10` slot model and add an explicit URL source-of-truth section.

## Root cause
- `TEST_PREVIEW_SLOTS.md` already defines the correct fixed slot domains as `https://test1.lovebud.pages.dev` through `https://test10.lovebud.pages.dev`.
- The later Wrangler runbook introduced a contradictory branch-to-domain mapping: `test/slot-X` → `https://test-slot-X.lovebud.pages.dev`.
- That contradiction caused executors to treat `test-slot-4.lovebud.pages.dev` as valid even though the LoveBud operational fixed slot is `https://test4.lovebud.pages.dev`.

## Changed files
- `docs/ops/FIXED_SLOT_DEPLOY_WITH_WRANGLER.md`
- `docs/ops/AGENTS.md`
- `docs/ops/FIXED_SLOT_MANUAL_E2E_GATE.md`

## Scope
- Docs-only ops guidance correction.
- No runtime, JavaScript, CSS, HTML, Auth, API, backend, DB, package, workflow, or Cloudflare configuration changes.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- Changed files reviewed: docs-only.
- Correct source of truth preserved: `TEST_PREVIEW_SLOTS.md` remains the domain map.
- Correct fixed slot URL example: `https://test4.lovebud.pages.dev`.
- Incorrect fixed slot URL example is now explicitly forbidden: `https://test-slot-4.lovebud.pages.dev`.
- Browser verification: NOT_REQUIRED for docs-only correction.
- Runtime verification: NOT_REQUIRED.

## Guardrails
- No main direct push.
- No ready transition or merge performed.
- No issue close keyword.
- No secrets, tokens, cookies, sessions, passwords, private keys, DB URLs, or private IDs exposed.
- PR #7/prototype/reference/demo/variant untouched.