### PR TITLE
ui: make private visibility controls non-actionable for v0.1

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -449,14 +449,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const visibility = (window.currentTreeData?.visibility || 'public');
             const isPublic = visibility === 'public';
             const nextActionLabel = isPublic
-                ? safeI18nText(i18n, 'editor_make_private', '이 트리 비공개로 전환')
-                : safeI18nText(i18n, 'editor_make_public', '이 트리 공개하기');
+                ? safeI18nText(i18n, 'visibility_public', '공개')
+                : safeI18nText(i18n, 'visibility_private', '비공개');
 
             visibilityToggleLabel.textContent = nextActionLabel;
-            visibilityToggleIcon.textContent = isPublic ? 'lock' : 'public';
+            visibilityToggleIcon.textContent = isPublic ? 'public' : 'lock';
             visibilityToggleBtn.setAttribute('aria-label', nextActionLabel);
             visibilityToggleBtn.setAttribute('title', nextActionLabel);
-            visibilityToggleBtn.disabled = !treeId;
+            visibilityToggleBtn.disabled = true;
             visibilityToggleBtn.dataset.idleLabel = nextActionLabel;
             visibilityToggleBtn.dataset.loadingLabel = isPublic
                 ? safeI18nText(i18n, 'editor_visibility_loading_private', '비공개로 전환하는 중...')
@@ -619,6 +619,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (sidebarVisibilityToggleBtn && sidebarVisibilityToggleBtn.dataset.bound !== '1') {
             sidebarVisibilityToggleBtn.dataset.bound = '1';
             sidebarVisibilityToggleBtn.addEventListener('click', async () => {
+                if (sidebarVisibilityToggleBtn.disabled) return;
                 if (!treeId) return;
                 const currentVisibility = window.currentTreeData?.visibility || 'public';
                 const isCurrentlyPublic = currentVisibility === 'public';

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -235,6 +235,7 @@
     var renameBtn = document.getElementById('manageRenameBtn');
     var deleteBtn = document.getElementById('manageDeleteBtn');
     var visibilityBtn = document.getElementById('manageVisibilityBtn');
+    if (visibilityBtn) visibilityBtn.style.display = 'none';
 
     if (totalEl) totalEl.textContent = total;
     if (publicEl) publicEl.textContent = publicCount;
@@ -260,15 +261,10 @@
       }
     }
 
-    [openBtn, renameBtn, deleteBtn, visibilityBtn].forEach(function(btn) {
+    [openBtn, renameBtn, deleteBtn].forEach(function(btn) {
       if (btn) btn.disabled = !selectedTree;
     });
 
-    if (visibilityBtn) {
-      visibilityBtn.textContent = selectedTree
-        ? getVisibilityActionLabel(selectedTree, i18n)
-        : (i18n('myTrees.manage_visibility') || '공개 설정');
-    }
 
     if (openBtn) {
       openBtn.onclick = function() {
@@ -293,12 +289,6 @@
       };
     }
 
-    if (visibilityBtn) {
-      visibilityBtn.onclick = function() {
-        if (!selectedTree || typeof options?.onToggleVisibility !== 'function') return;
-        options.onToggleVisibility(selectedTree.id, selectedTree.visibility);
-      };
-    }
 
     summaryBar.classList.remove('manage-summary-hidden');
     summaryBar.classList.add('manage-summary-visible');
@@ -388,11 +378,7 @@
         '<span class="material-symbols-outlined" aria-hidden="true">more_vert</span>',
       '</button>',
       '<div class="tree-card-dropdown" id="' + dropdownId + '">',
-        '<div class="dropdown-item visibility" data-action="visibility">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">' + cardMeta.visibilityIcon + '</span>',
-          cardMeta.visibilityActionLabel,
-        '</div>',
-        '<div class="dropdown-item rename" data-action="rename">',
+'<div class="dropdown-item rename" data-action="rename">',
           '<span class="material-symbols-outlined" style="font-size:16px;">edit</span>',
           i18n('rename') || '이름 변경',
         '</div>',
@@ -435,9 +421,7 @@
             }
 
             var action = this.getAttribute('data-action');
-            if (action === 'visibility' && typeof onToggleVisibility === 'function') {
-              onToggleVisibility(normalizedTree.id, normalizedTree.visibility);
-            } else if (action === 'rename' && typeof onRename === 'function') {
+            if (action === 'rename' && typeof onRename === 'function') {
               onRename(normalizedTree.id, title);
             } else if (action === 'delete' && typeof onDelete === 'function') {
               onDelete(normalizedTree.id, title);


### PR DESCRIPTION
## Summary
- Removed private visibility toggle action from My Trees card dropdown and manage panel for v0.1.
- Changed Editor sidebar visibility toggle from actionable button to non-actionable state-only display.
- Preserved informational private/public badge display for existing trees.
- Left `toggleTreeVisibility()` compatibility path intact for future re-enable.

## Product decision
- Private visibility setting is DEFERRED_OUT_OF_SCOPE for v0.1.
- This is not hiding a broken MVP core flow; it removes a future paid/private action from the free v0.1 action surface.
- Backend Plus entitlement guard remains in place for when the feature is re-enabled.

## Scope
- `js/my-trees/my-trees-ui.js`
- `js/editor.js`

## Guardrails
- No API/Auth/backend/DB/schema/migration changes.
- No public-by-default creation change.
- No Browse/public filter change.
- No Editor save/persistence behavior change.
- PR #7 and prototype/reference/demo/variant untouched.
- No secret/private data exposure.

## Verification
- git diff --check: PASS
- node --check js/my-trees/my-trees-ui.js: PASS
- node --check js/editor.js: PASS
- npm test: 205/205 PASS
- npm run verify: 150/150 PASS

## Required browser verification
- fixed slot + deployed SHA match required
- My Trees desktop/mobile:
  - no enabled private visibility action in dropdown or manage panel
  - rename/delete still work
  - private badge/state display preserved for existing private trees
- Editor desktop/mobile:
  - visibility control is non-actionable
  - shows current state (public/private) as informational display
  - click does not call visibility change API
  - editor open/save/cancel unaffected
- no fatal console errors
- no secret/private exposure

Refs #674
Refs #681
Refs #683
