### PR TITLE
fix(detail): stage viewing page loading states

### DIFF
--- a/css/detail.css
+++ b/css/detail.css
@@ -142,11 +142,32 @@
 .video-main {
     width: 100%;
     aspect-ratio: 16/9;
-    background: #000;
+    background: linear-gradient(135deg, rgba(51, 42, 43, 0.96), rgba(107, 77, 80, 0.9));
     border-radius: 2rem;
     overflow: hidden;
     box-shadow: 0 22px 54px -22px rgba(0,0,0,0.16);
     margin-bottom: 16px;
+}
+
+.detail-media-loading {
+    width: 100%;
+    height: 100%;
+    min-height: 220px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    color: rgba(255,255,255,0.88);
+    font-size: 0.95rem;
+    font-weight: 800;
+    background:
+        radial-gradient(circle at 20% 18%, rgba(255,255,255,0.14), transparent 28%),
+        linear-gradient(135deg, rgba(51,42,43,0.92), rgba(107,77,80,0.88));
+}
+
+.detail-media-loading .material-symbols-outlined {
+    font-size: 22px;
+    color: rgba(255,255,255,0.9);
 }
 
 .detail-memory-meta {
@@ -302,6 +323,66 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 16px;
+}
+
+.detail-context-state,
+.connected-loading-state {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 16px;
+    border-radius: 1.2rem;
+    background: rgba(255,255,255,0.72);
+    border: 1px solid rgba(144,73,81,0.08);
+}
+
+.detail-context-icon {
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border-radius: 12px;
+    background: var(--surface-container);
+    color: var(--primary);
+}
+
+.detail-context-icon .material-symbols-outlined,
+.connected-loading-state .material-symbols-outlined {
+    font-size: 22px;
+    color: var(--primary);
+}
+
+.detail-context-copy,
+.connected-loading-state > div {
+    flex: 1;
+    min-width: 0;
+}
+
+.detail-context-kicker {
+    margin-bottom: 4px;
+    font-size: 11px;
+    font-weight: 800;
+    color: var(--primary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.detail-context-state p,
+.connected-loading-state p {
+    margin: 0;
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+.connected-loading-title {
+    margin-bottom: 4px;
+    color: var(--on-surface);
+    font-size: 0.96rem;
+    font-weight: 800;
+    line-height: 1.45;
 }
 
 .growth-label {

--- a/js/detail/detail-connected.js
+++ b/js/detail/detail-connected.js
@@ -48,6 +48,20 @@
           const connectedSection = connectedFragments.closest('.connected-section');
           connectedSection.classList.remove('is-empty', 'is-solo', 'is-threaded');
 
+          if (degradedReason === 'context-loading') {
+                connectedFragments.innerHTML = `
+                    <div class="connected-loading-state">
+                        <span class="material-symbols-outlined">device_hub</span>
+                        <div>
+                            <div class="connected-loading-title">${tText('connected_loading_title', '이어진 순간을 불러오는 중이에요.')}</div>
+                            <p>${tText('connected_loading_desc', '현재 순간은 먼저 감상할 수 있어요. 연결된 기억은 준비되는 대로 이어서 보여드릴게요.')}</p>
+                        </div>
+                    </div>
+                `;
+                connectedSection.classList.add('is-empty');
+                return;
+          }
+
           if (degradedReason === 'missing-tree-id') {
                 connectedFragments.innerHTML = `
                     <div style="display:grid;grid-template-columns:1fr;gap:24px;">

--- a/js/detail/detail-copy.js
+++ b/js/detail/detail-copy.js
@@ -30,11 +30,14 @@
 
         const applyViewingPageCopy = ({ sourceContext, treeTitle, memoryTitleText, treeMomentCount, connectedCount, memory, degradedReason }) => {
             const isMissingTreeId = degradedReason === 'missing-tree-id';
+            const isContextLoading = degradedReason === 'context-loading';
             const isTreeDegraded = degradedReason === 'tree-load-partial' || degradedReason === 'tree-and-memories-load-failed';
 
             if (detailViewChipLabel) {
                 detailViewChipLabel.textContent = isMissingTreeId
                     ? tText('single_moment_view_chip', '한 순간 감상')
+                    : isContextLoading
+                        ? tText('detail_loading_view_chip', '순간 먼저 여는 중')
                     : isTreeDegraded
                         ? tText('moment_centered_view_chip', '지금은 이 순간 중심 감상')
                         : tText('public_tree_view_chip', '공개 러브트리 감상');
@@ -42,6 +45,8 @@
             if (detailHeroKicker) {
                 detailHeroKicker.textContent = isMissingTreeId
                     ? tText('single_moment_kicker', '남겨진 한 순간')
+                    : isContextLoading
+                        ? tText('detail_loading_kicker', '현재 순간 먼저 열기')
                     : isTreeDegraded
                         ? tText('moment_centered_kicker', '지금은 이 순간 중심 감상')
                         : tText('public_tree_kicker', '공개 러브트리');
@@ -49,6 +54,8 @@
             if (detailHeroTitle) {
                 detailHeroTitle.textContent = isMissingTreeId
                     ? (memoryTitleText || tText('single_moment_fallback_title', '이 순간에 남겨진 마음을 감상하고 있어요'))
+                    : isContextLoading
+                        ? (memoryTitleText || tText('detail_loading_title', '현재 순간을 먼저 열고 있어요'))
                     : treeTitle || getHeroFallbackTitle(memory);
             }
             if (detailHeroDesc) {
@@ -57,6 +64,8 @@
                     detailHeroDesc.textContent = memoryTitleText
                         ? `“${memoryTitleText}” ${tText('single_moment_hero_desc', '하나에 남겨진 감정을 따라가고 있어요.')}`
                         : tText('single_moment_hero_desc_fallback', '지금 남아 있는 이 장면 하나를 중심으로 감상하고 있어요.');
+                } else if (isContextLoading) {
+                    detailHeroDesc.textContent = tText('detail_loading_hero_desc', '현재 순간은 먼저 보여드리고, 이어진 트리 흐름은 따로 불러오고 있어요.');
                 } else if (isTreeDegraded) {
                     detailHeroDesc.textContent = tText('tree_partial_hero_desc', '지금 남아 있는 이 순간을 중심으로 감정의 결을 보고 있어요.');
                 } else {
@@ -73,16 +82,22 @@
             if (connectedKicker) {
                 connectedKicker.textContent = isMissingTreeId
                     ? tText('single_moment_connected_kicker', '지금 머무는 장면')
+                    : isContextLoading
+                        ? tText('connected_loading_kicker', '이어진 흐름 준비 중')
                     : tText('connected_flow_kicker', '이어진 흐름');
             }
             if (connectedTitle) {
                 connectedTitle.textContent = isMissingTreeId
                     ? tText('single_moment_connected_title', '지금은 이 순간을 중심으로 감상 중이에요')
+                    : isContextLoading
+                        ? tText('connected_loading_heading', '현재 순간을 먼저 감상해 주세요')
                     : tText('connected_flow_title', '이 트리의 이어진 기억');
             }
             if (connectedSummary) {
                 if (isMissingTreeId) {
                     connectedSummary.textContent = tText('single_moment_connected_summary', '지금 남아 있는 이 장면과 마음부터 따라가 볼 수 있어요.');
+                } else if (isContextLoading) {
+                    connectedSummary.textContent = tText('connected_loading_summary', '이어진 순간은 현재 장면과 분리해서 불러오고 있어요.');
                 } else if (connectedCount > 0) {
                     connectedSummary.textContent = treeMomentCount > 1
                         ? `${treeMomentCount}${tText('connected_flow_count_suffix', '개의 순간 가운데 지금 장면과 함께 읽히는 기억을 이어서 살펴보세요.')}`
@@ -106,6 +121,8 @@
                 };
                 growthLabel.textContent = isMissingTreeId
                     ? tText('single_moment_growth_label', '한 순간 감상 중')
+                    : isContextLoading
+                        ? tText('detail_loading_growth_label', '이어진 흐름 준비 중')
                     : isTreeDegraded
                         ? tText('moment_centered_growth_label', '지금은 이 순간 중심 감상 중')
                         : (growthMap[sourceContext] || growthMap.browse);

--- a/js/detail/detail-loader.js
+++ b/js/detail/detail-loader.js
@@ -100,6 +100,41 @@
             let degradedReason = null;
             if (!canonicalTreeId) degradedReason = 'missing-tree-id';
 
+            const stagedMemories = [memory];
+            const stagedTree = inferTreeContext({ treeId: canonicalTreeId, currentMemory: memory, mergedMemories: stagedMemories });
+            const stagedMomentCount = resolveTreeMomentCount({ tree: stagedTree, memories: stagedMemories, currentMemory: memory });
+            const stagedDegradedReason = hasTreeContext ? 'context-loading' : 'missing-tree-id';
+
+            renderMemoryBase(memory);
+            renderTreeContext({
+                hasTreeContext,
+                tree: stagedTree,
+                memories: stagedMemories,
+                sourceContext,
+                degradedReason: stagedDegradedReason,
+                currentMemory: memory
+            });
+            renderConnectedFragments({
+                memory,
+                memories: stagedMemories,
+                treeId: canonicalTreeId,
+                sourceContext,
+                degradedReason: stagedDegradedReason,
+                treeMomentCount: stagedMomentCount
+            });
+
+            const stagedTitle = memory.title || tText('tree_context_moment', '순간 상세');
+            document.title = `${stagedTitle} — ${tText('lovetree_brand', '러브트리')}`;
+            applyViewingPageCopy({
+                sourceContext,
+                treeTitle: String(stagedTree?.title || '').trim(),
+                memoryTitleText: memory.title,
+                treeMomentCount: stagedMomentCount,
+                connectedCount: 0,
+                memory,
+                degradedReason: stagedDegradedReason
+            });
+
             let tree = hasTreeContext && cache ? cache.get(TREE_CACHE_KEY(canonicalTreeId)) : null;
             let memories = hasTreeContext && cache ? cache.get(MEMORIES_CACHE_KEY(canonicalTreeId)) : null;
             let treeFetchState = tree ? 'cache' : 'idle';

--- a/js/detail/detail-render.js
+++ b/js/detail/detail-render.js
@@ -65,6 +65,21 @@
         const renderTreeContext = ({ hasTreeContext, tree, memories, sourceContext, degradedReason, currentMemory }) => {
             if (!treeContextEl) return;
 
+            if (degradedReason === 'context-loading') {
+                treeContextEl.innerHTML = `
+                    <div class="detail-context-state detail-context-state-loading">
+                        <div class="detail-context-icon">
+                            <span class="material-symbols-outlined">hourglass_top</span>
+                        </div>
+                        <div class="detail-context-copy">
+                            <div class="detail-context-kicker">${tText('tree_context_loading_kicker', '트리 흐름 확인 중')}</div>
+                            <p>${tText('tree_context_loading_desc', '현재 순간은 먼저 열어두었어요. 이어진 트리 흐름을 잠시 불러오고 있어요.')}</p>
+                        </div>
+                    </div>
+                `;
+                return;
+            }
+
             if (degradedReason === 'missing-tree-id') {
                 treeContextEl.innerHTML = `
                     <div style="display:flex; align-items:flex-start; gap:14px;">

--- a/js/i18n/i18n-detail.js
+++ b/js/i18n/i18n-detail.js
@@ -94,6 +94,14 @@
       ko: '감상 중',
       en: 'Viewing'
     },
+    'tree_context_loading_kicker': {
+      ko: '트리 흐름 확인 중',
+      en: 'Checking tree flow'
+    },
+    'tree_context_loading_desc': {
+      ko: '현재 순간은 먼저 열어두었어요. 이어진 트리 흐름을 잠시 불러오고 있어요.',
+      en: 'This moment is open first. The connected tree flow is still loading.'
+    },
     'tree_context_solo_view': {
       ko: '이 순간만 단독으로 감상하고 있어요.',
       en: 'You are viewing just this moment on its own.'
@@ -286,6 +294,14 @@
       ko: '지금은 이 순간을 먼저 보고 있어요.',
       en: 'For now, stay with this moment first.'
     },
+    'connected_loading_title': {
+      ko: '이어진 순간을 불러오는 중이에요.',
+      en: 'Loading connected moments.'
+    },
+    'connected_loading_desc': {
+      ko: '현재 순간은 먼저 감상할 수 있어요. 연결된 기억은 준비되는 대로 이어서 보여드릴게요.',
+      en: 'You can view this moment first. Connected memories will appear as soon as they are ready.'
+    },
     'connected_path_missing_title': {
       ko: '이어진 흐름이 아직 보이지 않아요.',
       en: 'The connected flow is not visible yet.'
@@ -346,6 +362,10 @@
       ko: '이 순간 감상',
       en: 'Viewing this moment'
     },
+    'detail_loading_view_chip': {
+      ko: '순간 먼저 여는 중',
+      en: 'Opening moment first'
+    },
     'public_tree_kicker': {
       ko: '공개 러브트리',
       en: 'Public LoveTree'
@@ -358,6 +378,10 @@
       ko: '이 순간 감상',
       en: 'Staying with this moment'
     },
+    'detail_loading_kicker': {
+      ko: '현재 순간 먼저 열기',
+      en: 'Opening the current moment first'
+    },
     'public_tree_fallback_title': {
       ko: '이 순간에서 시작된 마음',
       en: 'The feeling that began here'
@@ -369,6 +393,10 @@
     'single_moment_fallback_title': {
       ko: '이 순간에서 시작된 마음',
       en: 'The feeling that began here'
+    },
+    'detail_loading_title': {
+      ko: '현재 순간을 먼저 열고 있어요',
+      en: 'Opening this moment first'
     },
     'public_tree_desc_join': {
       ko: ' 안에서',
@@ -394,6 +422,10 @@
       ko: '이어진 장면들',
       en: 'Connected scenes'
     },
+    'detail_loading_hero_desc': {
+      ko: '현재 순간은 먼저 보여드리고, 이어진 트리 흐름은 따로 불러오고 있어요.',
+      en: 'The current moment is shown first while the connected tree flow loads separately.'
+    },
     'public_tree_context_desc': {
       ko: '이 트리 안에서 남겨진 순간을 감상하고 있어요.',
       en: 'You are viewing a moment within this tree.'
@@ -414,6 +446,10 @@
       ko: '이어진 순간들',
       en: 'Connected moments'
     },
+    'connected_loading_kicker': {
+      ko: '이어진 흐름 준비 중',
+      en: 'Preparing connected flow'
+    },
     'single_moment_connected_kicker': {
       ko: '지금 머무는 장면',
       en: 'The scene you are staying with'
@@ -422,6 +458,10 @@
       ko: '이어진 순간들',
       en: 'Connected moments'
     },
+    'connected_loading_heading': {
+      ko: '현재 순간을 먼저 감상해 주세요',
+      en: 'View this moment first'
+    },
     'single_moment_connected_title': {
       ko: '이어진 순간들',
       en: 'Connected moments'
@@ -429,6 +469,10 @@
     'connected_flow_summary': {
       ko: '함께 이어지는 순간들',
       en: 'Connected moments'
+    },
+    'connected_loading_summary': {
+      ko: '이어진 순간은 현재 장면과 분리해서 불러오고 있어요.',
+      en: 'Connected moments are loading separately from the current scene.'
     },
     'connected_flow_count_suffix': {
       ko: '개의 순간이 이어져 있어요.',
@@ -477,6 +521,10 @@
     'moment_centered_growth_label': {
       ko: '감정이 자라는 중',
       en: 'Feeling growing'
+    },
+    'detail_loading_growth_label': {
+      ko: '이어진 흐름 준비 중',
+      en: 'Preparing connected flow'
     },
     'back_to_browse_soft': {
       ko: '둘러보기로 돌아가기',

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/detail.css?v=20260426-1">
+    <link rel="stylesheet" href="../css/detail.css?v=20260505-646">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -23,21 +23,26 @@
             </a>
             <div class="detail-view-chip">
                 <span class="material-symbols-outlined">visibility</span>
-                <span id="detailViewChipLabel">&nbsp;</span>
+                <span id="detailViewChipLabel">순간 준비 중</span>
             </div>
         </div>
 
         <section id="detailHero" class="detail-hero reveal-scale reveal-up">
-            <div id="detailHeroKicker" class="detail-hero-kicker">&nbsp;</div>
-            <h2 id="detailHeroTitle" class="headline detail-hero-title">이 순간에서 시작된 마음</h2>
-            <p id="detailHeroDesc" class="detail-hero-desc">이어진 장면들</p>
+            <div id="detailHeroKicker" class="detail-hero-kicker">현재 순간 준비 중</div>
+            <h2 id="detailHeroTitle" class="headline detail-hero-title">남겨진 순간을 불러오고 있어요</h2>
+            <p id="detailHeroDesc" class="detail-hero-desc">순간이 열리면 이어진 흐름은 따로 불러올게요.</p>
             <div id="treeContext"></div>
         </section>
 
         <main class="detail-layout reveal-fade">
             <section class="detail-primary-stack">
                 <section class="detail-main-media">
-                    <div id="videoMain" class="video-main"></div>
+                    <div id="videoMain" class="video-main">
+                        <div class="detail-media-loading" role="status" aria-live="polite">
+                            <span class="material-symbols-outlined">hourglass_top</span>
+                            <span>대표 장면을 준비하고 있어요</span>
+                        </div>
+                    </div>
                     <div class="detail-memory-meta">
                         <span class="detail-meta-pill">
                             <span class="material-symbols-outlined">artist</span>
@@ -70,8 +75,8 @@
                 <div class="connected-section">
                     <div class="connected-heading">
                         <span id="connectedKicker" class="connected-kicker">&nbsp;</span>
-                        <h3 id="connectedTitle" class="headline">이어진 순간들</h3>
-                        <p id="connectedSummary" class="connected-summary">&nbsp;</p>
+                        <h3 id="connectedTitle" class="headline">이어진 흐름 준비 중</h3>
+                        <p id="connectedSummary" class="connected-summary">현재 순간이 열리면 연결된 기억을 이어서 불러올게요.</p>
                     </div>
                     <div id="connectedFragments" class="connected-fragments-grid"></div>
                 </div>
@@ -79,7 +84,7 @@
                 <div class="growth-visualization">
                     <div class="growth-line"></div>
                     <div class="growth-dot"></div>
-                    <p id="growthLabel" class="growth-label">감정이 자라는 중</p>
+                    <p id="growthLabel" class="growth-label">이어진 흐름 준비 중</p>
                 </div>
             </aside>
         </main>
@@ -93,11 +98,11 @@
 <script src="../js/detail/detail-utils.js?v=20260427-1"></script>
 <script src="../js/detail/detail-video.js?v=20260427-1"></script>
 <script src="../js/detail/detail-copy.js?v=20260427-1"></script>
-<script src="../js/detail/detail-render.js?v=20260427-1"></script>
-<script src="../js/detail/detail-connected.js?v=20260427-1"></script>
-<script src="../js/detail/detail-loader.js?v=20260427-1"></script>
+<script src="../js/detail/detail-render.js?v=20260505-646"></script>
+<script src="../js/detail/detail-connected.js?v=20260505-646"></script>
+<script src="../js/detail/detail-loader.js?v=20260505-646"></script>
 <script src="../js/detail/detail-loading-error-boundary.js?v=20260502-1"></script>
-<script src="../js/detail.js?v=20260422-6"></script>
+<script src="../js/detail.js?v=20260505-646"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
 <script src="../js/firebase-config.js?v=20260417-31"></script>
@@ -106,7 +111,7 @@
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
-    <script src="../js/i18n/i18n-detail.js?v=20260422-3"></script>
+    <script src="../js/i18n/i18n-detail.js?v=20260505-646"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260421-9"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260421-5"></script>
 <script src="../js/i18n/i18n-index.js?v=20260421-1"></script>

--- a/tests/contracts/detail-staged-rendering-contract.test.js
+++ b/tests/contracts/detail-staged-rendering-contract.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+test('detail loader renders current memory before tree and connected fetches settle', () => {
+  const src = read('js/detail/detail-loader.js');
+  const memoryMissingIndex = src.indexOf('if (!memory) {');
+  const stagedRenderIndex = src.indexOf('renderMemoryBase(memory);');
+  const loadPromisesIndex = src.indexOf('const loadPromises = [];');
+  const awaitTreeContextIndex = src.indexOf('await Promise.all(loadPromises)');
+
+  assert.ok(memoryMissingIndex >= 0, 'loader must keep missing memory boundary');
+  assert.ok(stagedRenderIndex > memoryMissingIndex, 'current memory should render only after missing memory guard');
+  assert.ok(loadPromisesIndex > stagedRenderIndex, 'tree/connected fetch setup should happen after staged current render');
+  assert.ok(awaitTreeContextIndex > stagedRenderIndex, 'current memory render must not wait for tree/connected fetches');
+});
+
+test('detail page exposes explicit initial media loading state', () => {
+  const html = read('pages/detail.html');
+  const css = read('css/detail.css');
+
+  assert.match(html, /class="detail-media-loading"/);
+  assert.match(html, /대표 장면을 준비하고 있어요/);
+  assert.match(css, /\.detail-media-loading/);
+  assert.doesNotMatch(html, /type="module"/);
+});
+
+test('detail connected flow has a separate staged loading state', () => {
+  const loader = read('js/detail/detail-loader.js');
+  const connected = read('js/detail/detail-connected.js');
+  const copy = read('js/detail/detail-copy.js');
+
+  assert.match(loader, /stagedDegradedReason = hasTreeContext \? 'context-loading' : 'missing-tree-id'/);
+  assert.match(connected, /degradedReason === 'context-loading'/);
+  assert.match(copy, /isContextLoading/);
+});


### PR DESCRIPTION
Refs #646

## Summary
- Stage the Detail/viewing page so the current moment renders as soon as the current memory is available.
- Keep tree context and connected moments on their own loading/degraded path.
- Replace the initial empty black media area with an explicit media loading state.

## Diagnosis findings
- `pages/detail.html` rendered static shell copy and an empty `.video-main` before runtime data arrived.
- `js/detail/detail-loader.js` fetched the current memory first, but then waited for tree and memories requests before calling `renderMemoryBase()`.
- If tree/context or connected memories were slow or unavailable, current moment media/title/memo stayed behind the same wait.
- Existing degraded copy covered some final failure states, but there was no separate in-between state for connected flow loading.

## Changed files
- `pages/detail.html`
- `css/detail.css`
- `js/detail/detail-loader.js`
- `js/detail/detail-render.js`
- `js/detail/detail-connected.js`
- `js/detail/detail-copy.js`
- `js/i18n/i18n-detail.js`
- `tests/contracts/detail-staged-rendering-contract.test.js`

## What changed
- Current memory media/title/meta/memo render immediately after the current memory is found.
- Detail hero/copy updates to a moment-first loading state while tree context and connected memories continue loading.
- Tree context and connected moments now have explicit `context-loading` UI states.
- Tree/memories load failures still keep the current moment visible and only degrade the connected flow.
- Added a contract test for staged Detail rendering and initial media loading markup.

## What did not change
- No Browse card or selected hub redesign.
- No Auth/API/backend/DB behavior changes.
- No package or workflow changes.
- No Editor/My Trees/Login/Intro changes.
- No ES module or `type="module"` conversion.
- No fixed-slot deployment or browser final verification in this step.

## Local checks
- `git diff --check`: PASS
- `node --check js/detail/detail-loader.js`: PASS
- `node --check js/detail/detail-render.js`: PASS
- `node --check js/detail/detail-connected.js`: PASS
- `node --check js/detail/detail-copy.js`: PASS
- `node --check js/i18n/i18n-detail.js`: PASS
- `node --test tests/routes/detail-alias-consistency.test.js tests/routes/search-runtime-modules.test.js tests/contracts/detail-staged-rendering-contract.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser verification required: YES

## Fixed slot deployment required: YES

## NOT_VERIFIED
- Fixed-slot deployed SHA match: NOT_VERIFIED
- Browse/감상허브 → Detail navigation runtime: NOT_VERIFIED
- Detail staged loading visible in browser: NOT_VERIFIED
- Current moment renders before/independent from connected flow: NOT_VERIFIED
- Media fallback/loading state: NOT_VERIFIED
- Desktop screenshot: NOT_VERIFIED
- Mobile 375px screenshot: NOT_VERIFIED
- Fatal console/network errors: NOT_VERIFIED

## Secret/private data exposure
NO