### PR TITLE
test(docs): add v0.1 UI trust pass gate contract

### DIFF
--- a/docs/engineering/V01_UI_TRUST_PASS_RELEASE_GATE_681.md
+++ b/docs/engineering/V01_UI_TRUST_PASS_RELEASE_GATE_681.md
@@ -1,0 +1,50 @@
+# v0.1 UI Trust Pass Release Gate Status Contract
+
+Status: active release-gate tracking contract
+Scope: docs and contract only
+Parent gate: #681
+
+This document records the current release-gate tracking shape for the v0.1 UI Trust Pass. It is not an implementation plan and does not authorize runtime, UI, Auth, API, backend, database, deployment, package, workflow, or credential changes.
+
+The purpose is to give reviewers and verification executors one stable place to classify active gate items without mixing unrelated PR queues.
+
+## Status Taxonomy
+
+Use these labels when reporting #681 child work:
+
+| Label | Meaning |
+| --- | --- |
+| ACTIVE_REVERIFY_REQUIRED | A patch exists and the next required step is fixed-slot or runtime verification. |
+| HOLD_CREDENTIAL_VERIFICATION | The patch remains on hold because credential-safe verification cannot currently complete. |
+| OPEN_DRAFT_VERIFY_BEFORE_USE | A draft document or policy exists, but its merge status and current content must be verified before relying on it. |
+| MERGED_OR_SUPERSEDED_VERIFY_FIRST | A prior related item may already be reflected elsewhere, but current repository state must be checked before using it as evidence. |
+
+## Active Gate Items
+
+| PR | Gate item | Current status | Required next check |
+| --- | --- | --- | --- |
+| #878 | Public detail owner identifier strip | ACTIVE_REVERIFY_REQUIRED | Fixed-slot public detail response and viewer reverify. |
+| #880 | Private visibility controls | HOLD_CREDENTIAL_VERIFICATION | Credential-safe logged-in fixed-slot verification before readiness decisions. |
+| #881 | Login and Settings auth consistency | ACTIVE_REVERIFY_REQUIRED | Fixed-slot logged-in Settings and Login redirect reverify. |
+| #870 | Visible action readiness policy | OPEN_DRAFT_VERIFY_BEFORE_USE | Verify draft status and current content before treating the policy as a gate input. |
+
+## Guardrails
+
+- Do not mix #681 gate documentation with runtime implementation.
+- Do not use this document as proof that browser verification passed.
+- Do not use this document as deploy, ready, merge, or issue-status authority.
+- Do not copy credential values, account values, tokens, sessions, cookies, raw payloads, database rows, or private identifiers into gate evidence.
+- Do not modify `docs/ux/V01_VISIBLE_ACTION_READINESS_POLICY.md` from this release-gate tracking contract.
+- Do not touch PR #7 or prototype/reference/demo/variant paths from this release-gate tracking contract.
+
+## Verification Contract
+
+Any PR that updates this document should verify:
+
+- changed files remain docs/contract only;
+- runtime JS/CSS/HTML/backend/Auth/API/DB/package/workflow files are unchanged;
+- the status taxonomy labels remain present;
+- #878, #880, #881, and #870 remain represented as explicit gate items;
+- reports use status labels and issue references only, without private values.
+
+Refs #681

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -46,6 +46,7 @@
 28. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
 29. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 30. [AUTH_EDITOR_RUNTIME_INVENTORY_834.md](./AUTH_EDITOR_RUNTIME_INVENTORY_834.md) - #834 auth/editor runtime inventory, dependency mapping, naming consistency audit, decomposition candidates
+31. [V01_UI_TRUST_PASS_RELEASE_GATE_681.md](./V01_UI_TRUST_PASS_RELEASE_GATE_681.md) - #681 v0.1 UI Trust Pass release-gate status taxonomy and active PR verification contract
 
 ---
 
@@ -81,6 +82,7 @@
 | [EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md](./EDITOR_HIDDEN_COMPATIBILITY_OVERRIDE_AUDIT.md) | Issue #516 hidden/compatibility selector references, runtime linkage, removal/relocation disposition, and future browser verification gates |
 | [SUPABASE_FREE_POC_PLAN.md](./SUPABASE_FREE_POC_PLAN.md) | Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획 |
 | [AUTH_EDITOR_RUNTIME_INVENTORY_834.md](./AUTH_EDITOR_RUNTIME_INVENTORY_834.md) | #834 auth/editor runtime inventory, dependency mapping, naming audit, decomposition candidates |
+| [V01_UI_TRUST_PASS_RELEASE_GATE_681.md](./V01_UI_TRUST_PASS_RELEASE_GATE_681.md) | #681 v0.1 UI Trust Pass release-gate status taxonomy and active PR verification contract |
 | [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) | 반복 false positive 방지 및 리뷰 규칙 |
 | [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) | 최근 코드 구조 정리 이력 |
 | [UTIL_USAGE_POLICY.md](./UTIL_USAGE_POLICY.md) | 공통 유틸 사용 정책 |

--- a/tests/contracts/docs-v01-ui-trust-pass-gate.test.js
+++ b/tests/contracts/docs-v01-ui-trust-pass-gate.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DOC_PATH = path.join(ROOT, 'docs/engineering/V01_UI_TRUST_PASS_RELEASE_GATE_681.md');
+const INDEX_PATH = path.join(ROOT, 'docs/engineering/engineering_index.md');
+
+function read(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+test('v0.1 UI Trust Pass release gate doc keeps required status taxonomy', () => {
+  const source = read(DOC_PATH);
+
+  for (const label of [
+    'ACTIVE_REVERIFY_REQUIRED',
+    'HOLD_CREDENTIAL_VERIFICATION',
+    'OPEN_DRAFT_VERIFY_BEFORE_USE',
+    'MERGED_OR_SUPERSEDED_VERIFY_FIRST',
+  ]) {
+    assert.match(source, new RegExp(label), `release gate doc must include status label ${label}`);
+  }
+});
+
+test('v0.1 UI Trust Pass release gate doc tracks current active PR gates', () => {
+  const source = read(DOC_PATH);
+
+  for (const token of ['#878', '#880', '#881', '#870']) {
+    assert.match(source, new RegExp(token), `release gate doc must track ${token}`);
+  }
+
+  assert.match(source, /Public detail owner identifier strip/);
+  assert.match(source, /Private visibility controls/);
+  assert.match(source, /Login and Settings auth consistency/);
+  assert.match(source, /Visible action readiness policy/);
+});
+
+test('v0.1 UI Trust Pass release gate doc stays docs-only and redaction-safe', () => {
+  const source = read(DOC_PATH);
+
+  assert.match(source, /Scope: docs and contract only/);
+  assert.match(source, /does not authorize runtime, UI, Auth, API, backend, database, deployment, package, workflow, or credential changes/);
+  assert.match(source, /Do not copy credential values/);
+  assert.match(source, /Refs #681/);
+  assert.doesNotMatch(source, /Fixes\s+#|Closes\s+#|Resolves\s+#/i);
+});
+
+test('engineering index links v0.1 UI Trust Pass release gate doc', () => {
+  const index = read(INDEX_PATH);
+
+  assert.match(index, /V01_UI_TRUST_PASS_RELEASE_GATE_681\.md/);
+  assert.match(index, /#681 v0\.1 UI Trust Pass release-gate status taxonomy/);
+});


### PR DESCRIPTION
## Summary
- Added a docs-only #681 v0.1 UI Trust Pass release-gate status contract.
- Tracked active gate items by status taxonomy only.
- Added a docs contract test for required labels, PR references, and redaction-safe scope.

## Scope
- docs/engineering/V01_UI_TRUST_PASS_RELEASE_GATE_681.md
- docs/engineering/engineering_index.md
- tests/contracts/docs-v01-ui-trust-pass-gate.test.js

## Guardrails
- No runtime JS/CSS/HTML changes.
- No Auth/API/Detail/Editor/My Trees changes.
- No backend/DB/schema/migration changes.
- No package/workflow/config changes.
- docs/ux/V01_VISIBLE_ACTION_READINESS_POLICY.md not touched.
- PR #7 and prototype/reference/demo/variant untouched.
- No secret/private data exposure.

## Verification
- git diff --check: PASS
- npm test: PASS
- npm run verify: PASS

Refs #681