### PR TITLE
fix(editor): keep add-next affordance clear of selected node

### DIFF
--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -12,10 +12,17 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     const {
         NODE_HALF,
-        AFFORDANCE_OFFSET_X,
-        AFFORDANCE_OFFSET_Y,
         AFFORDANCE_CARD_HALF
     } = constants;
+    const AFFORDANCE_SAFE_GAP = 28;
+    const AFFORDANCE_EDGE_PADDING = 28;
+    const AFFORDANCE_MIN_WIDTH = 174;
+    const AFFORDANCE_HEIGHT = 64;
+
+    function clamp(value, min, max) {
+        if (max < min) return min;
+        return Math.max(min, Math.min(value, max));
+    }
 
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
@@ -36,31 +43,52 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     function getGrowthAffordancePosition(anchorPos) {
         const metrics = getMetrics();
-        const edgePadding = 28;
-        const minCenterX = AFFORDANCE_CARD_HALF + edgePadding;
-        const maxCenterX = metrics.width - AFFORDANCE_CARD_HALF - edgePadding;
-        const hasRightRoom = anchorPos.x + NODE_HALF + AFFORDANCE_CARD_HALF + edgePadding <= metrics.width;
-        const hasLeftRoom = anchorPos.x - NODE_HALF - AFFORDANCE_CARD_HALF - edgePadding >= 0;
-        const shouldPlaceLeft = !hasRightRoom && hasLeftRoom;
+        const viewportWidth = Math.max(canvas.clientWidth || metrics.width, 320);
+        const viewportHeight = Math.max(canvas.clientHeight || metrics.height, 320);
+        const width = Math.min(AFFORDANCE_CARD_HALF * 2, Math.max(AFFORDANCE_MIN_WIDTH, viewportWidth - (AFFORDANCE_EDGE_PADDING * 2)));
+        const cardHalf = width / 2;
+        const minCenterX = cardHalf + AFFORDANCE_EDGE_PADDING;
+        const maxCenterX = viewportWidth - cardHalf - AFFORDANCE_EDGE_PADDING;
+        const nodeLeft = anchorPos.x - NODE_HALF;
+        const nodeRight = anchorPos.x + NODE_HALF;
+        const rightCenterX = nodeRight + AFFORDANCE_SAFE_GAP + cardHalf;
+        const leftCenterX = nodeLeft - AFFORDANCE_SAFE_GAP - cardHalf;
+        const hasRightRoom = rightCenterX + cardHalf + AFFORDANCE_EDGE_PADDING <= viewportWidth;
+        const hasLeftRoom = leftCenterX - cardHalf - AFFORDANCE_EDGE_PADDING >= 0;
+        const preferRight = anchorPos.x < viewportWidth * 0.56;
+        let side = preferRight
+            ? (hasRightRoom ? 'right' : (hasLeftRoom ? 'left' : 'below'))
+            : (hasLeftRoom ? 'left' : (hasRightRoom ? 'right' : 'below'));
+        let x = side === 'left' ? leftCenterX : rightCenterX;
+        let y = clamp(anchorPos.y - 10, 110, viewportHeight - 80);
+
+        if (side === 'below') {
+            x = clamp(anchorPos.x, minCenterX, maxCenterX);
+            const belowY = anchorPos.y + NODE_HALF + AFFORDANCE_SAFE_GAP + (AFFORDANCE_HEIGHT / 2);
+            const aboveY = anchorPos.y - NODE_HALF - AFFORDANCE_SAFE_GAP - (AFFORDANCE_HEIGHT / 2);
+            y = belowY + (AFFORDANCE_HEIGHT / 2) + AFFORDANCE_EDGE_PADDING <= viewportHeight
+                ? belowY
+                : clamp(aboveY, AFFORDANCE_EDGE_PADDING + (AFFORDANCE_HEIGHT / 2), viewportHeight - AFFORDANCE_EDGE_PADDING - (AFFORDANCE_HEIGHT / 2));
+            side = belowY + (AFFORDANCE_HEIGHT / 2) + AFFORDANCE_EDGE_PADDING <= viewportHeight ? 'below' : 'above';
+        }
 
         return {
-            x: Math.max(
-                minCenterX,
-                Math.min(
-                    shouldPlaceLeft ? anchorPos.x - AFFORDANCE_OFFSET_X : anchorPos.x + AFFORDANCE_OFFSET_X,
-                    maxCenterX
-                )
-            ),
-            y: Math.max(110, Math.min(anchorPos.y - AFFORDANCE_OFFSET_Y, metrics.height - 80)),
-            side: shouldPlaceLeft ? 'left' : 'right'
+            x: clamp(x, minCenterX, maxCenterX),
+            y,
+            side,
+            width,
+            height: AFFORDANCE_HEIGHT,
+            cardHalf
         };
     }
 
     function drawGrowthAffordanceBranch(startPos, endPos, side) {
         const path = documentRef.createElementNS('http://www.w3.org/2000/svg', 'path');
-        const tension = side === 'left' ? 0.55 : 0.45;
+        const tension = side === 'left' || side === 'above' ? 0.55 : 0.45;
         const cp1x = startPos.x + ((endPos.x - startPos.x) * tension);
-        const cp1y = Math.min(startPos.y, endPos.y) - 18;
+        const cp1y = side === 'below'
+            ? Math.max(startPos.y, endPos.y) + 18
+            : Math.min(startPos.y, endPos.y) - 18;
         const d = `M ${startPos.x},${startPos.y} Q ${cp1x},${cp1y} ${endPos.x},${endPos.y}`;
         path.setAttribute('d', d);
         path.setAttribute('class', 'branch-line branch-line-affordance');
@@ -81,9 +109,12 @@ function createEditorCanvasGrowthAffordance(deps) {
         wrap.className = 'memory-add-affordance';
         wrap.setAttribute('aria-label', labelText);
         wrap.style.position = 'absolute';
-        wrap.style.left = `${affPos.x - AFFORDANCE_CARD_HALF}px`;
-        wrap.style.top = `${affPos.y - 30}px`;
+        wrap.style.left = `${affPos.x - affPos.cardHalf}px`;
+        wrap.style.top = `${affPos.y - (affPos.height / 2)}px`;
         wrap.style.zIndex = '4';
+        wrap.style.width = `${affPos.width}px`;
+        wrap.style.minHeight = `${affPos.height}px`;
+        wrap.style.boxSizing = 'border-box';
         wrap.style.display = 'flex';
         wrap.style.alignItems = 'center';
         wrap.style.gap = '10px';
@@ -116,6 +147,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         textWrap.style.flexDirection = 'column';
         textWrap.style.alignItems = 'flex-start';
         textWrap.style.gap = helperText ? '1px' : '0';
+        textWrap.style.minWidth = '0';
 
         const titleEl = documentRef.createElement('span');
         titleEl.textContent = labelText;
@@ -123,6 +155,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         titleEl.style.fontWeight = '700';
         titleEl.style.color = 'var(--on-surface)';
         titleEl.style.lineHeight = '1.25';
+        titleEl.style.whiteSpace = 'normal';
 
         textWrap.appendChild(titleEl);
 
@@ -134,6 +167,7 @@ function createEditorCanvasGrowthAffordance(deps) {
             hintEl.style.color = 'var(--on-surface-variant)';
             hintEl.style.lineHeight = '1.25';
             hintEl.style.opacity = '0.82';
+            hintEl.style.whiteSpace = 'normal';
             textWrap.appendChild(hintEl);
         }
 
@@ -153,16 +187,24 @@ function createEditorCanvasGrowthAffordance(deps) {
             e.stopPropagation();
             openAddMomentFromCanvas();
         });
+        ['mousedown', 'pointerdown', 'touchstart'].forEach((eventName) => {
+            wrap.addEventListener(eventName, (e) => {
+                e.stopPropagation();
+            });
+        });
+
+        const branchStart = {
+            x: anchorPos.x + (affPos.side === 'left' ? (-NODE_HALF + 2) : (affPos.side === 'right' ? (NODE_HALF - 2) : 0)),
+            y: anchorPos.y + (affPos.side === 'below' ? (NODE_HALF - 2) : (affPos.side === 'above' ? (-NODE_HALF + 2) : 4))
+        };
+        const branchEnd = {
+            x: affPos.x + (affPos.side === 'left' ? affPos.cardHalf - 36 : (affPos.side === 'right' ? -affPos.cardHalf + 36 : 0)),
+            y: affPos.y + (affPos.side === 'below' ? -(affPos.height / 2) : (affPos.side === 'above' ? (affPos.height / 2) : 0))
+        };
 
         drawGrowthAffordanceBranch(
-            {
-                x: anchorPos.x + (affPos.side === 'left' ? (-NODE_HALF + 2) : (NODE_HALF - 2)),
-                y: anchorPos.y + 4
-            },
-            {
-                x: affPos.x + (affPos.side === 'left' ? 72 : -72),
-                y: affPos.y
-            },
+            branchStart,
+            branchEnd,
             affPos.side
         );
         canvas.appendChild(wrap);

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -20,7 +20,13 @@ window.LoveBudEditorCanvasInteraction = {
     canvas.style.touchAction = 'none';
 
     canvas.addEventListener('mousedown', (event) => {
-      if (event.target.closest('.memory-node') || event.target.closest('#addMemoryForm')) return;
+      if (
+        event.target.closest('.memory-node') ||
+        event.target.closest('#addMemoryForm') ||
+        event.target.closest('.memory-add-affordance')
+      ) {
+        return;
+      }
       viewportState.isPanning = true;
       viewportState.startX = event.clientX;
       viewportState.startY = event.clientY;

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const NODE_HALF = 54;
+
+function loadGrowthAffordanceFactory() {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+  const context = { window: {} };
+  vm.runInNewContext(source, context);
+  return context.window.createEditorCanvasGrowthAffordance;
+}
+
+function createGrowthAffordance({ width, height }) {
+  const factory = loadGrowthAffordanceFactory();
+  return factory({
+    canvas: {
+      clientWidth: width,
+      clientHeight: height,
+      querySelectorAll: () => []
+    },
+    svg: {
+      querySelectorAll: () => []
+    },
+    getMetrics: () => ({ width, height }),
+    constants: {
+      NODE_HALF,
+      AFFORDANCE_CARD_HALF: 108
+    }
+  });
+}
+
+function rectsOverlap(a, b) {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+function assertAffordanceClearsNode(position, anchorPos) {
+  const affordanceRect = {
+    left: position.x - position.cardHalf,
+    right: position.x + position.cardHalf,
+    top: position.y - (position.height / 2),
+    bottom: position.y + (position.height / 2)
+  };
+  const nodeRect = {
+    left: anchorPos.x - NODE_HALF,
+    right: anchorPos.x + NODE_HALF,
+    top: anchorPos.y - NODE_HALF,
+    bottom: anchorPos.y + NODE_HALF
+  };
+
+  assert.equal(rectsOverlap(affordanceRect, nodeRect), false);
+}
+
+test('growth affordance stays clear of selected node on desktop side placements', () => {
+  const growthAffordance = createGrowthAffordance({ width: 720, height: 520 });
+
+  const rightPlacementAnchor = { x: 240, y: 250 };
+  const rightPlacement = growthAffordance.getGrowthAffordancePosition(rightPlacementAnchor);
+  assert.equal(rightPlacement.side, 'right');
+  assertAffordanceClearsNode(rightPlacement, rightPlacementAnchor);
+
+  const leftPlacementAnchor = { x: 610, y: 250 };
+  const leftPlacement = growthAffordance.getGrowthAffordancePosition(leftPlacementAnchor);
+  assert.equal(leftPlacement.side, 'left');
+  assertAffordanceClearsNode(leftPlacement, leftPlacementAnchor);
+});
+
+test('growth affordance falls below or above the node on narrow mobile viewports', () => {
+  const growthAffordance = createGrowthAffordance({ width: 375, height: 520 });
+  const anchor = { x: 188, y: 210 };
+  const position = growthAffordance.getGrowthAffordancePosition(anchor);
+
+  assert.match(position.side, /^(below|above)$/);
+  assert.ok(position.x - position.cardHalf >= 28);
+  assert.ok(position.x + position.cardHalf <= 375 - 28);
+  assertAffordanceClearsNode(position, anchor);
+});
+
+test('canvas pan binding excludes add affordance presses', () => {
+  const interactionSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-interaction.js'), 'utf8');
+
+  assert.match(interactionSource, /target\.closest\(['"]\.memory-add-affordance['"]\)/);
+});


### PR DESCRIPTION
Refs #820

## Summary
- Keep the Editor add-next growth affordance clear of the selected/current moment node hit area.
- Preserve the affordance as a clickable/tappable button that opens the existing add moment form path.
- Add a narrow contract test for desktop edge placement, narrow mobile fallback placement, and canvas pan exclusion.

## Changed files
- `js/editor/editor-canvas-growth-affordance.js`
- `js/editor/editor-canvas-interaction.js`
- `tests/contracts/editor-growth-affordance-contract.test.js`

## What changed
- Reworked growth affordance position calculation to use the actual canvas viewport width/height and the affordance's rendered width.
- Added a safe gap around the selected node and side selection that moves the affordance left/right when possible.
- Added below/above fallback placement for narrow viewports so the affordance does not cover the node.
- Fixed affordance press handling so it is excluded from canvas pan start and stops pointer/mouse/touch press propagation while keeping button click functional.
- Kept add form opening routed through the existing `openAddMoment` / `showAddMemoryForm()` wiring.

## What did not change
- No Browse/Search/My Trees/Public Viewer/Detail changes.
- No backend/API/Auth/DB/package/workflow changes.
- No broad Editor redesign.
- No source URL, zoom/pan expansion, or package changes.
- No fixed-slot deployment or browser verification performed.

## Local checks
- `git diff --check`: PASS
- `node --check js/editor/editor-canvas-growth-affordance.js`: PASS
- `node --check js/editor/editor-canvas-interaction.js`: PASS
- `node --test tests/contracts/editor-growth-affordance-contract.test.js`: PASS
- `node --test tests/contracts/editor-script-order-contract.test.js tests/contracts/editor-growth-affordance-contract.test.js`: PASS
- `node --test tests/routes/editor-detail-ui-alias-consistency.test.js tests/routes/editor-memory-actions-save.test.js tests/routes/editor-auth-helper-callsite.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser verification required: YES

## Fixed slot deployment required: YES

## NOT_VERIFIED
- logged-in Editor populated tree: NOT_VERIFIED
- selected/current node hit area clear: NOT_VERIFIED
- add-next affordance opens form: NOT_VERIFIED
- form remains open after click: NOT_VERIFIED
- node selection while affordance visible: NOT_VERIFIED
- mobile 375px node tap and affordance tap: NOT_VERIFIED
- drag/pan preservation: NOT_VERIFIED
- fatal console/network errors: NOT_VERIFIED

## Secret/private data exposure
- NO