### PR TITLE
refactor(auth): thin bootstrap compatibility boundary

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -176,38 +176,24 @@ function setupLoginPageAuthUi() {
 
 // ── Auth Ready Callbacks (배열 패턴) ─────────────────────────────────────────
 // 여러 모듈이 등록해도 덮어쓰기 문제 없음
-window.__onAuthReadyCallbacks = window.__onAuthReadyCallbacks || [];
 var __authCallbacksModule = window.LoveBudAuthCallbacks || null;
+var __authReadyCallbackBridge = __authCallbacksModule.createAuthReadyCallbackBridge({
+  authReadyFlagKey: AUTH_READY_FLAG
+});
 
 /**
  * 인증 준비 후 실행할 콜백 등록
  * @param {Function} callback - user 객체를 받는 콜백 함수
  */
 window.registerOnAuthReady = function(callback) {
-  if (__authCallbacksModule) {
-    __authCallbacksModule.registerOnAuthReady(callback, AUTH_READY_FLAG);
-    return;
-  }
-  if (typeof callback !== 'function') return;
-  window.__onAuthReadyCallbacks.push(callback);
-  if (window[AUTH_READY_FLAG]) {
-    var user = window.__lastAuthUser || null;
-    try { callback(user); } catch (e) { console.error('[auth] Callback error:', e); }
-  }
+  __authReadyCallbackBridge.registerOnAuthReady(callback);
 };
 
 /**
  * 모든 등록된 콜백 실행 (auth.js 내부 사용)
  */
 function fireAuthReadyCallbacks(user) {
-  if (__authCallbacksModule) {
-    __authCallbacksModule.fireAuthReadyCallbacks(user);
-    return;
-  }
-  window.__lastAuthUser = user;
-  window.__onAuthReadyCallbacks.forEach(function(callback) {
-    try { callback(user); } catch (e) { console.error('[auth] Callback error:', e); }
-  });
+  __authReadyCallbackBridge.fireAuthReadyCallbacks(user);
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/js/auth/auth-callbacks.js
+++ b/js/auth/auth-callbacks.js
@@ -32,8 +32,21 @@
     });
   }
 
+  function createAuthReadyCallbackBridge(options) {
+    options = options || {};
+    var authReadyFlagKey = options.authReadyFlagKey;
+
+    return {
+      registerOnAuthReady: function (callback) {
+        registerOnAuthReady(callback, authReadyFlagKey);
+      },
+      fireAuthReadyCallbacks: fireAuthReadyCallbacks,
+    };
+  }
+
   window.LoveBudAuthCallbacks = {
     registerOnAuthReady: registerOnAuthReady,
     fireAuthReadyCallbacks: fireAuthReadyCallbacks,
+    createAuthReadyCallbackBridge: createAuthReadyCallbackBridge,
   };
 })();

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -144,6 +144,8 @@ test('shared header keeps optional/idempotent initAuth handoff after dynamic aut
 
 test('root auth bootstrap exposes compatibility window APIs and flags', () => {
   const source = readRepoFile('js/auth.js');
+  const callbacksSource = readRepoFile('js/auth/auth-callbacks.js');
+  const compatibilitySource = `${source}\n${callbacksSource}`;
 
   const contracts = [
     { label: 'window.initAuth', needles: ['window.initAuth'] },
@@ -158,8 +160,24 @@ test('root auth bootstrap exposes compatibility window APIs and flags', () => {
   ];
 
   for (const contract of contracts) {
-    assertIncludesAny(source, contract.label, contract.needles);
+    assertIncludesAny(compatibilitySource, contract.label, contract.needles);
   }
+
+  assert.match(
+    callbacksSource,
+    /createAuthReadyCallbackBridge/,
+    'auth callbacks helper must expose the auth-ready compatibility bridge'
+  );
+  assert.match(
+    source,
+    /createAuthReadyCallbackBridge\s*\(/,
+    'root auth must create the auth-ready callback bridge from LoveBudAuthCallbacks'
+  );
+  assert.match(
+    source,
+    /window\.registerOnAuthReady\s*=\s*function\s*\(callback\)\s*\{[\s\S]*__authReadyCallbackBridge\.registerOnAuthReady\(callback\)/,
+    'root auth must keep the public registerOnAuthReady export delegated through the bridge'
+  );
 });
 
 test('root auth delegates login page helpers through method-aware provider selection', () => {


### PR DESCRIPTION
## Summary
- Moved auth-ready callback compatibility wiring behind `LoveBudAuthCallbacks.createAuthReadyCallbackBridge`.
- Kept `js/auth.js` as the root browser-global bootstrap while thinning callback registry responsibility.
- Added contract coverage that the public `window.registerOnAuthReady` export remains delegated and compatibility flags remain represented.

## Scope
- `js/auth.js`
- `js/auth/auth-callbacks.js`
- `tests/contracts/auth-bootstrap-contract.test.js`

## Behavior preserved
- Browser-global script structure preserved.
- Existing `window.*` Auth exports preserved.
- `DOMContentLoaded -> initAuth` preserved.
- Auth cache keys preserved: `lovebud_auth_cache`, `lovebud_auth_confirmed`, `lovebud_auth_token`.
- Login/signup mode, Firebase provider, protected-route policy, API token behavior, and logout cache clear behavior unchanged.

## Changed files
- `js/auth.js`
- `js/auth/auth-callbacks.js`
- `tests/contracts/auth-bootstrap-contract.test.js`

## Validation
- git diff --check: PASS
- node --check js/auth.js: PASS
- node --check js/auth/auth-callbacks.js: PASS
- npm test: PASS
- npm run verify: PASS
- local smoke: NOT_RUN

## Required fixed-slot browser verification
- fixed slot or Cloudflare preview deployed SHA match required
- Login page opens in login mode.
- Login page opens in signup mode.
- Email login/signup flow remains wired.
- Google login button remains wired.
- Logged-out protected pages redirect/block as before.
- Logged-in navigation/header auth state renders.
- Logout clears confirmed auth state and redirects as before.
- My Trees protected load still works after login.
- Editor protected load still works after login.
- Browser console has no new fatal errors.
- No credential/private/raw payload exposure.

## Guardrails
- Auth behavior changed: NO
- Firebase config changed: NO
- token/cache key changed: NO
- protected-route policy changed: NO
- API path/payload changed: NO
- Login UX/copy changed: NO
- Search/Browse touched: NO
- Editor UI touched: NO
- My Trees UI touched: NO
- PR #7 and prototype/reference/demo/variant untouched.
- Secret/private exposure: NO

Refs #705
Refs #656