### PR TITLE
docs(qa): define member journey verification suite

### DIFF
--- a/docs/ops/AGENTS.md
+++ b/docs/ops/AGENTS.md
@@ -1,6 +1,7 @@
 # Ops Agent Security Rules
 
 Refs #299
+Refs #849
 
 ## Purpose
 
@@ -31,9 +32,14 @@ Agents may reference these local paths by name only:
 - `.secrets/`
 - `.env`
 - `.env.*`
+- `.local/test-accounts.json`
+- `.local/test-accounts.example.json`
+- `docs/ops/qa-credential-bundle/`
 - `~/.config/gh/hosts.yml`
 
 Referencing a path does not authorize printing its contents.
+
+`.local/test-accounts.json` is a credential-bearing runtime file. Agents may reference the path, selected credential keys, and safe preflight status only. They must not print email, password, confirmPassword, token, session, cookie, UID, request payload, or private values.
 
 ## Allowed checks
 
@@ -44,6 +50,8 @@ PowerShell examples:
 ```powershell
 Test-Path .secrets/lovebud-runtime.env
 Test-Path .env
+Test-Path .local/test-accounts.json
+Test-Path .local/test-accounts.example.json
 Test-Path ~/.config/gh/hosts.yml
 ```
 
@@ -53,7 +61,17 @@ Git examples:
 git check-ignore .secrets/lovebud-runtime.env
 git check-ignore .env
 git check-ignore .env.local
+git check-ignore .local/test-accounts.json
 ```
+
+Credential preflight examples:
+
+```bash
+npm run check:auth-credentials -- --key accounts.user
+npm run check:auth-credentials -- --key accounts.personaA001
+```
+
+Credential preflight must report only safe status fields such as key presence, non-empty status, whitespace status, confirmPassword match status, and final PASS/BLOCKED state. It must not print credential values.
 
 GitHub token creation may be directed to:
 
@@ -88,6 +106,7 @@ Do not run or request commands that print secret material, including:
 cat .env
 cat .env.*
 cat .secrets/*
+cat .local/test-accounts.json
 printenv
 env
 set
@@ -99,6 +118,8 @@ echo $CLOUDFLARE_API_TOKEN
 Get-Content .env
 Get-Content .env.*
 Get-Content .secrets/*
+Get-Content .local/test-accounts.json
+type .local/test-accounts.json
 echo $env:GH_TOKEN
 echo $env:CLOUDFLARE_API_TOKEN
 Get-ChildItem Env:
@@ -118,20 +139,35 @@ Also forbidden:
 Use this pattern when a local command needs a secret:
 
 1. Operator stores the secret in an approved local path.
-2. Automation references the path.
+2. Automation references the path and selected key, not the value.
 3. The local machine reads the value into process memory.
-4. The command receives the value through the CLI, environment, stdin, or approved credential manager.
+4. The command receives the value through the CLI, environment, stdin, browser automation, or approved credential manager.
 5. Reports include only status, never the value.
 
 Safe report example:
 
 ```text
-credential path: .secrets/lovebud-runtime.env
+credential path: .local/test-accounts.json
+selected credential key: accounts.personaA001
 credential file: EXISTS
 credential file gitignored: YES
 required key: PRESENT
 secret value exposed: NO
 ```
+
+## Browser login credential pattern
+
+For browser verification, agents should not ask the model to read credentials. Use this pattern instead:
+
+```text
+credential source: .local/test-accounts.json
+selected key: accounts.personaA001
+credential preflight: CREDENTIAL_PREFLIGHT_PASS
+browser login performed locally: YES
+credential values exposed: NO
+```
+
+A local browser executor may load the selected credential key into the browser form through local automation or manual operator entry. The model/report should see only key names and status fields.
 
 ## PR and Issue safety guidance
 

--- a/docs/ops/MEMBER_JOURNEY_PERSONAS.md
+++ b/docs/ops/MEMBER_JOURNEY_PERSONAS.md
@@ -1,0 +1,374 @@
+# Member Journey Personas
+
+Refs #846
+Refs #838
+Refs #839
+Refs #840
+Refs #841
+Refs #842
+Refs #843
+Refs #844
+
+## Purpose
+
+This document defines reusable personas for LoveBud member journey verification.
+
+The journey suite defines what paths must be checked. Personas define who is performing those paths and why.
+
+Use this order for runtime-sensitive QA:
+
+```text
+persona -> journey -> issue/PR verification -> report
+```
+
+A browser verification run should not only ask whether a button works. It should also ask whether the product makes sense for the user represented by the selected persona.
+
+## Persona selection rule
+
+Every runtime-sensitive PR should name at least one persona when requesting browser verification.
+
+Runtime-sensitive areas include:
+
+```text
+Auth
+My Trees
+Editor
+Browse/Search runtime
+Public Viewer
+public/private boundary
+member data creation/edit/persistence
+mobile-visible UI
+loading/empty/error/degraded states
+```
+
+Docs-only PRs with no runtime claim may use:
+
+```text
+Persona: N/A
+```
+
+## Persona A — First-time fan memory creator
+
+```text
+Persona ID: PERSONA_A_FIRST_TIME_CREATOR
+Display name: First-time fan memory creator
+Starting state: New visitor
+Device/viewport: Desktop first, mobile 375px when onboarding or layout is in scope
+Auth state: Logged out
+Data state: No existing LoveTree required
+Primary goal: Understand LoveBud and create the first fan-memory LoveTree
+Secondary goal: Confirm the saved tree appears in My Trees and can be reopened
+Likely confusion: What is a LoveTree? Where do I start? Did my first moment save?
+```
+
+Required journeys:
+
+```text
+AUTH_SIGNUP_LOGIN_JOURNEY
+FIRST_TREE_CREATION_JOURNEY
+MOBILE_375_FULL_JOURNEY when UI-visible or mobile-sensitive
+ERROR_RECOVERY_JOURNEY when loading/empty/degraded states are touched
+```
+
+Related issue families:
+
+```text
+first impression
+intro/login clarity
+signup/auth state
+first moment affordance
+first tree creation
+save and persistence
+mobile onboarding
+```
+
+Safe test data rule:
+
+```text
+Use fixed test slot for signup and first tree creation.
+Do not create production test accounts or production test LoveTrees unless separately approved.
+Use safe dummy content only.
+```
+
+Expected report labels:
+
+```text
+PERSONA_A_SELECTED
+SIGNUP_SUCCESS
+FIRST_CREATE_ENTRY_PRESENT
+FIRST_MOMENT_SAVE_SUCCESS
+OWNED_TREE_CARD_PRESENT
+PERSISTENCE_CONFIRMED
+NO_HORIZONTAL_OVERFLOW
+```
+
+## Persona B — Returning private scrapbook owner
+
+```text
+Persona ID: PERSONA_B_RETURNING_OWNER
+Display name: Returning private scrapbook owner
+Starting state: Returning member
+Device/viewport: Desktop first; mobile 375px if My Trees or Editor layout is in scope
+Auth state: Logged in or able to log in
+Data state: Has at least one existing private or owned LoveTree
+Primary goal: Reopen an existing tree and continue editing
+Secondary goal: Confirm edits persist after refresh or revisit
+Likely confusion: Which card opens my tree? Did editing save? Why did a protected page render before auth?
+```
+
+Required journeys:
+
+```text
+AUTH_SIGNUP_LOGIN_JOURNEY smoke
+MY_TREES_RETURNING_USER_JOURNEY
+EDITOR_MOMENT_EDITING_JOURNEY
+LOGOUT_AND_PROTECTED_ROUTE_JOURNEY when Auth/protection is in scope
+```
+
+Related issue families:
+
+```text
+My Trees card clarity
+protected-route gating
+Editor node selection
+moment editing
+save/cancel behavior
+session persistence
+```
+
+Safe test data rule:
+
+```text
+Use fixed test slot and approved test account.
+Do not print tree IDs, owner IDs, memory IDs, raw payloads, or DB row values.
+Use safe labels for existing data presence.
+```
+
+Expected report labels:
+
+```text
+PERSONA_B_SELECTED
+OWNED_TREE_CARD_PRESENT
+PRIMARY_OPEN_ACTION_WORKS
+EDITOR_LOADED
+NODE_SELECTION_WORKS
+DETAIL_PANEL_UPDATED
+EDIT_SAVE_SUCCESS
+PERSISTENCE_CONFIRMED
+PROTECTED_ROUTE_BLOCKED
+```
+
+## Persona C — Public viewer / fan visitor
+
+```text
+Persona ID: PERSONA_C_PUBLIC_VIEWER
+Display name: Public viewer / fan visitor
+Starting state: Visitor opening a public tree or shared route
+Device/viewport: Desktop and mobile 375px when viewer UI is in scope
+Auth state: Logged out or clean visitor session
+Data state: Public/read-only test tree available
+Primary goal: Open and understand a public LoveTree without editing it
+Secondary goal: Select a moment and view creator memo/media if available
+Likely confusion: Is this editable? Why is the tree empty? Is this public content or private owner data?
+```
+
+Required journeys:
+
+```text
+PUBLIC_VIEWER_READONLY_JOURNEY
+MOBILE_375_FULL_JOURNEY when viewer layout is in scope
+ERROR_RECOVERY_JOURNEY when loading/degraded states are touched
+```
+
+Related issue families:
+
+```text
+public viewer shell
+read-only boundary
+creator memo/media visibility
+owner controls hidden
+public/private data separation
+public loading/degraded states
+```
+
+Safe test data rule:
+
+```text
+Use public/read-only test data on fixed slot or approved deployed target.
+Use clean session where applicable.
+Do not expose private route parameters, private IDs, raw payloads, or owner-only data.
+```
+
+Expected report labels:
+
+```text
+PERSONA_C_SELECTED
+PUBLIC_VIEWER_OPENED
+PUBLIC_CONTENT_PRESENT
+READONLY_PANEL_PRESENT
+OWNER_CONTROLS_HIDDEN
+PRIVATE_BOUNDARY_PRESERVED
+```
+
+## Persona D — Mobile-only casual user
+
+```text
+Persona ID: PERSONA_D_MOBILE_CASUAL
+Display name: Mobile-only casual user
+Starting state: Mobile user arriving from a phone-class viewport
+Device/viewport: 375px baseline; 390/393/430/480px smoke when layout-risky
+Auth state: Logged out or logged in depending on target journey
+Data state: May be new or returning depending on target journey
+Primary goal: Complete the same core flow without desktop assumptions
+Secondary goal: Confirm menus, forms, cards, panels, and fixed elements remain usable
+Likely confusion: Hidden menu, clipped form, horizontal overflow, unreachable save/cancel, cramped editor/viewer panel
+```
+
+Required journeys:
+
+```text
+MOBILE_375_FULL_JOURNEY
+AUTH_SIGNUP_LOGIN_JOURNEY smoke when auth UI is in scope
+FIRST_TREE_CREATION_JOURNEY smoke when creation UI is in scope
+MY_TREES_RETURNING_USER_JOURNEY smoke when card UI is in scope
+EDITOR_MOMENT_EDITING_JOURNEY smoke when editor panel/canvas UI is in scope
+PUBLIC_VIEWER_READONLY_JOURNEY smoke when viewer UI is in scope
+```
+
+Related issue families:
+
+```text
+header/menu usability
+forms at mobile width
+card overflow
+Editor panel usability
+bottom sheet/detail panel usability
+wider mobile smoke
+```
+
+Safe test data rule:
+
+```text
+Use fixed test slot for Auth/data flows.
+Do not create production data by default.
+Capture screenshots without exposing private IDs or credentials.
+```
+
+Expected report labels:
+
+```text
+PERSONA_D_SELECTED
+NO_HORIZONTAL_OVERFLOW
+MOBILE_HEADER_USABLE
+FORM_USABLE
+MOBILE_CARD_LAYOUT_USABLE
+MOBILE_EDITOR_USABLE
+MOBILE_VIEWER_USABLE
+```
+
+## Persona E — Confused or interrupted user
+
+```text
+Persona ID: PERSONA_E_INTERRUPTED_USER
+Display name: Confused or interrupted user
+Starting state: User who reloads, backs out, cancels, or sees loading/error states
+Device/viewport: Desktop or mobile depending on target PR
+Auth state: Mixed; logged-out, auth-pending, and logged-in states may all be relevant
+Data state: Existing or newly created test data depending on target PR
+Primary goal: Recover without losing trust or seeing contradictory UI
+Secondary goal: Confirm cancel/back/reload/loading/error states are truthful
+Likely confusion: Did the app freeze? Did save happen? Why am I logged in and logged out at the same time? Did cancel mutate data?
+```
+
+Required journeys:
+
+```text
+ERROR_RECOVERY_JOURNEY
+LOGOUT_AND_PROTECTED_ROUTE_JOURNEY when Auth state is in scope
+AUTH_SIGNUP_LOGIN_JOURNEY smoke when auth-pending behavior is in scope
+EDITOR_MOMENT_EDITING_JOURNEY smoke when cancel/save/back behavior is in scope
+```
+
+Related issue families:
+
+```text
+loading state clarity
+empty state clarity
+cancel behavior
+back/close recovery
+auth-pending privacy
+degraded network/API state
+```
+
+Safe test data rule:
+
+```text
+Use non-destructive checks where possible.
+If data mutation is required, use fixed test slot only.
+Do not simulate destructive failures against production.
+```
+
+Expected report labels:
+
+```text
+PERSONA_E_SELECTED
+LOADING_STATE_CLEAR
+EMPTY_STATE_CLEAR
+DEGRADED_STATE_CLEAR
+BACK_NAVIGATION_RECOVERS
+AUTH_PENDING_PRIVATE_CONTENT_HIDDEN
+CANCEL_NO_MUTATION
+```
+
+## Issue and PR usage examples
+
+Use this format in executor prompts:
+
+```text
+Persona:
+- PERSONA_A_FIRST_TIME_CREATOR
+
+Journeys:
+- AUTH_SIGNUP_LOGIN_JOURNEY
+- FIRST_TREE_CREATION_JOURNEY
+- MOBILE_375_FULL_JOURNEY
+
+Target:
+- PR:
+- Fixed slot:
+- Expected head SHA:
+```
+
+Examples:
+
+```text
+Run PERSONA_A_FIRST_TIME_CREATOR against the signup + first-create path on fixed slot test-__.
+Run PERSONA_B_RETURNING_OWNER against My Trees + Editor after an Editor PR.
+Run PERSONA_C_PUBLIC_VIEWER against a public viewer PR using a clean visitor session.
+Run PERSONA_D_MOBILE_CASUAL at 375px for a mobile-visible UI PR.
+Run PERSONA_E_INTERRUPTED_USER when loading, cancel, reload, or protected-route behavior is touched.
+```
+
+## Final reporting rule
+
+Every runtime-sensitive browser verification report should include:
+
+```text
+Persona selected:
+Journey selected:
+Why this persona applies:
+Target URL:
+Expected head SHA:
+Deployed SHA:
+SHA match:
+Final status:
+```
+
+Use final status values from `MEMBER_JOURNEY_QA_SUITE.md`:
+
+```text
+PASS
+FAIL
+BLOCKED
+NOT_VERIFIED
+```

--- a/docs/ops/MEMBER_JOURNEY_PERSONAS.md
+++ b/docs/ops/MEMBER_JOURNEY_PERSONAS.md
@@ -47,6 +47,66 @@ Docs-only PRs with no runtime claim may use:
 Persona: N/A
 ```
 
+## Test data state matrix
+
+Use this matrix before assigning a persona to a browser verification task.
+
+| Persona | Required starting data state | Fixed slot requirement | Production default |
+|---------|------------------------------|------------------------|--------------------|
+| `PERSONA_A_FIRST_TIME_CREATOR` | New or disposable test account; no existing LoveTree required; first moment creation path available | Required for signup and creation | No signup or persistent data creation |
+| `PERSONA_B_RETURNING_OWNER` | Approved test account with at least one owned LoveTree; ideally at least two moments and editable memo/content | Required for private My Trees and Editor | Non-destructive smoke only |
+| `PERSONA_C_PUBLIC_VIEWER` | Public/read-only test tree or route available; clean visitor session preferred | Required when preparing public fixture or verifying PR runtime | Public route smoke only |
+| `PERSONA_D_MOBILE_CASUAL` | Same data state as paired persona, tested at 375px baseline and wider mobile when needed | Required for Auth/data/mobile runtime | Non-destructive smoke only |
+| `PERSONA_E_INTERRUPTED_USER` | Test state that can safely reload/back/cancel/error without exposing private data | Required when mutation or protected content is involved | Non-destructive smoke only |
+
+## Test data cleanup and reuse policy
+
+### Fixed test slot
+
+Allowed:
+
+```text
+new disposable test account
+safe dummy first moment
+safe dummy tree title/content
+edit/cancel/save checks
+public fixture preparation when scoped
+```
+
+Required:
+
+```text
+record PR number or run label in safe test data naming when visible to the tester
+avoid raw private IDs in reports
+reuse existing approved test account when the journey does not require signup
+prefer cleanup when the product has a safe cleanup path
+mark cleanup NOT_AVAILABLE when no safe cleanup UI/API exists
+```
+
+### Production
+
+Default production rule:
+
+```text
+no new account creation
+no persistent test tree creation
+no destructive mutation
+no private data probing
+public/landing/login smoke only
+```
+
+Exceptions require explicit CTO approval and must still avoid exposing credentials, tokens, sessions, cookies, private IDs, raw payloads, or DB row values.
+
+## Persona to issue-family matrix
+
+| Persona | Issue families it naturally exercises |
+|---------|----------------------------------------|
+| `PERSONA_A_FIRST_TIME_CREATOR` | Intro/Login clarity, signup, auth state, first moment, first tree save, My Trees first reflection, mobile onboarding |
+| `PERSONA_B_RETURNING_OWNER` | My Trees cards, protected routes, session persistence, Editor node selection, add/edit/save/cancel, persistence after refresh |
+| `PERSONA_C_PUBLIC_VIEWER` | Browse-to-viewer, public route, read-only boundary, owner controls hidden, public/private separation, creator memo/media visibility |
+| `PERSONA_D_MOBILE_CASUAL` | Mobile header/menu, mobile forms, card overflow, mobile Editor, mobile public viewer, wider mobile layout smoke |
+| `PERSONA_E_INTERRUPTED_USER` | Loading, empty, degraded/error states, back/close recovery, cancel/reload behavior, auth-pending privacy |
+
 ## Persona A — First-time fan memory creator
 
 ```text
@@ -318,6 +378,62 @@ DEGRADED_STATE_CLEAR
 BACK_NAVIGATION_RECOVERS
 AUTH_PENDING_PRIVATE_CONTENT_HIDDEN
 CANCEL_NO_MUTATION
+```
+
+## Browser Verification Executor prompt template
+
+Use this template when delegating persona-based browser verification.
+
+```text
+[CTO → Browser Verification Executor]
+
+작업 구분:
+Persona-based browser verification
+
+Persona:
+- PERSONA_ID_HERE
+
+Journeys:
+- JOURNEY_ID_HERE
+
+Target:
+- PR:
+- Issue:
+- Fixed slot URL:
+- Expected head SHA:
+
+Required preflight:
+1. Confirm fixed slot URL is the intended target.
+2. Confirm deployed SHA matches expected head SHA.
+3. Confirm real browser is used.
+4. Confirm required auth/test account state is available without printing credentials.
+5. Confirm no production data creation unless explicitly approved.
+
+Verification rules:
+- Use the selected persona's goal and likely confusion as the user lens.
+- Follow the selected journey checklist.
+- Capture screenshots when required.
+- Do not print credentials, tokens, sessions, cookies, headers, passwords, private keys, DB URLs, tree IDs, owner IDs, memory IDs, copied tree IDs, raw payloads, or DB row values.
+- Use safe labels only.
+
+Report format:
+- Persona selected:
+- Journey selected:
+- Why this persona applies:
+- Target URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match: YES / NO
+- Browser used: YES / NO
+- Viewports tested:
+- Test data state:
+- Cleanup status: DONE / NOT_REQUIRED / NOT_AVAILABLE
+- Findings:
+- Screenshots:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure: NO / PRESENT
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
 ```
 
 ## Issue and PR usage examples

--- a/docs/ops/MEMBER_JOURNEY_QA_SUITE.md
+++ b/docs/ops/MEMBER_JOURNEY_QA_SUITE.md
@@ -7,6 +7,7 @@ Refs #841
 Refs #842
 Refs #843
 Refs #844
+Refs #846
 
 ## Purpose
 
@@ -15,6 +16,31 @@ This document defines the reusable end-to-end member journey QA suite for LoveBu
 The suite verifies the product as a real member would experience it: first visit, signup, login, first tree creation, My Trees revisit, Editor usage, public/read-only viewing, logout, re-login, screenshots, and mobile coverage.
 
 This is not a replacement for narrow PR-level checks. It is a higher-level browser verification layer used when a change can affect whether the product works as a coherent user journey.
+
+## Persona-first execution model
+
+Before choosing journeys, select a persona from [MEMBER_JOURNEY_PERSONAS.md](MEMBER_JOURNEY_PERSONAS.md).
+
+Use this order for runtime-sensitive QA:
+
+```text
+persona -> journey -> issue/PR verification -> report
+```
+
+The persona answers who is using LoveBud and why. The journey answers which route and behavior must be verified. The issue/PR defines the exact implementation risk.
+
+Every runtime-sensitive browser verification report should include:
+
+```text
+Persona selected:
+Journey selected:
+Why this persona applies:
+Target URL:
+Expected head SHA:
+Deployed SHA:
+SHA match:
+Final status:
+```
 
 ## Verification target policy
 
@@ -76,6 +102,15 @@ Do not repeatedly create throwaway production accounts or persistent production 
 
 Use when a PR or issue can affect signup, login, logout, session persistence, protected routes, or shared header auth state.
 
+Typical personas:
+
+```text
+PERSONA_A_FIRST_TIME_CREATOR
+PERSONA_B_RETURNING_OWNER smoke
+PERSONA_D_MOBILE_CASUAL smoke
+PERSONA_E_INTERRUPTED_USER smoke
+```
+
 Required scenario:
 
 1. Visit the target as a logged-out user.
@@ -94,6 +129,7 @@ Report template:
 ```text
 AUTH_SIGNUP_LOGIN_JOURNEY
 Target:
+- Persona:
 - URL:
 - Expected head SHA:
 - Deployed SHA:
@@ -130,6 +166,13 @@ AUTH_STATE_CONSISTENT
 
 Use when a PR or issue can affect first-time creation, first moment entry, save behavior, My Trees reflection, or Editor/detail persistence.
 
+Typical personas:
+
+```text
+PERSONA_A_FIRST_TIME_CREATOR
+PERSONA_D_MOBILE_CASUAL smoke
+```
+
 Required scenario:
 
 1. Start from a logged-in test account on a fixed test slot.
@@ -148,6 +191,7 @@ Report template:
 ```text
 FIRST_TREE_CREATION_JOURNEY
 Target:
+- Persona:
 - URL:
 - Expected head SHA:
 - Deployed SHA:
@@ -183,6 +227,13 @@ PERSISTENCE_CONFIRMED
 
 Use when a PR or issue can affect My Trees, owned tree cards, card opening, loading/empty/error states, or account-gated rendering.
 
+Typical personas:
+
+```text
+PERSONA_B_RETURNING_OWNER
+PERSONA_D_MOBILE_CASUAL smoke
+```
+
 Required scenario:
 
 1. Log in with an approved test account that has at least one saved tree.
@@ -200,6 +251,7 @@ Report template:
 ```text
 MY_TREES_RETURNING_USER_JOURNEY
 Target:
+- Persona:
 - URL:
 - Expected head SHA:
 - Deployed SHA:
@@ -236,6 +288,14 @@ REFRESH_STABLE
 
 Use when a PR or issue can affect Editor canvas load, node selection, detail panel updates, add/edit/cancel/save behavior, or persistence.
 
+Typical personas:
+
+```text
+PERSONA_B_RETURNING_OWNER
+PERSONA_D_MOBILE_CASUAL smoke
+PERSONA_E_INTERRUPTED_USER smoke
+```
+
 Required scenario:
 
 1. Log in with an approved test account.
@@ -256,6 +316,7 @@ Report template:
 ```text
 EDITOR_MOMENT_EDITING_JOURNEY
 Target:
+- Persona:
 - URL:
 - Expected head SHA:
 - Deployed SHA:
@@ -295,6 +356,13 @@ PERSISTENCE_CONFIRMED
 
 Use when a PR or issue can affect public/read-only LoveTree viewing, public/private boundaries, public viewer node selection, or read-only moment details.
 
+Typical personas:
+
+```text
+PERSONA_C_PUBLIC_VIEWER
+PERSONA_D_MOBILE_CASUAL smoke
+```
+
 Required scenario:
 
 1. Prepare or identify a public/read-only test tree through an approved fixed-slot path.
@@ -313,6 +381,7 @@ Report template:
 ```text
 PUBLIC_VIEWER_READONLY_JOURNEY
 Target:
+- Persona:
 - URL:
 - Expected head SHA:
 - Deployed SHA:
@@ -349,6 +418,14 @@ COMMENT_LAYER_NOT_IMPLEMENTED
 ## 6. MOBILE_375_FULL_JOURNEY
 
 Use when a PR or issue can affect mobile layouts, header/menu behavior, forms, cards, Editor panels, public viewer, or fixed-position UI.
+
+Typical personas:
+
+```text
+PERSONA_D_MOBILE_CASUAL
+PERSONA_A_FIRST_TIME_CREATOR when onboarding is in scope
+PERSONA_C_PUBLIC_VIEWER when public viewer mobile is in scope
+```
 
 Minimum baseline:
 
@@ -392,6 +469,13 @@ MOBILE_EDITOR_USABLE
 
 Use with Auth and protected-page PRs.
 
+Typical personas:
+
+```text
+PERSONA_B_RETURNING_OWNER
+PERSONA_E_INTERRUPTED_USER
+```
+
 Required scenario:
 
 1. Log in.
@@ -415,6 +499,14 @@ HEADER_PAGE_AUTH_MATCH
 ## 8. ERROR_RECOVERY_JOURNEY
 
 Use when a PR or issue can affect loading, empty, degraded, failed, or back/close states.
+
+Typical personas:
+
+```text
+PERSONA_E_INTERRUPTED_USER
+PERSONA_A_FIRST_TIME_CREATOR smoke
+PERSONA_C_PUBLIC_VIEWER smoke
+```
 
 Required checks:
 
@@ -442,30 +534,36 @@ Use this mapping when deciding which journeys a future PR needs.
 
 ```text
 Auth PR:
+- Persona A or B depending on signup vs returning-user scope
 - AUTH_SIGNUP_LOGIN_JOURNEY required
 - LOGOUT_AND_PROTECTED_ROUTE_JOURNEY required
 - MOBILE_375_FULL_JOURNEY smoke when UI-visible
 
 My Trees PR:
+- Persona B required
 - MY_TREES_RETURNING_USER_JOURNEY required
 - AUTH_SIGNUP_LOGIN_JOURNEY smoke when auth-gated rendering is touched
 - MOBILE_375_FULL_JOURNEY required when card/layout changes
 
 Editor PR:
+- Persona B required
 - EDITOR_MOMENT_EDITING_JOURNEY required
 - FIRST_TREE_CREATION_JOURNEY smoke when first-create or persistence is touched
 - MOBILE_375_FULL_JOURNEY required for canvas/panel/form changes
 
 Public viewer PR:
+- Persona C required
 - PUBLIC_VIEWER_READONLY_JOURNEY required
 - MOBILE_375_FULL_JOURNEY required for viewer/panel changes
 - ERROR_RECOVERY_JOURNEY when loading/degraded states are touched
 
 Browse/Search PR:
+- Persona C when routes into public viewing are touched
 - Relevant Browse/Search-specific checklist plus PUBLIC_VIEWER_READONLY_JOURNEY smoke when routes into public viewing are touched
 - MOBILE_375_FULL_JOURNEY required when cards/hub/layout changes
 
 Docs-only PR:
+- Persona N/A unless the document claims runtime verification results
 - Browser journey not required unless the document claims runtime verification results
 ```
 

--- a/docs/ops/MEMBER_JOURNEY_QA_SUITE.md
+++ b/docs/ops/MEMBER_JOURNEY_QA_SUITE.md
@@ -1,0 +1,489 @@
+# Member Journey QA Suite
+
+Refs #838
+Refs #839
+Refs #840
+Refs #841
+Refs #842
+Refs #843
+Refs #844
+
+## Purpose
+
+This document defines the reusable end-to-end member journey QA suite for LoveBud.
+
+The suite verifies the product as a real member would experience it: first visit, signup, login, first tree creation, My Trees revisit, Editor usage, public/read-only viewing, logout, re-login, screenshots, and mobile coverage.
+
+This is not a replacement for narrow PR-level checks. It is a higher-level browser verification layer used when a change can affect whether the product works as a coherent user journey.
+
+## Verification target policy
+
+### Fixed test slot
+
+Use a fixed test slot for any journey that creates, edits, persists, deletes, or reads private/authenticated user data.
+
+Required evidence:
+
+```text
+fixed test slot URL
+expected PR head SHA
+actual deployed SHA
+SHA match: YES / NO
+real browser used: YES / NO
+login-capable test account available: YES / NO / NOT_REQUIRED
+```
+
+### Production
+
+Production checks are limited to non-destructive smoke unless explicitly approved.
+
+Allowed production smoke examples:
+
+```text
+landing page opens
+login page opens
+public/read-only route opens
+basic navigation renders
+no fatal console/page error on first load
+```
+
+Do not repeatedly create throwaway production accounts or persistent production test data unless separately approved.
+
+## Global guardrails
+
+- Do not push directly to `main`.
+- Do not mark a runtime-sensitive journey as final PASS without deployed SHA confirmation.
+- Do not use `localhost` or static inspection as final PASS for Auth, My Trees, Editor, Browse, Search, or public/private boundary checks.
+- Do not touch PR #7.
+- Do not modify prototype/reference/demo/variant paths.
+- Do not expose secrets, tokens, sessions, cookies, headers, passwords, private keys, DB URLs, tree IDs, owner IDs, memory IDs, copied tree IDs, raw restricted payloads, or DB row values.
+- Use safe status labels instead of raw private identifiers.
+
+## Journey tracks
+
+```text
+1. AUTH_SIGNUP_LOGIN_JOURNEY
+2. FIRST_TREE_CREATION_JOURNEY
+3. MY_TREES_RETURNING_USER_JOURNEY
+4. EDITOR_MOMENT_EDITING_JOURNEY
+5. PUBLIC_VIEWER_READONLY_JOURNEY
+6. MOBILE_375_FULL_JOURNEY
+7. LOGOUT_AND_PROTECTED_ROUTE_JOURNEY
+8. ERROR_RECOVERY_JOURNEY
+```
+
+## 1. AUTH_SIGNUP_LOGIN_JOURNEY
+
+Use when a PR or issue can affect signup, login, logout, session persistence, protected routes, or shared header auth state.
+
+Required scenario:
+
+1. Visit the target as a logged-out user.
+2. Confirm landing/intro/login entry points are understandable.
+3. Create a new test account on a fixed test slot when signup is in scope.
+4. Confirm post-signup route and header/account state.
+5. Log out.
+6. Attempt protected routes while logged out.
+7. Log in with the created or approved test account.
+8. Refresh and confirm session persistence.
+9. Log out again.
+10. Hard reload and confirm protected access remains blocked.
+
+Report template:
+
+```text
+AUTH_SIGNUP_LOGIN_JOURNEY
+Target:
+- URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match:
+
+Results:
+- Logged-out first visit:
+- Signup:
+- Post-signup route:
+- Login:
+- Session persistence:
+- Logout:
+- Protected route block:
+- Header/page auth consistency:
+- Screenshots:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure:
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
+```
+
+Safe labels:
+
+```text
+SIGNUP_FORM_PRESENT
+SIGNUP_SUCCESS
+LOGIN_SUCCESS
+SESSION_PERSISTED
+PROTECTED_ROUTE_BLOCKED
+AUTH_STATE_CONSISTENT
+```
+
+## 2. FIRST_TREE_CREATION_JOURNEY
+
+Use when a PR or issue can affect first-time creation, first moment entry, save behavior, My Trees reflection, or Editor/detail persistence.
+
+Required scenario:
+
+1. Start from a logged-in test account on a fixed test slot.
+2. Confirm the first tree/moment entry point is visible and understandable.
+3. Create safe dummy first-moment content.
+4. Save.
+5. Confirm success/transition state.
+6. Navigate to My Trees.
+7. Confirm the new tree appears as an owned tree card.
+8. Open the tree.
+9. Confirm saved content appears in Editor/detail context.
+10. Refresh and confirm persistence.
+
+Report template:
+
+```text
+FIRST_TREE_CREATION_JOURNEY
+Target:
+- URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match:
+
+Results:
+- First-create entry point:
+- Form/input clarity:
+- Save action:
+- Post-save route/state:
+- My Trees reflection:
+- Editor/detail open:
+- Persistence after refresh:
+- Desktop screenshot:
+- Mobile screenshot if in scope:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure:
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
+```
+
+Safe labels:
+
+```text
+FIRST_CREATE_ENTRY_PRESENT
+FIRST_MOMENT_SAVE_SUCCESS
+OWNED_TREE_CARD_PRESENT
+SAVED_CONTENT_PRESENT
+PERSISTENCE_CONFIRMED
+```
+
+## 3. MY_TREES_RETURNING_USER_JOURNEY
+
+Use when a PR or issue can affect My Trees, owned tree cards, card opening, loading/empty/error states, or account-gated rendering.
+
+Required scenario:
+
+1. Log in with an approved test account that has at least one saved tree.
+2. Open My Trees.
+3. Confirm owned tree cards load after Auth is confirmed.
+4. Confirm empty/loading/error states are truthful where applicable.
+5. Open an existing tree using the intended primary action.
+6. Confirm the target opens in the expected Editor/detail route.
+7. Return to My Trees.
+8. Refresh and confirm cards remain stable.
+9. Check desktop and mobile card layout if in scope.
+
+Report template:
+
+```text
+MY_TREES_RETURNING_USER_JOURNEY
+Target:
+- URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match:
+
+Results:
+- Login/account menu:
+- My Trees auth gating:
+- Owned card load:
+- Empty/loading/error state:
+- Primary open action:
+- Opened route:
+- Return navigation:
+- Refresh stability:
+- Desktop screenshot:
+- Mobile screenshot if in scope:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure:
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
+```
+
+Safe labels:
+
+```text
+OWNED_TREE_CARD_PRESENT
+PRIMARY_OPEN_ACTION_WORKS
+AUTH_CONFIRMED_BEFORE_RENDER
+RETURN_TO_MY_TREES_WORKS
+REFRESH_STABLE
+```
+
+## 4. EDITOR_MOMENT_EDITING_JOURNEY
+
+Use when a PR or issue can affect Editor canvas load, node selection, detail panel updates, add/edit/cancel/save behavior, or persistence.
+
+Required scenario:
+
+1. Log in with an approved test account.
+2. Open My Trees.
+3. Open an existing tree in Editor.
+4. Confirm canvas and detail/editor panels load after Auth is confirmed.
+5. Select an existing moment node.
+6. Confirm selected state and detail panel update.
+7. Open add-next or edit flow where applicable.
+8. Enter safe dummy content.
+9. Save and confirm persistence.
+10. Reopen or refresh Editor and confirm the updated content remains present.
+11. Test cancel behavior without unwanted mutation.
+12. Confirm desktop and mobile usability when in scope.
+
+Report template:
+
+```text
+EDITOR_MOMENT_EDITING_JOURNEY
+Target:
+- URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match:
+
+Results:
+- Login/account menu:
+- Editor auth gating:
+- Canvas load:
+- Node selection:
+- Detail panel update:
+- Add/edit form open:
+- Cancel behavior:
+- Save behavior:
+- Persistence after refresh:
+- Desktop screenshot:
+- Mobile screenshot if in scope:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure:
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
+```
+
+Safe labels:
+
+```text
+EDITOR_LOADED
+NODE_SELECTION_WORKS
+DETAIL_PANEL_UPDATED
+ADD_FORM_OPENED
+EDIT_SAVE_SUCCESS
+CANCEL_NO_MUTATION
+PERSISTENCE_CONFIRMED
+```
+
+## 5. PUBLIC_VIEWER_READONLY_JOURNEY
+
+Use when a PR or issue can affect public/read-only LoveTree viewing, public/private boundaries, public viewer node selection, or read-only moment details.
+
+Required scenario:
+
+1. Prepare or identify a public/read-only test tree through an approved fixed-slot path.
+2. Open the public viewer route as logged-out or clean-session visitor where applicable.
+3. Confirm public viewer shell loads.
+4. Confirm tree/moment content renders or fails gracefully.
+5. Select a visible node/moment if available.
+6. Confirm read-only detail panel or viewer state opens if implemented.
+7. Confirm no edit/delete/owner-only controls are visible.
+8. Confirm private-only data is not exposed.
+9. Confirm back/close navigation returns to the tree/viewer context.
+10. Capture desktop and mobile screenshots when in scope.
+
+Report template:
+
+```text
+PUBLIC_VIEWER_READONLY_JOURNEY
+Target:
+- URL:
+- Expected head SHA:
+- Deployed SHA:
+- SHA match:
+
+Results:
+- Public viewer route:
+- Logged-out/visitor access:
+- Public content render:
+- Node/moment selection:
+- Detail/read-only panel:
+- Owner controls hidden:
+- Private data boundary:
+- Back/close navigation:
+- Desktop screenshot:
+- Mobile screenshot if in scope:
+- Fatal console errors:
+- Fatal network blockers:
+- Secret/private data exposure:
+- Final status: PASS / FAIL / BLOCKED / NOT_VERIFIED
+```
+
+Safe labels:
+
+```text
+PUBLIC_VIEWER_OPENED
+PUBLIC_CONTENT_PRESENT
+READONLY_PANEL_PRESENT
+OWNER_CONTROLS_HIDDEN
+PRIVATE_BOUNDARY_PRESERVED
+COMMENT_LAYER_NOT_IMPLEMENTED
+```
+
+## 6. MOBILE_375_FULL_JOURNEY
+
+Use when a PR or issue can affect mobile layouts, header/menu behavior, forms, cards, Editor panels, public viewer, or fixed-position UI.
+
+Minimum baseline:
+
+```text
+375px mobile baseline
+```
+
+Wider mobile smoke when UI-sensitive or layout-risky:
+
+```text
+390px / 393px modern phone baseline
+430px large phone baseline
+480px large Android fallback where applicable
+```
+
+Required scenario:
+
+1. Visit the target at 375px viewport.
+2. Confirm no horizontal overflow.
+3. Confirm header/account/menu behavior.
+4. Signup/login where the target journey requires it.
+5. Open My Trees.
+6. Create or open a tree where applicable.
+7. Open Editor/detail/public viewer where applicable.
+8. Confirm forms, panels, cards, and fixed elements remain usable.
+9. Capture screenshots.
+
+Report fields may be combined with the relevant journey report. Always include viewport width and overflow result.
+
+Safe labels:
+
+```text
+NO_HORIZONTAL_OVERFLOW
+MOBILE_HEADER_USABLE
+FORM_USABLE
+MOBILE_CARD_LAYOUT_USABLE
+MOBILE_EDITOR_USABLE
+```
+
+## 7. LOGOUT_AND_PROTECTED_ROUTE_JOURNEY
+
+Use with Auth and protected-page PRs.
+
+Required scenario:
+
+1. Log in.
+2. Open a protected page.
+3. Confirm private content is visible only after Auth is confirmed.
+4. Log out.
+5. Hard reload.
+6. Attempt protected pages.
+7. Confirm block or redirect is consistent.
+8. Confirm header/page auth state is not contradictory.
+
+Safe labels:
+
+```text
+AUTH_CONFIRMED_BEFORE_RENDER
+LOGOUT_SUCCESS
+PROTECTED_ROUTE_BLOCKED
+HEADER_PAGE_AUTH_MATCH
+```
+
+## 8. ERROR_RECOVERY_JOURNEY
+
+Use when a PR or issue can affect loading, empty, degraded, failed, or back/close states.
+
+Required checks:
+
+1. Loading state is visible and truthful.
+2. Empty state is understandable.
+3. Degraded state does not look stuck.
+4. Failed network/API state has recovery or clear messaging where applicable.
+5. Auth-pending does not show private content.
+6. Hard reload does not create contradictory UI.
+7. Back/close navigation recovers cleanly.
+
+Safe labels:
+
+```text
+LOADING_STATE_CLEAR
+EMPTY_STATE_CLEAR
+DEGRADED_STATE_CLEAR
+BACK_NAVIGATION_RECOVERS
+AUTH_PENDING_PRIVATE_CONTENT_HIDDEN
+```
+
+## PR-to-journey mapping
+
+Use this mapping when deciding which journeys a future PR needs.
+
+```text
+Auth PR:
+- AUTH_SIGNUP_LOGIN_JOURNEY required
+- LOGOUT_AND_PROTECTED_ROUTE_JOURNEY required
+- MOBILE_375_FULL_JOURNEY smoke when UI-visible
+
+My Trees PR:
+- MY_TREES_RETURNING_USER_JOURNEY required
+- AUTH_SIGNUP_LOGIN_JOURNEY smoke when auth-gated rendering is touched
+- MOBILE_375_FULL_JOURNEY required when card/layout changes
+
+Editor PR:
+- EDITOR_MOMENT_EDITING_JOURNEY required
+- FIRST_TREE_CREATION_JOURNEY smoke when first-create or persistence is touched
+- MOBILE_375_FULL_JOURNEY required for canvas/panel/form changes
+
+Public viewer PR:
+- PUBLIC_VIEWER_READONLY_JOURNEY required
+- MOBILE_375_FULL_JOURNEY required for viewer/panel changes
+- ERROR_RECOVERY_JOURNEY when loading/degraded states are touched
+
+Browse/Search PR:
+- Relevant Browse/Search-specific checklist plus PUBLIC_VIEWER_READONLY_JOURNEY smoke when routes into public viewing are touched
+- MOBILE_375_FULL_JOURNEY required when cards/hub/layout changes
+
+Docs-only PR:
+- Browser journey not required unless the document claims runtime verification results
+```
+
+## Final report status values
+
+Use one final status:
+
+```text
+PASS
+FAIL
+BLOCKED
+NOT_VERIFIED
+```
+
+Do not mark a runtime-sensitive journey as `PASS` if:
+
+- fixed slot was required but not used;
+- deployed SHA was not confirmed;
+- browser was not used;
+- login was required but unavailable;
+- private data or secrets were exposed in the report.

--- a/docs/ops/PR_CHECKLIST.md
+++ b/docs/ops/PR_CHECKLIST.md
@@ -23,6 +23,7 @@
 
 ## Member Journey QA 영향
 - 적용 대상: AUTH / FIRST_TREE / MY_TREES / EDITOR / PUBLIC_VIEWER / MOBILE / ERROR_RECOVERY / N/A
+- 적용 persona: docs/ops/MEMBER_JOURNEY_PERSONAS.md 기준으로 기재
 - 필요한 journey: docs/ops/MEMBER_JOURNEY_QA_SUITE.md 기준으로 기재
 - fixed slot 필요 여부: YES / NO
 - 브라우저 검증 필요 여부: YES / NO
@@ -38,9 +39,15 @@
 
 ---
 
-## 2. Member Journey QA 매핑
+## 2. Member Persona + Journey QA 매핑
 
-PR이 Auth, My Trees, Editor, Public Viewer, Browse/Search, 모바일 레이아웃, loading/error 상태에 영향을 주면 [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md)를 기준으로 필요한 journey를 PR 본문에 명시해야 합니다.
+PR이 Auth, My Trees, Editor, Public Viewer, Browse/Search, 모바일 레이아웃, loading/error 상태에 영향을 주면 먼저 [MEMBER_JOURNEY_PERSONAS.md](MEMBER_JOURNEY_PERSONAS.md)에서 persona를 선택하고, 그 다음 [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md)를 기준으로 필요한 journey를 PR 본문에 명시해야 합니다.
+
+순서는 아래를 따릅니다.
+
+```text
+persona -> journey -> issue/PR verification -> report
+```
 
 ### 필수 판단 항목
 
@@ -52,18 +59,18 @@ PR이 Auth, My Trees, Editor, Public Viewer, Browse/Search, 모바일 레이아�
 - [ ] 이 PR이 모바일 375px 또는 wider mobile layout에 영향을 주는가?
 - [ ] 이 PR이 loading/empty/error/degraded/back recovery 상태에 영향을 주는가?
 
-### PR 유형별 기본 journey
+### PR 유형별 기본 persona + journey
 
-| PR 영향 범위 | 기본 요구 journey |
-|--------------|-------------------|
-| Auth / protected route | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` |
-| First-create / persistence | `FIRST_TREE_CREATION_JOURNEY` |
-| My Trees | `MY_TREES_RETURNING_USER_JOURNEY` |
-| Editor | `EDITOR_MOMENT_EDITING_JOURNEY` |
-| Public Viewer / read-only route | `PUBLIC_VIEWER_READONLY_JOURNEY` |
-| Mobile-visible UI | `MOBILE_375_FULL_JOURNEY` |
-| Loading/empty/error/degraded states | `ERROR_RECOVERY_JOURNEY` |
-| Docs-only with no runtime claim | `N/A` |
+| PR 영향 범위 | 기본 persona | 기본 요구 journey |
+|--------------|--------------|-------------------|
+| Auth / protected route | `PERSONA_A_FIRST_TIME_CREATOR` 또는 `PERSONA_B_RETURNING_OWNER` | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` |
+| First-create / persistence | `PERSONA_A_FIRST_TIME_CREATOR` | `FIRST_TREE_CREATION_JOURNEY` |
+| My Trees | `PERSONA_B_RETURNING_OWNER` | `MY_TREES_RETURNING_USER_JOURNEY` |
+| Editor | `PERSONA_B_RETURNING_OWNER` | `EDITOR_MOMENT_EDITING_JOURNEY` |
+| Public Viewer / read-only route | `PERSONA_C_PUBLIC_VIEWER` | `PUBLIC_VIEWER_READONLY_JOURNEY` |
+| Mobile-visible UI | `PERSONA_D_MOBILE_CASUAL` | `MOBILE_375_FULL_JOURNEY` |
+| Loading/empty/error/degraded states | `PERSONA_E_INTERRUPTED_USER` | `ERROR_RECOVERY_JOURNEY` |
+| Docs-only with no runtime claim | `N/A` | `N/A` |
 
 ### fixed slot gate
 
@@ -157,7 +164,7 @@ npx playwright test tests/editor-fieldvalue.spec.js
 2. ✅ PR description 필수 항목 포함
 3. ✅ 최소 1명 Approve 획득
 4. ✅ 테스트 실패 관련 코멘트 해결 완료
-5. ✅ runtime-sensitive PR은 필요한 Member Journey QA와 fixed slot/SHA evidence 포함
+5. ✅ runtime-sensitive PR은 필요한 persona, Member Journey QA, fixed slot/SHA evidence 포함
 
 ### 테스트 실패 시 처리 원칙
 

--- a/docs/ops/PR_CHECKLIST.md
+++ b/docs/ops/PR_CHECKLIST.md
@@ -25,6 +25,8 @@
 - 적용 대상: AUTH / FIRST_TREE / MY_TREES / EDITOR / PUBLIC_VIEWER / MOBILE / ERROR_RECOVERY / N/A
 - 적용 persona: docs/ops/MEMBER_JOURNEY_PERSONAS.md 기준으로 기재
 - 필요한 journey: docs/ops/MEMBER_JOURNEY_QA_SUITE.md 기준으로 기재
+- 테스트 데이터 상태: NEW_ACCOUNT / EXISTING_OWNER / PUBLIC_VIEWER_FIXTURE / CLEAN_SESSION / N/A
+- cleanup 필요 여부: YES / NO / NOT_AVAILABLE / N/A
 - fixed slot 필요 여부: YES / NO
 - 브라우저 검증 필요 여부: YES / NO
 
@@ -58,19 +60,20 @@ persona -> journey -> issue/PR verification -> report
 - [ ] 이 PR이 Public Viewer 또는 public/private boundary에 영향을 주는가?
 - [ ] 이 PR이 모바일 375px 또는 wider mobile layout에 영향을 주는가?
 - [ ] 이 PR이 loading/empty/error/degraded/back recovery 상태에 영향을 주는가?
+- [ ] 이 PR이 테스트 데이터 생성/수정/정리 정책에 영향을 주는가?
 
 ### PR 유형별 기본 persona + journey
 
-| PR 영향 범위 | 기본 persona | 기본 요구 journey |
-|--------------|--------------|-------------------|
-| Auth / protected route | `PERSONA_A_FIRST_TIME_CREATOR` 또는 `PERSONA_B_RETURNING_OWNER` | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` |
-| First-create / persistence | `PERSONA_A_FIRST_TIME_CREATOR` | `FIRST_TREE_CREATION_JOURNEY` |
-| My Trees | `PERSONA_B_RETURNING_OWNER` | `MY_TREES_RETURNING_USER_JOURNEY` |
-| Editor | `PERSONA_B_RETURNING_OWNER` | `EDITOR_MOMENT_EDITING_JOURNEY` |
-| Public Viewer / read-only route | `PERSONA_C_PUBLIC_VIEWER` | `PUBLIC_VIEWER_READONLY_JOURNEY` |
-| Mobile-visible UI | `PERSONA_D_MOBILE_CASUAL` | `MOBILE_375_FULL_JOURNEY` |
-| Loading/empty/error/degraded states | `PERSONA_E_INTERRUPTED_USER` | `ERROR_RECOVERY_JOURNEY` |
-| Docs-only with no runtime claim | `N/A` | `N/A` |
+| PR 영향 범위 | 기본 persona | 기본 요구 journey | 테스트 데이터 상태 |
+|--------------|--------------|-------------------|--------------------|
+| Auth / protected route | `PERSONA_A_FIRST_TIME_CREATOR` 또는 `PERSONA_B_RETURNING_OWNER` | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` | `NEW_ACCOUNT` 또는 `EXISTING_OWNER` |
+| First-create / persistence | `PERSONA_A_FIRST_TIME_CREATOR` | `FIRST_TREE_CREATION_JOURNEY` | `NEW_ACCOUNT` |
+| My Trees | `PERSONA_B_RETURNING_OWNER` | `MY_TREES_RETURNING_USER_JOURNEY` | `EXISTING_OWNER` |
+| Editor | `PERSONA_B_RETURNING_OWNER` | `EDITOR_MOMENT_EDITING_JOURNEY` | `EXISTING_OWNER` |
+| Public Viewer / read-only route | `PERSONA_C_PUBLIC_VIEWER` | `PUBLIC_VIEWER_READONLY_JOURNEY` | `PUBLIC_VIEWER_FIXTURE` 또는 `CLEAN_SESSION` |
+| Mobile-visible UI | `PERSONA_D_MOBILE_CASUAL` | `MOBILE_375_FULL_JOURNEY` | paired persona 기준 |
+| Loading/empty/error/degraded states | `PERSONA_E_INTERRUPTED_USER` | `ERROR_RECOVERY_JOURNEY` | target scope 기준 |
+| Docs-only with no runtime claim | `N/A` | `N/A` | `N/A` |
 
 ### fixed slot gate
 
@@ -87,6 +90,16 @@ Public/private boundary
 ```
 
 Production은 별도 승인 없이는 non-destructive smoke만 허용합니다.
+
+### cleanup gate
+
+테스트 데이터가 생성/수정되는 runtime-sensitive PR은 보고서에 cleanup 상태를 포함해야 합니다.
+
+```text
+Cleanup status: DONE / NOT_REQUIRED / NOT_AVAILABLE
+```
+
+`NOT_AVAILABLE`은 제품에 안전한 삭제/정리 경로가 없을 때만 사용합니다. 이 경우 테스트 데이터가 fixed slot에 남을 수 있음을 명시합니다.
 
 ---
 
@@ -165,6 +178,7 @@ npx playwright test tests/editor-fieldvalue.spec.js
 3. ✅ 최소 1명 Approve 획득
 4. ✅ 테스트 실패 관련 코멘트 해결 완료
 5. ✅ runtime-sensitive PR은 필요한 persona, Member Journey QA, fixed slot/SHA evidence 포함
+6. ✅ 데이터 생성/수정 PR은 테스트 데이터 상태와 cleanup 상태 포함
 
 ### 테스트 실패 시 처리 원칙
 

--- a/docs/ops/PR_CHECKLIST.md
+++ b/docs/ops/PR_CHECKLIST.md
@@ -23,9 +23,11 @@
 
 ## Member Journey QA 영향
 - 적용 대상: AUTH / FIRST_TREE / MY_TREES / EDITOR / PUBLIC_VIEWER / MOBILE / ERROR_RECOVERY / N/A
+- Synthetic actor track: DEVELOPMENT_TESTING / USER_BEHAVIOR_TESTING / AI_MODEL_ACTIVITY / N/A
 - 적용 persona: docs/ops/MEMBER_JOURNEY_PERSONAS.md 기준으로 기재
 - 필요한 journey: docs/ops/MEMBER_JOURNEY_QA_SUITE.md 기준으로 기재
 - 테스트 데이터 상태: NEW_ACCOUNT / EXISTING_OWNER / PUBLIC_VIEWER_FIXTURE / CLEAN_SESSION / N/A
+- credential location label: LOCAL_SECRET_STORE / ENCRYPTED_QA_HANDOFF / APPROVED_PASSWORD_MANAGER / CTO_MANAGED_SECRET / UNKNOWN_CREDENTIALS / N/A
 - cleanup 필요 여부: YES / NO / NOT_AVAILABLE / N/A
 - fixed slot 필요 여부: YES / NO
 - 브라우저 검증 필요 여부: YES / NO
@@ -45,10 +47,12 @@
 
 PR이 Auth, My Trees, Editor, Public Viewer, Browse/Search, 모바일 레이아웃, loading/error 상태에 영향을 주면 먼저 [MEMBER_JOURNEY_PERSONAS.md](MEMBER_JOURNEY_PERSONAS.md)에서 persona를 선택하고, 그 다음 [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md)를 기준으로 필요한 journey를 PR 본문에 명시해야 합니다.
 
+계정을 생성하거나 AI/synthetic account를 사용하는 경우 [SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md](SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md)를 기준으로 track과 credential location label을 함께 기록해야 합니다.
+
 순서는 아래를 따릅니다.
 
 ```text
-persona -> journey -> issue/PR verification -> report
+synthetic actor track -> persona -> journey -> issue/PR verification -> report
 ```
 
 ### 필수 판단 항목
@@ -61,19 +65,22 @@ persona -> journey -> issue/PR verification -> report
 - [ ] 이 PR이 모바일 375px 또는 wider mobile layout에 영향을 주는가?
 - [ ] 이 PR이 loading/empty/error/degraded/back recovery 상태에 영향을 주는가?
 - [ ] 이 PR이 테스트 데이터 생성/수정/정리 정책에 영향을 주는가?
+- [ ] 이 PR이 synthetic actor track 또는 AI model activity에 영향을 주는가?
+- [ ] 이 PR이 credential reuse / lost credential handling에 영향을 주는가?
 
-### PR 유형별 기본 persona + journey
+### PR 유형별 기본 track + persona + journey
 
-| PR 영향 범위 | 기본 persona | 기본 요구 journey | 테스트 데이터 상태 |
-|--------------|--------------|-------------------|--------------------|
-| Auth / protected route | `PERSONA_A_FIRST_TIME_CREATOR` 또는 `PERSONA_B_RETURNING_OWNER` | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` | `NEW_ACCOUNT` 또는 `EXISTING_OWNER` |
-| First-create / persistence | `PERSONA_A_FIRST_TIME_CREATOR` | `FIRST_TREE_CREATION_JOURNEY` | `NEW_ACCOUNT` |
-| My Trees | `PERSONA_B_RETURNING_OWNER` | `MY_TREES_RETURNING_USER_JOURNEY` | `EXISTING_OWNER` |
-| Editor | `PERSONA_B_RETURNING_OWNER` | `EDITOR_MOMENT_EDITING_JOURNEY` | `EXISTING_OWNER` |
-| Public Viewer / read-only route | `PERSONA_C_PUBLIC_VIEWER` | `PUBLIC_VIEWER_READONLY_JOURNEY` | `PUBLIC_VIEWER_FIXTURE` 또는 `CLEAN_SESSION` |
-| Mobile-visible UI | `PERSONA_D_MOBILE_CASUAL` | `MOBILE_375_FULL_JOURNEY` | paired persona 기준 |
-| Loading/empty/error/degraded states | `PERSONA_E_INTERRUPTED_USER` | `ERROR_RECOVERY_JOURNEY` | target scope 기준 |
-| Docs-only with no runtime claim | `N/A` | `N/A` | `N/A` |
+| PR 영향 범위 | 기본 track | 기본 persona | 기본 요구 journey | 테스트 데이터 상태 |
+|--------------|------------|--------------|-------------------|--------------------|
+| Auth / protected route | `DEVELOPMENT_TESTING` 또는 `USER_BEHAVIOR_TESTING` | `PERSONA_A_FIRST_TIME_CREATOR` 또는 `PERSONA_B_RETURNING_OWNER` | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` | `NEW_ACCOUNT` 또는 `EXISTING_OWNER` |
+| First-create / persistence | `USER_BEHAVIOR_TESTING` | `PERSONA_A_FIRST_TIME_CREATOR` | `FIRST_TREE_CREATION_JOURNEY` | `NEW_ACCOUNT` |
+| My Trees | `USER_BEHAVIOR_TESTING` | `PERSONA_B_RETURNING_OWNER` | `MY_TREES_RETURNING_USER_JOURNEY` | `EXISTING_OWNER` |
+| Editor | `USER_BEHAVIOR_TESTING` | `PERSONA_B_RETURNING_OWNER` | `EDITOR_MOMENT_EDITING_JOURNEY` | `EXISTING_OWNER` |
+| Public Viewer / read-only route | `USER_BEHAVIOR_TESTING` | `PERSONA_C_PUBLIC_VIEWER` | `PUBLIC_VIEWER_READONLY_JOURNEY` | `PUBLIC_VIEWER_FIXTURE` 또는 `CLEAN_SESSION` |
+| Mobile-visible UI | `USER_BEHAVIOR_TESTING` | `PERSONA_D_MOBILE_CASUAL` | `MOBILE_375_FULL_JOURNEY` | paired persona 기준 |
+| Loading/empty/error/degraded states | `USER_BEHAVIOR_TESTING` | `PERSONA_E_INTERRUPTED_USER` | `ERROR_RECOVERY_JOURNEY` | target scope 기준 |
+| AI Guide / Instructor | `AI_MODEL_ACTIVITY` | `N/A` 또는 product AI persona | AI-specific checklist required later | product-managed |
+| Docs-only with no runtime claim | `N/A` | `N/A` | `N/A` | `N/A` |
 
 ### fixed slot gate
 
@@ -90,6 +97,23 @@ Public/private boundary
 ```
 
 Production은 별도 승인 없이는 non-destructive smoke만 허용합니다.
+
+### credential reuse gate
+
+계정 생성을 수행한 검증은 report에 credential location label을 남겨야 합니다. 실제 credential 값은 절대 남기지 않습니다.
+
+Allowed labels:
+
+```text
+LOCAL_SECRET_STORE
+ENCRYPTED_QA_HANDOFF
+APPROVED_PASSWORD_MANAGER
+CTO_MANAGED_SECRET
+UNKNOWN_CREDENTIALS
+N/A
+```
+
+기존 계정의 credential이 없으면 `UNKNOWN_CREDENTIALS` 또는 `ORPHANED_TEST_ACCOUNT` 상태로만 보고하고, 비밀번호/세션/cookie/token 복구 시도나 출력은 금지합니다.
 
 ### cleanup gate
 
@@ -177,8 +201,9 @@ npx playwright test tests/editor-fieldvalue.spec.js
 2. ✅ PR description 필수 항목 포함
 3. ✅ 최소 1명 Approve 획득
 4. ✅ 테스트 실패 관련 코멘트 해결 완료
-5. ✅ runtime-sensitive PR은 필요한 persona, Member Journey QA, fixed slot/SHA evidence 포함
+5. ✅ runtime-sensitive PR은 필요한 synthetic actor track, persona, Member Journey QA, fixed slot/SHA evidence 포함
 6. ✅ 데이터 생성/수정 PR은 테스트 데이터 상태와 cleanup 상태 포함
+7. ✅ 계정 생성/재사용 PR은 credential location label 포함, credential 값 미노출
 
 ### 테스트 실패 시 처리 원칙
 

--- a/docs/ops/PR_CHECKLIST.md
+++ b/docs/ops/PR_CHECKLIST.md
@@ -21,6 +21,12 @@
 - 에디터 (editor.html)
 - shared 계층
 
+## Member Journey QA 영향
+- 적용 대상: AUTH / FIRST_TREE / MY_TREES / EDITOR / PUBLIC_VIEWER / MOBILE / ERROR_RECOVERY / N/A
+- 필요한 journey: docs/ops/MEMBER_JOURNEY_QA_SUITE.md 기준으로 기재
+- fixed slot 필요 여부: YES / NO
+- 브라우저 검증 필요 여부: YES / NO
+
 ## 실행한 테스트
 - [ ] tests/smoke.spec.js 통과
 - [ ] tests/editor-smoke.spec.js 통과
@@ -32,7 +38,52 @@
 
 ---
 
-## 2. Editor 변경 시 체크리스트
+## 2. Member Journey QA 매핑
+
+PR이 Auth, My Trees, Editor, Public Viewer, Browse/Search, 모바일 레이아웃, loading/error 상태에 영향을 주면 [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md)를 기준으로 필요한 journey를 PR 본문에 명시해야 합니다.
+
+### 필수 판단 항목
+
+- [ ] 이 PR이 회원가입/로그인/로그아웃/세션 유지/보호 라우트에 영향을 주는가?
+- [ ] 이 PR이 첫 트리 또는 첫 순간 생성에 영향을 주는가?
+- [ ] 이 PR이 My Trees 로드/카드/열기/빈 상태에 영향을 주는가?
+- [ ] 이 PR이 Editor canvas/detail/add/edit/save/cancel에 영향을 주는가?
+- [ ] 이 PR이 Public Viewer 또는 public/private boundary에 영향을 주는가?
+- [ ] 이 PR이 모바일 375px 또는 wider mobile layout에 영향을 주는가?
+- [ ] 이 PR이 loading/empty/error/degraded/back recovery 상태에 영향을 주는가?
+
+### PR 유형별 기본 journey
+
+| PR 영향 범위 | 기본 요구 journey |
+|--------------|-------------------|
+| Auth / protected route | `AUTH_SIGNUP_LOGIN_JOURNEY`, `LOGOUT_AND_PROTECTED_ROUTE_JOURNEY` |
+| First-create / persistence | `FIRST_TREE_CREATION_JOURNEY` |
+| My Trees | `MY_TREES_RETURNING_USER_JOURNEY` |
+| Editor | `EDITOR_MOMENT_EDITING_JOURNEY` |
+| Public Viewer / read-only route | `PUBLIC_VIEWER_READONLY_JOURNEY` |
+| Mobile-visible UI | `MOBILE_375_FULL_JOURNEY` |
+| Loading/empty/error/degraded states | `ERROR_RECOVERY_JOURNEY` |
+| Docs-only with no runtime claim | `N/A` |
+
+### fixed slot gate
+
+아래 범위는 최종 PASS에 fixed test slot + deployed SHA match + real browser가 필요합니다.
+
+```text
+Auth
+My Trees
+Editor
+Browse/Search runtime
+Public/private boundary
+회원 데이터 생성/수정/삭제/저장
+모바일 runtime-sensitive UI
+```
+
+Production은 별도 승인 없이는 non-destructive smoke만 허용합니다.
+
+---
+
+## 3. Editor 변경 시 체크리스트
 
 ### 사전 준비
 - [ ] [docs/ops/EDITOR_ARCHITECTURE.md](docs/ops/EDITOR_ARCHITECTURE.md) 숙독
@@ -67,7 +118,7 @@ npx playwright test tests/editor-fieldvalue.spec.js
 
 ---
 
-## 3. Shared/Standard Page 변경 시 체크리스트
+## 4. Shared/Standard Page 변경 시 체크리스트
 
 ### 필수 테스트 실행
 ```bash
@@ -99,13 +150,14 @@ npx playwright test tests/editor-fieldvalue.spec.js
 
 ---
 
-## 4. Merge Gate 제안
+## 5. Merge Gate 제안
 
 ### Merge 가능 조건 (모두 충족)
 1. ✅ CI/CD 파이프라인 통과 (Smoke 테스트)
 2. ✅ PR description 필수 항목 포함
 3. ✅ 최소 1명 Approve 획득
 4. ✅ 테스트 실패 관련 코멘트 해결 완료
+5. ✅ runtime-sensitive PR은 필요한 Member Journey QA와 fixed slot/SHA evidence 포함
 
 ### 테스트 실패 시 처리 원칙
 
@@ -143,7 +195,7 @@ npx playwright test tests/architecture-v2.spec.js
 
 ---
 
-## 5. 테스트 종류별 역할 구분
+## 6. 테스트 종류별 역할 구분
 
 > ⚠️ smoke.spec.js와 architecture-v2.spec.js는 서로 다른 것을 검증합니다. 혼동하지 마세요.
 
@@ -165,7 +217,7 @@ npx playwright test tests/architecture-v2.spec.js
 
 ---
 
-## 6. 빠른 참조 명령어
+## 7. 빠른 참조 명령어
 
 ```bash
 # 전체 테스트

--- a/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
+++ b/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
@@ -1,0 +1,269 @@
+# Synthetic Actor Account Strategy
+
+Refs #849
+Refs #838
+Refs #846
+
+## Purpose
+
+This document defines a simple three-track strategy for LoveBud accounts and AI/synthetic actors.
+
+The goal is to support three concrete needs without overcomplicating day-to-day operations:
+
+```text
+1. Development/testing-capable accounts
+2. General user behavior testing
+3. Explicit AI model activity as a product feature
+```
+
+The tracks can share infrastructure, account registry patterns, and safe reporting formats. They must not share the same public behavior rules.
+
+## Track 1 — Development testing accounts
+
+Purpose:
+
+```text
+developer/runtime QA
+signup/login verification
+fixed slot browser testing
+Auth/My Trees/Editor/Public Viewer regression checks
+```
+
+Rules:
+
+- fixed slot first;
+- production only with explicit approval;
+- account can be synthetic/test-only;
+- may create/edit/delete test data when scoped;
+- must not be treated as real community engagement;
+- must not appear in normal user rankings by default;
+- credentials must never be posted in GitHub issues, PRs, comments, docs, screenshots, or logs.
+
+Required public-safe account metadata:
+
+```text
+account_label: QA_DEV_ACCOUNT_###
+track: DEVELOPMENT_TESTING
+environment: fixed_slot / production_smoke_only
+credential_location_label: local_secret_store / approved_QA_handoff / unknown
+status: active / retired / unknown / orphaned
+cleanup_status: done / not_required / not_available
+```
+
+## Track 2 — General user behavior testing
+
+Purpose:
+
+```text
+simulate realistic user behavior
+observe onboarding confusion
+exercise first tree creation
+exercise returning user My Trees + Editor flows
+capture screenshots and UX findings
+```
+
+Rules:
+
+- use selected persona as a testing lens;
+- use fixed slot for signup/data mutation;
+- report behavior and confusion, not fake engagement;
+- do not present the account as a real public fan;
+- account activity is for QA evidence, not community activation.
+
+Examples:
+
+```text
+new fan creates first tree
+returning user edits existing tree
+mobile user signs in and opens My Trees
+confused user reloads/cancels/backs out
+```
+
+Required public-safe account metadata:
+
+```text
+account_label: QA_PERSONA_A_###
+track: USER_BEHAVIOR_TESTING
+persona_id: PERSONA_A_FIRST_TIME_CREATOR / PERSONA_B_RETURNING_OWNER / etc.
+environment: fixed_slot
+created_for_pr:
+created_for_issue:
+credential_location_label:
+cleanup_status:
+```
+
+## Track 3 — Explicit AI model activity
+
+Purpose:
+
+```text
+AI Guide / Instructor / fan-memory assistant
+user-facing AI DM support
+AI-created sample content where clearly labeled
+AI usage rankings and topic trends
+paid AI guidance features later
+```
+
+Rules:
+
+- must be clearly disclosed as AI;
+- must not pretend to be a real fan or normal user;
+- may answer user questions by request;
+- may have AI-only rankings such as most asked AI guide;
+- may have topic analytics such as group questions or feature questions;
+- must not generate fake likes, fake popularity, or fake community engagement;
+- AI sample content must be labeled as AI/sample/official guide content.
+
+Allowed public labels:
+
+```text
+AI Guide
+AI 기록 코치
+AI 입덕 도우미
+LoveBud AI Sample
+AI-generated sample tree
+```
+
+Disallowed behavior:
+
+```text
+AI pretending to be a real fan
+AI liking normal user content to inflate activity
+AI comments presented as human community reaction
+AI sample content mixed into real-user ranking without disclosure
+AI-created engagement counted as real user popularity
+```
+
+Required public-safe account metadata:
+
+```text
+account_label: AI_GUIDE_###
+track: AI_MODEL_ACTIVITY
+disclosure_label: AI Guide / AI Sample
+visibility: user_facing_ai / sample_only / internal
+ranking_policy: ai_guide_only / sample_only / excluded_from_user_rankings
+allowed_actions: dm_answer / sample_tree_create / analytics_aggregate
+```
+
+## Credential and account reuse policy
+
+### Problem
+
+Models or executors have created accounts during browser verification but did not preserve reusable credentials. As a result, accounts cannot be reused and the project risks accumulating orphaned test accounts.
+
+### Policy
+
+- Never store passwords in GitHub issues, PRs, comments, docs, screenshots, or logs.
+- Store only safe labels and metadata in GitHub reports.
+- Store actual credentials only in an approved local secret store or encrypted QA credential handoff.
+- If credentials are lost, mark the account as `UNKNOWN_CREDENTIALS` or `ORPHANED_TEST_ACCOUNT` by safe label only.
+- Do not attempt to recover or print secrets through logs.
+- Prefer creating a new controlled test account and recording its credential location safely.
+
+Safe public metadata:
+
+```text
+account_label
+track
+persona_id_or_ai_role
+environment
+created_for_pr
+created_for_issue
+created_at
+status
+credential_location_label
+cleanup_status
+```
+
+Forbidden in reports:
+
+```text
+password
+session
+cookie
+token
+private key
+raw credential
+private user ID
+DB row
+raw payload
+```
+
+## Credential location labels
+
+Use labels that describe where credentials are stored without revealing values.
+
+Allowed labels:
+
+```text
+LOCAL_SECRET_STORE
+ENCRYPTED_QA_HANDOFF
+APPROVED_PASSWORD_MANAGER
+CTO_MANAGED_SECRET
+UNKNOWN_CREDENTIALS
+```
+
+Do not include real paths if the path itself exposes private user information. Path-only references may be used only when already approved by ops security policy.
+
+## Account status values
+
+```text
+ACTIVE
+RETIRED
+UNKNOWN_CREDENTIALS
+ORPHANED_TEST_ACCOUNT
+CLEANUP_NOT_AVAILABLE
+```
+
+Use `ORPHANED_TEST_ACCOUNT` when an account was created but credentials were not preserved and safe cleanup is not available.
+
+## Account creation report template
+
+Use this template after any account-creation verification.
+
+```text
+Synthetic Account Creation Report
+
+Track:
+Account label:
+Persona or AI role:
+Environment:
+Created for PR:
+Created for Issue:
+Credential location label:
+Account status:
+Cleanup status:
+Production data created: YES / NO
+Secret/private data exposure: NO / PRESENT
+Notes:
+```
+
+## Three-track decision table
+
+| Need | Track | Public visibility | Credential handling | Ranking/engagement policy |
+|------|-------|-------------------|---------------------|----------------------------|
+| Check signup/login and protected routes | Development testing | Internal only | Secret store / QA handoff | Excluded |
+| Simulate a new or returning fan behavior | General user behavior testing | Internal QA evidence only by default | Secret store / QA handoff | Excluded |
+| Provide an AI guide users can ask questions | Explicit AI model activity | User-facing as AI | Product auth/AI system credentials, not public | AI-guide ranking only |
+| Publish AI sample content | Explicit AI model activity | User-facing with AI/sample label | Product-managed | Sample-only / excluded from real user ranking |
+| Generate likes or popularity | None | Disallowed | N/A | Disallowed |
+
+## Implementation guidance
+
+If this later becomes a database-backed system, prefer a neutral synthetic actor model:
+
+```text
+synthetic_actors
+- actor_id
+- track
+- persona_id
+- ai_role
+- disclosure_label
+- visibility
+- environment
+- allowed_actions
+- ranking_policy
+- status
+```
+
+Do not store plaintext credentials in this table.

--- a/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
+++ b/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
@@ -1,6 +1,7 @@
 # Synthetic Actor Account Strategy
 
 Refs #849
+Refs #851
 Refs #838
 Refs #846
 
@@ -17,6 +18,97 @@ The goal is to support three concrete needs without overcomplicating day-to-day 
 ```
 
 The tracks can share infrastructure, account registry patterns, and safe reporting formats. They must not share the same public behavior rules.
+
+## Initial free password manager recommendation
+
+Start with a free password manager rather than a custom credential vault.
+
+Recommended first option:
+
+```text
+Bitwarden Free
+```
+
+Reason:
+
+```text
+free plan supports unlimited devices and items
+core password management functions are available
+single CTO-managed vault is enough for the first account set
+GitHub stores only labels and credential keys, not values
+```
+
+Alternative:
+
+```text
+Proton Pass Free
+```
+
+Reason:
+
+```text
+free plan supports unlimited logins and unlimited devices
+browser, mobile, and desktop apps are available
+useful if the Proton ecosystem is preferred
+```
+
+Do not build a custom plaintext credential vault for the first phase.
+
+## Initial long-lived account set
+
+Start with roughly 10-11 reusable accounts only.
+
+```text
+DEVELOPMENT_TESTING
+- QA_DEV_001
+- QA_DEV_002
+- QA_ADMIN_001
+
+USER_BEHAVIOR_TESTING
+- QA_PERSONA_A_001
+- QA_PERSONA_B_001
+- QA_PERSONA_C_001
+- QA_PERSONA_D_001
+- QA_PERSONA_E_001
+
+AI_MODEL_ACTIVITY
+- AI_GUIDE_001
+- AI_GUIDE_002
+- AI_SAMPLE_001
+```
+
+Disposable signup accounts are separate from the long-lived set.
+
+```text
+QA_SIGNUP_DISPOSABLE_YYYYMMDD_001
+QA_SIGNUP_DISPOSABLE_YYYYMMDD_002
+```
+
+Use disposable accounts only when signup, clean onboarding, or account-isolation behavior is under test.
+
+## Password manager entry format
+
+Use stable entry titles.
+
+```text
+LoveBud / QA / QA_PERSONA_A_001
+LoveBud / QA / QA_PERSONA_B_001
+LoveBud / AI / AI_GUIDE_001
+LoveBud / AI / AI_SAMPLE_001
+LoveBud / Admin / QA_ADMIN_001
+```
+
+Use notes to store metadata that helps operators map the password manager entry to `.local/test-accounts.json` and GitHub-safe inventory.
+
+```text
+credential_key: accounts.personaA001
+track: USER_BEHAVIOR_TESTING
+persona: PERSONA_A_FIRST_TIME_CREATOR
+environment: fixed_slot
+custodian: CTO_MANAGED
+```
+
+Do not copy actual credential values into GitHub, PRs, issues, screenshots, or reports.
 
 ## Track 1 — Development testing accounts
 
@@ -311,8 +403,8 @@ Sensitivity class: STANDARD_QA_REUSABLE
 Persona or AI role: PERSONA_A_FIRST_TIME_CREATOR
 Environment: fixed_slot
 Credential key: accounts.personaA001
-Credential location label: ENCRYPTED_QA_HANDOFF + LOCAL_SECRET_STORE
-Custodian: OPS_BUNDLE_CUSTODIAN
+Credential location label: APPROVED_PASSWORD_MANAGER + LOCAL_SECRET_STORE
+Custodian: CTO_MANAGED
 Status: ACTIVE
 Rotation required: NO
 Cleanup status: NOT_REQUIRED

--- a/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
+++ b/docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
@@ -145,6 +145,181 @@ ranking_policy: ai_guide_only / sample_only / excluded_from_user_rankings
 allowed_actions: dm_answer / sample_tree_create / analytics_aggregate
 ```
 
+## Account storage tiers
+
+Local-only storage is not sufficient once accounts are reused across multiple agents, devices, and verification runs. Use a three-tier storage model.
+
+### Tier 0 — Public-safe registry
+
+Purpose:
+
+```text
+coordination only
+safe status reporting
+PR/Issue references
+account inventory without secrets
+```
+
+Allowed location:
+
+```text
+GitHub docs
+GitHub issues
+PR comments
+QA reports
+```
+
+Allowed fields:
+
+```text
+account_label
+track
+persona_id_or_ai_role
+environment
+credential_key
+credential_location_label
+status
+custodian
+rotation_required
+cleanup_status
+last_verified_status
+```
+
+Forbidden fields:
+
+```text
+email
+password
+confirmPassword
+token
+session
+cookie
+private UID
+raw credential
+raw auth payload
+```
+
+### Tier 1 — Local runtime credential file
+
+Purpose:
+
+```text
+actual browser login runtime
+local automation
+fixed-slot verification
+```
+
+Allowed location:
+
+```text
+.local/test-accounts.json
+```
+
+Rules:
+
+- must be gitignored;
+- values must never be printed;
+- selected key may be referenced, such as `accounts.personaA001`;
+- local preflight must report only safe status;
+- models should not read the file contents.
+
+### Tier 2 — Encrypted shared backup / restore source
+
+Purpose:
+
+```text
+restore credentials across machines
+avoid orphaned long-lived QA accounts
+support account rotation
+support custodian handoff
+```
+
+Allowed target locations:
+
+```text
+docs/ops/qa-credential-bundle/test-accounts-encrypted.zip
+docs/ops/qa-credential-bundle/test-accounts.json.age
+approved password manager export/import controlled by custodian
+```
+
+Rules:
+
+- encrypted bundle only;
+- plaintext credential file must not be committed;
+- bundle password must not be documented in repository;
+- restore procedure must report only existence/status;
+- production-grade or AI Guide credentials should prefer approved password manager or CTO-managed secret storage over ad-hoc local files.
+
+## Account sensitivity classes
+
+Not every account has the same risk. Assign a class before creating or storing credentials.
+
+| Class | Examples | Storage requirement | Reuse policy | Rotation policy |
+|------|----------|---------------------|--------------|-----------------|
+| `LOW_QA_DISPOSABLE` | signup disposable, one-off onboarding check | local runtime + optional encrypted backup | short-term only | may retire after run |
+| `STANDARD_QA_REUSABLE` | persona A/B/C/D/E, fixed-slot user | local runtime + encrypted backup | reusable | rotate on schedule or when leaked/lost |
+| `PRIVILEGED_QA` | admin/moderation/test admin | password manager or CTO-managed secret + encrypted backup metadata | tightly controlled | rotate more frequently |
+| `AI_GUIDE_PRODUCT` | user-facing AI guide account | product-managed secret storage / password manager | long-lived | rotation + audit required |
+| `AI_SAMPLE_CREATOR` | labeled sample content creator | password manager or product-managed | reusable with disclosure | rotate on schedule |
+
+## Custody model
+
+Every reusable account should have a custodian label. The custodian is responsible for maintaining credential location, status, and rotation metadata without exposing values.
+
+Allowed custodian labels:
+
+```text
+CTO_MANAGED
+LOCAL_VERIFIER_MANAGED
+OPS_BUNDLE_CUSTODIAN
+PRODUCT_AI_CUSTODIAN
+UNKNOWN_CUSTODIAN
+```
+
+Required rule:
+
+```text
+If custodian is UNKNOWN_CUSTODIAN and credentials are not recoverable from encrypted backup, mark account status as ORPHANED_TEST_ACCOUNT.
+```
+
+## Account inventory template
+
+Use this as a public-safe inventory row. It may appear in docs or reports because it contains no credential values.
+
+```text
+Account label:
+Track:
+Sensitivity class:
+Persona or AI role:
+Environment:
+Credential key:
+Credential location label:
+Custodian:
+Status:
+Rotation required: YES / NO
+Cleanup status:
+Last verified status:
+Secret values exposed: NO
+```
+
+Example:
+
+```text
+Account label: QA_PERSONA_A_001
+Track: USER_BEHAVIOR_TESTING
+Sensitivity class: STANDARD_QA_REUSABLE
+Persona or AI role: PERSONA_A_FIRST_TIME_CREATOR
+Environment: fixed_slot
+Credential key: accounts.personaA001
+Credential location label: ENCRYPTED_QA_HANDOFF + LOCAL_SECRET_STORE
+Custodian: OPS_BUNDLE_CUSTODIAN
+Status: ACTIVE
+Rotation required: NO
+Cleanup status: NOT_REQUIRED
+Last verified status: CREDENTIAL_PREFLIGHT_PASS
+Secret values exposed: NO
+```
+
 ## Credential and account reuse policy
 
 ### Problem
@@ -153,12 +328,14 @@ Models or executors have created accounts during browser verification but did no
 
 ### Policy
 
+- Reuse managed QA accounts when credentials are safely stored.
+- Create disposable accounts only when signup, clean onboarding, or account-isolation behavior is under test.
 - Never store passwords in GitHub issues, PRs, comments, docs, screenshots, or logs.
 - Store only safe labels and metadata in GitHub reports.
-- Store actual credentials only in an approved local secret store or encrypted QA credential handoff.
+- Store actual credentials only in an approved local secret store, encrypted QA credential handoff, approved password manager, or CTO-managed secret store.
 - If credentials are lost, mark the account as `UNKNOWN_CREDENTIALS` or `ORPHANED_TEST_ACCOUNT` by safe label only.
 - Do not attempt to recover or print secrets through logs.
-- Prefer creating a new controlled test account and recording its credential location safely.
+- For reusable accounts, record credential location label and custodian label at creation time.
 
 Safe public metadata:
 
@@ -171,7 +348,9 @@ created_for_pr
 created_for_issue
 created_at
 status
+credential_key
 credential_location_label
+custodian
 cleanup_status
 ```
 
@@ -200,6 +379,7 @@ LOCAL_SECRET_STORE
 ENCRYPTED_QA_HANDOFF
 APPROVED_PASSWORD_MANAGER
 CTO_MANAGED_SECRET
+PRODUCT_MANAGED_SECRET
 UNKNOWN_CREDENTIALS
 ```
 
@@ -213,6 +393,7 @@ RETIRED
 UNKNOWN_CREDENTIALS
 ORPHANED_TEST_ACCOUNT
 CLEANUP_NOT_AVAILABLE
+ROTATION_REQUIRED
 ```
 
 Use `ORPHANED_TEST_ACCOUNT` when an account was created but credentials were not preserved and safe cleanup is not available.
@@ -225,13 +406,15 @@ Use this template after any account-creation verification.
 Synthetic Account Creation Report
 
 Track:
+Sensitivity class:
 Account label:
 Persona or AI role:
 Environment:
-Created for PR:
-Created for Issue:
+Credential key:
 Credential location label:
+Custodian:
 Account status:
+Rotation required: YES / NO
 Cleanup status:
 Production data created: YES / NO
 Secret/private data exposure: NO / PRESENT
@@ -256,14 +439,19 @@ If this later becomes a database-backed system, prefer a neutral synthetic actor
 synthetic_actors
 - actor_id
 - track
+- sensitivity_class
 - persona_id
 - ai_role
 - disclosure_label
 - visibility
 - environment
+- credential_key
+- credential_location_label
+- custodian
 - allowed_actions
 - ranking_policy
 - status
+- rotation_required
 ```
 
 Do not store plaintext credentials in this table.


### PR DESCRIPTION
## Summary

Refs #838
Refs #839
Refs #840
Refs #841
Refs #842
Refs #843
Refs #844
Refs #846
Refs #849
Refs #851

Adds a reusable member journey QA suite for end-to-end browser verification, member personas, synthetic actor strategy, PR checklist guidance, and safe ops-agent handling for QA-account-backed verification flows.

The documents define:

- Auth signup/login journey
- First tree creation journey
- Returning user / My Trees journey
- Editor moment editing journey
- Public viewer read-only journey
- Mobile 375px full journey
- Logout/protected route journey
- Error recovery journey
- Member persona labels for journey-based verification
- Three-track synthetic actor strategy
- Initial password-manager-backed QA account inventory guidance
- PR checklist guidance for journey coverage
- fixed test slot and production smoke boundaries
- safe reporting labels and forbidden private data exposure

## Scope

Docs-only.

Changed files:

```text
docs/ops/AGENTS.md
docs/ops/MEMBER_JOURNEY_PERSONAS.md
docs/ops/MEMBER_JOURNEY_QA_SUITE.md
docs/ops/PR_CHECKLIST.md
docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md
```

## Non-goals

- No runtime implementation
- No HTML/CSS/JS changes
- No Auth/API/backend/DB changes
- No package/workflow changes
- No browser verification claim
- No PR #7 impact
- No prototype/reference/demo/variant changes
- No private value exposure

## Verification

GitHub Actions:

```text
CI completed / success for head a23ebad74e756d0ca778054649ce9236927d4260
```

Local verification still required before merge-ready:

```text
git fetch origin
git checkout docs/member-journey-qa-suite-838
git rev-parse HEAD
git diff --name-only origin/main...HEAD
git diff --check origin/main...HEAD
```

Browser verification is not required for this docs-only PR.