### PR TITLE
fix(security): strip owner identifiers from public tree detail responses

### DIFF
--- a/js/api/base-api-fetch.js
+++ b/js/api/base-api-fetch.js
@@ -81,6 +81,9 @@
     const headers = {
       'Content-Type': 'application/json'
     };
+    if (options.skipAuth === true || options.publicRead === true) {
+      return headers;
+    }
     const requireAuth = !!options.requireAuth;
 
     const cachedToken = getCachedTokenRecord();
@@ -125,20 +128,38 @@
 
   async function apiFetch(endpoint, options = {}) {
     const policy = window.LoveTreeAuthPolicy;
-    const requiresAuth = policy.endpointLikelyRequiresAuth(endpoint);
+    const skipAuth = options.skipAuth === true || options.publicRead === true;
+    const fetchOptions = { ...options };
+    delete fetchOptions.skipAuth;
+    delete fetchOptions.publicRead;
+    const requiresAuth = !skipAuth && policy.endpointLikelyRequiresAuth(endpoint);
     const authHeaders = await getAuthHeaders({
       forceLongWait: requiresAuth && policy.hasConfirmedAuthSession(),
-      requireAuth: requiresAuth
+      requireAuth: requiresAuth,
+      skipAuth
     });
     const hadAuthHeader = !!authHeaders.Authorization;
 
-    const buildConfig = (baseHeaders) => ({
-      ...options,
-      headers: {
+    const stripAuthorizationHeader = (headers) => {
+      const safeHeaders = { ...headers };
+      Object.keys(safeHeaders).forEach((key) => {
+        if (key.toLowerCase() === 'authorization') {
+          delete safeHeaders[key];
+        }
+      });
+      return safeHeaders;
+    };
+
+    const buildConfig = (baseHeaders) => {
+      const headers = {
         ...baseHeaders,
-        ...options.headers
-      }
-    });
+        ...fetchOptions.headers
+      };
+      return {
+        ...fetchOptions,
+        headers: skipAuth ? stripAuthorizationHeader(headers) : headers
+      };
+    };
 
     let config = buildConfig(authHeaders);
     let response = await fetch(`/api${endpoint}`, config);

--- a/js/detail/detail-loader.js
+++ b/js/detail/detail-loader.js
@@ -143,8 +143,11 @@
 
             if (hasTreeContext) {
                 if (!tree && window.apiClient && window.apiClient.getTree) {
+                    const loadTreeDetail = sourceContext === 'browse' && window.apiClient.getPublicTree
+                        ? () => window.apiClient.getPublicTree(canonicalTreeId)
+                        : () => window.apiClient.getTree(canonicalTreeId);
                     treeFetchState = 'loading';
-                    loadPromises.push(window.apiClient.getTree(canonicalTreeId)
+                    loadPromises.push(loadTreeDetail()
                         .then(apiTree => {
                             if (apiTree) {
                                 tree = apiTree;

--- a/js/postgres-client.js
+++ b/js/postgres-client.js
@@ -20,6 +20,7 @@
         return {
             getTrees: async () => BaseApiFetch.apiFetch('/trees'),
             getTree: async (treeId) => BaseApiFetch.apiFetch(`/trees/${treeId}`),
+            getPublicTree: async (treeId) => BaseApiFetch.apiFetch(`/trees/${treeId}`, { publicRead: true }),
             getFirstTree: async () => {
                 const trees = await BaseApiFetch.apiFetch('/trees');
                 return Array.isArray(trees) && trees.length > 0 ? trees[0] : null;

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -170,7 +170,7 @@ def fetch_public_memory(memory_id: str) -> dict[str, Any] | None:
 
 def fetch_public_tree(tree_id: str) -> dict[str, Any] | None:
     query = """
-        SELECT t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at,
+        SELECT t.id, t.title, t.visibility, t.created_at, t.updated_at,
                COUNT(m.id)::int AS memory_count
         FROM trees t
         LEFT JOIN memories m
@@ -178,7 +178,7 @@ def fetch_public_tree(tree_id: str) -> dict[str, Any] | None:
          AND m.visibility = 'public'
         WHERE t.id = %s
           AND t.visibility = 'public'
-        GROUP BY t.id, t.owner_id, t.title, t.visibility, t.created_at, t.updated_at
+        GROUP BY t.id, t.title, t.visibility, t.created_at, t.updated_at
         LIMIT 1;
     """
 
@@ -190,4 +190,4 @@ def fetch_public_tree(tree_id: str) -> dict[str, Any] | None:
 
     row = run_db_with_retry(operation)
 
-    return normalize_tree_row(row, row.get("memory_count")) if row else None
+    return normalize_tree_row(row, row.get("memory_count"), include_owner=False) if row else None

--- a/modal_compute/validation.py
+++ b/modal_compute/validation.py
@@ -90,16 +90,25 @@ def normalize_memory_row(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def normalize_tree_row(row: dict[str, Any], memory_count: int | None = None) -> dict[str, Any]:
-    return {
+def normalize_tree_row(
+    row: dict[str, Any],
+    memory_count: int | None = None,
+    *,
+    include_owner: bool = True,
+) -> dict[str, Any]:
+    tree = {
         "id": str(row["id"]),
-        "ownerId": str(row["owner_id"]) if row.get("owner_id") else None,
         "title": row.get("title") or "",
         "visibility": row.get("visibility") or "public",
         "createdAt": _to_isoformat(row.get("created_at")),
         "updatedAt": _to_isoformat(row.get("updated_at")),
         "memoryCount": int(memory_count or 0),
     }
+
+    if include_owner:
+        tree["ownerId"] = str(row["owner_id"]) if row.get("owner_id") else None
+
+    return tree
 
 
 def normalize_row(row: dict[str, Any], *, stage_override: str | None = None) -> dict[str, Any]:

--- a/tests/contracts/auth-confirmed-session-retry.test.js
+++ b/tests/contracts/auth-confirmed-session-retry.test.js
@@ -177,3 +177,108 @@ test('auth headers wait for currentUser when confirmed cache exists', async () =
   assert.equal(headers.Authorization, 'Bearer test-token');
   assert.ok(authReadCount > 1);
 });
+
+test('public-read api fetch omits authorization for tree detail even with cached token', async () => {
+  const localStorageState = new Map([
+    ['lovebud_auth_token', JSON.stringify({
+      uid: 'safe-test-user',
+      token: 'safe-test-token',
+      expiresAt: Date.now() + 60000,
+    })],
+  ]);
+  const localStorageMock = {
+    getItem(key) {
+      return localStorageState.has(key) ? localStorageState.get(key) : null;
+    },
+    setItem(key, value) {
+      localStorageState.set(key, String(value));
+    },
+    removeItem(key) {
+      localStorageState.delete(key);
+    },
+  };
+  let capturedHeaders = null;
+  const sandbox = {
+    window: {
+      __LOVEBUD_AUTH_WAIT_MS: 200,
+      __lovebudAuthReady: true,
+      localStorage: localStorageMock,
+      firebase: null,
+      LoveBudAuthState: null,
+    },
+    localStorage: localStorageMock,
+    firebase: null,
+    console,
+    fetch: async (_url, config) => {
+      capturedHeaders = config.headers;
+      return { ok: true, json: async () => ({ ok: true }) };
+    },
+    setTimeout,
+    clearTimeout,
+    CustomEvent: function CustomEvent(type, init) {
+      this.type = type;
+      this.detail = init && init.detail;
+    },
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(AUTH_POLICY_PATH, 'utf8'), sandbox, { filename: AUTH_POLICY_PATH });
+  vm.runInContext(fs.readFileSync(BASE_API_FETCH_PATH, 'utf8'), sandbox, { filename: BASE_API_FETCH_PATH });
+
+  await sandbox.window.LoveTreeBaseApiFetch.apiFetch('/trees/safe-public-tree', { publicRead: true });
+
+  assert.equal(capturedHeaders.Authorization, undefined);
+  assert.equal(capturedHeaders.authorization, undefined);
+});
+
+test('private tree api fetch still attaches authorization from cached token', async () => {
+  const localStorageState = new Map([
+    ['lovebud_auth_token', JSON.stringify({
+      uid: 'safe-test-user',
+      token: 'safe-test-token',
+      expiresAt: Date.now() + 60000,
+    })],
+  ]);
+  const localStorageMock = {
+    getItem(key) {
+      return localStorageState.has(key) ? localStorageState.get(key) : null;
+    },
+    setItem(key, value) {
+      localStorageState.set(key, String(value));
+    },
+    removeItem(key) {
+      localStorageState.delete(key);
+    },
+  };
+  let capturedHeaders = null;
+  const sandbox = {
+    window: {
+      __LOVEBUD_AUTH_WAIT_MS: 200,
+      __lovebudAuthReady: true,
+      localStorage: localStorageMock,
+      firebase: null,
+      LoveBudAuthState: null,
+    },
+    localStorage: localStorageMock,
+    firebase: null,
+    console,
+    fetch: async (_url, config) => {
+      capturedHeaders = config.headers;
+      return { ok: true, json: async () => ({ ok: true }) };
+    },
+    setTimeout,
+    clearTimeout,
+    CustomEvent: function CustomEvent(type, init) {
+      this.type = type;
+      this.detail = init && init.detail;
+    },
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(AUTH_POLICY_PATH, 'utf8'), sandbox, { filename: AUTH_POLICY_PATH });
+  vm.runInContext(fs.readFileSync(BASE_API_FETCH_PATH, 'utf8'), sandbox, { filename: BASE_API_FETCH_PATH });
+
+  await sandbox.window.LoveTreeBaseApiFetch.apiFetch('/trees');
+
+  assert.equal(capturedHeaders.Authorization, 'Bearer safe-test-token');
+});

--- a/tests/contracts/detail-staged-rendering-contract.test.js
+++ b/tests/contracts/detail-staged-rendering-contract.test.js
@@ -41,3 +41,13 @@ test('detail connected flow has a separate staged loading state', () => {
   assert.match(connected, /degradedReason === 'context-loading'/);
   assert.match(copy, /isContextLoading/);
 });
+
+test('browse detail context uses public tree detail read path', () => {
+  const loader = read('js/detail/detail-loader.js');
+  const client = read('js/postgres-client.js');
+
+  assert.match(client, /getPublicTree:\s*async \(treeId\) => BaseApiFetch\.apiFetch\(`\/trees\/\$\{treeId\}`,\s*\{ publicRead: true \}\)/);
+  assert.match(loader, /sourceContext === 'browse' && window\.apiClient\.getPublicTree/);
+  assert.match(loader, /window\.apiClient\.getPublicTree\(canonicalTreeId\)/);
+  assert.match(loader, /window\.apiClient\.getTree\(canonicalTreeId\)/);
+});

--- a/tests/contracts/modal-public-read-routes-contract.test.js
+++ b/tests/contracts/modal-public-read-routes-contract.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const ROOT = path.resolve(__dirname, '..', '..');
 const MODAL_APP = path.join(ROOT, 'modal_compute/app.py');
 const MODAL_PUBLIC_READS = path.join(ROOT, 'modal_compute/public_reads.py');
+const MODAL_VALIDATION = path.join(ROOT, 'modal_compute/validation.py');
 
 function readModalApp() {
   return fs.readFileSync(MODAL_APP, 'utf8').replace(/\r\n/g, '\n');
@@ -13,6 +14,10 @@ function readModalApp() {
 
 function readModalPublicReads() {
   return fs.readFileSync(MODAL_PUBLIC_READS, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function readModalValidation() {
+  return fs.readFileSync(MODAL_VALIDATION, 'utf8').replace(/\r\n/g, '\n');
 }
 
 function hasString(content, pattern) {
@@ -116,7 +121,25 @@ test('modal public read helpers preserve public visibility filters and normaliza
   const treeHelper = extractPythonFunction(content, 'fetch_public_tree');
   assert.ok(hasString(treeHelper, "t.visibility = 'public'"));
   assert.ok(hasString(treeHelper, "m.visibility = 'public'"));
-  assert.ok(hasString(treeHelper, 'return normalize_tree_row(row, row.get("memory_count")) if row else None'));
+  assert.ok(hasString(treeHelper, 'return normalize_tree_row(row, row.get("memory_count"), include_owner=False) if row else None'));
+});
+
+test('public tree detail helper omits owner identifier from response shape', () => {
+  const content = readModalPublicReads();
+  const treeHelper = extractPythonFunction(content, 'fetch_public_tree');
+
+  assert.ok(!hasString(treeHelper, 't.owner_id'), 'public tree detail must not select owner_id');
+  assert.ok(!hasString(treeHelper, 'owner_id,'), 'public tree detail must not return owner_id');
+  assert.ok(hasString(treeHelper, 'include_owner=False'), 'public tree detail must omit owner identifiers at normalization');
+});
+
+test('tree normalizer preserves owner identifiers by default for private routes', () => {
+  const content = readModalValidation();
+  const normalizer = extractPythonFunction(content, 'normalize_tree_row');
+
+  assert.ok(hasString(normalizer, 'include_owner: bool = True'));
+  assert.ok(hasString(normalizer, 'if include_owner:'));
+  assert.ok(hasString(normalizer, 'tree["ownerId"] = str(row["owner_id"]) if row.get("owner_id") else None'));
 });
 
 test('modal public read route limits remain clamped at route boundary', () => {


### PR DESCRIPTION
## Summary
- Removed owner identifier fields from public tree detail responses.
- Added a no-auth public tree detail read path for browse/detail viewer context.
- Preserved owner/private authenticated response behavior and existing route structure.

## Root cause
- WRONG_CODE_PATH: public/detail viewer could attach Authorization for `/api/trees/:id`, which routed the request to the owner-preserving private branch instead of the public Modal branch.

## Scope
- `modal_compute/public_reads.py`
- `modal_compute/validation.py`
- `js/api/base-api-fetch.js`
- `js/postgres-client.js`
- `js/detail/detail-loader.js`
- `tests/contracts/modal-public-read-routes-contract.test.js`
- `tests/contracts/auth-confirmed-session-retry.test.js`
- `tests/contracts/detail-staged-rendering-contract.test.js`

## Security boundary
- Public read-only responses should expose display metadata only.
- Public/detail viewer tree detail loads now use public-read mode without Authorization.
- Owner/private reads continue to use authenticated owner-preserving routes.
- No raw private identifiers, credentials, tokens, sessions, or DB rows are printed.

## Guardrails
- No DB schema/migration changes.
- No Firebase config/provider changes.
- No broad Auth rewrite.
- No Browse/My Trees/Editor UI redesign.
- No package/workflow changes.
- PR #7 and prototype/reference/demo/variant untouched.

## Verification
- git diff --check: PASS
- node --check changed JS files: PASS
- python3 -m py_compile changed Python files: PASS
- npm test: PASS
- npm run verify: PASS

## Required browser/API verification
- fixed slot + deployed SHA match required
- public tree detail route still renders
- public/detail tree request avoids Authorization in browse context
- public response owner identifier absent by network/contract check without printing values
- owner/private authenticated reads still work
- owner controls hidden in public context
- fatal console errors: NO
- secret/private exposure: NO

Refs #875
Refs #872
Refs #843
Refs #681