### PR TITLE
ui(search): lighten Browse hub flow moments

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -200,39 +200,31 @@
 }
 
 .preview-flow-toggle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    min-height: 36px;
-    max-width: 100%;
-    padding: 7px 12px;
-    border: 1px solid rgba(144, 73, 81, 0.18);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.68);
+    display: inline;
     color: var(--primary);
     font: inherit;
     font-size: 13px;
-    font-weight: 800;
+    font-weight: 600;
     line-height: 1.2;
     cursor: pointer;
-    overflow-wrap: anywhere;
-    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    text-decoration: underline;
+    text-decoration-color: rgba(144, 73, 81, 0.25);
+    text-underline-offset: 3px;
 }
 
 .preview-flow-toggle:hover {
-    background: var(--surface-container);
-    border-color: rgba(144, 73, 81, 0.28);
+    color: var(--primary-vibrant);
+    text-decoration-color: var(--primary);
 }
 
 .preview-flow-toggle:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
-}
-
-.preview-flow-toggle .material-symbols-outlined {
-    font-size: 18px;
-    flex: 0 0 auto;
+    border-radius: 2px;
 }
 
 @media (max-width: 480px) {
@@ -240,11 +232,8 @@
     .preview-flow-more-list {
         grid-template-columns: minmax(0, 1fr);
     }
-
-    .preview-flow-toggle {
-        width: 100%;
-    }
 }
+
 
 .preview-panel-icon {
     font-size: 14px;

--- a/js/search/search-preview-renderer-builders.js
+++ b/js/search/search-preview-renderer-builders.js
@@ -90,18 +90,22 @@
     }
 
     function renderPathStageBadge(index, title) {
-        return '<span class="preview-flow-stage" style="display:inline-flex;align-items:center;gap:4px;padding:4px 10px;background:var(--surface-container);border-radius:8px;font-size:13px;">' +
+        return '<span class="preview-flow-stage" style="display:inline-flex;align-items:center;gap:4px;padding:2px 6px;background:transparent;border-radius:4px;font-size:13px;color:var(--on-surface-variant);min-height:auto;">' +
             '<span style="color:var(--primary);font-weight:800;flex:0 0 auto;">' + index + '</span>' +
             '<span class="preview-flow-stage-label" title="' + escapeHtml(title) + '" aria-label="' + escapeHtml(title) + '">' + escapeHtml(title) + '</span>' +
             '</span>';
     }
 
-    function renderPathStages(memories, startIndex) {
+    function renderPathStages(memories, startIndex, showArrows = true) {
         if (startIndex === undefined) startIndex = 0;
         return memories.map(function(memory, index) {
             var fallbackKo = startIndex + index === 0 ? '시작 순간' : '이어진 순간';
             var fallbackEn = startIndex + index === 0 ? 'Starting moment' : 'Connected moment';
-            return renderPathStageBadge(startIndex + index + 1, getMomentLabel(memory, fallbackKo, fallbackEn));
+            var badge = renderPathStageBadge(startIndex + index + 1, getMomentLabel(memory, fallbackKo, fallbackEn));
+            if (showArrows && index < memories.length - 1) {
+                return badge + '<span class="flow-arrow" style="color:var(--on-surface-variant);font-size:14px;margin:0 4px;">→</span>';
+            }
+            return badge;
         }).join('');
     }
 
@@ -126,7 +130,7 @@
     function renderHiddenPathStages(hiddenMemories, startIndex, isExpanded) {
         if (!isExpanded || !hiddenMemories.length) return '';
         return '<div class="preview-flow-more-list">' +
-            renderPathStages(hiddenMemories, startIndex) +
+            renderPathStages(hiddenMemories, startIndex, false) +
             '</div>';
     }
 

--- a/js/search/search-preview-renderer-builders.js
+++ b/js/search/search-preview-renderer-builders.js
@@ -116,14 +116,12 @@
             : formatSearchCopy(
                 'search.previewShowMoreMoments',
                 { count: hiddenCount },
-                '{count}개의 순간 더 보기',
-                'Show {count} more moments'
+                '... 그리고 {count}개의 순간 더',
+                '... and {count} more moments'
             );
-        var icon = isExpanded ? 'expand_less' : 'expand_more';
         return '<button type="button" class="preview-flow-toggle" data-preview-flow-toggle aria-expanded="' +
             (isExpanded ? 'true' : 'false') + '">' +
-            '<span>' + escapeHtml(label) + '</span>' +
-            '<span class="material-symbols-outlined" aria-hidden="true">' + icon + '</span>' +
+            escapeHtml(label) +
             '</button>';
     }
 


### PR DESCRIPTION
## Summary
- Refines the Browse selected 감상허브 `이어진 흐름` visual treatment.
- Makes visible flow moments lighter and less box/card-heavy.
- Preserves the ordered flow feeling with subtle arrow/connection treatment.
- Converts the expand/collapse affordance to a quieter text-style control.
- Preserves the existing #601 expand/collapse behavior.
- Does not implement #766 selectable moment preview switching.

## Changed files
- `js/search/search-preview-renderer-builders.js`
- `css/search/preview-sidebar.css`

## Scope
- Browse selected hub flow visual treatment only.
- No Browse API/Auth/backend/DB/package/workflow changes.
- No Browse card grid/search/filter/copy/import behavior changes.
- No full 감상 page implementation.
- No #766 selectable moment behavior.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check` changed JS files: PASS
- `npm test`: PASS 223/223
- `npm run verify`: PASS 147/147

## Browser/UI verification
Browser screenshot review is separated under the current CTO operating rule.
Post-merge/post-deploy UI review should confirm:
- selected hub opens in populated state;
- collapsed flow remains readable;
- text-style expand control is discoverable and works;
- expanded flow remains readable;
- collapse works;
- desktop and mobile 375px remain usable;
- no fatal console errors;
- no secret/private exposure.

Refs #768
Refs #601
Refs #603