### PR TITLE
refactor(search): continue preview renderer builder split

### DIFF
--- a/js/search/search-preview-renderer-builders.js
+++ b/js/search/search-preview-renderer-builders.js
@@ -189,119 +189,85 @@
     }
 
 
+    function getCurrentLocale() {
+        var helper = window.LoveBudSearchPreviewCopyHelper;
+        if (helper && helper.getCurrentLocale) return helper.getCurrentLocale();
+        var locale = window.i18n?.currentLang || document.documentElement?.lang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    function getTimelineLabel(tree, memories) {
+        var titleHelper = getSearchTitleHelper();
+        var formatDate = titleHelper && titleHelper.formatShortDate || (function() {
+            var helper = window.LoveBudSearchPreviewCopyHelper;
+            if (helper && helper.formatShortDate) return helper.formatShortDate;
+            return function(value) {
+                if (!value) return '';
+                var date = new Date(value);
+                if (Number.isNaN(date.getTime())) return '';
+                return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', { month: 'short', day: 'numeric' });
+            };
+        })();
+        var updatedAt = tree && tree.updatedAt || '';
+        var createdAt = tree && tree.createdAt || '';
+        var firstTimestamp = memories && memories[0] && memories[0].timestamp || '';
+        var lastTimestamp = memories && memories[memories.length - 1] && memories[memories.length - 1].timestamp || '';
+        var safeUpdated = formatDate(updatedAt);
+        var safeCreated = formatDate(createdAt);
+        var safeFirst = formatDate(firstTimestamp);
+        var safeLast = formatDate(lastTimestamp);
+        if (safeUpdated) return getSearchCopy('search.previewTimelineRecentUpdate', '최근에 이어진 감정', 'Recently added moment') + ' ' + safeUpdated;
+        if (safeLast) return getSearchCopy('search.previewTimelineLastMoment', '가장 최근에 남은 순간', 'Latest saved moment') + ' ' + safeLast;
+        if (safeFirst && safeLast && safeFirst !== safeLast) return safeFirst + ' ~ ' + safeLast;
+        if (safeCreated) return getSearchCopy('search.previewTimelineCreated', '처음 남긴 날', 'First saved on') + ' ' + safeCreated;
+        return getSearchCopy('search.previewTimelineUnavailable', '아직 시작 순간을 기다리는 중이에요', 'Still waiting for the first moment');
+    }
+
     function getPreviewTimeRange(tree) {
-        var raw = String(tree && tree.timeRange ? tree.timeRange : '').trim();
+        var raw = String((tree && tree.timeRange) || '').trim();
         var missingRangeLabels = [
-            '기록 없음',
-            'no records',
-            'no record',
-            'unknown',
-            'n/a',
+            '기록 없음', 'no records', 'no record', 'unknown', 'n/a',
             getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')
         ].map(function(label) { return String(label || '').trim().toLowerCase(); }).filter(Boolean);
-
         if (!raw) return '';
         return missingRangeLabels.indexOf(raw.toLowerCase()) !== -1 ? '' : raw;
     }
 
     function getPreviewSummaryCopy(tree, memories) {
         var titleHelper = getSearchTitleHelper();
-        var displayTitle = (titleHelper && titleHelper.getBrowseDisplayTitle)
+        var displayTitle = titleHelper && titleHelper.getBrowseDisplayTitle
             ? titleHelper.getBrowseDisplayTitle(tree)
-            : (String(tree && tree.title ? tree.title : '').trim() || getDefaultTreeName());
-        var themeLabel = (titleHelper && titleHelper.getThemeLabel)
-            ? titleHelper.getThemeLabel(tree)
-            : '';
+            : (String((tree && tree.title) || '').trim() || getDefaultTreeName());
+        var themeLabel = titleHelper && titleHelper.getThemeLabel ? titleHelper.getThemeLabel(tree) : '';
         var timeRange = getPreviewTimeRange(tree);
-        var memoryCount = Number(tree && tree.memoryCount ? tree.memoryCount : 0);
+        var memoryCount = Number((tree && tree.memoryCount) || 0);
         var safeTitle = escapeHtml(displayTitle);
         var safeTheme = escapeHtml(themeLabel);
         var safeRange = escapeHtml(timeRange);
-
-        if (!memories.length) {
-            if (themeLabel) {
-                return formatSearchCopy(
-                    'search.previewSummaryThemeStart',
-                    { title: safeTitle, theme: safeTheme },
-                    '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 공개 러브트리예요.',
-                    '<strong style="color:var(--on-surface);">{title}</strong> is a public LoveTree that has just begun with <strong style="color:var(--on-surface);">{theme}</strong>.'
-                );
-            }
-            return formatSearchCopy(
-                'search.previewSummaryStart',
-                { title: safeTitle },
+        if (!memories || !memories.length) {
+            if (themeLabel) return formatSearchCopy('search.previewSummaryThemeStart', { title: safeTitle, theme: safeTheme },
+                '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 공개 러브트리예요.',
+                '<strong style="color:var(--on-surface);">{title}</strong> is a public LoveTree that has just begun with <strong style="color:var(--on-surface);">{theme}</strong>.');
+            return formatSearchCopy('search.previewSummaryStart', { title: safeTitle },
                 '<strong style="color:var(--on-surface);">{title}</strong>는 이제 막 시작된 공개 러브트리예요.',
-                '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.'
-            );
+                '<strong style="color:var(--on-surface);">{title}</strong> is a newly started public LoveTree.');
         }
-
         if (!timeRange) {
-            if (themeLabel) {
-                return formatSearchCopy(
-                    'search.previewSummaryThemeNoRange',
-                    { theme: safeTheme, count: memoryCount },
-                    '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
-                    '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> are connected.'
-                );
-            }
-            return formatSearchCopy(
-                'search.previewSummaryNoRange',
-                { title: safeTitle, count: memoryCount },
+            if (themeLabel) return formatSearchCopy('search.previewSummaryThemeNoRange', { theme: safeTheme, count: memoryCount },
+                '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+                '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> are connected.');
+            return formatSearchCopy('search.previewSummaryNoRange', { title: safeTitle, count: memoryCount },
                 '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
-                '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> are connected.'
-            );
+                '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> are connected.');
         }
-
-        if (themeLabel) {
-            return formatSearchCopy(
-                'search.previewSummaryThemeRange',
-                { theme: safeTheme, count: memoryCount, range: safeRange },
-                '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 <strong>{range}</strong>에 걸쳐 이어졌어요.',
-                '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> continued across <strong>{range}</strong>.'
-            );
-        }
-        return formatSearchCopy(
-            'search.previewSummaryRange',
-            { title: safeTitle, count: memoryCount, range: safeRange },
+        if (themeLabel) return formatSearchCopy('search.previewSummaryThemeRange', { theme: safeTheme, count: memoryCount, range: safeRange },
+            '<strong style="color:var(--on-surface);">{theme}</strong>와 함께한 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 <strong>{range}</strong>에 걸쳐 이어졌어요.',
+            '<strong style="color:var(--on-surface);">{count} moments</strong> with <strong style="color:var(--on-surface);">{theme}</strong> continued across <strong>{range}</strong>.');
+        return formatSearchCopy('search.previewSummaryRange', { title: safeTitle, count: memoryCount, range: safeRange },
             '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 <strong>{range}</strong>에 걸쳐 이어졌어요.',
-            '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> continued across <strong>{range}</strong>.'
-        );
+            '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> continued across <strong>{range}</strong>.');
     }
 
-    function renderPlaceholder() {
-        var lead = getSearchCopy(
-            'search.previewEmptyLead',
-            '트리를 고르면',
-            'When you choose a tree,'
-        );
-        var body = getSearchCopy(
-            'search.previewEmptyBody',
-            '대표 순간과 이어진 감정이 이곳에 열립니다.',
-            'the featured moment and connected feelings open here.'
-        );
-
-        return '<div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;color:var(--on-surface-variant);font-size:14px;text-align:center;padding:20px;">' +
-            '<p style="margin:0 0 8px;">' + escapeHtml(lead) + '</p>' +
-            '<p style="margin:0;line-height:1.5;">' + escapeHtml(body) + '</p>' +
-            '</div>';
-    }
-
-    function renderShareButton(tree) {
-        var helper = window.LoveBudSearchPreviewActionHelper;
-        if (helper && helper.renderShareButton) {
-            return helper.renderShareButton(tree);
-        }
-        if (!(tree && tree.id)) return '';
-        var label = getSearchCopy(
-            'search.previewShareLink',
-            '감상 링크 복사',
-            'Copy view link'
-        );
-        return '<button type="button" data-share-tree-link="' + escapeHtml(tree.id) + '" class="btn-round preview-share-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;gap:6px;background:var(--surface-container);color:var(--on-surface-variant);border:1px solid var(--outline-variant);">' +
-            '<span class="material-symbols-outlined" style="font-size:16px;">link</span>' +
-            '<span data-share-tree-link-label>' + escapeHtml(label) + '</span>' +
-            '</button>';
-    }
     window.LoveBudSearchPreviewBuilders = {
         renderSectionHeading: renderSectionHeading,
         renderInfoCallout: renderInfoCallout,
@@ -315,10 +281,9 @@
         getDefaultTreeName: getDefaultTreeName,
         getTreeIcon: getTreeIcon,
         getSharedUtils: getSharedUtils,
+        getTimelineLabel: getTimelineLabel,
         getPreviewTimeRange: getPreviewTimeRange,
-        getPreviewSummaryCopy: getPreviewSummaryCopy,
-        renderPlaceholder: renderPlaceholder,
-        renderShareButton: renderShareButton
+        getPreviewSummaryCopy: getPreviewSummaryCopy
     };
 
     console.log('[LoveBudSearchPreviewBuilders] Preview builder helpers loaded v20260506-1');

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Renderer
- * v20260504-1
+ * v20260506-1
  * 
  * Rendering layer: preview sidebar panel.
  * DOM-agnostic - updates passed DOM elements.
@@ -220,56 +220,31 @@
     const renderEmotionTags = previewBuilders.renderEmotionTags || function(tags) { return ''; };
 
     function getTimelineLabel(tree, memories) {
-        const titleHelper = getSearchTitleHelper();
-        const formatDate = titleHelper?.formatShortDate || (() => {
-            const helper = window.LoveBudSearchPreviewCopyHelper;
-            if (helper?.formatShortDate) {
-                return helper.formatShortDate;
-            }
-            return (value) => {
-                if (!value) return '';
-                const date = new Date(value);
-                if (Number.isNaN(date.getTime())) return '';
-                return date.toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR', {
-                    month: 'short',
-                    day: 'numeric'
-                });
-            };
-        })();
-
-        const updatedAt = tree.updatedAt || '';
-        const createdAt = tree.createdAt || '';
-        const firstTimestamp = memories[0]?.timestamp || '';
-        const lastTimestamp = memories[memories.length - 1]?.timestamp || '';
-
-        const safeUpdated = formatDate(updatedAt);
-        const safeCreated = formatDate(createdAt);
-        const safeFirst = formatDate(firstTimestamp);
-        const safeLast = formatDate(lastTimestamp);
-
-        if (safeUpdated) {
-            return `${getSearchCopy('search.previewTimelineRecentUpdate', '최근에 이어진 감정', 'Recently added moment')} ${safeUpdated}`;
-        }
-        if (safeLast) {
-            return `${getSearchCopy('search.previewTimelineLastMoment', '가장 최근에 남은 순간', 'Latest saved moment')} ${safeLast}`;
-        }
-        if (safeFirst && safeLast && safeFirst !== safeLast) {
-            return `${safeFirst} ~ ${safeLast}`;
-        }
-        if (safeCreated) {
-            return `${getSearchCopy('search.previewTimelineCreated', '처음 남긴 날', 'First saved on')} ${safeCreated}`;
+        if (previewBuilders.getTimelineLabel) {
+            return previewBuilders.getTimelineLabel(tree, memories);
         }
         return getSearchCopy('search.previewTimelineUnavailable', '아직 시작 순간을 기다리는 중이에요', 'Still waiting for the first moment');
     }
 
     const getDefaultTreeName = previewBuilders.getDefaultTreeName || function() { return '러브트리'; };
 
-    const getPreviewTimeRange = previewBuilders.getPreviewTimeRange || function(tree) {
-        return String(tree && tree.timeRange ? tree.timeRange : '').trim();
+    function getPreviewTimeRange(tree) {
+        if (previewBuilders.getPreviewTimeRange) {
+            return previewBuilders.getPreviewTimeRange(tree);
+        }
+        const raw = String(tree?.timeRange || '').trim();
+        return raw || '';
     }
 
-    const getPreviewSummaryCopy = previewBuilders.getPreviewSummaryCopy || function(tree, memories) {
-        return '';
+    function getPreviewSummaryCopy(tree, memories) {
+        if (previewBuilders.getPreviewSummaryCopy) {
+            return previewBuilders.getPreviewSummaryCopy(tree, memories);
+        }
+        const displayTitle = String(tree?.title || '').trim() || '러브트리';
+        return formatSearchCopy('search.previewSummaryNoRange',
+            { title: escapeHtml(displayTitle), count: Number(tree?.memoryCount || 0) },
+            '<strong style="color:var(--on-surface);">{title}</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">{count}개의 순간</span>이 이어졌어요.',
+            '<strong style="color:var(--on-surface);">{count} moments</strong> in <strong style="color:var(--on-surface);">{title}</strong> are connected.');
     }
 
     const renderSectionHeading = previewBuilders.renderSectionHeading || function(icon, label) { return ''; };
@@ -592,5 +567,5 @@
         }
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260504-1');
+    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260506-1');
 })();

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -62,7 +62,6 @@ test('search UI module implements card accessibility and event delegation', () =
 });
 
 test('search preview summary omits range phrase for missing time range labels', () => {
-  const previewBuilders = read('js/search/search-preview-renderer-builders.js');
   const previewRenderer = read('js/search/search-preview-renderer.js');
   const previewBuilders = read('js/search/search-preview-renderer-builders.js');
   const i18nSearch = read('js/i18n/i18n-search.js');

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -64,16 +64,15 @@ test('search UI module implements card accessibility and event delegation', () =
 test('search preview summary omits range phrase for missing time range labels', () => {
   const previewBuilders = read('js/search/search-preview-renderer-builders.js');
   const previewRenderer = read('js/search/search-preview-renderer.js');
+  const previewBuilders = read('js/search/search-preview-renderer-builders.js');
   const i18nSearch = read('js/i18n/i18n-search.js');
 
-  assert.match(previewBuilders, /function getPreviewTimeRange\(tree\)/);
+  assert.match(previewRenderer, /function getPreviewTimeRange\(tree\)/);
   assert.match(previewBuilders, /'기록 없음'/);
   assert.match(previewBuilders, /getSearchCopy\('search\.previewUnknownRange'/);
-  assert.match(previewBuilders, /if \(!timeRange\)/);
+  assert.match(previewBuilders, /function getPreviewSummaryCopy\(/);
   assert.match(previewBuilders, /search\.previewSummaryThemeNoRange/);
   assert.match(previewBuilders, /search\.previewSummaryNoRange/);
-
-  assert.match(previewRenderer, /previewBuilders\.getPreviewTimeRange/);
 
   assert.match(i18nSearch, /'search\.previewSummaryThemeNoRange'/);
   assert.match(i18nSearch, /'search\.previewSummaryNoRange'/);


### PR DESCRIPTION
## Summary
- Extract `getTimelineLabel`, `getPreviewTimeRange`, `getPreviewSummaryCopy` from renderer to builders
- Renderer retains thin delegation wrappers with minimal fallbacks
- Refs #656

## Extracted helpers
- `getTimelineLabel` — timeline label string formatting
- `getPreviewTimeRange` — time range validation and filtering
- `getPreviewSummaryCopy` — summary copy template formatting

## Changed files
- `js/search/search-preview-renderer.js`
- `js/search/search-preview-renderer-builders.js`
- `tests/routes/search-runtime-modules.test.js`

## Line count before/after
| File | Before | After | Delta |
|------|--------|-------|-------|
| search-preview-renderer.js | 700 | 598 | -102 |
| search-preview-renderer-builders.js | 207 | 290 | +83 |

## Verification
- `git diff --check`: PASS
- `npm run verify`: 149/149 PASS
- `npm test`: 203/203 PASS

## Guardrails
- No UX/DOM/structure/class name changes
- No search URL state behavior changes
- No auth/API path/payload changes
- No filter/sort/limit behavior changes
- No preview open/close behavior changes
- No fallback/error behavior changes
- No desktop/mobile behavior changes
- No new helper files created
- Delegation fallbacks maintained

## Browser verification required
- YES — preview summary copy, timeline label, and time range rendering should be verified via browser smoke

## Non-goals
- Does not change any other search runtime module
- Does not touch PR #7 / prototypes / reference / demo / variant paths
- Does not add new script loading entries