### PR TITLE
ui(login): harden returning-user login hierarchy

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -99,7 +99,7 @@
     transition: all 0.2s;
 }
 
-/* ÀÔ·ÂÃ¢ Æ÷Ä¿½º ½ºÅ¸ÀÏ °í±ŞÈ­ */
+/* ì…ë ¥ì°½ í¬ì»¤ìŠ¤ ìŠ¤íƒ€ì¼ ê³ ê¸‰í™” */
 input[type="text"],
 input[type="email"],
 input[type="password"] {
@@ -445,13 +445,6 @@ input[type="password"]:focus {
     text-decoration: underline;
 }
 
-.login-first-time-note {
-    color: var(--on-surface-variant);
-    font-size: 13px;
-    margin-top: 16px;
-    opacity: 0.7;
-}
-
 @media (max-width: 768px) {
     .login-shell {
         padding: 16px;
@@ -460,4 +453,10 @@ input[type="password"]:focus {
     .login-card {
         padding: 32px 16px;
     }
+}
+.login-first-time-note {
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    margin-top: 16px;
+    opacity: 0.7;
 }

--- a/css/login.css
+++ b/css/login.css
@@ -99,7 +99,7 @@
     transition: all 0.2s;
 }
 
-/* ì…ë ¥ì°½ í¬ì»¤ìŠ¤ ìŠ¤íƒ€ì¼ ê³ ê¸‰í™” */
+/* ÀÔ·ÂÃ¢ Æ÷Ä¿½º ½ºÅ¸ÀÏ °í±ŞÈ­ */
 input[type="text"],
 input[type="email"],
 input[type="password"] {
@@ -443,6 +443,13 @@ input[type="password"]:focus {
     font-size: 0.9rem;
     cursor: pointer;
     text-decoration: underline;
+}
+
+.login-first-time-note {
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    margin-top: 16px;
+    opacity: 0.7;
 }
 
 @media (max-width: 768px) {

--- a/js/i18n/i18n-login.js
+++ b/js/i18n/i18n-login.js
@@ -2,151 +2,149 @@
  * LoveBud - i18n Login Dictionary
  * v20260423-1
  *
- * ·Î±×ÀÎ/È¸¿ø°¡ÀÔ ÆäÀÌÁö ¹ø¿ª Å°
+ * ë¡œê·¸ì¸/íšŒì›ê°€ì… í˜ì´ì§€ ë²ˆì—­ í‚¤
  */
 (function() {
   'use strict';
   window.i18nLogin = {
-    // ¸®´ÙÀÌ·ºÆ® ¾Ë¸²
+    // ë¦¬ë‹¤ì´ë ‰íŠ¸ ì•Œë¦¼
     'redirect_notice_title': {
-      ko: '³» ·¯ºêÆ®¸®¸¦ ÀÌ¿ëÇÏ·Á¸é ·Î±×ÀÎÀÌ ÇÊ¿äÇÕ´Ï´Ù',
+      ko: 'ë‚´ ëŸ¬ë¸ŒíŠ¸ë¦¬ë¥¼ ì´ìš©í•˜ë ¤ë©´ ë¡œê·¸ì¸ì´ í•„ìš”í•©ë‹ˆë‹¤',
       en: 'Login is required to use your LoveTree'
     },
     'redirect_notice_desc': {
-      ko: '·Î±×ÀÎ ÈÄ ÀÚµ¿À¸·Î ÀÌµ¿ÇÕ´Ï´Ù',
+      ko: 'ë¡œê·¸ì¸ í›„ ìë™ìœ¼ë¡œ ì´ë™í•©ë‹ˆë‹¤',
       en: 'You will be redirected automatically after login'
     },
 
-    // ·Î±×ÀÎ ÆäÀÌÁö
+    // ë¡œê·¸ì¸ í˜ì´ì§€
     'login_title': {
-      ko: '´Ù½Ã ·¯ºêÆ®¸®¿¡ ·Î±×ÀÎÇÏ¼¼¿ä',
+      ko: 'ë‹¤ì‹œ ëŸ¬ë¸ŒíŠ¸ë¦¬ì— ë¡œê·¸ì¸í•˜ì„¸ìš”',
       en: 'Log back in to LoveTree'
     },
     'login_desc': {
-      ko: '±â·ÏÇØ µĞ ¼ø°£°ú ·¯ºêÆ®¸®¸¦ ÀÌ¾î¼­ º¸·Á¸é ·Î±×ÀÎÇÏ¼¼¿ä.',
+      ko: 'ê¸°ë¡í•´ ë‘” ìˆœê°„ê³¼ ëŸ¬ë¸ŒíŠ¸ë¦¬ë¥¼ ì´ì–´ì„œ ë³´ë ¤ë©´ ë¡œê·¸ì¸í•˜ì„¸ìš”.',
       en: 'Log in to continue viewing your moments and LoveTree.'
     },
 
-    // ¼Ò¼È ·Î±×ÀÎ
+    // ì†Œì…œ ë¡œê·¸ì¸
     'google_login': {
-      ko: 'Google·Î ·Î±×ÀÎ',
+      ko: 'Googleë¡œ ë¡œê·¸ì¸',
       en: 'Log in with Google'
     },
     'google_signup': {
-      ko: 'Google·Î °è¼ÓÇÏ±â',
+      ko: 'Googleë¡œ ê³„ì†í•˜ê¸°',
       en: 'Continue with Google'
     },
 
-    // ±¸ºĞ¼±
+    // êµ¬ë¶„ì„ 
     'or_email': {
-      ko: '¶Ç´Â ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
+      ko: 'ë˜ëŠ” ì´ë©”ì¼ë¡œ ë¡œê·¸ì¸',
       en: 'Or log in with email'
     },
     'email_login': {
-      ko: 'ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
+      ko: 'ì´ë©”ì¼ë¡œ ë¡œê·¸ì¸',
       en: 'Log in with email'
     },
 
-    // Ã³À½ ¿À¼Ì³ª¿ä ³ëÆ®
-    'first_time_note': {
-      ko: 'Ã³À½ ¿À¼Ì³ª¿ä? Google ¶Ç´Â ÀÌ¸ŞÀÏ·Î °èÁ¤À» ¸¸µé ¼ö ÀÖ¾î¿ä.',
-      en: 'New here? You can create an account with Google or email.'
-    },
-
-    // È¸¿ø°¡ÀÔ ¼½¼Ç ¾È³»
+    // íšŒì›ê°€ì… ì„¹ì…˜ ì•ˆë‚´
     'signup_intro_badge': {
-      ko: 'Ã³À½ ¿À¼Ì³ª¿ä?',
+      ko: 'ì²˜ìŒ ì˜¤ì…¨ë‚˜ìš”?',
       en: 'New here?'
     },
     'signup_intro_title': {
-      ko: 'Ã³À½ÀÌ¾îµµ °°Àº ¹öÆ°À¸·Î ¹Ù·Î ½ÃÀÛÇÒ ¼ö ÀÖ¾î¿ä',
+      ko: 'ì²˜ìŒì´ì–´ë„ ê°™ì€ ë²„íŠ¼ìœ¼ë¡œ ë°”ë¡œ ì‹œì‘í•  ìˆ˜ ìˆì–´ìš”',
       en: 'New here? The same buttons get you started.'
     },
     'signup_intro_desc': {
-      ko: 'Google ¶Ç´Â ÀÌ¸ŞÀÏ·Î °è¼ÓÇÏ¸é ÇÊ¿äÇÑ °æ¿ì °èÁ¤ »ı¼º±îÁö °°Àº Èå¸§¿¡¼­ ÀÌ¾îÁı´Ï´Ù.',
+      ko: 'Google ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì†í•˜ë©´ í•„ìš”í•œ ê²½ìš° ê³„ì • ìƒì„±ê¹Œì§€ ê°™ì€ íë¦„ì—ì„œ ì´ì–´ì§‘ë‹ˆë‹¤.',
       en: 'Continue with Google or email; account creation is included in the same flow when needed.'
     },
     'google_signup_helper': {
-      ko: 'Google °èÁ¤À¸·Î ·Î±×ÀÎ¸¸ ÇÏ¸é º°µµ °¡ÀÔ ¾øÀÌ ¹Ù·Î ½ÃÀÛµË´Ï´Ù',
+      ko: 'Google ê³„ì •ìœ¼ë¡œ ë¡œê·¸ì¸ë§Œ í•˜ë©´ ë³„ë„ ê°€ì… ì—†ì´ ë°”ë¡œ ì‹œì‘ë©ë‹ˆë‹¤',
       en: 'Sign in with Google and start right away without a separate sign-up step'
     },
     'or_create_with_email': {
-      ko: '¶Ç´Â ÀÌ¸ŞÀÏ·Î °èÁ¤ ¸¸µé±â',
+      ko: 'ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì • ë§Œë“¤ê¸°',
       en: 'Or create an account with email'
     },
 
-    // ÀÌ¸ŞÀÏ ÀÎÁõ ¸ğ´Ş
+    // ì´ë©”ì¼ ì¸ì¦ ëª¨ë‹¬
     'email_modal_title_login': {
-      ko: 'ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
+      ko: 'ì´ë©”ì¼ë¡œ ë¡œê·¸ì¸',
       en: 'Sign in with email'
     },
     'email_modal_desc_login': {
-      ko: 'ÀÌ¹Ì ¸¸µç ÀÌ¸ŞÀÏ °èÁ¤À¸·Î ·Î±×ÀÎÇÕ´Ï´Ù',
+      ko: 'ì´ë¯¸ ë§Œë“  ì´ë©”ì¼ ê³„ì •ìœ¼ë¡œ ë¡œê·¸ì¸í•©ë‹ˆë‹¤',
       en: 'Sign in with an email account you already created'
     },
     'email_modal_title_signup': {
-      ko: 'ÀÌ¸ŞÀÏ·Î È¸¿ø°¡ÀÔ',
+      ko: 'ì´ë©”ì¼ë¡œ íšŒì›ê°€ì…',
       en: 'Create an account with email'
     },
     'email_modal_desc_signup': {
-      ko: 'ÀÌ¸ŞÀÏ°ú ´Ğ³×ÀÓÀ¸·Î ·¯ºêÆ®¸®¸¦ ½ÃÀÛÇÕ´Ï´Ù',
+      ko: 'ì´ë©”ì¼ê³¼ ë‹‰ë„¤ì„ìœ¼ë¡œ ëŸ¬ë¸ŒíŠ¸ë¦¬ë¥¼ ì‹œì‘í•©ë‹ˆë‹¤',
       en: 'Start your LoveTree with an email address and display name'
     },
 
-    // Æû ·¹ÀÌºí
+    // í¼ ë ˆì´ë¸”
     'display_name_label': {
-      ko: '´Ğ³×ÀÓ',
+      ko: 'ë‹‰ë„¤ì„',
       en: 'Display name'
     },
     'display_name_placeholder': {
-      ko: '¿¹: XG Alpha',
+      ko: 'ì˜ˆ: XG Alpha',
       en: 'e.g. XG Alpha'
     },
     'email_label': {
-      ko: 'ÀÌ¸ŞÀÏ',
+      ko: 'ì´ë©”ì¼',
       en: 'Email'
     },
     'password_label': {
-      ko: 'ºñ¹Ğ¹øÈ£',
+      ko: 'ë¹„ë°€ë²ˆí˜¸',
       en: 'Password'
     },
 
-    // ¹öÆ° ¹®±¸
+    // ë²„íŠ¼ ë¬¸êµ¬
     'login_btn': {
-      ko: '·Î±×ÀÎ',
+      ko: 'ë¡œê·¸ì¸',
       en: 'Log in'
     },
     'signup_btn': {
-      ko: 'È¸¿ø°¡ÀÔ ¿Ï·á',
+      ko: 'íšŒì›ê°€ì… ì™„ë£Œ',
       en: 'Create account'
     },
     'later': {
-      ko: '³ªÁß¿¡ ½ÃÀÛÇÏ±â',
+      ko: 'ë‚˜ì¤‘ì— ì‹œì‘í•˜ê¸°',
       en: 'Maybe later'
     },
 
-    // ÀüÈ¯ ¸µÅ©
+    // ì „í™˜ ë§í¬
     'switch_to_signup': {
-      ko: '°èÁ¤ÀÌ ¾ø³ª¿ä? È¸¿ø°¡ÀÔÀ¸·Î ÀüÈ¯',
+      ko: 'ê³„ì •ì´ ì—†ë‚˜ìš”? íšŒì›ê°€ì…ìœ¼ë¡œ ì „í™˜',
       en: 'No account? Switch to sign up'
     },
     'switch_to_login': {
-      ko: 'ÀÌ¹Ì °èÁ¤ÀÌ ÀÖ³ª¿ä? ·Î±×ÀÎÀ¸·Î ÀüÈ¯',
+      ko: 'ì´ë¯¸ ê³„ì •ì´ ìˆë‚˜ìš”? ë¡œê·¸ì¸ìœ¼ë¡œ ì „í™˜',
       en: 'Already have an account? Switch to login'
     },
 
-    // ¹èÁö (login.html .badge-group)
+    // ë°°ì§€ (login.html .badge-group)
     'badge_first_moment': {
-      ko: 'Ã¹ ¼ø°£ ±â·Ï',
+      ko: 'ì²« ìˆœê°„ ê¸°ë¡',
       en: 'First moment'
     },
     'badge_tree_grow': {
-      ko: '°¨Á¤ ³ª¹« ¼ºÀå',
+      ko: 'ê°ì • ë‚˜ë¬´ ì„±ì¥',
       en: 'Tree grows'
     },
     'badge_safe': {
-      ko: '¾ÈÀüÇÑ º¸°ü',
+      ko: 'ì•ˆì „í•œ ë³´ê´€',
       en: 'Safe storage'
+    },
+    'first_time_note': {
+      ko: 'ì²˜ìŒ ì˜¤ì…¨ë‚˜ìš”? Google ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì •ì„ ë§Œë“¤ ìˆ˜ ìˆì–´ìš”.',
+      en: 'New here? You can create an account with Google or email.'
     }
-  };
+  };;
 })();

--- a/js/i18n/i18n-login.js
+++ b/js/i18n/i18n-login.js
@@ -146,5 +146,5 @@
       ko: '처음 오셨나요? Google 또는 이메일로 계정을 만들 수 있어요.',
       en: 'New here? You can create an account with Google or email.'
     }
-  };;
+  };
 })();

--- a/js/i18n/i18n-login.js
+++ b/js/i18n/i18n-login.js
@@ -2,144 +2,150 @@
  * LoveBud - i18n Login Dictionary
  * v20260423-1
  *
- * ë¡œê·¸ì¸/íšŒì›ê°€ì… í˜ì´ì§€ ë²ˆì—­ í‚¤
+ * ·Î±×ÀÎ/È¸¿ø°¡ÀÔ ÆäÀÌÁö ¹ø¿ª Å°
  */
 (function() {
   'use strict';
   window.i18nLogin = {
-    // ë¦¬ë‹¤ì´ë ‰íŠ¸ ì•Œë¦¼
+    // ¸®´ÙÀÌ·ºÆ® ¾Ë¸²
     'redirect_notice_title': {
-      ko: 'ë‚´ ëŸ¬ë¸ŒíŠ¸ë¦¬ë¥¼ ì´ìš©í•˜ë ¤ë©´ ë¡œê·¸ì¸ì´ í•„ìš”í•©ë‹ˆë‹¤',
+      ko: '³» ·¯ºêÆ®¸®¸¦ ÀÌ¿ëÇÏ·Á¸é ·Î±×ÀÎÀÌ ÇÊ¿äÇÕ´Ï´Ù',
       en: 'Login is required to use your LoveTree'
     },
     'redirect_notice_desc': {
-      ko: 'ë¡œê·¸ì¸ í›„ ìë™ìœ¼ë¡œ ì´ë™í•©ë‹ˆë‹¤',
+      ko: '·Î±×ÀÎ ÈÄ ÀÚµ¿À¸·Î ÀÌµ¿ÇÕ´Ï´Ù',
       en: 'You will be redirected automatically after login'
     },
 
-    // ë¡œê·¸ì¸ í˜ì´ì§€
+    // ·Î±×ÀÎ ÆäÀÌÁö
     'login_title': {
-      ko: 'ë‹¹ì‹ ì˜ ê°ì • ë‚˜ë¬´ë¥¼ ì‹œì‘í•˜ì„¸ìš”',
-      en: 'Start your emotion tree'
+      ko: '´Ù½Ã ·¯ºêÆ®¸®¿¡ ·Î±×ÀÎÇÏ¼¼¿ä',
+      en: 'Log back in to LoveTree'
     },
     'login_desc': {
-      ko: 'ì²˜ìŒ ì‚¬ë‘ì— ë¹ ì§„ ìˆœê°„ë¶€í„°, íŒ¬ì´ ë˜ì–´ê°€ëŠ” ëª¨ë“  ê²½ë¡œë¥¼<br>ì˜ìƒê³¼ ë©”ëª¨ë¡œ ì—°ê²°í•´ ê¸°ë¡í•˜ì„¸ìš”.',
-      en: 'From the first moment you fell in love, connect every path you become a fan of with videos and notes.'
+      ko: '±â·ÏÇØ µĞ ¼ø°£°ú ·¯ºêÆ®¸®¸¦ ÀÌ¾î¼­ º¸·Á¸é ·Î±×ÀÎÇÏ¼¼¿ä.',
+      en: 'Log in to continue viewing your moments and LoveTree.'
     },
 
-    // ì†Œì…œ ë¡œê·¸ì¸
+    // ¼Ò¼È ·Î±×ÀÎ
     'google_login': {
-      ko: 'Googleë¡œ ê³„ì†í•˜ê¸°',
-      en: 'Continue with Google'
+      ko: 'Google·Î ·Î±×ÀÎ',
+      en: 'Log in with Google'
     },
     'google_signup': {
-      ko: 'Googleë¡œ ê³„ì†í•˜ê¸°',
+      ko: 'Google·Î °è¼ÓÇÏ±â',
       en: 'Continue with Google'
     },
 
-    // êµ¬ë¶„ì„ 
+    // ±¸ºĞ¼±
     'or_email': {
-      ko: 'ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì†í•˜ê¸°',
-      en: 'Or continue with email'
+      ko: '¶Ç´Â ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
+      en: 'Or log in with email'
     },
     'email_login': {
-      ko: 'ì´ë©”ì¼ë¡œ ë¡œê·¸ì¸',
-      en: 'Continue with email'
+      ko: 'ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
+      en: 'Log in with email'
     },
 
-    // íšŒì›ê°€ì… ì„¹ì…˜ ì•ˆë‚´
+    // Ã³À½ ¿À¼Ì³ª¿ä ³ëÆ®
+    'first_time_note': {
+      ko: 'Ã³À½ ¿À¼Ì³ª¿ä? Google ¶Ç´Â ÀÌ¸ŞÀÏ·Î °èÁ¤À» ¸¸µé ¼ö ÀÖ¾î¿ä.',
+      en: 'New here? You can create an account with Google or email.'
+    },
+
+    // È¸¿ø°¡ÀÔ ¼½¼Ç ¾È³»
     'signup_intro_badge': {
-      ko: 'ì²˜ìŒ ì˜¤ì…¨ë‚˜ìš”?',
+      ko: 'Ã³À½ ¿À¼Ì³ª¿ä?',
       en: 'New here?'
     },
     'signup_intro_title': {
-      ko: 'ì²˜ìŒì´ì–´ë„ ê°™ì€ ë²„íŠ¼ìœ¼ë¡œ ë°”ë¡œ ì‹œì‘í•  ìˆ˜ ìˆì–´ìš”',
+      ko: 'Ã³À½ÀÌ¾îµµ °°Àº ¹öÆ°À¸·Î ¹Ù·Î ½ÃÀÛÇÒ ¼ö ÀÖ¾î¿ä',
       en: 'New here? The same buttons get you started.'
     },
     'signup_intro_desc': {
-      ko: 'Google ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì†í•˜ë©´ í•„ìš”í•œ ê²½ìš° ê³„ì • ìƒì„±ê¹Œì§€ ê°™ì€ íë¦„ì—ì„œ ì´ì–´ì§‘ë‹ˆë‹¤.',
+      ko: 'Google ¶Ç´Â ÀÌ¸ŞÀÏ·Î °è¼ÓÇÏ¸é ÇÊ¿äÇÑ °æ¿ì °èÁ¤ »ı¼º±îÁö °°Àº Èå¸§¿¡¼­ ÀÌ¾îÁı´Ï´Ù.',
       en: 'Continue with Google or email; account creation is included in the same flow when needed.'
     },
     'google_signup_helper': {
-      ko: 'Google ê³„ì •ìœ¼ë¡œ ë¡œê·¸ì¸ë§Œ í•˜ë©´ ë³„ë„ ê°€ì… ì—†ì´ ë°”ë¡œ ì‹œì‘ë©ë‹ˆë‹¤',
+      ko: 'Google °èÁ¤À¸·Î ·Î±×ÀÎ¸¸ ÇÏ¸é º°µµ °¡ÀÔ ¾øÀÌ ¹Ù·Î ½ÃÀÛµË´Ï´Ù',
       en: 'Sign in with Google and start right away without a separate sign-up step'
     },
     'or_create_with_email': {
-      ko: 'ë˜ëŠ” ì´ë©”ì¼ë¡œ ê³„ì • ë§Œë“¤ê¸°',
+      ko: '¶Ç´Â ÀÌ¸ŞÀÏ·Î °èÁ¤ ¸¸µé±â',
       en: 'Or create an account with email'
     },
 
-    // ì´ë©”ì¼ ì¸ì¦ ëª¨ë‹¬
+    // ÀÌ¸ŞÀÏ ÀÎÁõ ¸ğ´Ş
     'email_modal_title_login': {
-      ko: 'ì´ë©”ì¼ë¡œ ë¡œê·¸ì¸',
+      ko: 'ÀÌ¸ŞÀÏ·Î ·Î±×ÀÎ',
       en: 'Sign in with email'
     },
     'email_modal_desc_login': {
-      ko: 'ì´ë¯¸ ë§Œë“  ì´ë©”ì¼ ê³„ì •ìœ¼ë¡œ ë¡œê·¸ì¸í•©ë‹ˆë‹¤',
+      ko: 'ÀÌ¹Ì ¸¸µç ÀÌ¸ŞÀÏ °èÁ¤À¸·Î ·Î±×ÀÎÇÕ´Ï´Ù',
       en: 'Sign in with an email account you already created'
     },
     'email_modal_title_signup': {
-      ko: 'ì´ë©”ì¼ë¡œ íšŒì›ê°€ì…',
+      ko: 'ÀÌ¸ŞÀÏ·Î È¸¿ø°¡ÀÔ',
       en: 'Create an account with email'
     },
     'email_modal_desc_signup': {
-      ko: 'ì´ë©”ì¼ê³¼ ë‹‰ë„¤ì„ìœ¼ë¡œ ëŸ¬ë¸ŒíŠ¸ë¦¬ë¥¼ ì‹œì‘í•©ë‹ˆë‹¤',
+      ko: 'ÀÌ¸ŞÀÏ°ú ´Ğ³×ÀÓÀ¸·Î ·¯ºêÆ®¸®¸¦ ½ÃÀÛÇÕ´Ï´Ù',
       en: 'Start your LoveTree with an email address and display name'
     },
 
-    // í¼ ë ˆì´ë¸”
+    // Æû ·¹ÀÌºí
     'display_name_label': {
-      ko: 'ë‹‰ë„¤ì„',
+      ko: '´Ğ³×ÀÓ',
       en: 'Display name'
     },
     'display_name_placeholder': {
-      ko: 'ì˜ˆ: XG Alpha',
+      ko: '¿¹: XG Alpha',
       en: 'e.g. XG Alpha'
     },
     'email_label': {
-      ko: 'ì´ë©”ì¼',
+      ko: 'ÀÌ¸ŞÀÏ',
       en: 'Email'
     },
     'password_label': {
-      ko: 'ë¹„ë°€ë²ˆí˜¸',
+      ko: 'ºñ¹Ğ¹øÈ£',
       en: 'Password'
     },
 
-    // ë²„íŠ¼ ë¬¸êµ¬
+    // ¹öÆ° ¹®±¸
     'login_btn': {
-      ko: 'ë¡œê·¸ì¸',
+      ko: '·Î±×ÀÎ',
       en: 'Log in'
     },
     'signup_btn': {
-      ko: 'íšŒì›ê°€ì… ì™„ë£Œ',
+      ko: 'È¸¿ø°¡ÀÔ ¿Ï·á',
       en: 'Create account'
     },
     'later': {
-      ko: 'ë‚˜ì¤‘ì— ì‹œì‘í•˜ê¸°',
+      ko: '³ªÁß¿¡ ½ÃÀÛÇÏ±â',
       en: 'Maybe later'
     },
 
-    // ì „í™˜ ë§í¬
+    // ÀüÈ¯ ¸µÅ©
     'switch_to_signup': {
-      ko: 'ê³„ì •ì´ ì—†ë‚˜ìš”? íšŒì›ê°€ì…ìœ¼ë¡œ ì „í™˜',
+      ko: '°èÁ¤ÀÌ ¾ø³ª¿ä? È¸¿ø°¡ÀÔÀ¸·Î ÀüÈ¯',
       en: 'No account? Switch to sign up'
     },
     'switch_to_login': {
-      ko: 'ì´ë¯¸ ê³„ì •ì´ ìˆë‚˜ìš”? ë¡œê·¸ì¸ìœ¼ë¡œ ì „í™˜',
+      ko: 'ÀÌ¹Ì °èÁ¤ÀÌ ÀÖ³ª¿ä? ·Î±×ÀÎÀ¸·Î ÀüÈ¯',
       en: 'Already have an account? Switch to login'
     },
 
-    // ë°°ì§€ (login.html .badge-group)
+    // ¹èÁö (login.html .badge-group)
     'badge_first_moment': {
-      ko: 'ì²« ìˆœê°„ ê¸°ë¡',
+      ko: 'Ã¹ ¼ø°£ ±â·Ï',
       en: 'First moment'
     },
     'badge_tree_grow': {
-      ko: 'ê°ì • ë‚˜ë¬´ ì„±ì¥',
+      ko: '°¨Á¤ ³ª¹« ¼ºÀå',
       en: 'Tree grows'
     },
     'badge_safe': {
-      ko: 'ì•ˆì „í•œ ë³´ê´€',
+      ko: '¾ÈÀüÇÑ º¸°ü',
       en: 'Safe storage'
     }
   };

--- a/pages/login.html
+++ b/pages/login.html
@@ -65,19 +65,6 @@
             </a>
         </div>
     </div>
-            <div class="badge-group">
-                <span class="badge" data-i18n="badge_first_moment">첫 순간 기록</span>
-                <span class="badge" data-i18n="badge_tree_grow">감정 나무 성장</span>
-                <span class="badge" data-i18n="badge_safe">안전한 보관</span>
-            </div>
-
-            <p class="login-first-time-note" data-i18n="first_time_note">처음 오셨나요? Google 또는 이메일로 계정을 만들 수 있어요.</p>
-
-            <a href="../index.html" class="login-later-link" data-i18n="later">
-                나중에 시작하기
-            </a>
-        </div>
-    </div>
 
     <!-- Firebase SDK -->
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>

--- a/pages/login.html
+++ b/pages/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>�α��� | ����Ʈ��</title>
+    <title>로그인 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
@@ -24,16 +24,16 @@
                 <div class="login-redirect-notice-row">
                     <span class="material-symbols-outlined login-redirect-icon">lock</span>
                     <div class="login-redirect-content">
-                        <div class="login-redirect-title" data-i18n="redirect_notice_title">�� ����Ʈ���� �̿��Ϸ��� �α����� �ʿ��մϴ�</div>
-                        <div class="login-redirect-desc" data-i18n="redirect_notice_desc">�α��� �� �ڵ����� �̵��մϴ�</div>
+                        <div class="login-redirect-title" data-i18n="redirect_notice_title">내 러브트리를 이용하려면 로그인이 필요합니다</div>
+                        <div class="login-redirect-desc" data-i18n="redirect_notice_desc">로그인 후 자동으로 이동합니다</div>
                     </div>
                 </div>
             </div>
 
-            <div class="serif login-brand-title">����Ʈ��</div>
-            <h1 class="headline login-headline" data-i18n="login_title">�ٽ� ����Ʈ���� �α����ϼ���</h1>
+            <div class="serif login-brand-title">러브트리</div>
+            <h1 class="headline login-headline" data-i18n="login_title">다시 러브트리에 로그인하세요</h1>
             <p class="login-desc" data-i18n="login_desc">
-                ����� �� ������ ����Ʈ���� �̾ ������ �α����ϼ���.
+                기록해 둔 순간과 러브트리를 이어서 보려면 로그인하세요.
             </p>
 
             <button id="login-btn-google" class="login-btn-google">
@@ -43,25 +43,38 @@
                     <path fill="#FBBC05" d="M9.84,26.68c-1.56-2.92-2.4-6.08-2.4-9.48c0-3.4,0.84-6.56,2.4-9.48L3.2,12.08C1.24,16.52,0.04,21.48,0.04,26.32C0.04,31.16,1.24,36.12,3.2,40.56L9.84,26.68z"/>
                     <path fill="#EA4335" d="M19.12,12.32c4.76,0,8.24,1.92,10.04,3.56l7.24-7.16C34.76,5.92,29.32,4.8,23.72,4.8c-7.4,0-14,4.4-17.6,10.96l7.76,6.44C15.48,16.84,18.32,12.32,19.12,12.32z"/>
                 </svg>
-                <span data-i18n="google_login">Google�� �α���</span>
+                <span data-i18n="google_login">Google로 로그인</span>
             </button>
 
-            <div class="login-divider" data-i18n="or_email">�Ǵ� �̸��Ϸ� �α���</div>
+            <div class="login-divider" data-i18n="or_email">또는 이메일로 로그인</div>
 
             <button id="login-btn-email" class="btn-round btn-outline login-email-button" data-i18n="email_login">
-                �̸��Ϸ� �α���
+                이메일로 로그인
             </button>
 
             <div class="badge-group">
-                <span class="badge" data-i18n="badge_first_moment">ù ���� ���</span>
-                <span class="badge" data-i18n="badge_tree_grow">���� ���� ����</span>
-                <span class="badge" data-i18n="badge_safe">������ ����</span>
+                <span class="badge" data-i18n="badge_first_moment">첫 순간 기록</span>
+                <span class="badge" data-i18n="badge_tree_grow">감정 나무 성장</span>
+                <span class="badge" data-i18n="badge_safe">안전한 보관</span>
             </div>
 
-            <p class="login-first-time-note" data-i18n="first_time_note">ó�� ���̳���? Google �Ǵ� �̸��Ϸ� ������ ���� �� �־��.</p>
+            <p class="login-first-time-note" data-i18n="first_time_note">처음 오셨나요? Google 또는 이메일로 계정을 만들 수 있어요.</p>
 
             <a href="../index.html" class="login-later-link" data-i18n="later">
-                ���߿� �����ϱ�
+                나중에 시작하기
+            </a>
+        </div>
+    </div>
+            <div class="badge-group">
+                <span class="badge" data-i18n="badge_first_moment">첫 순간 기록</span>
+                <span class="badge" data-i18n="badge_tree_grow">감정 나무 성장</span>
+                <span class="badge" data-i18n="badge_safe">안전한 보관</span>
+            </div>
+
+            <p class="login-first-time-note" data-i18n="first_time_note">처음 오셨나요? Google 또는 이메일로 계정을 만들 수 있어요.</p>
+
+            <a href="../index.html" class="login-later-link" data-i18n="later">
+                나중에 시작하기
             </a>
         </div>
     </div>
@@ -74,37 +87,37 @@
     <!-- Email Auth Modal -->
     <div id="email-auth-modal" role="dialog" aria-modal="true" aria-labelledby="email-auth-title" aria-describedby="email-auth-helper" class="login-email-modal" style="display:none;">
     <div class="login-email-modal-card">
-    <button id="email-auth-close" aria-label="��� �ݱ�" class="login-email-close">&times;</button>
-<!-- ��� ǥ�� -->
+    <button id="email-auth-close" aria-label="모달 닫기" class="login-email-close">&times;</button>
+<!-- 모드 표시 -->
 <div id="auth-mode-badge" class="login-auth-mode-badge">
-    �α���
+    로그인
 </div>
-<h2 id="email-auth-title" class="login-email-title" data-i18n="email_modal_title_login">�̸��Ϸ� �α���</h2>
-<p id="email-auth-helper" class="login-email-helper" data-i18n="email_modal_desc_login">�̹� ���� �̸��� �������� �α����մϴ�</p>
+<h2 id="email-auth-title" class="login-email-title" data-i18n="email_modal_title_login">이메일로 로그인</h2>
+<p id="email-auth-helper" class="login-email-helper" data-i18n="email_modal_desc_login">이미 만든 이메일 계정으로 로그인합니다</p>
  <form id="email-auth-form" class="login-form" novalidate>
  <div data-auth-display-name-wrap class="login-form-group-large" style="display:none;">
-     <label for="email-auth-display-name" class="login-form-label" data-i18n="display_name_label">�г���</label>
+     <label for="email-auth-display-name" class="login-form-label" data-i18n="display_name_label">닉네임</label>
      <input
          type="text"
          id="email-auth-display-name"
          maxlength="30"
-         placeholder="��: XG Alpha"
+         placeholder="예: XG Alpha"
          data-i18n-placeholder="display_name_placeholder"
          class="login-form-input"
      >
  </div>
  <div class="login-form-group-large">
-     <label for="email-auth-email" class="login-form-label" data-i18n="email_label">�̸���</label>
+     <label for="email-auth-email" class="login-form-label" data-i18n="email_label">이메일</label>
      <input type="email" id="email-auth-email" required class="login-form-input" aria-describedby="email-auth-error">
  </div>
 <div class="login-form-group-xl">
-    <label for="email-auth-password" class="login-form-label" data-i18n="password_label">��й�ȣ</label>
+    <label for="email-auth-password" class="login-form-label" data-i18n="password_label">비밀번호</label>
     <input type="password" id="email-auth-password" required class="login-form-input" aria-describedby="email-auth-error">
 </div>
 <p id="email-auth-error" class="login-form-error" role="alert" aria-live="polite" aria-hidden="true" hidden></p>
-<button type="submit" id="email-auth-submit" class="login-submit-button login-submit-button-primary" data-i18n="login_btn">�α���</button>
+<button type="submit" id="email-auth-submit" class="login-submit-button login-submit-button-primary" data-i18n="login_btn">로그인</button>
 </form>
-<button id="email-auth-toggle" class="login-email-toggle" data-i18n="switch_to_signup">������ ������? ȸ���������� ��ȯ</button>
+<button id="email-auth-toggle" class="login-email-toggle" data-i18n="switch_to_signup">계정이 없나요? 회원가입으로 전환</button>
 </div>
 </div>
 

--- a/pages/login.html
+++ b/pages/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>로그인 | 러브트리</title>
+    <title>�α��� | ����Ʈ��</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
@@ -24,18 +24,16 @@
                 <div class="login-redirect-notice-row">
                     <span class="material-symbols-outlined login-redirect-icon">lock</span>
                     <div class="login-redirect-content">
-                        <div class="login-redirect-title" data-i18n="redirect_notice_title">내 러브트리를 이용하려면 로그인이 필요합니다</div>
-                        <div class="login-redirect-desc" data-i18n="redirect_notice_desc">로그인 후 자동으로 이동합니다</div>
+                        <div class="login-redirect-title" data-i18n="redirect_notice_title">�� ����Ʈ���� �̿��Ϸ��� �α����� �ʿ��մϴ�</div>
+                        <div class="login-redirect-desc" data-i18n="redirect_notice_desc">�α��� �� �ڵ����� �̵��մϴ�</div>
                     </div>
                 </div>
             </div>
 
-            <div class="serif login-brand-title">러브트리</div>
-            <h1 class="headline login-headline" data-i18n="login_title">당신의 감정 나무를 시작하세요</h1>
+            <div class="serif login-brand-title">����Ʈ��</div>
+            <h1 class="headline login-headline" data-i18n="login_title">�ٽ� ����Ʈ���� �α����ϼ���</h1>
             <p class="login-desc" data-i18n="login_desc">
-                처음 사랑에 빠진 순간부터, 팬이 되어가는 모든 경로를<br>
-                영상과 메모로 연결해 기록하세요.<br>
-                <small style="opacity: 0.7; font-size: 0.9em;">처음이라도 같은 버튼으로 계정이 자동 생성되거나 로그인됩니다.</small>
+                ����� �� ������ ����Ʈ���� �̾ ������ �α����ϼ���.
             </p>
 
             <button id="login-btn-google" class="login-btn-google">
@@ -45,34 +43,25 @@
                     <path fill="#FBBC05" d="M9.84,26.68c-1.56-2.92-2.4-6.08-2.4-9.48c0-3.4,0.84-6.56,2.4-9.48L3.2,12.08C1.24,16.52,0.04,21.48,0.04,26.32C0.04,31.16,1.24,36.12,3.2,40.56L9.84,26.68z"/>
                     <path fill="#EA4335" d="M19.12,12.32c4.76,0,8.24,1.92,10.04,3.56l7.24-7.16C34.76,5.92,29.32,4.8,23.72,4.8c-7.4,0-14,4.4-17.6,10.96l7.76,6.44C15.48,16.84,18.32,12.32,19.12,12.32z"/>
                 </svg>
-                <span data-i18n="google_login">Google로 계속하기</span>
+                <span data-i18n="google_login">Google�� �α���</span>
             </button>
 
-            <div class="login-divider" data-i18n="or_email">또는 이메일로 계속하기</div>
+            <div class="login-divider" data-i18n="or_email">�Ǵ� �̸��Ϸ� �α���</div>
 
             <button id="login-btn-email" class="btn-round btn-outline login-email-button" data-i18n="email_login">
-                이메일로 로그인
+                �̸��Ϸ� �α���
             </button>
 
             <div class="badge-group">
-                <span class="badge" data-i18n="badge_first_moment">첫 순간 기록</span>
-                <span class="badge" data-i18n="badge_tree_grow">감정 나무 성장</span>
-                <span class="badge" data-i18n="badge_safe">안전한 보관</span>
+                <span class="badge" data-i18n="badge_first_moment">ù ���� ���</span>
+                <span class="badge" data-i18n="badge_tree_grow">���� ���� ����</span>
+                <span class="badge" data-i18n="badge_safe">������ ����</span>
             </div>
 
-            <a href="../index.html" class="login-later-link" data-i18n="later">
-                나중에 시작하기
-            </a>
-        </div>
-    </div>
-            <div class="badge-group">
-                <span class="badge" data-i18n="badge_first_moment">첫 순간 기록</span>
-                <span class="badge" data-i18n="badge_tree_grow">감정 나무 성장</span>
-                <span class="badge" data-i18n="badge_safe">안전한 보관</span>
-            </div>
+            <p class="login-first-time-note" data-i18n="first_time_note">ó�� ���̳���? Google �Ǵ� �̸��Ϸ� ������ ���� �� �־��.</p>
 
             <a href="../index.html" class="login-later-link" data-i18n="later">
-                나중에 시작하기
+                ���߿� �����ϱ�
             </a>
         </div>
     </div>
@@ -85,37 +74,37 @@
     <!-- Email Auth Modal -->
     <div id="email-auth-modal" role="dialog" aria-modal="true" aria-labelledby="email-auth-title" aria-describedby="email-auth-helper" class="login-email-modal" style="display:none;">
     <div class="login-email-modal-card">
-    <button id="email-auth-close" aria-label="모달 닫기" class="login-email-close">&times;</button>
-<!-- 모드 표시 -->
+    <button id="email-auth-close" aria-label="��� �ݱ�" class="login-email-close">&times;</button>
+<!-- ��� ǥ�� -->
 <div id="auth-mode-badge" class="login-auth-mode-badge">
-    로그인
+    �α���
 </div>
-<h2 id="email-auth-title" class="login-email-title" data-i18n="email_modal_title_login">이메일로 로그인</h2>
-<p id="email-auth-helper" class="login-email-helper" data-i18n="email_modal_desc_login">이미 만든 이메일 계정으로 로그인합니다</p>
+<h2 id="email-auth-title" class="login-email-title" data-i18n="email_modal_title_login">�̸��Ϸ� �α���</h2>
+<p id="email-auth-helper" class="login-email-helper" data-i18n="email_modal_desc_login">�̹� ���� �̸��� �������� �α����մϴ�</p>
  <form id="email-auth-form" class="login-form" novalidate>
  <div data-auth-display-name-wrap class="login-form-group-large" style="display:none;">
-     <label for="email-auth-display-name" class="login-form-label" data-i18n="display_name_label">닉네임</label>
+     <label for="email-auth-display-name" class="login-form-label" data-i18n="display_name_label">�г���</label>
      <input
          type="text"
          id="email-auth-display-name"
          maxlength="30"
-         placeholder="예: XG Alpha"
+         placeholder="��: XG Alpha"
          data-i18n-placeholder="display_name_placeholder"
          class="login-form-input"
      >
  </div>
  <div class="login-form-group-large">
-     <label for="email-auth-email" class="login-form-label" data-i18n="email_label">이메일</label>
+     <label for="email-auth-email" class="login-form-label" data-i18n="email_label">�̸���</label>
      <input type="email" id="email-auth-email" required class="login-form-input" aria-describedby="email-auth-error">
  </div>
 <div class="login-form-group-xl">
-    <label for="email-auth-password" class="login-form-label" data-i18n="password_label">비밀번호</label>
+    <label for="email-auth-password" class="login-form-label" data-i18n="password_label">��й�ȣ</label>
     <input type="password" id="email-auth-password" required class="login-form-input" aria-describedby="email-auth-error">
 </div>
 <p id="email-auth-error" class="login-form-error" role="alert" aria-live="polite" aria-hidden="true" hidden></p>
-<button type="submit" id="email-auth-submit" class="login-submit-button login-submit-button-primary" data-i18n="login_btn">로그인</button>
+<button type="submit" id="email-auth-submit" class="login-submit-button login-submit-button-primary" data-i18n="login_btn">�α���</button>
 </form>
-<button id="email-auth-toggle" class="login-email-toggle" data-i18n="switch_to_signup">계정이 없나요? 회원가입으로 전환</button>
+<button id="email-auth-toggle" class="login-email-toggle" data-i18n="switch_to_signup">������ ������? ȸ���������� ��ȯ</button>
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Removed duplicate DOM block (badge-group + later link) outside login-shell in pages/login.html
- Updated login page copy to returning-user intent: title/desc/Google button/divider now clearly say login not continue/start
- Simplified login description, removed CTA-like first-time note embedded in desc
- Added quiet first-time note as separate small text (not competing with login CTA)
- Updated i18n-login.js keys to returning-user intent
- Added first_time_note i18n key
- Added minimal CSS for .login-first-time-note

## Scope
- pages/login.html - DOM cleanup and copy update
- js/i18n/i18n-login.js - i18n key updates
- css/login.css - minimal first-time note style

## Guardrails
- Auth provider / Firebase / login handler behavior: NOT CHANGED
- js/auth.js: NOT CHANGED
- js/auth/*: NOT CHANGED
- js/login/*: NOT CHANGED
- signup route: NOT ADDED
- pages/signup.html: NOT ADDED

## Verification
- git diff --check: PASS
- node --check js/i18n/i18n-login.js: PASS
- npm test: 204/204 PASS
- npm run verify: 149/149 PASS

## NOT_VERIFIED (requires fixed-slot browser check)
- fixed-slot SHA match
- desktop login page hierarchy
- mobile 375 login page hierarchy
- duplicate badge/later block removed
- Google login button visible/clickable
- email login button visible/clickable
- email modal opens
- email modal login/signup toggle still works
- no Auth provider behavior regression
- no fatal console errors
- no secret/private exposure

Refs #776