### PR TITLE
fix(auth): align My Trees API load with confirmed auth state

### DIFF
--- a/js/api/base-api-fetch.js
+++ b/js/api/base-api-fetch.js
@@ -1,5 +1,7 @@
 (function () {
   // auth-state.js의 AUTH_TOKEN_KEY 상수를 재사용, fallback으로 기존 문자열 유지
+  const AUTH_CACHE_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_CACHE_KEY) || 'lovebud_auth_cache';
+  const AUTH_CONFIRMED_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_CONFIRMED_KEY) || 'lovebud_auth_confirmed';
   const AUTH_TOKEN_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_TOKEN_KEY) || 'lovebud_auth_token';
 
   function getCachedTokenRecord() {
@@ -32,16 +34,63 @@
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
 
+  async function waitForAuthBootstrapReady(maxMs) {
+    const bootstrap = window.LoveBudAuthBootstrap;
+    if (!bootstrap || typeof bootstrap.whenReady !== 'function') return;
+    try {
+      const snapshot = typeof bootstrap.getSnapshot === 'function' ? bootstrap.getSnapshot() : null;
+      if (snapshot && snapshot.ready) return;
+      await Promise.race([
+        bootstrap.whenReady(),
+        new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(maxMs || 0))))
+      ]);
+    } catch (e) {}
+  }
+
+  function clearConfirmedAuthState() {
+    try {
+      localStorage.removeItem(AUTH_CACHE_KEY);
+      localStorage.removeItem(AUTH_CONFIRMED_KEY);
+      localStorage.removeItem(AUTH_TOKEN_KEY);
+    } catch (e) {}
+
+    try {
+      if (window.clearPrivateCaches) {
+        window.clearPrivateCaches();
+      }
+    } catch (e) {}
+
+    try {
+      if (
+        window.LoveBudProtectedRoute &&
+        typeof window.LoveBudProtectedRoute.setAuthState === 'function'
+      ) {
+        window.LoveBudProtectedRoute.setAuthState(true, null);
+      }
+    } catch (e) {}
+
+    try {
+      window.dispatchEvent(new CustomEvent('lovebud-auth-cache-cleared', {
+        detail: { reason: 'api-auth-failure' }
+      }));
+    } catch (e) {}
+  }
+
   async function getAuthHeaders(options = {}) {
     const policy = window.LoveTreeAuthPolicy;
     const headers = {
       'Content-Type': 'application/json'
     };
+    const requireAuth = !!options.requireAuth;
 
     const cachedToken = getCachedTokenRecord();
     if (cachedToken && cachedToken.token) {
       headers.Authorization = `Bearer ${cachedToken.token}`;
       return headers;
+    }
+
+    if (requireAuth && policy.hasConfirmedAuthSession()) {
+      await waitForAuthBootstrapReady(Math.max(policy.AUTH_WAIT_MS, 3000));
     }
 
     let attempts = 0;
@@ -64,7 +113,7 @@
             if (tokenResult) setCachedTokenRecord(user, tokenResult);
             return headers;
           }
-        } else {
+        } else if (!requireAuth || !policy.hasConfirmedAuthSession()) {
           return headers;
         }
       }
@@ -76,7 +125,11 @@
 
   async function apiFetch(endpoint, options = {}) {
     const policy = window.LoveTreeAuthPolicy;
-    const authHeaders = await getAuthHeaders();
+    const requiresAuth = policy.endpointLikelyRequiresAuth(endpoint);
+    const authHeaders = await getAuthHeaders({
+      forceLongWait: requiresAuth && policy.hasConfirmedAuthSession(),
+      requireAuth: requiresAuth
+    });
     const hadAuthHeader = !!authHeaders.Authorization;
 
     const buildConfig = (baseHeaders) => ({
@@ -93,11 +146,11 @@
     if (
       (response.status === 401 || response.status === 403) &&
       !hadAuthHeader &&
-      policy.endpointLikelyRequiresAuth(endpoint) &&
+      requiresAuth &&
       policy.hasConfirmedAuthSession()
     ) {
       await waitForAuthToken(Math.min(1200, policy.AUTH_WAIT_MS));
-      const retryHeaders = await getAuthHeaders({ forceLongWait: true });
+      const retryHeaders = await getAuthHeaders({ forceLongWait: true, requireAuth: true });
       if (retryHeaders.Authorization) {
         config = buildConfig(retryHeaders);
         response = await fetch(`/api${endpoint}`, config);
@@ -105,6 +158,10 @@
     }
 
     if (!response.ok) {
+      if (response.status === 401 && requiresAuth && policy.hasConfirmedAuthSession()) {
+        clearConfirmedAuthState();
+      }
+
       let errorMsg = `HTTP Error ${response.status}`;
       let errorData = null;
       try {
@@ -135,6 +192,8 @@
     getCachedTokenRecord,
     setCachedTokenRecord,
     waitForAuthToken,
+    waitForAuthBootstrapReady,
+    clearConfirmedAuthState,
     getAuthHeaders,
     apiFetch,
   };

--- a/tests/contracts/auth-confirmed-session-retry.test.js
+++ b/tests/contracts/auth-confirmed-session-retry.test.js
@@ -6,6 +6,7 @@ const vm = require('node:vm');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const AUTH_POLICY_PATH = path.join(ROOT, 'js', 'api', 'auth-policy.js');
+const BASE_API_FETCH_PATH = path.join(ROOT, 'js', 'api', 'base-api-fetch.js');
 const PUBLIC_TREE_ADAPTER_PATH = path.join(ROOT, 'js', 'api', 'public-tree-adapter.js');
 const POSTGRES_CLIENT_PATH = path.join(ROOT, 'js', 'postgres-client.js');
 
@@ -106,4 +107,73 @@ test('community endpoints stay outside auth-required classification', () => {
   assert.equal(internals.endpointLikelyRequiresAuth('/community/memories'), false);
   assert.equal(internals.endpointLikelyRequiresAuth('/trees'), true);
   assert.equal(internals.endpointLikelyRequiresAuth('/memories'), true);
+});
+
+test('auth headers wait for currentUser when confirmed cache exists', async () => {
+  const localStorageState = new Map([
+    ['lovebud_auth_confirmed', 'true'],
+    ['lovebud_auth_cache', JSON.stringify({ uid: 'test-user' })],
+  ]);
+  const localStorageMock = {
+    getItem(key) {
+      return localStorageState.has(key) ? localStorageState.get(key) : null;
+    },
+    setItem(key, value) {
+      localStorageState.set(key, String(value));
+    },
+    removeItem(key) {
+      localStorageState.delete(key);
+    },
+  };
+  const authUser = {
+    uid: 'test-user',
+    getIdTokenResult: async () => ({
+      token: 'test-token',
+      expirationTime: new Date(Date.now() + 60000).toISOString(),
+    }),
+  };
+  let authReadCount = 0;
+  const firebaseMock = {
+    auth: () => ({
+      get currentUser() {
+        authReadCount += 1;
+        return authReadCount === 1 ? null : authUser;
+      },
+    }),
+  };
+
+  const sandbox = {
+    window: {
+      __LOVEBUD_AUTH_WAIT_MS: 200,
+      __lovebudAuthReady: true,
+      LoveBudAuthBootstrap: {
+        getSnapshot: () => ({ ready: true, user: null }),
+        whenReady: () => Promise.resolve(null),
+      },
+      localStorage: localStorageMock,
+      firebase: firebaseMock,
+      LoveBudAuthState: null,
+    },
+    localStorage: localStorageMock,
+    firebase: firebaseMock,
+    console,
+    setTimeout,
+    clearTimeout,
+    CustomEvent: function CustomEvent(type, init) {
+      this.type = type;
+      this.detail = init && init.detail;
+    },
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(AUTH_POLICY_PATH, 'utf8'), sandbox, { filename: AUTH_POLICY_PATH });
+  vm.runInContext(fs.readFileSync(BASE_API_FETCH_PATH, 'utf8'), sandbox, { filename: BASE_API_FETCH_PATH });
+
+  const headers = await sandbox.window.LoveTreeBaseApiFetch.getAuthHeaders({
+    forceLongWait: true,
+    requireAuth: true,
+  });
+
+  assert.equal(headers.Authorization, 'Bearer test-token');
+  assert.ok(authReadCount > 1);
 });


### PR DESCRIPTION
## Summary
- Diagnosed the Auth/UI state vs `/api/trees` 401 inconsistency.
- Applied a narrow fix to align protected API loading with confirmed auth state.
- Preserved Firebase provider behavior and existing route structure.

## Root cause
- CODE
- `shared-header` and auth UI can mark a cached confirmed session ready before Firebase `currentUser` is available. `base-api-fetch` could then build headers for protected endpoints while `currentUser` was still unavailable and send `/api/trees` without Authorization.
- A 401 from a protected endpoint also left the confirmed auth cache in place, allowing stale authenticated UI to remain visible.

## Scope
- `js/api/base-api-fetch.js`
- `tests/contracts/auth-confirmed-session-retry.test.js`

## Guardrails
- Firebase config/provider behavior: NOT CHANGED
- DB/schema/migration: NOT CHANGED
- broad Auth rewrite: NOT DONE
- UI polish: NOT CHANGED
- PR #7 / prototype/reference/demo/variant: NOT CHANGED
- secret/private data exposure: NO

## Local verification
- git diff --check: PASS
- node --check changed JS files: PASS
- npm test: PASS
- npm run verify: PASS

## Required browser verification
- fixed slot + deployed SHA match required
- logged-out `/pages/my-trees.html` block/redirect
- logged-in My Trees waits for confirmed auth before data load
- `/api/trees` succeeds or reports truthful auth failure
- header/page auth state consistent
- logout clears protected access
- hard reload after logout remains logged out
- fatal console errors: NO
- secret/private exposure: NO

Refs #805
Refs #825
Refs #681
