### PR TITLE
ui(search): align Browse heading with LoveTree brand system

### DIFF
--- a/css/search/controls.css
+++ b/css/search/controls.css
@@ -73,7 +73,12 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    margin: 0 0 22px;
+    margin: 0 0 18px;
+    padding: 14px;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.48);
+    box-shadow: 0 14px 32px rgba(75, 64, 57, 0.035);
     min-width: 0;
 }
 

--- a/css/search/hero-controls.css
+++ b/css/search/hero-controls.css
@@ -4,7 +4,7 @@
  */
 
 .browse-curation-shell {
-    margin-bottom: 20px;
+    margin-bottom: 18px;
     padding: 0;
     background: transparent;
     border: 0;
@@ -12,7 +12,7 @@
 }
 
 .search-panel-header {
-    margin-bottom: 10px;
+    margin-bottom: 0;
 }
 
 .search-panel-eyebrow {
@@ -29,11 +29,20 @@
     margin-bottom: 14px;
 }
 
+.search-panel-header h1,
 .search-panel-header h2 {
-    font-size: clamp(2.28rem, 4.2vw, 3.4rem);
-    margin-bottom: 8px;
-    line-height: 1.04;
-    letter-spacing: -0.035em;
+    max-width: 640px;
+    margin: 18px 0 10px;
+    color: var(--on-surface);
+    font-size: clamp(3rem, 5vw, 4.35rem);
+    font-weight: 900;
+    line-height: 0.99;
+    letter-spacing: -0.052em;
+}
+
+.search-panel-header .title-accent {
+    color: var(--hero-warm-color, var(--primary));
+    font-weight: 900;
 }
 
 .search-panel-header p {
@@ -65,15 +74,17 @@
     align-items: flex-end;
     justify-content: space-between;
     gap: 16px;
-    margin-bottom: 18px;
+    margin: 4px 0 18px;
+    padding-top: 18px;
+    border-top: 1px solid rgba(144, 73, 81, 0.09);
 }
 
 .browse-results-head h3 {
     margin: 0;
-    font-size: 1.7rem;
-    font-weight: 900;
+    font-size: 1.22rem;
+    font-weight: 820;
     color: var(--on-surface);
-    letter-spacing: -0.02em;
+    letter-spacing: -0.012em;
 }
 
 .browse-results-head p {

--- a/css/search/responsive.css
+++ b/css/search/responsive.css
@@ -154,10 +154,11 @@
         margin-bottom: 16px;
     }
 
+    .search-panel-header h1,
     .search-panel-header h2 {
-        font-size: 2.0rem;
+        font-size: 2.62rem;
         line-height: 1.08;
-        margin-bottom: 7px;
+        margin: 14px 0 8px;
     }
 
     .search-panel-header p {
@@ -345,11 +346,12 @@
     }
 
     .browse-results-head h3 {
-        font-size: 1.45rem;
+        font-size: 1.12rem;
     }
 
     .browse-utility-row {
         gap: 10px;
         margin-top: 14px;
+        padding: 12px;
     }
 }

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -9,13 +9,25 @@
   'use strict';
 
   window.i18nSearch = {
+    'search.eyebrow': {
+      ko: '공개 러브트리',
+      en: 'Public LoveTrees'
+    },
     'search.title': {
-      ko: '러브트리 감상 둘러보기',
-      en: 'Browse LoveTree moments'
+      ko: '<span class="title-accent">러브트리</span> 둘러보기',
+      en: 'Browse <span class="title-accent">LoveTrees</span>'
     },
     'search.subtitle': {
-      ko: '첫 순간과 이어진 마음을 따라가 보세요',
-      en: 'Follow first moments and the feelings that grew from them'
+      ko: '다른 사람이 남긴 순간의 흐름을 가볍게 살펴보세요.',
+      en: 'Lightly explore the flow of moments others have shared.'
+    },
+    'search.resultsHeading': {
+      ko: '공개 러브트리',
+      en: 'Public LoveTrees'
+    },
+    'search.resultsPopularHeading': {
+      ko: '많이 감상한 러브트리',
+      en: 'Popular LoveTrees'
     },
     'search.intentNote': {
       ko: '트리를 고르면 열려요.',

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -129,10 +129,10 @@
 
         const SORT_COPY = {
             latest: {
-                title: () => getSearchCopy('search.resultsHeading', '최근 러브트리', 'Recent LoveTrees')
+                title: () => getSearchCopy('search.resultsHeading', '공개 러브트리', 'Public LoveTrees')
             },
             popular: {
-                title: () => getCurrentLocale() === 'en' ? 'Popular LoveTrees' : '인기 많은 러브트리'
+                title: () => getSearchCopy('search.resultsPopularHeading', '많이 감상한 러브트리', 'Popular LoveTrees')
             }
         };
 

--- a/pages/search.html
+++ b/pages/search.html
@@ -21,8 +21,9 @@
         <section>
             <div class="browse-curation-shell reveal-up">
                 <div class="search-panel-header">
-                    <h2 class="headline" data-i18n="search.title">러브트리 감상 둘러보기</h2>
-                    <p data-i18n="search.subtitle">첫 순간과 이어진 마음을 따라가 보세요</p>
+                    <div class="search-panel-eyebrow"><span data-i18n="search.eyebrow">공개 러브트리</span></div>
+                    <h1 class="headline" data-i18n="search.title" data-i18n-html><span class="title-accent">러브트리</span> 둘러보기</h1>
+                    <p data-i18n="search.subtitle">다른 사람이 남긴 순간의 흐름을 가볍게 살펴보세요.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Aligns the Browse heading with the Home hero LoveTree brand rhythm.
- Shortens the heading toward a tree-first Browse message.
- Separates heading, search/filter controls, and result-section hierarchy.
- Preserves existing Browse search/filter/runtime behavior.

## Changed files
- `pages/search.html`
- `css/search/hero-controls.css`
- `css/search/controls.css`
- `css/search/responsive.css`
- `js/i18n/i18n-search.js`
- `js/search/search-ui.js`

## Scope
- Browse heading copy and visual hierarchy only.
- Search/filter grouping visual separation only.
- Result-section hierarchy clarity only.

## Non-goals
- No backend/API/Auth/DB/package/workflow changes.
- No selectable moment behavior.
- No selected hub empty-state cleanup beyond what is necessary for heading hierarchy.
- No broad Browse redesign.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/i18n/i18n-search.js`: PASS
- `node --check js/search/search-ui.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser/UI verification
Post-merge/deploy screenshot review should confirm:
- desktop Browse heading reads as warm LoveTree Browse, not dashboard;
- `러브트리` emphasis is consistent with Home hero rhythm;
- search/filter controls are visually separated from heading;
- result section start is clear;
- mobile 375px has no overlap or horizontal overflow;
- no fatal console errors;
- no secret/private exposure.

Refs #903
Refs #597
Refs #455
Refs #239
Refs #681
