### PR TITLE
refactor(search): extract preview action helpers

### DIFF
--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -130,6 +130,7 @@
 
     // Public API
     window.LoveBudSearchPreviewActionHelper = {
+        getBasePath: getBasePath,
         getTreeDetailHref: getTreeDetailHref,
         renderPreviewActionButton: renderPreviewActionButton,
         renderShareButton: renderShareButton

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -90,6 +90,10 @@
     }
 
     function getBasePath() {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.getBasePath) {
+            return helper.getBasePath();
+        }
         const utils = getSharedUtils();
         if (utils?.getBasePath) {
             return utils.getBasePath();
@@ -106,11 +110,7 @@
         if (helper?.getTreeDetailHref) {
             return helper.getTreeDetailHref(tree);
         }
-        const memories = Array.isArray(tree?.memories) ? tree.memories : [];
-        const firstMemory = memories[0];
-        if (!tree?.id || !firstMemory?.id) return '';
-        const basePath = getBasePath();
-        return `${basePath}detail.html?id=${encodeURIComponent(firstMemory.id)}&tree=${encodeURIComponent(tree.id)}&from=browse`;
+        return '';
     }
 
     function renderPreviewActionButton(tree) {
@@ -118,19 +118,7 @@
         if (helper?.renderPreviewActionButton) {
             return helper.renderPreviewActionButton(tree);
         }
-        const href = getTreeDetailHref(tree);
-        if (!href) return '';
-        const label = getSearchCopy(
-            'search.previewOpenViewingCta',
-            '감상 열기',
-            'Open viewing'
-        );
-        return `
-            <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
-                <span class="material-symbols-outlined" style="font-size:18px;">play_circle</span>
-                ${escapeHtml(label)}
-            </a>
-        `;
+        return '';
     }
 
     const renderShareButton = previewBuilders.renderShareButton || function(tree) {

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -86,7 +86,8 @@ test('browse selected hub primary CTA label matches detail viewing route', () =>
   assert.match(actionHelper, /detail\.html\?id=/);
   assert.match(actionHelper, /from=browse/);
   assert.match(actionHelper, /search\.previewOpenViewingCta/);
-  assert.match(previewRenderer, /search\.previewOpenViewingCta/);
+  assert.match(previewRenderer, /helper\?\.renderPreviewActionButton/);
+  assert.match(previewRenderer, /return '';/);
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.doesNotMatch(actionHelper, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);


### PR DESCRIPTION
## Summary

Refs #656

Extract preview action helper delegation from \js/search/search-preview-renderer.js\ so action URL/button logic stays in \js/search/search-preview-action-helper.js\.

## Scope

- Expose \getBasePath\ from \LoveBudSearchPreviewActionHelper\
- Delegate \getTreeDetailHref\ from renderer to action helper
- Delegate \enderPreviewActionButton\ from renderer to action helper
- Keep safe empty-string fallback in renderer
- Update search runtime module test expectations to assert delegation rather than old inline copy ownership

## Changed files

- \js/search/search-preview-action-helper.js\
- \js/search/search-preview-renderer.js\
- \	ests/routes/search-runtime-modules.test.js\

## Guardrails

- No HTML changes
- No CSS changes
- No script insertion changes
- No Search URL state behavior changes
- No filter/sort/limit behavior changes
- No preview open/close behavior changes
- No share button changes
- No media/thumbnail fallback changes
- No auth/API/editor changes
- No PR #7 / prototype / reference / demo / variant impact

## Verification

- git diff --check: PASS
- node --check changed JS files: PASS
- Search runtime module tests: PASS
- npm test: PASS (203/203)
- npm run verify: PASS (148/148)

## Browser verification

Required before ready/merge:
fixed slot + SHA match + real browser Browse/Search smoke.