### PR TITLE
docs: refresh runtime files over 500 lines audit

### DIFF
--- a/docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md
+++ b/docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md
@@ -1,60 +1,58 @@
-# Runtime JS files over 500 lines audit
+# Runtime JS files over 500 lines audit (refresh)
 
-Date: 2026-04-28
-Branch: `audit/runtime-files-over-500-lines`
+Date: 2026-05-05
+Branch: `audit/runtime-files-over-500-lines-refresh-656`
 Base branch: `main`
-Base SHA: `1dddfa7633445ac10e2851b5794a55ab85c9dad2`
-Related issues: #223, #224
+Base SHA: `948ac142dd741b83146086f5defae01f464253c1`
+Related issues: #223, #224, #656
+
+Previous audit: `docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md` (2026-04-28, SHA `1dddfa7`)
 
 ## Scope
 
-This is a pre-refactor audit only. No runtime JavaScript, HTML, CSS, tests, prototypes, references, demos, variants, auth providers, login provider flow, fallback code, or editor behavior were changed.
-
-Primary requested files:
-
-- `js/auth.js`
-- `js/editor.js`
-- `js/my-trees.js`
-- `js/search.js`
-- `js/settings.js`
-- `js/postgres-client.js`
-
-Additional `js/**/*.js` files found during the audit and included because they exceed the 500-line threshold:
-
-- `js/editor/editor-canvas.js`
-- `js/editor/editor-detail-ui.js`
-
-## Method and limitation
-
-The audit was performed against current GitHub `main` using the GitHub connector. Local `git clone` / `wc -l` could not be used in this execution environment because external DNS resolution for `github.com` failed. The line counts below are normalized logical line counts from fetched GitHub file contents. CRLF/LF differences may change counts by zero lines only; threshold classification is unaffected.
-
-Because the repository contains many docs and legacy artifacts, this audit focuses on runtime browser JavaScript under `js/`, not docs, tests, Netlify legacy functions, prototypes, reference/demo/variant files, or server-side runtime files.
+This is a docs-only refresh of the previous audit after auth refactoring (PRs #826, #827) and editor decomposition. No runtime files were changed in this refresh.
 
 ## Summary
 
 ### Files over 500 lines
 
-| Path | Lines | Over 500 | Current role | Recommendation |
-|---|---:|:---:|---|---|
-| `js/editor.js` | 1,071 | Yes | entry orchestrator / compatibility-heavy page bootstrap | Refactor first |
-| `js/auth.js` | 954 | Yes | compatibility shim + auth bootstrap bridge | Audit-only until contract/smoke guard is explicit |
-| `js/editor/editor-detail-ui.js` | 846 | Yes | active runtime module / DOM renderer | Refactor after editor entry reduction |
-| `js/editor/editor-canvas.js` | 735 | Yes | active runtime module / canvas controller | Refactor after detail UI split |
-| `js/my-trees.js` | 528 | Yes | page controller / compatibility bridge | Refactor later, after active parallel my-trees work settles |
+| Path | Lines | Previous audit | Delta | Current role | Recommendation |
+|---|---|---|---:|---:|---|---|
+| `js/search/search-preview-renderer.js` | 718 | Not audited | — | active runtime module / browser preview renderer | Audit candidate |
+| `js/auth.js` | 698 | 954 | -256 | auth bootstrap bridge | Refactoring reduced lines; reassess threshold |
+| `js/editor.js` | 634 | 1,071 | -437 | entry orchestrator | Refactoring reduced significantly; remaining orchestrator code |
+| `js/editor/editor-memory-form.js` | 530 | Not audited | — | active runtime module / memory form controller | Audit candidate |
+| `js/editor/editor-canvas.js` | 527 | 735 | -208 | canvas controller | Below 500 after editor decomposition |
+
+### Files 450-499
+
+None in current refresh.
+
+### Previous over-500 files that dropped below threshold
+
+| Path | Previous lines | Current lines | Reason |
+|---|---|---|---|
+| `js/my-trees.js` | 528 | 298 | Auth gate extraction + my-trees module decomposition |
+| `js/editor/editor-detail-ui.js` | 846 | 385 | Detail UI decomposition into sidebar-status-boundary, detail-ui-builders |
 
 ### Requested files at or below 500 lines
 
-| Path | Lines | Over 500 | Current role | Recommendation |
-|---|---:|:---:|---|---|
-| `js/search.js` | 374 | No | page orchestrator | Do not refactor for line count now |
-| `js/settings.js` | 298 | No | page controller | Do not refactor now |
-| `js/postgres-client.js` | 224 | No | active runtime API client facade | Do not refactor now |
+| Path | Lines | Previous | Current role | Recommendation |
+|---|---|---|---|---|
+| `js/my-trees.js` | 298 | 528 | page controller / compatibility bridge | Below threshold now |
+| `js/settings.js` | 276 | 298 | page controller | Do not refactor now |
+| `js/search.js` | 230 | 374 | page orchestrator | Do not refactor now |
+| `js/postgres-client.js` | 175 | 224 | API client facade | Do not refactor now |
 
-### Additional checked runtime candidates under `js/`
+### JavaScript files over 500 lines (full list)
 
-| Path | Lines | Over 500 | Notes |
-|---|---:|:---:|---|
-| `js/editor/editor-data-loader-fallbacks.js` | 283 | No | Extracted fallback helper; not a current 500-line target |
+| Path | Lines | Role |
+|---|---|---|
+| `js/search/search-preview-renderer.js` | 718 | Browser preview renderer / UI builder |
+| `js/auth.js` | 698 | Auth bootstrap bridge |
+| `js/editor.js` | 634 | Editor entry orchestrator |
+| `js/editor/editor-memory-form.js` | 530 | Memory form controller |
+| `js/editor/editor-canvas.js` | 527 | Canvas controller |
 
 ## Detailed file audit
 

--- a/docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md
+++ b/docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md
@@ -10,19 +10,23 @@ Previous audit: `docs/reports/RUNTIME_FILES_OVER_500_LINES_AUDIT.md` (2026-04-28
 
 ## Scope
 
-This is a docs-only refresh of the previous audit after auth refactoring (PRs #826, #827) and editor decomposition. No runtime files were changed in this refresh.
+This is a docs-only refresh of the previous audit after auth refactoring (PRs #826, #827) and editor decomposition. No runtime JavaScript, HTML, CSS, tests, prototypes, references, demos, variants, auth providers, login provider flow, fallback code, or editor behavior were changed in this refresh.
+
+## Method and limitation
+
+This audit records current runtime browser JavaScript line-count targets under `js/` against the PR base shown above. It intentionally excludes docs, tests, legacy Netlify functions, prototype/reference/demo/variant files, and non-browser runtime files.
 
 ## Summary
 
 ### Files over 500 lines
 
 | Path | Lines | Previous audit | Delta | Current role | Recommendation |
-|---|---|---|---:|---:|---|---|
+|---|---:|---:|---:|---|---|
 | `js/search/search-preview-renderer.js` | 718 | Not audited | — | active runtime module / browser preview renderer | Audit candidate |
-| `js/auth.js` | 698 | 954 | -256 | auth bootstrap bridge | Refactoring reduced lines; reassess threshold |
-| `js/editor.js` | 634 | 1,071 | -437 | entry orchestrator | Refactoring reduced significantly; remaining orchestrator code |
+| `js/auth.js` | 698 | 954 | -256 | auth bootstrap bridge | Audit-only until auth contracts and browser smoke checklist are ready |
+| `js/editor.js` | 634 | 1,071 | -437 | editor entry orchestrator | First refactor target |
 | `js/editor/editor-memory-form.js` | 530 | Not audited | — | active runtime module / memory form controller | Audit candidate |
-| `js/editor/editor-canvas.js` | 527 | 735 | -208 | canvas controller | Below 500 after editor decomposition |
+| `js/editor/editor-canvas.js` | 527 | 735 | -208 | canvas controller | Still over threshold; refactor later due interaction risk |
 
 ### Files 450-499
 
@@ -31,74 +35,41 @@ None in current refresh.
 ### Previous over-500 files that dropped below threshold
 
 | Path | Previous lines | Current lines | Reason |
-|---|---|---|---|
-| `js/my-trees.js` | 528 | 298 | Auth gate extraction + my-trees module decomposition |
-| `js/editor/editor-detail-ui.js` | 846 | 385 | Detail UI decomposition into sidebar-status-boundary, detail-ui-builders |
+|---|---:|---:|---|
+| `js/my-trees.js` | 528 | 298 | Dropped below threshold after auth gate extraction and my-trees module decomposition |
+| `js/editor/editor-detail-ui.js` | 846 | 385 | Dropped below threshold after detail UI decomposition into sidebar-status-boundary and detail-ui-builders |
 
 ### Requested files at or below 500 lines
 
-| Path | Lines | Previous | Current role | Recommendation |
-|---|---|---|---|---|
-| `js/my-trees.js` | 298 | 528 | page controller / compatibility bridge | Below threshold now |
+| Path | Lines | Previous audit | Current role | Recommendation |
+|---|---:|---:|---|---|
+| `js/my-trees.js` | 298 | 528 | page controller / compatibility bridge | No line-count refactor now |
+| `js/editor/editor-detail-ui.js` | 385 | 846 | detail panel renderer bridge | No line-count refactor now |
 | `js/settings.js` | 276 | 298 | page controller | Do not refactor now |
 | `js/search.js` | 230 | 374 | page orchestrator | Do not refactor now |
 | `js/postgres-client.js` | 175 | 224 | API client facade | Do not refactor now |
 
-### JavaScript files over 500 lines (full list)
-
-| Path | Lines | Role |
-|---|---|---|
-| `js/search/search-preview-renderer.js` | 718 | Browser preview renderer / UI builder |
-| `js/auth.js` | 698 | Auth bootstrap bridge |
-| `js/editor.js` | 634 | Editor entry orchestrator |
-| `js/editor/editor-memory-form.js` | 530 | Memory form controller |
-| `js/editor/editor-canvas.js` | 527 | Canvas controller |
-
-## Detailed file audit
+## Detailed current 500+ audit
 
 ## 1. `js/editor.js`
 
-- Line count: 1,071
+- Line count: 634
 - 500-line status: over threshold
-- Current role: entry orchestrator, page bootstrap, editor auth gate, editor shell copy synchronizer, data loading coordinator, form/action binder, compatibility fallback bridge
-- Refactoring risk: medium-high
-- Recommendation: yes, first refactor target
-
-### Window globals / dependencies
-
-Observed dependency surface includes:
-
-- `window.LoveBudEditorDataLoaderFallbacks`
-- `window.LoveBudEditorResolverFallbacks`
-- `window.LoveBudEditorUtils`
-- `window.LoveBudEditorHelpers`
-- `window.LoveBudEditorSaveStatus`
-- `window.LoveBudEditorPageHelpers`
-- `window.LoveBudEditorTreeHelpers`
-- `window.LoveBudEditorBindings`
-- `window.LoveBudEditorDataLoader`
-- `window.LoveBudEditorAuthHelpers`
-- `window.LoveBudNormalize`
-- `window.LoveBudCache`
-- `window.apiClient`
-- `window.createEditorDetailUI`
-- `window.createEditorCanvas`
-- `window.t`
-- `window.currentTreeData`
-- `window.currentTreeMemories`
+- Current role: editor entry orchestrator, page bootstrap, editor auth gate, shell copy synchronizer, data loading coordinator, form/action binder, compatibility bridge
+- Refactoring risk: medium
+- Recommendation: first refactor target
 
 ### Refactoring judgment
 
-This is the safest first target because it is already structured as an orchestrator that delegates to extracted editor modules. The first refactor should move remaining entry-only helper logic without changing runtime behavior.
+This remains the best first target because prior decomposition has already reduced the file from 1,071 to 634 lines. The next step should extract remaining entry-only helper logic without changing runtime behavior.
 
 ### First PR scope
 
 Allowed files:
 
 - `js/editor.js`
-- `js/editor/editor-entry-fallbacks.js`
-- `js/editor/editor-page-helpers.js`
-- optional new file only if named narrowly, e.g. `js/editor/editor-shell-copy.js`
+- existing narrowly scoped editor entry/helper files only if needed
+- optional new helper only if named narrowly, e.g. `js/editor/editor-shell-copy.js`
 
 Forbidden files:
 
@@ -111,22 +82,14 @@ Forbidden files:
 - `js/postgres-client.js`
 - prototype/reference/demo/variant files
 
-First PR should only extract shell copy and entry fallback helper code. It must not alter editor behavior, auth gating, API payloads, memory creation, visibility update behavior, canvas behavior, or script type.
+### Needed verification
 
-### Needed contract tests
-
-- Existing editor entry namespace availability check, or add a no-runtime-change contract test that verifies required editor globals are defined before `js/editor.js` uses them.
-- Verify fallback factories remain available on `window.LoveBudEditorDataLoaderFallbacks` and `window.LoveBudEditorResolverFallbacks`.
-- Verify `window.currentTreeData` / `window.currentTreeMemories` compatibility names remain unchanged.
-
-### Needed browser smoke
-
-- Logged-out direct load of `/pages/editor.html` redirects to login or remains protected per current behavior.
-- Logged-in load of `/pages/editor.html?treeId=<owned-tree>` opens without blank screen.
+- Existing editor entry contract checks remain green.
+- Logged-out editor route behavior remains unchanged.
+- Logged-in editor opens an owned tree without blank screen.
 - Empty tree state renders.
 - Existing tree with memories renders canvas and detail panel.
 - Add memory form opens/closes.
-- Visibility toggle still calls existing API path.
 - Browser console has no new fatal errors.
 
 ### Absolute no-go items
@@ -136,42 +99,158 @@ First PR should only extract shell copy and entry fallback helper code. It must 
 - No auth flow changes.
 - No API endpoint or payload changes.
 - No CSS/HTML changes.
-- No deletion of fallback code in the first PR.
+- No fallback deletion in the first runtime PR.
 
-## 2. `js/auth.js`
+## 2. `js/search/search-preview-renderer.js`
 
-- Line count: 954
+- Line count: 718
 - 500-line status: over threshold
-- Current role: compatibility shim, auth bootstrap bridge, login-page delegation bridge, cached-auth bridge, Firebase auth fallback bridge, nav UI bridge
-- Refactoring risk: high
-- Recommendation: do not implement first; audit-only until auth-specific contract/smoke coverage is confirmed
-
-### Window globals / dependencies
-
-Observed dependency surface includes:
-
-- `window.LoveBudAuthState`
-- `window.LoveBudAuthUI`
-- `window.LoveBudAuthSession`
-- `window.LoveBudAuthFirebase`
-- `window.LoveBudAuthBootstrap`
-- `window.LoveBudAuthCallbacks`
-- `window.LoveBudAuthCache`
-- `window.LoveBudAuthLoginPage`
-- `window.LoveBudLoginPageController`
-- `window.__initialAuthMode`
-- `window.__onAuthReadyCallbacks`
-- `window.__lastAuthUser`
-- `window.getBasePath`
-- `window.registerOnAuthReady`
-- `window.applyI18n`
-- `window.apiClient`
-- `firebase`
-- `initFirebase`
+- Current role: browser preview renderer / UI builder
+- Refactoring risk: medium-high because Browse/Search preview behavior requires real browser verification
+- Recommendation: audit candidate after editor entry reduction
 
 ### Refactoring judgment
 
-This file is oversized, but it is not the best first implementation target. It sits on the login/logout/protected-route critical path and still contains compatibility fallbacks. Removing or moving code before contract tests can create subtle auth regressions.
+This is now the largest runtime browser JavaScript file in the audit. It should be handled as a Browse/Search UI refactor with fixed-slot browser verification, not as a generic line-count cleanup.
+
+### First PR scope
+
+Allowed files:
+
+- `js/search/search-preview-renderer.js`
+- optional narrowly named search preview helper file
+- relevant Search/Browse contract tests if needed
+
+Forbidden files:
+
+- `pages/search.html`
+- broad search runtime rewrites
+- auth files
+- editor files
+- my-trees files
+- CSS/HTML changes unless explicitly scoped in a later UI PR
+- prototype/reference/demo/variant files
+
+### Needed verification
+
+- Public Browse/Search list loads.
+- Desktop preview hydration works.
+- Mobile preview open/close works.
+- Sort/filter/search URL state remains unchanged.
+- Growing trees fallback behavior remains unchanged.
+- Fixed slot + SHA match + real browser verification is required.
+
+### Absolute no-go items
+
+- No URL state behavior changes.
+- No API path or payload changes.
+- No preview cache behavior changes.
+- No Browse/Search behavior PASS from text-only or local-only checks.
+
+## 3. `js/editor/editor-memory-form.js`
+
+- Line count: 530
+- 500-line status: over threshold
+- Current role: active runtime module / memory form controller
+- Refactoring risk: medium-high because it affects editor moment creation
+- Recommendation: audit candidate after editor entry reduction
+
+### Refactoring judgment
+
+The file is just over threshold and directly touches memory creation UX. Any split should be helper-only and preserve parent selection, URL validation, fallback local save mode, canvas refresh, and detail/sidebar update behavior.
+
+### First PR scope
+
+Allowed files:
+
+- `js/editor/editor-memory-form.js`
+- optional narrowly named helper file for pure validation or form state utilities
+- relevant editor form contract tests if needed
+
+Forbidden files:
+
+- `pages/editor.html`
+- `css/**`
+- `js/auth.js`
+- `js/editor.js` unless the PR is explicitly coordinated with entry wiring
+- API client files
+- prototype/reference/demo/variant files
+
+### Needed verification
+
+- Add memory form opens/closes.
+- YouTube URL validation remains unchanged.
+- Parent memory selection remains unchanged.
+- First moment creation still works.
+- Non-root child moment creation still works.
+- Canvas and detail/sidebar refresh after creation.
+- Browser console has no new fatal errors.
+
+### Absolute no-go items
+
+- No API payload changes.
+- No parent/root resolution changes.
+- No local save fallback deletion.
+- No CSS/HTML changes.
+
+## 4. `js/editor/editor-canvas.js`
+
+- Line count: 527
+- 500-line status: over threshold
+- Current role: active runtime module, editor canvas controller, layout state, node rendering, drag/pan/viewport orchestration, growth affordance renderer
+- Refactoring risk: high
+- Recommendation: refactor later due interaction risk
+
+### Refactoring judgment
+
+This file remains above threshold after the current decomposition. It should not be first because it owns behavior-sensitive canvas interactions: panning, dragging, viewport persistence, node rendering, fallback paths, and growth affordance.
+
+### First PR scope
+
+Allowed files:
+
+- `js/editor/editor-canvas.js`
+- optional new helper only for pure rendering, e.g. `js/editor/editor-canvas-affordance.js`
+
+Forbidden files:
+
+- `pages/editor.html`
+- `css/editor.css`
+- `js/editor.js`
+- `js/editor/editor-detail-ui.js`
+- API/auth files
+- prototype/reference/demo/variant files
+
+### Needed verification
+
+- Existing tree renders nodes.
+- Branches render.
+- Dragging node persists position.
+- Canvas pan works.
+- Recenter works.
+- Focus selected works.
+- Growth affordance opens add memory form.
+- Mobile viewport has no blank canvas regression.
+
+### Absolute no-go items
+
+- No layout algorithm change in first PR.
+- No localStorage key change.
+- No SVG path behavior change.
+- No node drag/pan behavior change.
+- No CSS/HTML changes.
+
+## 5. `js/auth.js`
+
+- Line count: 698
+- 500-line status: over threshold
+- Current role: auth bootstrap bridge, login-page delegation bridge, cached-auth bridge, Firebase auth fallback bridge, nav UI bridge
+- Refactoring risk: high
+- Recommendation: audit-only until auth contract and browser smoke coverage are explicit
+
+### Refactoring judgment
+
+This file remains oversized, but it is not the best first implementation target. It sits on login/logout/protected-route critical paths and requires strict auth regression protection.
 
 ### First PR scope
 
@@ -191,25 +270,19 @@ Forbidden files:
 - Firebase provider changes
 - auth provider switching
 - CSS/HTML changes
+- prototype/reference/demo/variant files
 
-### Needed contract tests
+### Needed verification
 
-- Auth bootstrap `whenReady()` resolves exactly once.
-- `registerOnAuthReady()` preserves callback behavior before and after auth ready.
-- Confirmed auth cache read/write/clear semantics remain unchanged.
-- Offline fallback behavior remains unchanged.
-- Login page email mode delegation remains unchanged.
-
-### Needed browser smoke
-
+- Auth bootstrap readiness still resolves once.
 - Login page opens in login mode.
 - Login page opens in signup mode.
-- Google login button wiring remains intact.
 - Email login/signup modal works as before.
+- Google login button wiring remains intact.
 - Logged-out protected pages redirect.
 - Logged-in navigation dropdown renders.
 - Logout clears confirmed auth cache and redirects.
-- Firebase unavailable/offline path does not create clickable stale auth UI.
+- Firebase unavailable/offline path does not create stale clickable auth UI.
 
 ### Absolute no-go items
 
@@ -220,258 +293,66 @@ Forbidden files:
 - No Firebase config changes.
 - No broad auth refactor combined with UI/CSS work.
 
-## 3. `js/editor/editor-detail-ui.js`
+## Below-threshold notes
 
-- Line count: 846
-- 500-line status: over threshold
-- Current role: active runtime module, detail panel DOM renderer, inline edit UI builder, tree meta block renderer, share/detail action binder
-- Refactoring risk: medium-high
-- Recommendation: yes, but after `js/editor.js` entry reduction
+## `js/editor/editor-detail-ui.js`
 
-### Window globals / dependencies
-
-Observed dependency surface includes:
-
-- `window.t` through injected `i18n`
-- `window.currentTreeData` indirectly through injected `getCurrentTreeData`
-- `navigator.clipboard`
-- DOM ids in `pages/editor.html`, including detail panel, edit fields, save indicator, tree meta mount, memory action controls
-- injected callbacks: `updateTreeVisibility`, `openCurrentMomentDetail`, `focusSelectedMoment`, `updateSelectedMemoryFields`
-
-### Refactoring judgment
-
-The module is large because it mixes renderer construction, inline styles, edit mode state, share action binding, and detail-panel state transitions. It is refactorable, but it is an active runtime module, not a compatibility shim. First split should be internal helper extraction, not behavior change.
-
-### First PR scope
-
-Allowed files:
-
-- `js/editor/editor-detail-ui.js`
-- optional new file: `js/editor/editor-detail-ui-builders.js` or `js/editor/editor-detail-actions.js`
-
-Forbidden files:
-
-- `pages/editor.html`
-- `css/editor.css`
-- `js/editor.js`
-- API client files
-- auth files
-
-### Needed contract tests
-
-- `createEditorDetailUI()` returns the same public methods: `setDetailEmptyState`, `updateFocusSelectedBtn`, `updateSidebarStatus`, `updateDetailPanel`.
-- Required callback names and dependency keys remain unchanged.
-
-### Needed browser smoke
-
-- Selecting a memory updates detail panel.
-- Inline title edit saves/cancels.
-- Inline memo edit saves/cancels.
-- Share link button still copies expected detail URL.
-- Open detail button navigates to detail page.
-- Empty state remains unchanged.
-
-### Absolute no-go items
-
-- No CSS extraction in the first runtime PR.
-- No DOM id changes.
-- No copy/i18n key changes.
-- No visibility or share behavior changes.
-
-## 4. `js/editor/editor-canvas.js`
-
-- Line count: 735
-- 500-line status: over threshold
-- Current role: active runtime module, editor canvas controller, layout state, node rendering, drag/pan/viewport orchestration, growth affordance renderer
-- Refactoring risk: high
-- Recommendation: refactor later, after detail UI split
-
-### Window globals / dependencies
-
-Observed dependency surface includes:
-
-- `window.currentTreeData`
-- `window.LoveBudEditorCanvasLayout`
-- `window.LoveBudEditorCanvasNode`
-- `window.LoveBudEditorCanvasInteraction`
-- `window.LoveBudEditorCanvasViewport`
-- `window.LoveBudUI`
-- `window.t`
-- DOM ids for canvas, SVG, viewport controls, add memory controls, and memory nodes
-- localStorage layout key `lovebud_tree_layout_v2_<treeId>`
-
-### Refactoring judgment
-
-This file is large and behavior-sensitive. It owns panning, dragging, viewport persistence, node rendering, fallback paths, and growth affordance. It is refactorable, but should not be first because visual/interaction regressions are likely.
-
-### First PR scope
-
-Allowed files:
-
-- `js/editor/editor-canvas.js`
-- optional new helper only for pure rendering, e.g. `js/editor/editor-canvas-affordance.js`
-
-Forbidden files:
-
-- `pages/editor.html`
-- `css/editor.css`
-- `js/editor.js`
-- `js/editor/editor-detail-ui.js`
-- API/auth files
-
-### Needed contract tests
-
-- `createEditorCanvas()` public return shape remains unchanged.
-- `focusNodeById`, `recenterViewport`, `calcPosition`, `drawBranch`, `drawNode`, `initCanvas` remain callable if currently exported.
-- Layout localStorage key remains unchanged.
-
-### Needed browser smoke
-
-- Existing tree renders nodes.
-- Branches render.
-- Dragging node persists position.
-- Canvas pan works.
-- Recenter works.
-- Focus selected works.
-- Growth affordance opens add memory form.
-- Mobile viewport has no blank canvas regression.
-
-### Absolute no-go items
-
-- No layout algorithm change in first PR.
-- No localStorage key change.
-- No SVG path behavior change.
-- No node drag/pan behavior change.
-- No CSS/HTML changes.
-
-## 5. `js/my-trees.js`
-
-- Line count: 528
-- 500-line status: over threshold
-- Current role: page controller, compatibility bridge, auth boot, list render fallback, card menu fallback, action delegation
-- Refactoring risk: medium
-- Recommendation: refactor later, not before editor entry reduction
-
-### Window globals / dependencies
-
-Observed dependency surface includes:
-
-- `window.LoveBudMyTreesUI`
-- `window.LoveBudMyTreesActions`
-- `window.LoveBudMyTreesData`
-- `window.LoveBudMyTreesState`
-- `window.LoveBudMyTreesPage`
-- `window.LoveBudUI`
-- `window.LoveBudNormalize`
-- `window.LoveBudAuthBootstrap`
-- `window.registerOnAuthReady`
-- `window.getConfirmedAuthUser`
-- `window.t`
-
-### Refactoring judgment
-
-This file has already been partially decomposed into `js/my-trees/*`. Remaining large sections are legacy fallback rendering and page boot wiring. It is safe to refactor after current my-trees parallel work settles, but should not be combined with editor or auth work.
-
-### First PR scope
-
-Allowed files:
-
-- `js/my-trees.js`
-- `js/my-trees/my-trees-page.js`
-- optional existing `js/my-trees/my-trees-ui.js` only if moving pure render helpers
-
-Forbidden files:
-
-- `pages/my-trees.html`
-- `css/**`
-- `js/auth.js`
-- `js/editor.js`
-- `js/search.js`
-- `js/my-trees/my-trees-actions.js` unless action delegation is the only explicit scope
-
-### Needed contract tests
-
-- My Trees page namespace availability.
-- Header create button still delegates to `createNewTree`.
-- Retry button still delegates to `loadTrees`.
-- Auth bootstrap cached-user path remains unchanged.
-
-### Needed browser smoke
-
-- Logged-out direct load redirects to login.
-- Logged-in load shows tree list.
-- Empty state shows create CTA.
-- Create tree redirects to editor.
-- Card click opens editor.
-- Card menu visibility/rename/delete still works.
-
-### Absolute no-go items
-
-- No visibility policy change.
-- No default visibility change.
-- No my-trees action behavior change.
-- No CSS/HTML change.
-
-## Below-threshold requested files
-
-## `js/search.js`
-
-- Line count: 374
+- Line count: 385
 - 500-line status: not over threshold
-- Current role: search page orchestrator
-- Refactoring risk: medium
+- Current role: detail panel renderer bridge
 - Recommendation: no line-count refactor now
-- Reason: It already delegates to search UI, card renderer, preview renderer, preview cache, URL state, and adapter modules. Refactoring now would risk Browse regressions without solving the 500-line target.
 
-Needed smoke if touched later:
-
-- Public browse list loads.
-- Search input filters.
-- Tag chips filter.
-- Sort/limit controls preserve URL state.
-- Desktop preview hydration works.
-- Mobile preview open/close works.
-- Growing trees section handles API failure gracefully.
-
-## `js/settings.js`
+## `js/my-trees.js`
 
 - Line count: 298
 - 500-line status: not over threshold
+- Current role: page controller / compatibility bridge
+- Recommendation: no line-count refactor now
+
+## `js/search.js`
+
+- Line count: 230
+- 500-line status: not over threshold
+- Current role: search page orchestrator
+- Recommendation: no line-count refactor now
+
+## `js/settings.js`
+
+- Line count: 276
+- 500-line status: not over threshold
 - Current role: settings page controller
-- Refactoring risk: low-medium
 - Recommendation: no refactor now
-- Reason: Below threshold and narrow page controller. Only touch when settings product behavior changes.
 
 ## `js/postgres-client.js`
 
-- Line count: 224
+- Line count: 175
 - 500-line status: not over threshold
 - Current role: active browser API client facade for same-origin `/api/*`
-- Refactoring risk: medium-high despite size
 - Recommendation: no refactor now
-- Reason: Small enough and central to API behavior. It should not be modified during a line-count cleanup.
 
 ## Recommended refactoring order
 
 1. `js/editor.js` entry orchestrator reduction
-2. `js/editor/editor-detail-ui.js` detail renderer helper extraction
-3. `js/editor/editor-canvas.js` canvas affordance/helper extraction
-4. `js/my-trees.js` legacy fallback/page bridge reduction
-5. `js/auth.js` only after auth contracts and browser smoke checklist are explicitly ready
+2. `js/search/search-preview-renderer.js` preview renderer helper extraction
+3. `js/editor/editor-memory-form.js` memory form helper extraction
+4. `js/editor/editor-canvas.js` canvas helper extraction after interaction smoke coverage is ready
+5. `js/auth.js` only after auth contracts and fixed-slot browser smoke checklist are explicitly ready
 
 ## Directly refactorable now
 
 - `js/editor.js`
 
-Potentially refactorable after current parallel work is checked:
+## Audit candidates after editor entry reduction
 
-- `js/my-trees.js`
-- `js/editor/editor-detail-ui.js`
+- `js/search/search-preview-renderer.js`
+- `js/editor/editor-memory-form.js`
+- `js/editor/editor-canvas.js`
 
 ## Audit-only for now
 
 - `js/auth.js`
-- `js/editor/editor-canvas.js`
+- `js/editor/editor-detail-ui.js`
+- `js/my-trees.js`
 - `js/search.js`
 - `js/settings.js`
 - `js/postgres-client.js`
@@ -486,10 +367,12 @@ Potentially refactorable after current parallel work is checked:
 - No fallback deletion in this audit PR.
 - No auth/login/provider transition.
 - No editor runtime behavior change.
+- No Browse/Search behavior change.
 - No CSS/HTML modification.
 - No `type="module"` conversion.
 - No Jest introduction.
 - No API path or payload change.
+- Browse/Search/Editor/My Trees/Auth verification must use fixed slot + SHA match + real browser when runtime work is introduced later.
 
 ## Test status
 


### PR DESCRIPTION
## Summary

Refresh of the prior runtime line-count audit after auth refactoring (PRs #826, #827) and editor decomposition reduced several previously over-500-threshold files.

### Changes from previous audit

| File | Previous | Current | Status |
|---|---|---|---|
| `js/editor.js` | 1,071 | 634 | Down 437 lines |
| `js/auth.js` | 954 | 698 | Down 256 lines |
| `js/editor/editor-detail-ui.js` | 846 | 385 | Dropped below threshold |
| `js/editor/editor-canvas.js` | 735 | 527 | Down 208 lines |
| `js/my-trees.js` | 528 | 298 | Dropped below threshold |

### New 500+ files discovered

- `js/search/search-preview-renderer.js` (718 lines)
- `js/editor/editor-memory-form.js` (530 lines)

### Files 450-499

None in this refresh.

Refs #656