### PR TITLE
test(security): guard public tree detail owner id exposure

### DIFF
--- a/tests/contracts/modal-public-read-routes-contract.test.js
+++ b/tests/contracts/modal-public-read-routes-contract.test.js
@@ -62,6 +62,12 @@ test('modal public read route handlers remain in app.py', () => {
   }
 });
 
+test('normalize_tree_row omits ownerId for public tree detail', () => {
+  const validationContent = fs.readFileSync(path.join(ROOT, 'modal_compute', 'validation.py'), 'utf8').replace(/\r\n/g, '\n');
+  const func = extractPythonFunction(validationContent, 'normalize_tree_row');
+  assert.ok(!hasString(func, '"ownerId"'), 'normalize_tree_row should not include "ownerId" in its return dict');
+});
+
 test('modal public read handlers call their current helper functions', () => {
   const content = readModalApp();
 


### PR DESCRIPTION
## Summary
- Adds a security contract guard for #875.
- Asserts public tree detail responses must not expose ownerId.
- This intentionally reproduces the current finding until the implementation fix lands.

## Scope
- Test-only.
- No runtime/source behavior changes.
- No Auth/API implementation changes.
- No browser UI changes.

## Verification
- Targeted contract test: FAIL, finding reproduced.
- Full verify: FAIL due to the expected #875 guard failure.

Refs #875
Refs #872
