### PR TITLE
refactor(editor): simplify editor shell helper setup

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -256,6 +256,11 @@ document.addEventListener('DOMContentLoaded', () => {
         confirmBtn: document.getElementById('confirmAddMemory')
     });
 
+    const setElementDisplay = (id, value) => {
+        const el = document.getElementById(id);
+        if (el) el.style.display = value;
+    };
+
     const prepareEditorShell = () => {
         applyEditorShellCopy(safeI18nText, i18n);
         const backToMyTreesLink = document.getElementById('backToMyTreesLink');
@@ -263,12 +268,9 @@ document.addEventListener('DOMContentLoaded', () => {
             backToMyTreesLink.setAttribute('href', getMyTreesHref());
             backToMyTreesLink.setAttribute('aria-label', safeI18nText(i18n, 'editor_back_to_my_trees', '내 러브트리로 돌아가기'));
         }
-        const detailEmptyState = document.getElementById('detailEmptyState');
-        const detailViewMode = document.getElementById('detailViewMode');
-        const detailEditMode = document.getElementById('detailEditMode');
-        if (detailEmptyState) detailEmptyState.style.display = 'block';
-        if (detailViewMode) detailViewMode.style.display = 'none';
-        if (detailEditMode) detailEditMode.style.display = 'none';
+        setElementDisplay('detailEmptyState', 'block');
+        setElementDisplay('detailViewMode', 'none');
+        setElementDisplay('detailEditMode', 'none');
     };
 
     const startEditor = async () => {


### PR DESCRIPTION
## Summary

Refs #656

Simplify editor entry shell helper setup in js/editor.js without changing editor runtime behavior.

## Scope

- js/editor.js only
- No new files

## Changes

- Introduced `setElementDisplay` helper to reduce DOM display-setting verbosity
- Replaced inline detail panel display logic with reusable helper

## Guardrails

- No HTML/CSS changes
- No auth flow changes
- No API path or payload changes
- No memory/canvas/detail behavior changes
- No PR #7 / prototype / reference / demo / variant impact

## Verification

- git diff --check: PASS
- npm run verify: PASS (147/147)
- npm test: PASS (203/203)

## Browser verification

Required after PR creation because this touches editor runtime:
fixed test slot + SHA match + real browser login/editor smoke.