### PR TITLE
feat(editor): add tree viewport controls

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -12,7 +12,7 @@
 @import url("./editor/layout.css?v=20260504-775");
 @import url("./editor/sidebar.css");
 @import url("./editor/canvas.css?v=20260504-787");
-@import url("./editor/canvas-toolbar.css");
+@import url("./editor/canvas-toolbar.css?v=20260507-655");
 @import url("./editor/memory-form.css");
 @import url("./editor/detail-panel.css?v=20260504-627");
 @import url("./editor/responsive.css");

--- a/css/editor/canvas-toolbar.css
+++ b/css/editor/canvas-toolbar.css
@@ -45,21 +45,107 @@
 .editor-canvas-toolbar {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
     gap: 8px;
     padding: 8px;
-    border-radius: 999px;
+    max-width: min(100%, 360px);
+    border-radius: 18px;
     background: rgba(255,250,244,0.82);
     border: 1px solid rgba(230,207,194,0.78);
     box-shadow: 0 14px 30px rgba(161,119,96,0.10);
     backdrop-filter: blur(8px);
 }
 
-.editor-canvas-toolbar .sidebar-btn {
-    min-height: 38px;
-    padding: 0 14px;
-    border-radius: 999px;
+.editor-canvas-tool-btn {
+    position: relative;
+    width: 38px;
+    height: 38px;
+    min-width: 38px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 0;
+    border-radius: 12px;
     background: rgba(255,255,255,0.74);
     border: 1px solid rgba(221,198,184,0.84);
     color: #7f6258;
     box-shadow: none;
+    cursor: pointer;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.editor-canvas-tool-btn:hover:not(:disabled),
+.editor-canvas-tool-btn:focus-visible:not(:disabled) {
+    background: rgba(255,255,255,0.96);
+    border-color: rgba(144,73,81,0.26);
+    color: var(--primary);
+    transform: translateY(-1px);
+}
+
+.editor-canvas-tool-btn:focus-visible {
+    outline: 2px solid var(--control-focus-ring, rgba(144,73,81,0.32));
+    outline-offset: 2px;
+}
+
+.editor-canvas-tool-btn:disabled,
+.editor-canvas-tool-btn.is-disabled {
+    opacity: 0.46;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.editor-canvas-tool-btn .material-symbols-outlined {
+    font-size: 20px;
+    line-height: 1;
+}
+
+.editor-canvas-tool-btn-wide {
+    width: auto;
+    min-width: 38px;
+    max-width: 150px;
+    padding: 0 12px;
+}
+
+.editor-canvas-tool-label {
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1.15;
+    white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+    .editor-canvas-topbar {
+        left: 14px;
+        right: 14px;
+        gap: 10px;
+    }
+
+    .editor-canvas-toolbar {
+        max-width: 100%;
+        padding: 6px;
+        gap: 6px;
+    }
+
+    .editor-canvas-tool-btn {
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+    }
+
+    .editor-canvas-tool-btn-wide {
+        width: 36px;
+        max-width: 36px;
+        padding: 0;
+    }
+
+    .editor-canvas-tool-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+    }
 }

--- a/js/editor/editor-canvas-interaction-helpers.js
+++ b/js/editor/editor-canvas-interaction-helpers.js
@@ -37,9 +37,10 @@ window.LoveBudEditorCanvasInteractionHelpers = {
         if (Math.abs(dx) > 2 || Math.abs(dy) > 2) {
           viewportState.dragMoved = true;
         }
+        const scale = viewportState.scale || 1;
         viewportState.positions[viewportState.dragNodeId] = {
-          x: Math.round(viewportState.dragStartWorldX + dx),
-          y: Math.round(viewportState.dragStartWorldY + dy)
+          x: Math.round(viewportState.dragStartWorldX + (dx / scale)),
+          y: Math.round(viewportState.dragStartWorldY + (dy / scale))
         };
         scheduleInitCanvas();
         return;

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -42,9 +42,10 @@ window.LoveBudEditorCanvasInteraction = {
           viewportState.dragMoved = true;
         }
         if (!viewportState.dragMoved) return;
+        const scale = viewportState.scale || 1;
         viewportState.positions[viewportState.dragNodeId] = {
-          x: Math.round(viewportState.dragStartWorldX + dx),
-          y: Math.round(viewportState.dragStartWorldY + dy)
+          x: Math.round(viewportState.dragStartWorldX + (dx / scale)),
+          y: Math.round(viewportState.dragStartWorldY + (dy / scale))
         };
         scheduleRender();
         return;

--- a/js/editor/editor-canvas-layout.js
+++ b/js/editor/editor-canvas-layout.js
@@ -5,16 +5,17 @@ window.LoveBudEditorCanvasLayout = {
     function load() {
       try {
         const raw = localStorage.getItem(layoutStorageKey);
-        if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0 };
+        if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
         const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0 };
+        if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
         return {
           positions: parsed.positions && typeof parsed.positions === 'object' ? parsed.positions : {},
           offsetX: typeof parsed.offsetX === 'number' ? parsed.offsetX : 0,
-          offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0
+          offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0,
+          scale: typeof parsed.scale === 'number' ? parsed.scale : 1
         };
       } catch (error) {
-        return { positions: {}, offsetX: 0, offsetY: 0 };
+        return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
       }
     }
 
@@ -24,6 +25,7 @@ window.LoveBudEditorCanvasLayout = {
         return {
           offsetX: storedLayout.offsetX,
           offsetY: storedLayout.offsetY,
+          scale: storedLayout.scale,
           initialized: false,
           isPanning: false,
           startX: 0,
@@ -45,7 +47,8 @@ window.LoveBudEditorCanvasLayout = {
           localStorage.setItem(layoutStorageKey, JSON.stringify({
             positions: viewportState.positions,
             offsetX: viewportState.offsetX,
-            offsetY: viewportState.offsetY
+            offsetY: viewportState.offsetY,
+            scale: viewportState.scale || 1
           }));
         } catch (error) {}
       }

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -1,7 +1,28 @@
 window.LoveBudEditorCanvasViewport = {
+  minScale: 0.65,
+  maxScale: 1.55,
+  zoomStep: 1.18,
   readableCenter: {
     x: 0.5,
     y: 0.38
+  },
+
+  getScale(viewportState) {
+    const scale = Number(viewportState && viewportState.scale);
+    if (!Number.isFinite(scale) || scale <= 0) return 1;
+    return Math.min(this.maxScale, Math.max(this.minScale, scale));
+  },
+
+  setScale(viewportState, nextScale) {
+    viewportState.scale = Math.min(this.maxScale, Math.max(this.minScale, Number(nextScale) || 1));
+  },
+
+  projectWorldPosition(world, viewportState) {
+    const scale = this.getScale(viewportState);
+    return {
+      x: world.x * scale + viewportState.offsetX,
+      y: world.y * scale + viewportState.offsetY
+    };
   },
 
   getViewportTargets(options) {
@@ -26,6 +47,7 @@ window.LoveBudEditorCanvasViewport = {
     const targets = this.getViewportTargets(options);
     if (!targets.length) return null;
 
+    const scale = this.getScale(options.viewportState);
     const points = targets.map((memory) => getWorldPosition(memory));
     const minX = Math.min(...points.map((point) => point.x));
     const maxX = Math.max(...points.map((point) => point.x));
@@ -34,13 +56,45 @@ window.LoveBudEditorCanvasViewport = {
     const metrics = getMetrics();
 
     return {
-      offsetX: Math.round(metrics.width * this.readableCenter.x - ((minX + maxX) / 2)),
-      offsetY: Math.round(metrics.height * this.readableCenter.y - ((minY + maxY) / 2))
+      offsetX: Math.round(metrics.width * this.readableCenter.x - (((minX + maxX) / 2) * scale)),
+      offsetY: Math.round(metrics.height * this.readableCenter.y - (((minY + maxY) / 2) * scale))
+    };
+  },
+
+  getFitViewport(options) {
+    const { getWorldPosition, getMetrics } = options;
+    const targets = this.getViewportTargets(options);
+    if (!targets.length) {
+      return { scale: 1, offsetX: 0, offsetY: 0 };
+    }
+
+    const points = targets.map((memory) => getWorldPosition(memory));
+    const minX = Math.min(...points.map((point) => point.x));
+    const maxX = Math.max(...points.map((point) => point.x));
+    const minY = Math.min(...points.map((point) => point.y));
+    const maxY = Math.max(...points.map((point) => point.y));
+    const metrics = getMetrics();
+    const padding = Math.min(180, Math.max(96, Math.round(metrics.width * 0.12)));
+    const boundsWidth = Math.max(1, maxX - minX + 180);
+    const boundsHeight = Math.max(1, maxY - minY + 180);
+    const fitScale = Math.min(
+      this.maxScale,
+      Math.max(
+        this.minScale,
+        Math.min((metrics.width - padding) / boundsWidth, (metrics.height - padding) / boundsHeight)
+      )
+    );
+
+    return {
+      scale: fitScale,
+      offsetX: Math.round(metrics.width * this.readableCenter.x - (((minX + maxX) / 2) * fitScale)),
+      offsetY: Math.round(metrics.height * this.readableCenter.y - (((minY + maxY) / 2) * fitScale))
     };
   },
 
   prepareInitialViewport(options) {
     const { viewportState } = options;
+    this.setScale(viewportState, viewportState.scale || 1);
     if (viewportState.initialViewportApplied) return;
 
     if (viewportState.hasStoredViewportOffset) {
@@ -78,8 +132,9 @@ window.LoveBudEditorCanvasViewport = {
 
     const world = getWorldPosition(target);
     const metrics = getMetrics();
-    viewportState.offsetX = Math.round(metrics.width * 0.5 - world.x);
-    viewportState.offsetY = Math.round(metrics.height * 0.38 - world.y);
+    const scale = this.getScale(viewportState);
+    viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
+    viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
     initCanvas();
     reapplySelection(nodeId);
   },
@@ -90,25 +145,39 @@ window.LoveBudEditorCanvasViewport = {
     if (!treeMemories.length) {
       viewportState.offsetX = 0;
       viewportState.offsetY = 0;
+      this.setScale(viewportState, 1);
       initCanvas();
       return;
     }
 
-    const nextOffset = this.getReadableViewportOffset(options);
+    const nextOffset = this.getFitViewport(options);
     if (!nextOffset) return;
 
+    this.setScale(viewportState, nextOffset.scale);
     viewportState.offsetX = nextOffset.offsetX;
     viewportState.offsetY = nextOffset.offsetY;
     initCanvas();
   },
 
   bindControls(options) {
-    const { viewportState, focusNodeById, recenterViewport } = options;
+    const { viewportState, focusNodeById, recenterViewport, zoomBy } = options;
     if (viewportState.controlsBound) return;
     viewportState.controlsBound = true;
 
     const focusBtn = document.getElementById('focusSelectedBtn');
     const recenterBtn = document.getElementById('recenterCanvasBtn');
+    const zoomInBtn = document.getElementById('zoomInCanvasBtn');
+    const zoomOutBtn = document.getElementById('zoomOutCanvasBtn');
+
+    [focusBtn, recenterBtn, zoomInBtn, zoomOutBtn].forEach((button) => {
+      if (!button) return;
+      button.addEventListener('mousedown', (event) => {
+        event.stopPropagation();
+      });
+      button.addEventListener('touchstart', (event) => {
+        event.stopPropagation();
+      }, { passive: true });
+    });
 
     if (focusBtn) {
       focusBtn.addEventListener('click', () => {
@@ -120,12 +189,20 @@ window.LoveBudEditorCanvasViewport = {
     }
 
     if (recenterBtn) {
-      recenterBtn.addEventListener('mousedown', (event) => {
-        event.stopPropagation();
-      });
-
       recenterBtn.addEventListener('click', () => {
         recenterViewport();
+      });
+    }
+
+    if (zoomInBtn && typeof zoomBy === 'function') {
+      zoomInBtn.addEventListener('click', () => {
+        zoomBy(this.zoomStep);
+      });
+    }
+
+    if (zoomOutBtn && typeof zoomBy === 'function') {
+      zoomOutBtn.addEventListener('click', () => {
+        zoomBy(1 / this.zoomStep);
       });
     }
   }

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -34,22 +34,24 @@ function loadStoredLayout() {
             return {
                 positions: initialState.positions,
                 offsetX: initialState.offsetX,
-                offsetY: initialState.offsetY
+                offsetY: initialState.offsetY,
+                scale: initialState.scale
             };
         }
 
         try {
             const raw = localStorage.getItem(layoutStorageKey);
-            if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0 };
+            if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
             const parsed = JSON.parse(raw);
-            if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0 };
+            if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
             return {
                 positions: (parsed.positions && typeof parsed.positions === 'object') ? parsed.positions : {},
                 offsetX: typeof parsed.offsetX === 'number' ? parsed.offsetX : 0,
-                offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0
+                offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0,
+                scale: typeof parsed.scale === 'number' ? parsed.scale : 1
             };
         } catch (e) {
-            return { positions: {}, offsetX: 0, offsetY: 0 };
+            return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
         }
     }
 
@@ -58,6 +60,7 @@ function loadStoredLayout() {
     const viewportState = {
         offsetX: storedLayout.offsetX,
         offsetY: storedLayout.offsetY,
+        scale: storedLayout.scale || 1,
         initialized: false,
         isPanning: false,
         startX: 0,
@@ -104,7 +107,11 @@ function loadStoredLayout() {
     }
 
     function calcPosition(mem) {
-        return window.EditorCanvasGeometry.calcPosition(mem, viewportState, getWorldPosition);
+        const world = getWorldPosition(mem);
+        if (typeof canvasViewport.projectWorldPosition === 'function') {
+            return canvasViewport.projectWorldPosition(world, viewportState);
+        }
+        return { x: world.x + viewportState.offsetX, y: world.y + viewportState.offsetY };
     }
 
     function persistStoredPositions() {
@@ -118,7 +125,8 @@ function loadStoredLayout() {
             localStorage.setItem(layoutStorageKey, JSON.stringify({
                 positions: viewportState.positions,
                 offsetX: viewportState.offsetX,
-                offsetY: viewportState.offsetY
+                offsetY: viewportState.offsetY,
+                scale: viewportState.scale || 1
             }));
         } catch (e) {}
     }
@@ -324,6 +332,8 @@ function isNodeWithinSafeViewport(pos) {
     function applyNodePosition(nodeEl, pos, mem) {
         nodeEl.style.left = `${pos.x - NODE_HALF}px`;
         nodeEl.style.top = `${pos.y - NODE_HALF}px`;
+        nodeEl.style.transform = `scale(${viewportState.scale || 1})`;
+        nodeEl.style.transformOrigin = 'center center';
         nodeEl.style.animationDelay = mem.delay || '0s';
     }
 
@@ -469,6 +479,7 @@ function isNodeWithinSafeViewport(pos) {
                 initCanvas,
                 reapplySelection
             });
+            persistStoredPositions();
             return;
         }
 
@@ -479,10 +490,12 @@ function isNodeWithinSafeViewport(pos) {
 
         const world = getWorldPosition(target);
         const metrics = getMetrics();
-        viewportState.offsetX = Math.round(metrics.width * 0.5 - world.x);
-        viewportState.offsetY = Math.round(metrics.height * 0.38 - world.y);
+        const scale = viewportState.scale || 1;
+        viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
+        viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
         initCanvas();
         reapplySelection(nodeId);
+        persistStoredPositions();
     }
 
     function recenterViewport() {
@@ -494,6 +507,7 @@ function isNodeWithinSafeViewport(pos) {
                 viewportState,
                 initCanvas
             });
+            persistStoredPositions();
             return;
         }
 
@@ -501,7 +515,9 @@ function isNodeWithinSafeViewport(pos) {
         if (!treeMemories.length) {
             viewportState.offsetX = 0;
             viewportState.offsetY = 0;
+            viewportState.scale = 1;
             initCanvas();
+            persistStoredPositions();
             return;
         }
 
@@ -515,6 +531,7 @@ function isNodeWithinSafeViewport(pos) {
         viewportState.offsetX = Math.round(metrics.width * 0.5 - ((minX + maxX) / 2));
         viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
         initCanvas();
+        persistStoredPositions();
     }
 
     function bindViewportControls() {
@@ -522,7 +539,8 @@ function isNodeWithinSafeViewport(pos) {
             canvasViewport.bindControls({
                 viewportState,
                 focusNodeById,
-                recenterViewport
+                recenterViewport,
+                zoomBy
             });
             return;
         }
@@ -547,6 +565,27 @@ function isNodeWithinSafeViewport(pos) {
                 recenterViewport();
             });
         }
+    }
+
+    function zoomBy(factor) {
+        if (!factor || factor === 1) return;
+        const metrics = getMetrics();
+        const oldScale = viewportState.scale || 1;
+        const minScale = typeof canvasViewport.minScale === 'number' ? canvasViewport.minScale : 0.65;
+        const maxScale = typeof canvasViewport.maxScale === 'number' ? canvasViewport.maxScale : 1.55;
+        const nextScale = Math.min(maxScale, Math.max(minScale, oldScale * factor));
+        if (Math.abs(nextScale - oldScale) < 0.001) return;
+
+        const centerX = metrics.width * 0.5;
+        const centerY = metrics.height * 0.5;
+        const centerWorldX = (centerX - viewportState.offsetX) / oldScale;
+        const centerWorldY = (centerY - viewportState.offsetY) / oldScale;
+
+        viewportState.scale = nextScale;
+        viewportState.offsetX = Math.round(centerX - (centerWorldX * nextScale));
+        viewportState.offsetY = Math.round(centerY - (centerWorldY * nextScale));
+        persistStoredPositions();
+        initCanvas();
     }
 
     const bindCanvasPan = () => {
@@ -597,7 +636,8 @@ function scheduleInitCanvas() {
         viewportState,
         focusNodeById,
         recenterViewport,
-        keepSelectionVisible
+        keepSelectionVisible,
+        zoomBy
     };
 }
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -67,10 +67,20 @@
                     <h2>순간을 이어가는 중</h2>
                     <p class="editor-canvas-caption">좋아하는 순간들이 가지 위에 천천히 붙어가는 작업 공간입니다.</p>
                 </div>
-                <div class="editor-canvas-toolbar">
-                    <button type="button" class="sidebar-btn" id="recenterCanvasBtn">
-                        <span class="btn-icon">⌂</span>
-                        <span class="btn-label" id="recenterCanvasBtnLabel">트리 한눈에 보기</span>
+                <div class="editor-canvas-toolbar" role="toolbar" aria-label="트리 화면 조정">
+                    <button type="button" class="editor-canvas-tool-btn" id="zoomOutCanvasBtn" aria-label="축소" title="축소">
+                        <span class="material-symbols-outlined" aria-hidden="true">zoom_out</span>
+                    </button>
+                    <button type="button" class="editor-canvas-tool-btn" id="zoomInCanvasBtn" aria-label="확대" title="확대">
+                        <span class="material-symbols-outlined" aria-hidden="true">zoom_in</span>
+                    </button>
+                    <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="recenterCanvasBtn" aria-label="트리 한눈에 보기" title="트리 한눈에 보기">
+                        <span class="material-symbols-outlined" aria-hidden="true">fit_screen</span>
+                        <span class="editor-canvas-tool-label" id="recenterCanvasBtnLabel">트리 한눈에 보기</span>
+                    </button>
+                    <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="focusSelectedBtn" aria-label="선택한 순간 보기" title="선택한 순간 보기" disabled>
+                        <span class="material-symbols-outlined" aria-hidden="true">center_focus_strong</span>
+                        <span class="editor-canvas-tool-label" id="focusSelectedBtnLabel">선택한 순간 보기</span>
                     </button>
                 </div>
             </div>
@@ -242,17 +252,17 @@
     <script src="../js/utils/media.js?v=20260418-1"></script>
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
     <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
-    <script src="../js/editor/editor-canvas-layout.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
-    <script src="../js/editor/editor-canvas-interaction.js?v=20260421-1"></script>
-    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-canvas-viewport.js?v=20260504-651"></script>
+    <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-viewport.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-canvas.js?v=20260504-651"></script>
+    <script src="../js/editor/editor-canvas.js?v=20260507-655"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>

--- a/tests/contracts/editor-viewport-controls-contract.test.js
+++ b/tests/contracts/editor-viewport-controls-contract.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+test('editor page mounts viewport control buttons with accessible labels', () => {
+  const html = read('pages/editor.html');
+
+  for (const id of [
+    'zoomOutCanvasBtn',
+    'zoomInCanvasBtn',
+    'recenterCanvasBtn',
+    'focusSelectedBtn',
+  ]) {
+    assert.match(html, new RegExp(`id=["']${id}["']`), `${id} must be mounted in editor toolbar`);
+  }
+
+  assert.match(html, /role=["']toolbar["']/, 'canvas controls must expose toolbar semantics');
+  assert.match(html, /aria-label=["']축소["']/, 'zoom out must have an accessible label');
+  assert.match(html, /aria-label=["']확대["']/, 'zoom in must have an accessible label');
+  assert.match(html, /aria-label=["']트리 한눈에 보기["']/, 'fit whole tree must have an accessible label');
+  assert.match(html, /aria-label=["']선택한 순간 보기["']/, 'focus selected moment must have an accessible label');
+});
+
+test('editor canvas viewport module owns zoom, fit, and focus math', () => {
+  const source = read('js/editor/editor-canvas-viewport.js');
+
+  assert.match(source, /minScale:\s*0\.65/, 'viewport must bound zoom-out scale');
+  assert.match(source, /maxScale:\s*1\.55/, 'viewport must bound zoom-in scale');
+  assert.match(source, /zoomStep:\s*1\.18/, 'viewport must define a stable zoom step');
+  assert.match(source, /projectWorldPosition\s*\(/, 'viewport must project world positions through scale and offset');
+  assert.match(source, /getFitViewport\s*\(/, 'viewport must compute fit-whole-tree state');
+  assert.match(source, /focusNodeById\s*\(/, 'viewport must preserve selected/current moment focus');
+  assert.match(source, /zoomBy\(this\.zoomStep\)/, 'zoom in control must delegate to zoomBy');
+  assert.match(source, /zoomBy\(1 \/ this\.zoomStep\)/, 'zoom out control must delegate to zoomBy');
+});
+
+test('editor canvas persists scale and keeps node dragging scale-aware', () => {
+  const canvas = read('js/editor/editor-canvas.js');
+  const layout = read('js/editor/editor-canvas-layout.js');
+  const interaction = read('js/editor/editor-canvas-interaction.js');
+  const fallbackInteraction = read('js/editor/editor-canvas-interaction-helpers.js');
+
+  assert.match(canvas, /scale:\s*storedLayout\.scale \|\| 1/, 'canvas state must initialize viewport scale');
+  assert.match(canvas, /projectWorldPosition\(world,\s*viewportState\)/, 'canvas must render through viewport projection');
+  assert.match(canvas, /nodeEl\.style\.transform = `scale\(\$\{viewportState\.scale \|\| 1\}\)`/, 'node cards must visually scale with viewport');
+  assert.match(canvas, /function\s+zoomBy\s*\(factor\)/, 'canvas must expose zoom action');
+  assert.match(canvas, /persistStoredPositions\(\)/, 'viewport control changes must persist safely');
+  assert.match(layout, /scale:\s*typeof parsed\.scale === 'number' \? parsed\.scale : 1/, 'layout store must read persisted scale defensively');
+  assert.match(layout, /scale:\s*viewportState\.scale \|\| 1/, 'layout store must persist viewport scale');
+  assert.match(interaction, /dx \/ scale/, 'primary node drag must account for zoom scale');
+  assert.match(fallbackInteraction, /dx \/ scale/, 'fallback node drag must account for zoom scale');
+});
+
+test('editor viewport controls stay scoped away from branch slot implementation', () => {
+  const html = read('pages/editor.html');
+  const canvas = read('js/editor/editor-canvas.js');
+  const viewport = read('js/editor/editor-canvas-viewport.js');
+
+  assert.doesNotMatch(`${html}\n${canvas}\n${viewport}`, /branch slot|branchSlot|slot affordance/i);
+});


### PR DESCRIPTION
## Summary
- Added Editor tree viewport controls for zoom in, zoom out, fit whole tree, and focus selected moment.
- Extended canvas viewport state with bounded scale, fit math, persisted viewport scale, and scale-aware node dragging.
- Added contract coverage for toolbar mount, accessible labels, viewport math ownership, and non-goal scope.

## Scope
- Editor canvas viewport/control runtime files only.
- Editor toolbar CSS and `pages/editor.html` control mount/cache keys.
- Contract test for viewport control behavior and scope.

## Non-goals
- #653 branch slot UX is not implemented.
- Moment selection, editing, save, visibility controls, Auth, API, Detail, My Trees, Modal, backend, and DB behavior are not changed.

## Verification
- git diff --check: PASS
- node --check changed JS files: PASS
- npm test: PASS
- npm run verify: PASS

## Required browser verification
- fixed slot + deployed SHA match required
- logged-in account required
- tree with multiple moments required
- zoom in/out works
- fit whole tree works
- focus selected/current moment works
- controls do not interfere with moment selection/editing
- desktop screenshot required
- mobile 375 screenshot required
- no horizontal overflow
- fatal console errors: NO
- private data exposure: NO

Secret/private exposure: NO

Refs #655
Refs #681