### PR TITLE
refactor(search): delegate preview share helper

### DIFF
--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -121,9 +121,12 @@
         return '';
     }
 
-    const renderShareButton = previewBuilders.renderShareButton || function(tree) {
-        if (!(tree && tree.id)) return '';
-        return '<button type="button" data-share-tree-link="' + escapeHtml(tree.id) + '">' + escapeHtml(getSearchCopy('search.previewShareLink', '감상 링크 복사', 'Copy view link')) + '</button>';
+    function renderShareButton(tree) {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.renderShareButton) {
+            return helper.renderShareButton(tree);
+        }
+        return '';
     }
 
     const VISIBLE_FLOW_MOMENT_COUNT = 4;

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -93,4 +93,19 @@ test('browse selected hub primary CTA label matches detail viewing route', () =>
   assert.doesNotMatch(actionHelper, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
   assert.doesNotMatch(previewRenderer, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
   assert.doesNotMatch(i18nSearch, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
+
+
+test('browse selected hub share button delegates to action helper', () => {
+  const actionHelper = read('js/search/search-preview-action-helper.js');
+  const previewRenderer = read('js/search/search-preview-renderer.js');
+
+  assert.match(actionHelper, /renderShareButton:/);
+  assert.match(actionHelper, /data-share-tree-link/);
+  assert.match(actionHelper, /data-share-tree-link-label/);
+  assert.match(previewRenderer, /helper\?\.renderShareButton/);
+  assert.match(previewRenderer, /function renderShareButton\(tree\)/);
+  const fallbackCount = (previewRenderer.match(/return '';/g) || []).length;
+  assert.ok(fallbackCount >= 2, 'renderer should have at least 2 empty string fallbacks (action + share)');
+  assert.doesNotMatch(previewRenderer, /data-share-tree-link="\+' \+ escapeHtml\(tree\.id\)/);
+});
 });


### PR DESCRIPTION
## Summary
- `search-preview-renderer.js`의 `renderShareButton`을 `LoveBudSearchPreviewActionHelper.renderShareButton`으로 위임
- PR #848과 동일한 delegation/fallback 패턴 적용
- `renderPreviewActionButton`과 `renderShareButton`이 동일한 action helper boundary로 통합

## Scope
파일 2개 변경 (action helper 수정 없음):
- `js/search/search-preview-renderer.js` — inline share button markup 제거, helper delegation 패턴 적용
- `tests/routes/search-runtime-modules.test.js` — share button delegation 테스트 보강

## Changed files
- `js/search/search-preview-renderer.js`
- `tests/routes/search-runtime-modules.test.js`

## Guardrails
- No HTML changes
- No CSS changes
- No script insertion/order changes
- No Search URL state behavior changes
- No filter/sort/limit behavior changes
- No preview open/close behavior changes
- No preview CTA href behavior changes
- No media/thumbnail fallback changes
- No auth/API/editor changes
- No PR #7 / prototype / reference / demo / variant impact

## Verification
- `node --check js/search/search-preview-renderer.js` — PASS
- `node --check js/search/search-preview-action-helper.js` — PASS
- `npm test` — 204/204 PASS
- `npm run verify` — 148/148 PASS

## Browser verification required before ready/merge
Slot deploy → SHA match → Playwright check:
- Search page load
- Preview open/close
- Share button rendered
- `data-share-tree-link` present
- `data-share-tree-link-label` present
- Console fatal errors NONE
- Desktop 1440 PASS
- Mobile 375 PASS

Refs #656