### PR TITLE
ui(browse): improve mobile controls and selection affordance

### DIFF
--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -105,7 +105,54 @@
 }
 
 .browse-scroll-load-sentinel.is-idle {
-    min-height: 1px;
+    min-height: 0;
     margin: 0;
+    padding: 0;
+    border: 0;
     overflow: hidden;
+    visibility: hidden;
+    opacity: 0;
+}
+
+/* Issue #911: Mobile filter density reduction */
+@media (max-width: 480px) {
+    .filter-row {
+        gap: 6px;
+        justify-content: flex-start;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        padding-bottom: 4px;
+    }
+
+    .filter-row::-webkit-scrollbar {
+        display: none;
+    }
+
+    .tag-chip {
+        padding: 6px 10px;
+        font-size: 11px;
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
+    .browse-utility-row {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .search-input-wrapper {
+        flex: 1 1 100%;
+        max-width: 100%;
+    }
+
+    .search-input {
+        padding: 12px 14px 12px 40px;
+        font-size: 0.9rem;
+    }
+
+    .search-icon {
+        left: 12px;
+        font-size: 18px;
+    }
 }

--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -106,6 +106,7 @@
 
 .browse-scroll-load-sentinel.is-idle {
     min-height: 0;
+    height: 0;
     margin: 0;
     padding: 0;
     border: 0;

--- a/css/search/hero-controls.css
+++ b/css/search/hero-controls.css
@@ -98,3 +98,30 @@
     white-space: nowrap;
     box-shadow: 0 8px 18px rgba(75,64,57,0.03);
 }
+
+/* Issue #911: Mobile sort hierarchy improvement */
+@media (max-width: 480px) {
+    .browse-results-head {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .browse-head-right {
+        align-self: flex-end;
+        width: 100%;
+    }
+
+    .browse-results-head h3 {
+        font-size: 1.4rem;
+    }
+
+    #browseSortControls {
+        justify-content: flex-start;
+    }
+
+    #browseSortControls .tag-chip {
+        padding: 5px 10px;
+        font-size: 11px;
+    }
+}

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -221,6 +221,10 @@
       ko: '감상 열기',
       en: 'Open viewing'
     },
+    'search.previewOpenTreeCta': {
+      ko: '트리 열기',
+      en: 'Open tree'
+    },
     'search.previewSummaryThemeStart': {
       ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 러브트리예요.',
       en: '<strong style="color:var(--on-surface);">{title}</strong> has just begun with <strong style="color:var(--on-surface);">{theme}</strong>.'

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -210,6 +210,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         ui.syncActiveCard();
 
         const selectedTree = previewController.getSelectedTreeFromFiltered(filtered);
+
+        if (!state.selectedTreeId && resetPreviewWhenNoSelection && filtered.length > 0) {
+            const firstTree = filtered[0];
+            const firstCard = findRenderedTreeCard(firstTree.id);
+            previewController.selectTree(firstTree, firstCard);
+            return;
+        }
+
         if (!state.selectedTreeId && resetPreviewWhenNoSelection) {
             ui.clearSelectedPreview();
             return;
@@ -222,6 +230,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else if (!selectedTree && resetPreviewWhenNoSelection) {
             ui.clearSelectedPreview();
         }
+    }
+
+    function findRenderedTreeCard(treeId) {
+        let selector = '';
+        try {
+            selector = `.tree-card[data-tree-id="${CSS.escape(treeId)}"]`;
+        } catch (e) {
+            selector = `.tree-card[data-tree-id="${treeId.replace(/"/g, '\\"')}"]`;
+        }
+
+        const allCardContainers = [refs.resultsList, refs.growingList].filter(Boolean);
+        for (const container of allCardContainers) {
+            const activeCard = container.querySelector(selector);
+            if (activeCard) return activeCard;
+        }
+        return null;
     }
 
 

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -128,12 +128,34 @@
         `;
     }
 
+    /**
+     * Render open tree CTA button (secondary action)
+     * @param {Object} tree - Tree object
+     * @returns {string} Button HTML markup
+     */
+    function renderOpenTreeButton(tree) {
+        if (!tree?.id) return '';
+        const href = `${getBasePath()}detail.html?tree=${encodeURIComponent(tree.id)}`;
+        const label = getSearchCopy(
+            'search.previewOpenTreeCta',
+            '트리 열기',
+            'Open tree'
+        );
+        return `
+            <a href="${escapeHtml(href)}" class="btn-round preview-secondary-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:13px;font-weight:700;gap:6px;background:transparent;color:var(--primary);border:1px solid var(--outline-variant);">
+                <span class="material-symbols-outlined" style="font-size:16px;">account_tree</span>
+                ${escapeHtml(label)}
+            </a>
+        `;
+    }
+
     // Public API
     window.LoveBudSearchPreviewActionHelper = {
         getBasePath: getBasePath,
         getTreeDetailHref: getTreeDetailHref,
         renderPreviewActionButton: renderPreviewActionButton,
-        renderShareButton: renderShareButton
+        renderShareButton: renderShareButton,
+        renderOpenTreeButton: renderOpenTreeButton
     };
 
     console.log('[LoveBudSearchPreviewActionHelper] Search preview action helper loaded v20260501-1');

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -432,6 +432,7 @@
         }
 
         if (_dom.previewDesc) {
+            _dom.previewDesc.hidden = false;
             if (!hasMemories) {
                 const noRecordsLine = formatSearchCopy(
                     'search.previewNoRecordsLine',
@@ -470,6 +471,7 @@
                 const firstMomentLabel = getMomentLabel(firstMem, '시작 순간', 'Starting moment');
                 const lastMomentLabel = getMomentLabel(memories[memories.length - 1], '최근에 남은 순간', 'Latest saved moment');
 
+                _dom.previewDesc.hidden = false;
                 _dom.previewDesc.innerHTML = `
                     <div style="background:var(--surface-container-low);padding:20px;border-radius:1rem;margin-bottom:16px;">
                         ${renderSectionHeading('route', getSearchCopy('search.previewTimelineHeading', '대표 순간에서 이어진 흐름', 'Flow connected from the featured moment'))}

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -129,6 +129,14 @@
         return '';
     }
 
+    function renderOpenTreeButton(tree) {
+        const helper = window.LoveBudSearchPreviewActionHelper;
+        if (helper?.renderOpenTreeButton) {
+            return helper.renderOpenTreeButton(tree);
+        }
+        return '';
+    }
+
     const VISIBLE_FLOW_MOMENT_COUNT = 4;
 
     let _dom = null;
@@ -450,6 +458,7 @@
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '이제 막 감상이 시작될 공개 러브트리예요.', 'This public LoveTree is just about to begin.'))}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderOpenTreeButton(tree)}
                     ${renderShareButton(tree)}
                 `;
             } else {
@@ -477,6 +486,7 @@
                         ${renderInfoCallout('touch_app', getSearchCopy('search.previewJourneyCta', '이곳에서 대표 순간과 이어진 감정을 훑어보고, 마음이 머무는 순간으로 들어가 보세요.', 'Scan the featured moment and connected feelings here, then open the moment that draws you in.'), 'primary')}
                     </div>
                     ${renderPreviewActionButton(tree)}
+                    ${renderOpenTreeButton(tree)}
                     ${renderShareButton(tree)}
                 `;
             }

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -115,7 +115,7 @@ test('search preview summary omits range phrase for missing time range labels', 
   assert.match(i18nSearch, /span style="color:var\(--primary\);font-weight:700;">\{count\}개의 순간<\/span>이 이어졌어요/);
 });
 
-test('browse selected hub primary CTA label matches detail viewing route', () => {
+test('browse selected hub primary and secondary CTA labels match detail viewing routes', () => {
   const actionHelper = read('js/search/search-preview-action-helper.js');
   const previewRenderer = read('js/search/search-preview-renderer.js');
   const i18nSearch = read('js/i18n/i18n-search.js');
@@ -127,9 +127,11 @@ test('browse selected hub primary CTA label matches detail viewing route', () =>
   assert.match(previewRenderer, /return '';/);
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
-  assert.doesNotMatch(actionHelper, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
-  assert.doesNotMatch(previewRenderer, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
-  assert.doesNotMatch(i18nSearch, /이 트리 열기|Open this tree|search\.previewOpenTreeCta/);
+  assert.match(actionHelper, /renderOpenTreeButton/);
+  assert.match(actionHelper, /search\.previewOpenTreeCta/);
+  assert.match(previewRenderer, /renderOpenTreeButton/);
+  assert.match(i18nSearch, /'search\.previewOpenTreeCta'/);
+  assert.match(i18nSearch, /ko:\s*'트리 열기'/);
 
 
 test('browse selected hub share button delegates to action helper', () => {


### PR DESCRIPTION
## Summary
- Defaulted the Browse preview hub to the first available result.
- Added visible mobile card selection affordance / CTA.
- Simplified mobile Browse control density.
- Removed or hid the stray idle marker.
- Preserved #905 continuous feed behavior and #909 selected hub copy cleanup.
- Updated the Browse test contract for the Issue #911 secondary CTA requirement.
- Addressed browser verification blockers for hidden preview CTAs and idle sentinel spacing.

## Changed files
- js/search/index.js: Auto-select first tree on initial load
- js/search/search-preview-action-helper.js: Added renderOpenTreeButton
- js/search/search-preview-renderer.js: Render secondary "트리 열기" CTA and reveal the preview CTA container when tree content is rendered
- js/i18n/i18n-search.js: Added search.previewOpenTreeCta copy
- css/search/controls.css: Mobile filter density + sentinel idle adjustment
- css/search/hero-controls.css: Mobile sort hierarchy improvement
- tests/routes/search-runtime-modules.test.js: Updated Browse secondary CTA contract

## Scope boundaries
- No Auth/API/backend/DB/package/workflow changes.
- No PR #7 impact.
- No prototype/reference/demo/variant changes.
- No PR #909 changes.
- No PR #906 changes.

## Verification
- git diff --check: PASS
- node --check: PASS
- npm test: 223/223 PASS
- npm run verify: 147/147 PASS
- GitHub CI: success

## Browser verification
- Preview: https://4a4831d7.lovebud.pages.dev
- Deployed SHA: 546ae9f
- SHA match: YES
- Mobile 375px: PASS
- Desktop 1440px: PASS
- Mobile secondary CTA visible: PASS
- Idle sentinel collapsed: PASS
- Fatal console errors: NONE

Refs #911