### PR TITLE
fix(auth): stabilize login and settings auth-state routing

### DIFF
--- a/js/auth/auth-firebase.js
+++ b/js/auth/auth-firebase.js
@@ -281,7 +281,9 @@
           setupSignupForm: options.setupSignupForm,
           setupSignupGoogleBtn: options.setupSignupGoogleBtn,
           authInitFlag: options.authInitFlag,
-          authReadyFlag: options.authReadyFlag
+          authReadyFlag: options.authReadyFlag,
+          isLoginPage: options.isLoginPage,
+          getRedirectTarget: options.getRedirectTarget
         });
       },
       initOfflineAuth: function () {
@@ -334,6 +336,8 @@
     var setupSignupGoogleBtn = options && options.setupSignupGoogleBtn;
     var authInitFlag = options && options.authInitFlag;
     var authReadyFlag = options && options.authReadyFlag;
+    var isLoginPage = options && options.isLoginPage;
+    var getRedirectTarget = options && options.getRedirectTarget;
 
     if (typeof resolveEmailAuthMode === 'function') {
       window.EMAIL_AUTH_MODE = resolveEmailAuthMode();
@@ -438,6 +442,9 @@
       }
       if (typeof fireAuthReadyCallbacks === 'function') {
         fireAuthReadyCallbacks(user);
+      }
+      if (user && typeof isLoginPage === 'function' && isLoginPage()) {
+        window.location.replace(typeof getRedirectTarget === 'function' ? getRedirectTarget() : 'my-trees.html');
       }
     });
 

--- a/js/auth/auth-login-page.js
+++ b/js/auth/auth-login-page.js
@@ -34,6 +34,8 @@
   function resolveLoginRedirectTarget() {
     try {
       var params = new URLSearchParams(window.location.search || '');
+      var returnTo = params.get('returnTo');
+      if (returnTo) return returnTo;
       return params.get('redirect') || 'my-trees.html';
     } catch (error) {
       return 'my-trees.html';
@@ -151,7 +153,7 @@
     }
 
     var params = new URLSearchParams(window.location.search);
-    var redirect = params.get('redirect');
+    var redirect = params.get('redirect') || params.get('returnTo');
     var noticeEl = document.getElementById('redirect-notice');
     if (noticeEl) {
       noticeEl.style.display = redirect ? 'block' : 'none';

--- a/js/auth/auth-session.js
+++ b/js/auth/auth-session.js
@@ -5,6 +5,8 @@
 (function () {
   function getRedirectTarget(getBasePath) {
     var params = new URLSearchParams(window.location.search);
+    var returnTo = params.get('returnTo');
+    if (returnTo) return returnTo;
     var redirect = params.get('redirect');
     if (redirect) return redirect;
     var basePath = typeof getBasePath === 'function' ? getBasePath() : '';

--- a/js/login/login-page.js
+++ b/js/login/login-page.js
@@ -112,7 +112,7 @@
     var redirect = '';
     try {
       var params = new URLSearchParams(global.location ? global.location.search : '');
-      redirect = params.get('redirect') || '';
+      redirect = params.get('redirect') || params.get('returnTo') || '';
     } catch (error) {
       redirect = '';
     }

--- a/js/settings.js
+++ b/js/settings.js
@@ -7,6 +7,7 @@
 
 (function() {
   var SETTINGS_KEY = 'lovebud_user_settings';
+  var SETTINGS_AUTH_RECOVERY_TIMEOUT_MS = 1200;
   var DEFAULT_SETTINGS = {
     defaultVisibility: 'private'
   };
@@ -138,6 +139,72 @@
 
   function redirectToLogin() {
     window.location.replace(getLoginRedirectHref());
+  }
+
+  function getLiveFirebaseUser() {
+    try {
+      if (typeof initFirebase === 'function') initFirebase();
+      if (typeof firebase === 'undefined' || !firebase.auth) return null;
+      return firebase.auth().currentUser || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function waitForRecoverableAuthUser() {
+    return new Promise(function(resolve) {
+      var liveUser = getLiveFirebaseUser();
+      if (isAuthenticatedUser(liveUser)) {
+        resolve(liveUser);
+        return;
+      }
+
+      var settled = false;
+      var unsubscribe = null;
+      var timeoutId = setTimeout(function() {
+        if (settled) return;
+        settled = true;
+        try {
+          if (typeof unsubscribe === 'function') unsubscribe();
+        } catch (e) {}
+        resolve(null);
+      }, SETTINGS_AUTH_RECOVERY_TIMEOUT_MS);
+
+      try {
+        if (typeof firebase === 'undefined' || !firebase.auth || typeof firebase.auth().onAuthStateChanged !== 'function') {
+          clearTimeout(timeoutId);
+          settled = true;
+          resolve(null);
+          return;
+        }
+
+        unsubscribe = firebase.auth().onAuthStateChanged(function(user) {
+          if (!isAuthenticatedUser(user) || settled) return;
+          settled = true;
+          clearTimeout(timeoutId);
+          try {
+            if (typeof unsubscribe === 'function') unsubscribe();
+          } catch (e) {}
+          resolve(user);
+        });
+      } catch (e) {
+        clearTimeout(timeoutId);
+        settled = true;
+        resolve(null);
+      }
+    });
+  }
+
+  function recoverSettingsAuthOrRedirect() {
+    waitForRecoverableAuthUser().then(function(user) {
+      if (isAuthenticatedUser(user)) {
+        startSettings(user);
+        return;
+      }
+      redirectToLogin();
+    }).catch(function() {
+      redirectToLogin();
+    });
   }
 
   function applyHeaderNavFallbacks() {
@@ -278,7 +345,7 @@
         returnTo: window.location.pathname + window.location.search + window.location.hash,
         allowCachedUser: false,
         onAuthenticated: startSettings,
-        onUnauthenticated: redirectToLogin
+        onUnauthenticated: recoverSettingsAuthOrRedirect
       });
       return;
     }

--- a/js/settings.js
+++ b/js/settings.js
@@ -123,17 +123,17 @@
   }
 
   function getLoginRedirectHref() {
-    var target = window.location.pathname;
+    var target = window.location.pathname + window.location.search + window.location.hash;
 
     try {
       var params = new URLSearchParams(window.location.search || '');
       var returnTo = params.get('returnTo');
       if (returnTo && isSafeReturnTarget(returnTo)) {
-        target += '?returnTo=' + encodeURIComponent(normalizeReturnTarget(returnTo));
+        target = window.location.pathname + '?returnTo=' + encodeURIComponent(normalizeReturnTarget(returnTo));
       }
     } catch (e) {}
 
-    return 'login.html?redirect=' + encodeURIComponent(target);
+    return 'login.html?returnTo=' + encodeURIComponent(target);
   }
 
   function redirectToLogin() {
@@ -269,6 +269,20 @@
   }
 
   function initSettings() {
+    if (
+      window.LoveBudProtectedRoute &&
+      typeof window.LoveBudProtectedRoute.requireAuthenticatedPage === 'function'
+    ) {
+      window.LoveBudProtectedRoute.requireAuthenticatedPage({
+        redirectTo: 'login.html',
+        returnTo: window.location.pathname + window.location.search + window.location.hash,
+        allowCachedUser: false,
+        onAuthenticated: startSettings,
+        onUnauthenticated: redirectToLogin
+      });
+      return;
+    }
+
     if (window.LoveBudAuthBootstrap && typeof window.LoveBudAuthBootstrap.whenReady === 'function') {
       try {
         window.LoveBudAuthBootstrap.whenReady().then(function(user) {

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -273,6 +273,27 @@ test('auth firebase fallback keeps protected-route-aware offline behavior', () =
   assert.match(source, /initOfflineAuth/, 'auth-firebase must keep offline auth fallback logic');
 });
 
+test('login page redirects confirmed authenticated users away from login state', () => {
+  const source = readRepoFile('js/auth/auth-firebase.js');
+  const session = readRepoFile('js/auth/auth-session.js');
+
+  assert.match(source, /user\s*&&\s*typeof\s+isLoginPage\s*===\s*'function'\s*&&\s*isLoginPage\(\)/, 'auth-firebase must detect signed-in login-page state');
+  assert.match(source, /window\.location\.replace\(typeof getRedirectTarget === 'function' \? getRedirectTarget\(\) : 'my-trees\.html'\)/, 'signed-in login page must redirect to the resolved auth target');
+  assert.match(session, /var\s+returnTo\s*=\s*params\.get\('returnTo'\)/, 'auth session target resolver must read returnTo');
+  assert.match(session, /if\s*\(returnTo\)\s*return returnTo/, 'returnTo must win before legacy redirect target');
+});
+
+test('settings page uses protected route helper and stable returnTo login target', () => {
+  const source = readRepoFile('js/settings.js');
+
+  assert.match(source, /LoveBudProtectedRoute\.requireAuthenticatedPage/, 'settings must use protected-route helper when available');
+  assert.match(source, /allowCachedUser:\s*false/, 'settings must not unlock from stale confirmed cache alone');
+  assert.match(source, /onAuthenticated:\s*startSettings/, 'settings authenticated path must start settings content');
+  assert.match(source, /onUnauthenticated:\s*redirectToLogin/, 'settings unauthenticated path must use local login redirect');
+  assert.match(source, /return 'login\.html\?returnTo='/, 'settings login redirect must use stable returnTo target');
+  assert.doesNotMatch(source, /login\.html\?redirect=/, 'settings must not use legacy redirect query for protected-route login target');
+});
+
 test('auth UI logout uses delegated data attribute and blocks inline signOut onclick regression', () => {
   const source = readRepoFile('js/auth/auth-ui.js');
 

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -276,11 +276,15 @@ test('auth firebase fallback keeps protected-route-aware offline behavior', () =
 test('login page redirects confirmed authenticated users away from login state', () => {
   const source = readRepoFile('js/auth/auth-firebase.js');
   const session = readRepoFile('js/auth/auth-session.js');
+  const loginPage = readRepoFile('js/auth/auth-login-page.js');
 
   assert.match(source, /user\s*&&\s*typeof\s+isLoginPage\s*===\s*'function'\s*&&\s*isLoginPage\(\)/, 'auth-firebase must detect signed-in login-page state');
   assert.match(source, /window\.location\.replace\(typeof getRedirectTarget === 'function' \? getRedirectTarget\(\) : 'my-trees\.html'\)/, 'signed-in login page must redirect to the resolved auth target');
   assert.match(session, /var\s+returnTo\s*=\s*params\.get\('returnTo'\)/, 'auth session target resolver must read returnTo');
   assert.match(session, /if\s*\(returnTo\)\s*return returnTo/, 'returnTo must win before legacy redirect target');
+  assert.match(loginPage, /var\s+returnTo\s*=\s*params\.get\('returnTo'\)/, 'login-page auth observer must read returnTo before redirect');
+  assert.match(loginPage, /if\s*\(returnTo\)\s*return returnTo/, 'login-page auth observer must preserve settings returnTo before auth-firebase redirect runs');
+  assert.match(loginPage, /params\.get\('redirect'\)\s*\|\|\s*params\.get\('returnTo'\)/, 'login-page redirect notice must support returnTo-only login redirects');
 });
 
 test('settings page uses protected route helper and stable returnTo login target', () => {

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -293,9 +293,15 @@ test('settings page uses protected route helper and stable returnTo login target
   assert.match(source, /LoveBudProtectedRoute\.requireAuthenticatedPage/, 'settings must use protected-route helper when available');
   assert.match(source, /allowCachedUser:\s*false/, 'settings must not unlock from stale confirmed cache alone');
   assert.match(source, /onAuthenticated:\s*startSettings/, 'settings authenticated path must start settings content');
-  assert.match(source, /onUnauthenticated:\s*redirectToLogin/, 'settings unauthenticated path must use local login redirect');
+  assert.match(source, /onUnauthenticated:\s*recoverSettingsAuthOrRedirect/, 'settings unauthenticated path must recover live auth before redirecting');
+  assert.match(source, /function\s+waitForRecoverableAuthUser\s*\(/, 'settings must have a bounded live-auth recovery path for returnTo after login');
+  assert.match(source, /firebase\.auth\(\)\.currentUser/, 'settings recovery must check live Firebase currentUser');
+  assert.match(source, /firebase\.auth\(\)\.onAuthStateChanged/, 'settings recovery must wait for the live Firebase auth observer before redirecting');
+  assert.match(source, /SETTINGS_AUTH_RECOVERY_TIMEOUT_MS/, 'settings live-auth recovery must be bounded');
+  assert.match(source, /startSettings\(user\)/, 'settings recovery must start settings after live authenticated user is observed');
   assert.match(source, /return 'login\.html\?returnTo='/, 'settings login redirect must use stable returnTo target');
   assert.doesNotMatch(source, /login\.html\?redirect=/, 'settings must not use legacy redirect query for protected-route login target');
+  assert.doesNotMatch(source, /allowCachedUser:\s*true/, 'settings must not fix the returnTo loop by unlocking from cached auth alone');
 });
 
 test('auth UI logout uses delegated data attribute and blocks inline signOut onclick regression', () => {

--- a/tests/contracts/login-controller-skeleton-contract.test.js
+++ b/tests/contracts/login-controller-skeleton-contract.test.js
@@ -74,7 +74,8 @@ test('login controller redirect notice is gated by explicit redirect query param
 
   assert.match(source, /new URLSearchParams\(global\.location \? global\.location\.search : ''\)/, 'controller must parse query params without performing navigation');
   assert.match(source, /params\.get\('redirect'\)/, 'redirect notice must use the explicit redirect query param');
-  assert.match(source, /noticeEl\.style\.display\s*=\s*redirect \? 'block' : 'none'/, 'redirect notice display must depend on redirect param only');
+  assert.match(source, /params\.get\('returnTo'\)/, 'redirect notice must also support explicit returnTo query param');
+  assert.match(source, /noticeEl\.style\.display\s*=\s*redirect \? 'block' : 'none'/, 'redirect notice display must depend on explicit auth-route param only');
   assert.doesNotMatch(source, /noticeEl\.style\.display\s*=\s*global\.location\s*&&\s*global\.location\.search/, 'redirect notice must not depend on any query string presence');
 });
 


### PR DESCRIPTION
## Summary
- Stabilized Login and Settings auth-state routing.
- Prevented contradictory logged-in/logged-out page states.
- Preserved #874 Auth/API consistency fix and did not touch public detail security paths.
- Follow-up: aligned the login-page auth observer with `returnTo` so Settings can return after login without bouncing.

## Scope
- `js/auth/auth-firebase.js`
- `js/auth/auth-login-page.js`
- `js/auth/auth-session.js`
- `js/login/login-page.js`
- `js/settings.js`
- `tests/contracts/auth-bootstrap-contract.test.js`
- `tests/contracts/login-controller-skeleton-contract.test.js`

## Guardrails
- No broad Auth rewrite.
- No Firebase config/provider changes.
- No API/base fetch/detail/public read changes.
- No backend/DB/schema/migration changes.
- No package/workflow changes.
- PR #7 and prototype/reference/demo/variant untouched.
- No secret/private data exposure.

## Verification
- git diff --check: PASS
- node --check changed JS files: PASS
- npm test: PASS
- npm run verify: PASS

## Required browser verification
- fixed slot + deployed SHA match required
- logged-out settings routes to login/block with returnTo
- logged-in settings does not bounce to login
- logged-in login page has no contradictory login-required/account state
- logout clears settings access
- fatal console errors: NO
- credential values exposed: NO

Refs #825
Refs #681