### PR TITLE
docs: mark corrupted legacy documents as non-authoritative

### DIFF
--- a/docs/backend/backend_index.md
+++ b/docs/backend/backend_index.md
@@ -9,13 +9,13 @@
 이 폴더를 처음 접할 때는 다음 순서로 읽는 것을 권장합니다:
 
 1. **[backend.md](./backend.md)** — 전체 백엔드 아키텍처 개요 및 API 계약
-2. **[DATA_MODEL_DRAFT.md](./DATA_MODEL_DRAFT.md)** — 데이터 모델 상세
+2. **[DATA_MODEL_DRAFT.md](./DATA_MODEL_DRAFT.md)** — 데이터 모델 상세 *(corrupted legacy, see #898)*
 3. 필요시 운영 문서는 `docs/ops/` 참조
 
 ## 현재 문서
 
 - [backend.md](./backend.md) - Netlify Functions 백엔드 개요 *(루트에서 이동)*
-- [DATA_MODEL_DRAFT.md](./DATA_MODEL_DRAFT.md) - 데이터 모델 초안 *(product에서 이동)*
+- [DATA_MODEL_DRAFT.md](./DATA_MODEL_DRAFT.md) - 데이터 모델 초안 *(product에서 이동, corrupted legacy #898)*
 
 백엔드 논의가 커지면 이 폴더 아래로 문서를 분리합니다.
 

--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -240,7 +240,7 @@ Reference 문서는 `docs/reference/` 아래에 정리됩니다.
 실행 계획은 `docs/plans/` 아래에 정리됩니다.
 
 - **index**: [plans_index.md](./plans/plans_index.md)
-- [FRONTEND_ROADMAP.md](./plans/FRONTEND_ROADMAP.md)
+- [FRONTEND_ROADMAP.md](./plans/FRONTEND_ROADMAP.md) *(corrupted legacy, see #898)*
 - [ROADMAP.md](./plans/ROADMAP.md)
 
 ## archive 문서군

--- a/docs/plans/plans_index.md
+++ b/docs/plans/plans_index.md
@@ -4,7 +4,7 @@
 
 ## 용도
 - **프로젝트 전체 실행 계획**: 현재 상태, 남은 우선순위, 다음 작업 (ROADMAP.md)
- - **프론트엔드 구현 상세 계획**: 페이지별 품질 기준, 빌드 큐, Phase별 실행 계획 (FRONTEND_ROADMAP.md) *(corrupted legacy, see #898)*
+- **프론트엔드 구현 상세 계획**: 페이지별 품질 기준, 빌드 큐, Phase별 실행 계획 (FRONTEND_ROADMAP.md) *(corrupted legacy, see #898)*
 - 단기/중기/장기 실행 방향 및 우선순위 관리
 
 ## 먼저 읽기 순서

--- a/docs/plans/plans_index.md
+++ b/docs/plans/plans_index.md
@@ -4,7 +4,7 @@
 
 ## 용도
 - **프로젝트 전체 실행 계획**: 현재 상태, 남은 우선순위, 다음 작업 (ROADMAP.md)
-- **프론트엔드 구현 상세 계획**: 페이지별 품질 기준, 빌드 큐, Phase별 실행 계획 (FRONTEND_ROADMAP.md)
+ - **프론트엔드 구현 상세 계획**: 페이지별 품질 기준, 빌드 큐, Phase별 실행 계획 (FRONTEND_ROADMAP.md) *(corrupted legacy, see #898)*
 - 단기/중기/장기 실행 방향 및 우선순위 관리
 
 ## 먼저 읽기 순서
@@ -12,13 +12,13 @@
 이 폴더의 문서를 처음 접할 경우 권장 순서:
 
 1. **ROADMAP.md** — 전체 프로젝트의 현재 상태와 다음 우선순위 파악
-2. **FRONTEND_ROADMAP.md** — 프론트엔드 구현의 품질 기준 및 단계별 계획 확인
+2. **FRONTEND_ROADMAP.md** — 프론트엔드 구현의 품질 기준 및 단계별 계획 확인 *(corrupted legacy, see #898)*
 
 ## 파일 목록
 
 | 파일명 | 설명 |
 |--------|------|
-| [FRONTEND_ROADMAP.md](FRONTEND_ROADMAP.md) | 프론트엔드 구현 로드맵 및 빌드 큐 *(backend에서 이동)* |
+| [FRONTEND_ROADMAP.md](FRONTEND_ROADMAP.md) | 프론트엔드 구현 로드맵 및 빌드 큐 *(backend에서 이동, corrupted legacy #898)* |
 | [ROADMAP.md](ROADMAP.md) | 프로젝트 로드맵 및 우선순위 *(product에서 이동)* |
 
 ## 참조


### PR DESCRIPTION
This PR adds deprecation notices to index references, marking the following as corrupted legacy artifacts:

- docs/plans/FRONTEND_ROADMAP.md
- docs/backend/DATA_MODEL_DRAFT.md

Both documents already contain warning notices at the top. This PR updates index pages (backend_index.md, plans_index.md, doc_index.md) to clearly indicate their corrupted status and reference #898 for disposition tracking.

No content reconstruction attempted. Follow-up handling is tracked in #898.

Refs #898