### PR TITLE
copy(browse): align selected hub CTA with viewing route

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -217,9 +217,9 @@
       ko: '... 그리고 {count}개의 순간 더',
       en: '... and {count} more moments'
     },
-    'search.previewOpenTreeCta': {
-      ko: '이 트리 열기',
-      en: 'Open this tree'
+    'search.previewOpenViewingCta': {
+      ko: '감상 열기',
+      en: 'Open viewing'
     },
     'search.previewSummaryThemeStart': {
       ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 러브트리예요.',

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -75,7 +75,7 @@
     }
 
     /**
-     * Generate tree detail href for CTA button
+     * Generate detail viewing href for the selected tree's featured moment CTA.
      * @param {Object} tree - Tree object
      * @returns {string} Detail page href
      */
@@ -96,9 +96,9 @@
         const href = getTreeDetailHref(tree);
         if (!href) return '';
         const label = getSearchCopy(
-            'search.previewOpenTreeCta',
-            '이 트리 열기',
-            'Open this tree'
+            'search.previewOpenViewingCta',
+            '감상 열기',
+            'Open viewing'
         );
         return `
             <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -134,9 +134,9 @@
         const href = getTreeDetailHref(tree);
         if (!href) return '';
         const label = getSearchCopy(
-            'search.previewOpenTreeCta',
-            '이 트리 열기',
-            'Open this tree'
+            'search.previewOpenViewingCta',
+            '감상 열기',
+            'Open viewing'
         );
         return `
             <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">

--- a/pages/search.html
+++ b/pages/search.html
@@ -134,8 +134,8 @@
     <script src="../js/search/search-card-renderer.js?v=20260503-618"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-action-helper.js?v=20260503-594"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260504-601"></script>
+    <script src="../js/search/search-preview-action-helper.js?v=20260505-605"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260505-605"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260504-777-2"></script>
      <script src="../js/search/url-state.js?v=20260429-1"></script>
@@ -150,7 +150,7 @@
     <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260505-605"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260421-9"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260421-5"></script>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -76,3 +76,19 @@ test('search preview summary omits range phrase for missing time range labels', 
   assert.match(i18nSearch, /'search\.previewSummaryNoRange'/);
   assert.match(i18nSearch, /span style="color:var\(--primary\);font-weight:700;">\{count\}개의 순간<\/span>이 이어졌어요/);
 });
+
+test('browse selected hub primary CTA label matches detail viewing route', () => {
+  const actionHelper = read('js/search/search-preview-action-helper.js');
+  const previewRenderer = read('js/search/search-preview-renderer.js');
+  const i18nSearch = read('js/i18n/i18n-search.js');
+
+  assert.match(actionHelper, /detail\.html\?id=/);
+  assert.match(actionHelper, /from=browse/);
+  assert.match(actionHelper, /search\.previewOpenViewingCta/);
+  assert.match(previewRenderer, /search\.previewOpenViewingCta/);
+  assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
+  assert.match(i18nSearch, /ko:\s*'감상 열기'/);
+  assert.doesNotMatch(actionHelper, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
+  assert.doesNotMatch(previewRenderer, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
+  assert.doesNotMatch(i18nSearch, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
+});


### PR DESCRIPTION
Refs #605

## Summary
- Align the Browse selected hub primary CTA label with its actual Detail/viewing route target.
- Keep the current route target unchanged.
- Do not add an enabled `트리 열기` action until a Browse-to-tree-view bridge is verified.

## Route diagnosis
- `DETAIL_ROUTE_PRESENT`: YES
- `TREE_ROUTE_PRESENT`: YES
- `CURRENT_PRIMARY_CTA_LABEL`: `감상 열기`
- `CURRENT_PRIMARY_CTA_TARGET`: DETAIL_ROUTE
- `TREE_ROUTE_READY_FOR_BROWSE`: NOT_VERIFIED
- `CTA_LABEL_MATCHED`: YES

Current main diagnosis before this PR:
- The selected hub primary CTA generated `detail.html?id=...&tree=...&from=browse`.
- The visible label was `이 트리 열기`, which implied a true tree-view route.
- `pages/tree.html` and `js/viewer/public-tree-viewer.js` exist, but this PR did not verify or wire Browse selected hub navigation into that viewer route.

## Changed files
- `js/search/search-preview-action-helper.js`
- `js/search/search-preview-renderer.js`
- `js/i18n/i18n-search.js`
- `pages/search.html`
- `tests/routes/search-runtime-modules.test.js`

## What changed
- Renamed the selected hub primary CTA copy to `감상 열기` / `Open viewing`.
- Updated helper and renderer fallback copy to use the viewing CTA key.
- Bumped Search page cache keys for the touched Browse runtime scripts and i18n file.
- Added a route/copy contract test to ensure the primary CTA remains a Detail/viewing route and does not use the tree-open label.

## What did not change
- No route target change.
- No enabled `트리 열기` action added.
- No read-only public tree viewer implementation or bridge wiring.
- No Browse card grid redesign or selected hub redesign.
- No Auth/API/backend/DB behavior changes.
- No copy-to-my-tree behavior changes.
- No infinite scroll changes.
- No package or workflow changes.
- No Editor/My Trees/Login/Intro changes.
- No ES module or `type="module"` conversion.

## Local checks
- `git diff --check`: PASS
- `node --check js/search/search-preview-action-helper.js`: PASS
- `node --check js/search/search-preview-renderer.js`: PASS
- `node --check js/i18n/i18n-search.js`: PASS
- `node --test tests/routes/search-runtime-modules.test.js tests/routes/detail-alias-consistency.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser verification required: YES

## Fixed slot deployment required: YES

## NOT_VERIFIED
- Fixed-slot deployed SHA match: NOT_VERIFIED
- Browse selected hub populated state: NOT_VERIFIED
- Current CTA label in browser: NOT_VERIFIED
- CTA route target pattern: NOT_VERIFIED
- `감상 열기` opens Detail/viewing route: NOT_VERIFIED
- `트리 열기` hidden or only present for true tree-view route: NOT_VERIFIED
- Back navigation from Detail to Browse: NOT_VERIFIED
- Desktop screenshot: NOT_VERIFIED
- Mobile 375px screenshot: NOT_VERIFIED
- Fatal console/network errors: NOT_VERIFIED

## Secret/private data exposure
NO