### PR TITLE
ui(browse): clean feed loading controls

### DIFF
--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -103,3 +103,9 @@
 .browse-scroll-load-sentinel.is-loading .material-symbols-outlined {
     animation: spin 1s linear infinite;
 }
+
+.browse-scroll-load-sentinel.is-idle {
+    min-height: 1px;
+    margin: 0;
+    overflow: hidden;
+}

--- a/js/search/search-controls.js
+++ b/js/search/search-controls.js
@@ -2,6 +2,12 @@
     function createSearchControls({ refs, state, callbacks, ui }) {
         const { searchInput, tagChips } = refs;
         let searchInputTimer = null;
+        const DEFAULT_LIMIT = 6;
+
+        function resetPaginationState() {
+            state.currentLimit = DEFAULT_LIMIT;
+            state.hasMoreTrees = true;
+        }
 
         function bindSearchInput() {
             if (!searchInput) return;
@@ -10,8 +16,10 @@
                 state.currentQuery = event.target.value.trim();
                 if (searchInputTimer) clearTimeout(searchInputTimer);
                 searchInputTimer = setTimeout(() => {
+                    resetPaginationState();
                     callbacks.renderResults(false);
                     callbacks.updateUrlState();
+                    ui?.syncControlsFromState?.();
                 }, 180);
             });
         }
@@ -24,8 +32,10 @@
                     tagChips.forEach(c => c.classList.remove('active'));
                     chip.classList.add('active');
                     state.currentCategory = chip.dataset.category || chip.textContent.trim();
+                    resetPaginationState();
                     callbacks.renderResults(false);
                     callbacks.updateUrlState();
+                    ui?.syncControlsFromState?.();
                 });
             });
         }

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -130,11 +130,11 @@
         const SORT_COPY = {
             latest: {
                 title: () => getSearchCopy('search.resultsHeading', '최근 러브트리', 'Recent LoveTrees'),
-                badge: (count) => getCurrentLocale() === 'en' ? `${count} to start with` : `지금 먼저 볼 ${count}개`
+                badge: () => getCurrentLocale() === 'en' ? 'Continuous feed' : '이어지는 감상'
             },
             popular: {
                 title: () => getCurrentLocale() === 'en' ? 'Popular LoveTrees' : '인기 많은 러브트리',
-                badge: (count) => getCurrentLocale() === 'en' ? `${count} trending now` : `지금 반응 좋은 ${count}개`
+                badge: () => getCurrentLocale() === 'en' ? 'Most connected' : '많이 이어진 감상'
             }
         };
 
@@ -197,24 +197,8 @@
             if (refs.resultsBadge) {
                 refs.resultsBadge.innerHTML = `
                     <span class="material-symbols-outlined" style="font-size:15px;">auto_awesome</span>
-                    ${copy.badge(Math.min(state.currentLimit, 60))}
+                    ${copy.badge()}
                 `;
-            }
-            const loadMoreBtn = document.getElementById('browseLoadMoreBtn');
-            if (loadMoreBtn) {
-                const shouldDisable = !state.apiTreesLoaded || state.currentLimit >= 60 || !state.hasMoreTrees || state.isLoadingMore;
-                loadMoreBtn.disabled = shouldDisable;
-
-                if (state.isLoadingMore) {
-                    loadMoreBtn.innerHTML = `
-                        <span class="material-symbols-outlined" style="animation: spin 1s linear infinite;">progress_activity</span>
-                        ${getCurrentLocale() === 'en' ? 'Loading...' : '로딩 중...'}
-                    `;
-                } else {
-                    loadMoreBtn.textContent = state.currentLimit >= 60
-                        ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
-                        : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
-                }
             }
         }
 
@@ -248,25 +232,6 @@
                 chip.classList.toggle('active', chip.dataset.browseSort === state.currentSort);
             });
 
-            const loadMoreBtn = controls.querySelector('#browseLoadMoreBtn');
-            if (loadMoreBtn) {
-                const shouldHide = state.currentLimit >= 60 || !state.hasMoreTrees;
-                loadMoreBtn.style.display = shouldHide ? 'none' : 'inline-flex';
-
-                // Update button text and state for loading
-                if (state.isLoadingMore) {
-                    loadMoreBtn.disabled = true;
-                    loadMoreBtn.innerHTML = `
-                        <span class="material-symbols-outlined" style="animation: spin 1s linear infinite;">progress_activity</span>
-                        ${getCurrentLocale() === 'en' ? 'Loading...' : '로딩 중...'}
-                    `;
-                } else {
-                    loadMoreBtn.disabled = !state.apiTreesLoaded;
-                    loadMoreBtn.textContent = state.currentLimit >= 60
-                        ? (getCurrentLocale() === 'en' ? 'Max 60' : '최대 60개')
-                        : (getCurrentLocale() === 'en' ? 'Load more' : '더 보기');
-                }
-            }
             syncScrollLoadSentinel();
         }
 
@@ -287,13 +252,19 @@
             const isDone = !state.apiTreesLoaded || state.currentLimit >= 60 || !state.hasMoreTrees;
             scrollLoadSentinel.hidden = isDone;
             scrollLoadSentinel.classList.toggle('is-loading', Boolean(state.isLoadingMore));
+            scrollLoadSentinel.classList.toggle('is-idle', !state.isLoadingMore);
             scrollLoadSentinel.setAttribute('aria-hidden', isDone ? 'true' : 'false');
+
+            const icon = scrollLoadSentinel.querySelector('.material-symbols-outlined');
+            if (icon) {
+                icon.hidden = !state.isLoadingMore;
+            }
 
             const text = scrollLoadSentinel.querySelector('[data-scroll-load-label]');
             if (!text) return;
             text.textContent = state.isLoadingMore
                 ? 'Loading more LoveTrees...'
-                : 'More LoveTrees will appear as you scroll.';
+                : '';
         }
 
         function isSentinelNearViewport() {
@@ -400,7 +371,6 @@
                     <button type="button" class="tag-chip" data-browse-sort="latest">${getCurrentLocale() === 'en' ? 'Latest' : '최신순'}</button>
                     <button type="button" class="tag-chip" data-browse-sort="popular">${getCurrentLocale() === 'en' ? 'Popular' : '많은 순간순'}</button>
                 </div>
-                <button type="button" id="browseLoadMoreBtn" class="tag-chip">${getCurrentLocale() === 'en' ? 'Load more' : '더 보기'}</button>
             `;
 
             let rightGroup = refs.resultsHead.querySelector('.browse-head-right');
@@ -425,14 +395,12 @@
                     const nextSort = button.dataset.browseSort || 'latest';
                     if (nextSort === state.currentSort) return;
                     state.currentSort = nextSort;
+                    state.currentLimit = 6;
+                    state.hasMoreTrees = true;
                     syncControlsFromState();
                     callbacks.updateUrlState();
                     await callbacks.loadPublicTrees({ resetSelection: true });
                 });
-            });
-
-            controls.querySelector('#browseLoadMoreBtn')?.addEventListener('click', async () => {
-                await callbacks.loadMorePublicTrees?.({ source: 'button' });
             });
 
             ensureScrollLoadSentinel();

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -129,12 +129,10 @@
 
         const SORT_COPY = {
             latest: {
-                title: () => getSearchCopy('search.resultsHeading', '최근 러브트리', 'Recent LoveTrees'),
-                badge: () => getCurrentLocale() === 'en' ? 'Continuous feed' : '이어지는 감상'
+                title: () => getSearchCopy('search.resultsHeading', '최근 러브트리', 'Recent LoveTrees')
             },
             popular: {
-                title: () => getCurrentLocale() === 'en' ? 'Popular LoveTrees' : '인기 많은 러브트리',
-                badge: () => getCurrentLocale() === 'en' ? 'Most connected' : '많이 이어진 감상'
+                title: () => getCurrentLocale() === 'en' ? 'Popular LoveTrees' : '인기 많은 러브트리'
             }
         };
 
@@ -195,10 +193,8 @@
                 refs.resultsTitle.textContent = typeof copy.title === 'function' ? copy.title() : copy.title;
             }
             if (refs.resultsBadge) {
-                refs.resultsBadge.innerHTML = `
-                    <span class="material-symbols-outlined" style="font-size:15px;">auto_awesome</span>
-                    ${copy.badge()}
-                `;
+                refs.resultsBadge.hidden = true;
+                refs.resultsBadge.textContent = '';
             }
         }
 

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -64,8 +64,11 @@ test('browse feed controls do not expose batch strategy as product UI', () => {
   const uiModule = read('js/search/search-ui.js');
 
   assert.doesNotMatch(uiModule, /지금 먼저 볼|to start with|More LoveTrees will appear as you scroll/);
+  assert.doesNotMatch(uiModule, /이어지는 감상|Continuous feed|많이 이어진 감상|Most connected/);
   assert.doesNotMatch(uiModule, /id=["']browseLoadMoreBtn["']/);
   assert.doesNotMatch(uiModule, /getElementById\(['"]browseLoadMoreBtn['"]\)/);
+  assert.match(uiModule, /refs\.resultsBadge\.hidden = true/);
+  assert.match(uiModule, /refs\.resultsBadge\.textContent = ''/);
   assert.match(uiModule, /browseScrollLoadSentinel/);
   assert.match(uiModule, /callbacks\.loadMorePublicTrees/);
 });

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -60,6 +60,28 @@ test('search UI module preserves orchestrator contract methods', () => {
   }
 });
 
+test('browse feed controls do not expose batch strategy as product UI', () => {
+  const uiModule = read('js/search/search-ui.js');
+
+  assert.doesNotMatch(uiModule, /지금 먼저 볼|to start with|More LoveTrees will appear as you scroll/);
+  assert.doesNotMatch(uiModule, /id=["']browseLoadMoreBtn["']/);
+  assert.doesNotMatch(uiModule, /getElementById\(['"]browseLoadMoreBtn['"]\)/);
+  assert.match(uiModule, /browseScrollLoadSentinel/);
+  assert.match(uiModule, /callbacks\.loadMorePublicTrees/);
+});
+
+test('browse filter and sort changes reset pagination state without changing feed cards', () => {
+  const uiModule = read('js/search/search-ui.js');
+  const controlsModule = read('js/search/search-controls.js');
+
+  assert.match(controlsModule, /const DEFAULT_LIMIT = 6/);
+  assert.match(controlsModule, /function resetPaginationState\(\)/);
+  assert.match(controlsModule, /state\.currentLimit = DEFAULT_LIMIT/);
+  assert.match(controlsModule, /state\.hasMoreTrees = true/);
+  assert.match(uiModule, /state\.currentLimit = 6/);
+  assert.match(uiModule, /state\.hasMoreTrees = true/);
+});
+
 test('search UI module implements card accessibility and event delegation', () => {
   const uiModule = read('js/search/search-ui.js');
   


### PR DESCRIPTION
## Summary
- Removed the top-level peer-style Browse load-more button from the sort controls row.
- Removed first-batch count copy from the Browse results badge.
- Kept existing scroll-near-bottom loading as the continuation path and hid idle scroll-loading copy.
- Reset Browse pagination state when search, filter, or sort changes.

## Current behavior found
- Initial visible count is 6 via `state.currentLimit` and Search URL default limit.
- `더 보기` was not the only load-more path: scroll-near-bottom loading already existed through `browseScrollLoadSentinel` and `callbacks.loadMorePublicTrees`.
- The top-level `더 보기` button called the same load-more path as a manual fallback but appeared as a peer sort chip.
- The first-batch badge exposed the internal batch count through `지금 먼저 볼 6개` / `6 to start with`.
- The bottom sentinel exposed duplicate idle copy: `More LoveTrees will appear as you scroll.`

## Final interaction model
- Browse presents one continuous result feed.
- Sort controls remain limited to `최신순` and `많은 순간순`.
- Additional cards continue loading through the existing scroll-near-bottom sentinel.
- The sentinel shows a loading state only while more cards are being fetched.
- Search, filter, and sort changes reset pagination state safely.

## Changed files
- `js/search/search-ui.js`
- `js/search/search-controls.js`
- `css/search/controls.css`
- `tests/routes/search-runtime-modules.test.js`

## Verification
- `git diff --check`: PASS
- `node --check js/search/search-ui.js`: PASS
- `node --check js/search/search-controls.js`: PASS
- `node --test tests/routes/search-runtime-modules.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Required browser verification
- Cloudflare Preview or fixed slot with deployed SHA match required before ready/merge.
- Browser verification: REQUIRED_NOT_RUN
- Login required: NO
- Browse loads.
- Initial cards render.
- `지금 먼저 볼 6개` is not exposed.
- `더 보기` is not exposed as a top-level sort/filter peer control.
- Additional cards can still load.
- `최신순` / `많은 순간순` work.
- Search/filter work.
- Duplicate cards: NO
- Fatal console errors: NO
- Desktop screenshot required.
- Mobile 375px screenshot required.
- Horizontal overflow: NO
- Secret/private exposure: NO

Secret/private exposure: NO

Refs #606
Refs #596
Refs #598
Refs #607
Refs #456
