### PR TITLE
docs(engineering): define editor branch slot interaction plan

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -152,6 +152,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 - [SCRIPT_LOAD_ORDER.md](./engineering/SCRIPT_LOAD_ORDER.md) - pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist
 - [SEARCH_RUNTIME_CONTRACT.md](./engineering/SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, forbidden changes, smoke checklist
 - [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, file ownership, 금지 조합, fixed test slot 검증 기준
+- [EDITOR_BRANCH_SLOT_INTERACTION_PLAN_653.md](./engineering/EDITOR_BRANCH_SLOT_INTERACTION_PLAN_653.md) - #653 Editor branch slot interaction plan, #655 viewport prerequisite, owner-only slot boundary, staged implementation gates
 - [SUPABASE_FREE_POC_PLAN.md](./engineering/SUPABASE_FREE_POC_PLAN.md) - Supabase Free PoC 기반 장기 backend 구조 단순화 검증 계획
 - [REVIEW_GUARDRAILS.md](./engineering/REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
 - [RECENT_REFACTORING.md](./engineering/RECENT_REFACTORING.md) - 최근 코드 구조 정리 이력


### PR DESCRIPTION
## Summary
- Added a docs-only #653 branch slot interaction plan.
- Defined how #653 depends on #655 viewport controls without bundling implementation.
- Documented owner-only slot visibility, staged implementation, accessibility requirements, and fixed-slot verification requirements.

## Scope
- `docs/engineering/EDITOR_BRANCH_SLOT_INTERACTION_PLAN_653.md`

## Guardrails
- Docs-only.
- No runtime JS/CSS/HTML changes.
- No Editor implementation changes.
- No Auth/API/Detail/My Trees/Modal/backend/DB changes.
- No package/workflow/config changes.
- PR #7 and prototype/reference/demo/variant untouched.
- No secret/private data exposure.

## Verification
- GitHub file creation completed.
- Runtime verification not required for this docs-only planning PR.

## Follow-up
- If required by doc-index hygiene, add index links in a narrow follow-up commit before ready review.

Refs #653
Refs #655
Refs #652
Refs #648
Refs #801