### PR TITLE
fix(ui): improve first-moment add-next affordance placement

### DIFF
--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -214,8 +214,9 @@ function createEditorCanvasGrowthAffordance(deps) {
         if (!anchorMem) return;
         const opts = options || {};
         const labelText = opts.labelText || (i18n('editor_add_memory') || '새 순간 이어가기');
-        const helperText = opts.isFirstStep
-            ? ''
+        const isFirstStep = opts.isFirstStep;
+        const helperText = isFirstStep
+            ? (i18n('growth_first_step_hint') || '첫 순간에서 이어지는 감정을 기록해보세요')
             : (opts.helperText || i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요');
 
         createGrowthAffordanceElement(anchorMem, labelText, helperText);

--- a/js/i18n/i18n-editor.js
+++ b/js/i18n/i18n-editor.js
@@ -70,6 +70,7 @@ Object.assign(window.i18nEditor, {
     editor_canvas_empty_desc: { ko: '첫 순간을 만들면 오른쪽에서 내용을 다듬고, 가운데에서 감정의 흐름을 이어갈 수 있어요.', en: 'Create the first moment, refine it on the right, and continue the emotional flow from the center.' },
     continue_moment: { ko: '순간 이어가기', en: 'Continue this moment' },
     growth_start_hint: { ko: '여기서 다음 가지가 자라나요', en: 'The next branch grows from here' },
+    growth_first_step_hint: { ko: '첫 순간에서 이어지는 감정을 기록해보세요', en: 'Record the feeling that continues from your first moment' },
     growth_continue_hint: { ko: '선택한 순간 뒤로 감정이 이어져요', en: 'The feeling continues from the selected moment' },
     detail_empty_desc: { ko: '가운데에서 첫 순간을 만들면 이곳에서 제목과 마음 기록을 다듬을 수 있어요.', en: 'Create the first moment from the center, then refine its title and note here.' },
     editor_make_private: { ko: '이 트리 비공개로 전환', en: 'Make this tree private' },


### PR DESCRIPTION
## Summary

Improve the add-next affordance for first-moment-only state. When the editor shows only one moment node, the affordance now includes a hint text guiding users to continue from the first moment, making the user flow more natural.

### Changes

- Added helper text for  ('첫 순간에서 이어지는 감정을 기록해보세요') instead of showing empty text
- Instead of blank space below the label, first-step affordance now shows an inviting hint

Refs #824