### PR TITLE
docs(product): define vertical tree layout decision

### DIFF
--- a/docs/product/VERTICAL_TREE_LAYOUT_DECISION.md
+++ b/docs/product/VERTICAL_TREE_LAYOUT_DECISION.md
@@ -1,0 +1,193 @@
+# Vertical Tree Layout Decision
+
+Refs #652
+Refs #648
+Refs #923
+
+## Purpose
+
+LoveBud should make the LoveTree visual metaphor feel like an actual tree rather than a horizontal timeline. This document records the product/layout decision for Editor and the future read-only LoveTree viewer.
+
+The selected direction is a vertical tree model: the first/root moment sits closer to the lower/root area, and later connected moments grow upward through visible branches.
+
+## Decision
+
+Use a vertical tree-growth model as the target direction for both:
+
+- owner-side Editor tree layout; and
+- public read-only LoveTree viewer layout.
+
+This does not mean a quick CSS rotation of the current canvas. The implementation should be treated as a layout model and interaction change with its own runtime PRs and browser verification follow-up.
+
+## Product rationale
+
+A LoveTree should communicate growth, branching, and emotional progression. The current horizontal flow can read as a timeline or carousel, especially when moments appear side-by-side.
+
+A vertical tree model better supports the product metaphor:
+
+- the first moment feels like the root or origin;
+- connected memories feel like branches growing out of that root;
+- branch splits are easier to understand as growth paths;
+- later moments can visually rise from earlier moments;
+- the read-only viewer can present a full tree shape rather than a preview card or video-led timeline.
+
+## Target visual model
+
+The intended model is tree-shaped, not just vertically stacked.
+
+Recommended structure:
+
+```text
+           later moment
+          /            \
+   branch moment      branch moment
+          \            /
+        connected moment
+              |
+        first/root moment
+```
+
+The root or first moment should sit near the lower center when possible. Later moments extend upward and outward. Branches should remain legible and should not collapse into a simple one-column list unless the viewport requires a simplified mobile fallback.
+
+## Editor behavior direction
+
+The Editor should eventually use the same vertical growth logic but with owner-only capabilities layered on top.
+
+Allowed Editor capabilities:
+
+- select moment;
+- add next moment;
+- edit title/memo/source where owner-authorized;
+- delete where owner-authorized;
+- focus selected moment;
+- fit-to-view;
+- safe placement or layout adjustment if implemented.
+
+However, vertical layout work must not bundle unrelated editing feature expansion. Add/edit/delete/source controls should remain existing capability surfaces, not layout side effects.
+
+## Read-only viewer behavior direction
+
+The read-only LoveTree viewer should use the vertical model without Editor authority.
+
+Allowed viewer capabilities:
+
+- view public tree structure;
+- select a public moment;
+- inspect selected moment content;
+- follow visible branch relationships;
+- fit or focus the tree;
+- open public-safe moment detail where applicable.
+
+Forbidden viewer capabilities:
+
+- edit;
+- delete;
+- add;
+- drag/reorder;
+- title edit;
+- memo edit;
+- source edit;
+- owner-only diagnostics;
+- hidden Editor fallback controls.
+
+Viewer implementation must not expose `pages/editor.html` as the public viewing surface.
+
+## Desktop layout principles
+
+Desktop should prioritize tree comprehension.
+
+- Root/first moment starts near lower center.
+- Primary connected path rises upward.
+- Branch splits move left/right from parent nodes.
+- Selected node remains visible without losing the whole-tree context.
+- Moment panel can sit to the side or below depending on available width.
+- Fit-to-view should frame the full tree shape.
+- Long trees may require pan/scroll, but the first impression should still read as a tree.
+
+## Mobile layout principles
+
+Mobile should preserve the tree metaphor while avoiding horizontal overflow.
+
+Acceptable mobile adaptations:
+
+- vertical scroll through a simplified tree shape;
+- reduced horizontal branch spread;
+- selected moment panel below the tree;
+- focus-selected or fit-to-view control;
+- collapsed branch spacing when necessary.
+
+Unacceptable mobile adaptations:
+
+- turning the viewer into a plain list without tree relationship cues;
+- requiring precise drag to understand the tree;
+- hiding selected moment context behind ambiguous controls;
+- exposing Editor controls to public users.
+
+## Layout risks to solve in implementation
+
+Vertical layout implementation must account for:
+
+- node overlap;
+- branch density;
+- long trees;
+- sparse trees;
+- mobile 375px width;
+- pan/zoom or scroll behavior;
+- fit-to-view behavior;
+- selected moment focus;
+- keyboard focus order;
+- screenshot-based visual review;
+- public/private visibility boundaries in viewer mode.
+
+## Phased implementation recommendation
+
+Do not convert Editor and viewer in one large PR.
+
+Suggested phases:
+
+1. Read-only viewer route shell and public-safe payload boundary (#923).
+2. Static vertical layout renderer for public-safe moment data.
+3. Viewer node selection and selected-moment panel.
+4. Mobile vertical tree behavior and 375px verification.
+5. Editor vertical layout adoption after viewer model is stable.
+6. Optional owner-only placement refinements or editable branch slots after separate planning (#653).
+
+## Implementation guardrails
+
+- No PR #7 changes.
+- No prototype/reference/demo/variant changes.
+- No backend/schema migration unless a separate issue approves it.
+- No broad Browse redesign.
+- No My Trees redesign.
+- No public Editor exposure.
+- No owner IDs, memory IDs, tree IDs, DB rows, raw payloads, sessions, cookies, tokens, headers, passwords, or private URLs in reports.
+
+## Verification policy
+
+Runtime implementation PRs may merge after code, local verification, CI, scope review, and product-direction review under the current separated verification policy.
+
+Browser verification remains required but should be tracked as a separate post-merge/post-deploy Browser Verification issue.
+
+For vertical layout implementation, browser verification should include:
+
+- deployed SHA match;
+- desktop screenshot;
+- mobile 375px screenshot;
+- tree shape visible;
+- root/first moment lower than connected later moments when data supports it;
+- branch relationships legible;
+- selected moment still usable;
+- no viewer edit/add/delete/source-edit controls;
+- no fatal console errors;
+- no private data exposure.
+
+## Acceptance criteria for #652
+
+This planning decision is complete when:
+
+- the project has selected vertical tree-growth as the target model;
+- the document distinguishes vertical tree shape from a plain vertical list;
+- Editor and viewer capability differences are documented;
+- desktop and mobile layout principles are documented;
+- implementation risks and phased rollout are documented;
+- #923 or later implementation issues can proceed from this decision.

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -10,6 +10,7 @@
 - 전역 UI 카피 운영 기준 정리
 - public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책 정리
 - Browse sort semantics and public discovery language 정리
+- Editor/viewer vertical LoveTree layout decision 정리
 
 ## 파일 목록
 
@@ -20,6 +21,9 @@
 | [PUBLICATION_AND_PRIVACY_UX_POLICY.md](PUBLICATION_AND_PRIVACY_UX_POLICY.md) | public-first visibility, Plus private storage, memory visibility inheritance, anonymous public exposure, Browse/Search eligibility 정책 |
 | [PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md](PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md) | public-by-default 정책과 private entitlement 이전 visibility mismatch를 안전하게 audit/backfill 판단하기 위한 count-only 계획 |
 | [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
+| [READ_ONLY_LOVETREE_VIEWER_PLAN.md](READ_ONLY_LOVETREE_VIEWER_PLAN.md) | read-only LoveTree viewer의 route, public-safe data, viewer/editor separation, interaction, privacy guardrail 계획 |
+| [VERTICAL_TREE_LAYOUT_DECISION.md](VERTICAL_TREE_LAYOUT_DECISION.md) | Editor와 read-only viewer의 세로형 tree-growth layout 채택 결정, desktop/mobile 원칙, phased rollout 기준 |
+| [BROWSE_TREE_FIRST_DISCOVERY_PLAN.md](BROWSE_TREE_FIRST_DISCOVERY_PLAN.md) | Browse를 tree-first public LoveTree discovery로 발전시키기 위한 card/감상허브/viewer route semantics 계획 |
 | [PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md](PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md) | public LoveTree viewer에서 tree-level / moment-level social placeholder 배치 방향, desktop/mobile placement, empty-state copy, write affordance 분리 기준 |
 | [TREE_MOMENT_SOCIAL_MODEL.md](TREE_MOMENT_SOCIAL_MODEL.md) | public LoveTree의 tree-level / moment-level comments, reactions, permissions, moderation, phased implementation 모델 |
 | [TREE_LEVEL_COMMENTS_READ_CONTRACT.md](TREE_LEVEL_COMMENTS_READ_CONTRACT.md) | public LoveTree 전체에 붙는 tree-level comments의 read contract, visibility guard, safe response, empty/error state 기준 |
@@ -56,6 +60,14 @@
 - Browse `popular` sort는 현재 true engagement popularity가 아니라 `publicMemoryCount DESC, createdAt DESC` proxy입니다.
 - private tree 아래 public memory가 가능하더라도 Browse/Search, community memories list, public memory detail read 노출은 parent tree visibility guard를 함께 봅니다.
 - owner/private read는 private access policy에 따라 private tree 아래 public/private memory를 조회할 수 있습니다.
+
+## Read-only viewer highlights
+
+The read-only LoveTree viewer is the planned full-tree public viewing surface. It should use public-safe data, stay separate from Editor authority, and never create edit/delete/drag/add/title-edit/memo-edit/source-edit affordances in viewer mode.
+
+## Vertical tree layout highlights
+
+Editor and read-only viewer layout direction is vertical tree-growth, not a plain vertical list. The first/root moment should sit closer to the lower root area, while later connected moments grow upward through visible branches. Runtime implementation should proceed in phases and use screenshot-based review when visual quality is in scope.
 
 ## Social model highlights
 
@@ -102,23 +114,26 @@ Strong primary CTAs require Ready status and valid runtime verification when Aut
 3. **PUBLICATION_AND_PRIVACY_UX_POLICY.md** — public-first visibility / Plus private storage / anonymous public exposure / Browse/Search eligibility 정책
 4. **PUBLIC_DEFAULT_VISIBILITY_AUDIT_PLAN.md** — public-by-default 정책 alignment와 private entitlement 이전 visibility mismatch audit/backfill gate
 5. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
-6. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
-7. **PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md** — public viewer social placeholder 배치 및 phasing 계획
-8. **TREE_LEVEL_COMMENTS_READ_CONTRACT.md** — tree-level comments read scope, parent-tree guard, public-safe response, empty/error state contract
-9. **MOMENT_LEVEL_COMMENTS_READ_CONTRACT.md** — moment-level comments read scope, parent-tree guard, target-moment guard, public-safe response, empty/error state contract
-10. **V01_CTA_EXPOSURE_POLICY.md** — v0.1 unfinished/partial action 노출 기준과 CTA readiness 분류 정책
-11. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-12. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-13. **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-14. **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-15. **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-16. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-17. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-18. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-19. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-20. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-21. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-22. **필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md**
+6. **READ_ONLY_LOVETREE_VIEWER_PLAN.md** — read-only LoveTree viewer route/data/viewer-editor separation 계획
+7. **VERTICAL_TREE_LAYOUT_DECISION.md** — 세로형 tree-growth layout 채택 결정
+8. **BROWSE_TREE_FIRST_DISCOVERY_PLAN.md** — Browse tree-first discovery와 viewer route semantics 계획
+9. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
+10. **PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md** — public viewer social placeholder 배치 및 phasing 계획
+11. **TREE_LEVEL_COMMENTS_READ_CONTRACT.md** — tree-level comments read scope, parent-tree guard, public-safe response, empty/error state contract
+12. **MOMENT_LEVEL_COMMENTS_READ_CONTRACT.md** — moment-level comments read scope, parent-tree guard, target-moment guard, public-safe response, empty/error state contract
+13. **V01_CTA_EXPOSURE_POLICY.md** — v0.1 unfinished/partial action 노출 기준과 CTA readiness 분류 정책
+14. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+15. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+16. **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+17. **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+18. **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+19. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+20. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+21. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+22. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+23. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+24. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+25. **필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md**
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`


### PR DESCRIPTION
## Summary
- Documents the product/layout decision to target a vertical tree-growth model for Editor and the read-only LoveTree viewer.
- Clarifies that the intended shape is an actual tree, not a plain vertical list or quick CSS tweak.
- Defines root/later-moment placement, desktop/mobile principles, viewer/editor capability separation, risks, phased implementation, and verification policy.
- Updates the product document index and reading order.

## Changed files
- `docs/product/VERTICAL_TREE_LAYOUT_DECISION.md`
- `docs/product/product_index.md`

## Scope
- Docs-only.
- No runtime, API, CSS, HTML, Auth, backend, DB, package, workflow, Browse, Editor, My Trees, viewer, PR #7, prototype, reference, demo, or variant changes.

## Decision
The target layout direction is vertical tree-growth:

```text
first/root moment lower in the tree
connected later moments grow upward
branch splits remain visible
mobile may simplify spacing but must preserve tree relationship cues
```

## Verification
- GitHub API file creation/update: PASS
- Scope check: docs-only, 2 files
- Local `git diff --check`, `npm test`, `npm run verify`: NOT_RUN in this environment
- Runtime/browser verification: NOT_REQUIRED for docs-only planning PR

Refs #652
Refs #648
Refs #923