### PR TITLE
ui(browse): align heading with Home brand system

### DIFF
--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -9,9 +9,21 @@
   'use strict';
 
   window.i18nSearch = {
+    'search.eyebrow': {
+      ko: '오늘의 공개 감상',
+      en: 'Today\'s Public Picks'
+    },
     'search.title': {
       ko: '러브트리를 둘러보세요',
       en: 'Browse LoveTree moments'
+    },
+    'search.titleBrand': {
+      ko: '러브트리',
+      en: 'LoveTrees'
+    },
+    'search.titleAction': {
+      ko: '를 둘러보세요',
+      en: ' to browse'
     },
     'search.subtitle': {
       ko: '첫 순간과 이어진 마음을 따라가 보세요',

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -9,8 +9,13 @@
   'use strict';
 
   window.i18nSearch = {
+    'search.eyebrow': {
+      ko: 'BROWSE',
+      en: 'BROWSE'
+    },
+
     'search.title': {
-      ko: '러브트리 감상 둘러보기',
+      ko: '러브트리를 둘러보세요',
       en: 'Browse LoveTree moments'
     },
     'search.subtitle': {

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -9,11 +9,6 @@
   'use strict';
 
   window.i18nSearch = {
-    'search.eyebrow': {
-      ko: 'BROWSE',
-      en: 'BROWSE'
-    },
-
     'search.title': {
       ko: '러브트리를 둘러보세요',
       en: 'Browse LoveTree moments'

--- a/pages/search.html
+++ b/pages/search.html
@@ -22,7 +22,7 @@
             <div class="browse-curation-shell reveal-up">
                 <div class="search-panel-header">
                     <div class="browse-eyebrow" data-i18n="search.eyebrow">BROWSE</div>
-                    <h2 class="headline" data-i18n="search.title"><span class="brand-emphasis">러브트리</span>를 둘러보세요</h2>
+                    <h2 class="headline"><span class="brand-emphasis" data-i18n="search.titleBrand">러브트리</span><span data-i18n="search.titleAction">를 둘러보세요</span></h2>
                     <p data-i18n="search.subtitle">첫 순간과 이어진 마음을 따라가 보세요</p>
                 </div>
             </div>

--- a/pages/search.html
+++ b/pages/search.html
@@ -21,7 +21,8 @@
         <section>
             <div class="browse-curation-shell reveal-up">
                 <div class="search-panel-header">
-                    <h2 class="headline" data-i18n="search.title">러브트리 감상 둘러보기</h2>
+                    <div class="browse-eyebrow" data-i18n="search.eyebrow">BROWSE</div>
+                    <h2 class="headline" data-i18n="search.title">러브트리를 <span class="brand-emphasis">둘러보세요</span></h2>
                     <p data-i18n="search.subtitle">첫 순간과 이어진 마음을 따라가 보세요</p>
                 </div>
             </div>

--- a/pages/search.html
+++ b/pages/search.html
@@ -22,7 +22,7 @@
             <div class="browse-curation-shell reveal-up">
                 <div class="search-panel-header">
                     <div class="browse-eyebrow" data-i18n="search.eyebrow">BROWSE</div>
-                    <h2 class="headline" data-i18n="search.title">러브트리를 <span class="brand-emphasis">둘러보세요</span></h2>
+                    <h2 class="headline" data-i18n="search.title"><span class="brand-emphasis">러브트리</span>를 둘러보세요</h2>
                     <p data-i18n="search.subtitle">첫 순간과 이어진 마음을 따라가 보세요</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Align Browse page heading with Home hero brand system. Shorten heading, preserve the 러브트리 emphasis span, and add the Browse eyebrow copy through the i18n dictionary.

## Changes
- Heading shortened: 러브트리 감상 둘러보기 -> 러브트리를 둘러보세요
- 러브트리 remains the emphasized brand target in the heading markup
- 둘러보세요 remains warm base text outside the emphasis span
- Added the missing `search.eyebrow` i18n key required by CI
- Split heading i18n into `search.titleBrand` and `search.titleAction` so runtime i18n does not overwrite the emphasis markup

## Scope
- js/i18n/i18n-search.js
- pages/search.html

## CI failure fix
- GitHub CI failed in `npm run verify` because `pages/search.html` referenced `data-i18n="search.eyebrow"` without a matching dictionary key.
- Added the missing key and kept the heading markup from being replaced by full-H2 i18n text.

## Verification
- git diff --check: PASS
- UTF-8 strict/BOM check for changed files: PASS
- node --check js/i18n/i18n-search.js: PASS
- node --test tests/routes/search-runtime-modules.test.js tests/smoke/routes.test.js: PASS
- npm test: PASS, 221/221
- npm run verify: PASS, 147/147

## Required UI review
Cloudflare Preview or fixed slot deployment required before merge.
Final visual judgment is CTO/UI Lead responsibility.

Refs #903
Refs #597
Refs #455
Refs #239
Refs #681
