### PR TITLE
ui(search): clean Browse selected hub empty copy

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -98,6 +98,37 @@
     line-height: 1.7;
 }
 
+.preview-empty-guide {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 22px;
+    color: var(--on-surface-variant);
+    font-size: 14px;
+    line-height: 1.65;
+    text-align: center;
+}
+
+.preview-empty-guide p,
+.preview-empty-description {
+    margin: 0;
+}
+
+.preview-empty-guide p:first-child {
+    color: var(--on-surface);
+    font-weight: 800;
+}
+
+.preview-empty-description {
+    color: var(--on-surface-variant);
+    font-size: 14px;
+    line-height: 1.65;
+}
+
 .tree-meta {
     display: flex;
     gap: 12px;
@@ -400,6 +431,11 @@
 .preview-sidebar.preview-state-loading .preview-badge {
     background: rgba(122, 139, 110, 0.10);
     color: #6f7c61;
+}
+
+.preview-sidebar.preview-state-empty .tree-meta,
+.preview-sidebar.preview-state-no-moments .tree-meta {
+    display: none;
 }
 
 /* Mobile bottom sheet: body scroll lock when sheet is open */

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -86,32 +86,32 @@
       en: 'Selected Tree'
     },
     'search.previewKicker': {
-      ko: '트리를 고르면 열려요.',
-      en: 'Choose a tree to open it.'
+      ko: '러브트리를 고르면 흐름이 열려요.',
+      en: 'Choose a LoveTree to open its flow.'
     },
     'search.previewPlaceholder': {
-      ko: '트리를 선택해보세요',
-      en: 'Select a tree to preview'
+      ko: '러브트리를 고르면',
+      en: 'Choose a LoveTree'
     },
     'search.previewDescriptionPlaceholder': {
-      ko: '대표 순간과 이어진 마음이 이곳에 열려요.',
-      en: 'The featured moment and connected feelings open here.'
+      ko: '이어진 순간의 흐름이 여기에 열려요.',
+      en: 'to open its connected moments here.'
     },
     'search.previewEmptyLead': {
-      ko: '트리를 선택해보세요',
-      en: 'Select a tree to preview'
+      ko: '러브트리를 고르면',
+      en: 'Choose a LoveTree'
     },
     'search.previewEmptyBody': {
-      ko: '대표 순간과 이어진 마음이 이곳에 열려요.',
-      en: 'The featured moment and connected feelings open here.'
+      ko: '이어진 순간의 흐름이 여기에 열려요.',
+      en: 'to open its connected moments here.'
     },
     'search.previewNoMomentTitle': {
-      ko: '아직 대표 순간이 없어요.',
-      en: 'No featured moment yet.'
+      ko: '아직 이어진 순간을 기다리는 트리예요.',
+      en: 'This tree is still waiting for connected moments.'
     },
     'search.previewNoMomentBody': {
-      ko: '첫 순간이 더해지면 열려요.',
-      en: 'It opens once the first moment is added.'
+      ko: '대표 순간이 더해지면 이곳에서 감정의 흐름을 볼 수 있어요.',
+      en: 'Once a featured moment is added, its emotional flow will open here.'
     },
     'search.previewStartFromFirstMoment': {
       ko: '대표 순간부터 감상하기',
@@ -122,12 +122,12 @@
       en: 'Connected flow'
     },
     'search.previewTimelineEmpty': {
-      ko: '아직 이어진 순간이 없어요.',
-      en: 'No connected moments yet.'
+      ko: '아직 흐름으로 펼칠 순간이 없어요.',
+      en: 'There are no moments to unfold yet.'
     },
 'search.previewTimelineEmptyBody': {
-      ko: '아직 이어진 순간이 없어요.',
-      en: 'No connected moments yet.'
+      ko: '대표 순간이 남겨지면 이 감상 허브에서 먼저 보여드릴게요.',
+      en: 'When a featured moment is saved, it will appear in this viewing hub first.'
     },
     'search.previewCopyToMyTrees': {
       ko: '내 러브트리로 가져오기',
@@ -162,20 +162,20 @@
       en: 'Open copied tree'
     },
     'search.previewNoRecordsYet': {
-      ko: '아직 남은 순간은 없지만',
-      en: 'There are no saved moments yet, but'
+      ko: '아직 보여줄 순간 수는 없지만',
+      en: 'There are no visible moments yet, but'
     },
     'search.previewNoRecordsFollowup': {
-      ko: '다음 순간이 이어지면 열려요.',
-      en: 'when the next moment is added, it opens here.'
+      ko: '첫 순간이 이어지면 이곳에 조용히 열려요.',
+      en: 'the first connected moment will open here gently.'
     },
     'search.previewNoRecordsLine': {
       ko: '{countLabel} {followup}',
       en: '{countLabel} {followup}'
     },
     'search.previewNewTreeInfo': {
-      ko: '막 자라기 시작한 러브트리예요.',
-      en: 'This LoveTree has just begun to grow.'
+      ko: '숫자보다 첫 순간을 기다리는 공개 러브트리예요.',
+      en: 'This public LoveTree is waiting for its first moment, not showing a metric yet.'
     },
     'search.previewJourneyCta': {
       ko: '마음이 닿는 순간으로',
@@ -190,8 +190,8 @@
       en: 'Waiting for the first moment'
     },
     'search.previewStatsPending': {
-      ko: '대기 중',
-      en: 'Pending'
+      ko: '첫 순간을 기다리는 중',
+      en: 'Waiting for the first moment'
     },
     'search.previewEmotionTagsLabel': {
       ko: '이어진 감정',

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -366,6 +366,7 @@
         const isFlowExpanded = !!treeKey && expandedFlowTreeKey === treeKey;
         const firstMem = memories[0];
         const hasMemories = memories.length > 0;
+        const displayMemoryCount = Number(tree?.memoryCount || memories.length || 0);
         const previewStats = getPreviewStatsElement();
         const titleHelper = getSearchTitleHelper();
         const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
@@ -422,11 +423,14 @@
         if (_dom.previewTitle) {
             const safeTimeRange = escapeHtml(String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')).trim());
             const memoryCountSuffix = getSearchCopy('search.previewMomentCountSuffix', '개의 순간', 'moments');
+            const titleMeta = hasMemories
+                ? `${displayMemoryCount}${escapeHtml(memoryCountSuffix)} · ${safeTimeRange}`
+                : escapeHtml(getSearchCopy('search.previewStatsPending', '첫 순간을 기다리는 중', 'Waiting for the first moment'));
 
             _dom.previewTitle.innerHTML = `
                 <div style="margin-bottom:12px;">
                     <div style="font-size:1.18rem;font-weight:900;color:var(--on-surface);line-height:1.25;overflow-wrap:anywhere;">${safeTreeTitle}</div>
-                    <div style="font-size:12px;color:var(--on-surface-variant);margin-top:2px;">${tree.memoryCount}${escapeHtml(memoryCountSuffix)} · ${safeTimeRange}</div>
+                    <div style="font-size:12px;color:var(--on-surface-variant);margin-top:2px;">${titleMeta}</div>
                 </div>
             `;
         }
@@ -495,13 +499,13 @@
         }
 
         if (previewStats) {
-            previewStats.hidden = false;
+            previewStats.hidden = !hasMemories;
         }
         if (_dom.previewMemoriesCount) {
-            _dom.previewMemoriesCount.textContent = tree.memoryCount;
+            _dom.previewMemoriesCount.textContent = hasMemories ? displayMemoryCount : '';
         }
         if (_dom.previewTreeDuration) {
-            _dom.previewTreeDuration.textContent = getTimelineLabel(tree, memories);
+            _dom.previewTreeDuration.textContent = hasMemories ? getTimelineLabel(tree, memories) : '';
         }
         if (_dom.previewEmotionTags) {
             _dom.previewEmotionTags.innerHTML = renderEmotionTags(tree.emotionTags);
@@ -511,9 +515,9 @@
     }
 
     const renderPlaceholder = previewBuilders.renderPlaceholder || function() {
-        return '<div style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;color:var(--on-surface-variant);font-size:14px;text-align:center;padding:20px;">' +
-            '<p>' + escapeHtml(getSearchCopy('search.previewEmptyLead', '트리를 고르면', 'When you choose a tree,')) + '</p>' +
-            '<p>' + escapeHtml(getSearchCopy('search.previewEmptyBody', '대표 순간과 이어진 감정이 이곳에 열립니다.', 'the featured moment and connected feelings open here.')) + '</p>' +
+        return '<div class="preview-empty-guide">' +
+            '<p>' + escapeHtml(getSearchCopy('search.previewEmptyLead', '러브트리를 고르면', 'Choose a LoveTree')) + '</p>' +
+            '<p>' + escapeHtml(getSearchCopy('search.previewEmptyBody', '이어진 순간의 흐름이 여기에 열려요.', 'to open its connected moments here.')) + '</p>' +
             '</div>';
     }
 
@@ -525,13 +529,13 @@
         const previewStats = getPreviewStatsElement();
         const placeholderTitle = getSearchCopy(
             'search.previewPlaceholder',
-            '트리를 골라 감상하기',
-            'Select a tree to preview'
+            '러브트리를 고르면',
+            'Choose a LoveTree'
         );
         const placeholderDescription = getSearchCopy(
             'search.previewDescriptionPlaceholder',
-            '트리를 고르면 대표 순간과 이어진 감정이 이곳에 열립니다.',
-            'Choose a tree to open the featured moment and connected feelings here.'
+            '이어진 순간의 흐름이 여기에 열려요.',
+            'to open its connected moments here.'
         );
         setPreviewState('empty');
 
@@ -539,10 +543,11 @@
             _dom.previewContainer.innerHTML = renderPlaceholder();
         }
         if (_dom.previewTitle) {
-            _dom.previewTitle.textContent = '';
+            _dom.previewTitle.textContent = placeholderTitle;
         }
         if (_dom.previewDesc) {
-            _dom.previewDesc.hidden = true;
+            _dom.previewDesc.hidden = false;
+            _dom.previewDesc.innerHTML = '<p class="preview-empty-description">' + escapeHtml(placeholderDescription) + '</p>';
         }
         if (previewStats) {
             previewStats.hidden = true;

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -169,12 +169,12 @@
 
             const previewKicker = document.querySelector('.preview-kicker');
             if (previewKicker) {
-                previewKicker.textContent = getSearchCopy('search.previewKicker', '대표 순간과 이어진 감정을 먼저 열어보세요.', 'Begin with the featured moment and connected feelings.');
+                previewKicker.textContent = getSearchCopy('search.previewKicker', '러브트리를 고르면 흐름이 열려요.', 'Choose a LoveTree to open its flow.');
             }
 
             const previewStatsPending = document.querySelector('#previewTreeStats .tree-meta-item:first-child span:last-child');
             if (previewStatsPending) {
-                previewStatsPending.textContent = getSearchCopy('search.previewStatsPending', '대표 순간이 열리면 함께 보여드릴게요', 'This will appear once the featured moment opens.');
+                previewStatsPending.textContent = getSearchCopy('search.previewStatsPending', '첫 순간을 기다리는 중', 'Waiting for the first moment');
             }
 
             const emotionLabel = document.querySelector('.emotion-tags-label span:last-child');

--- a/pages/search.html
+++ b/pages/search.html
@@ -90,7 +90,7 @@
             </div>
             <div id="previewVideoContainer" class="video-container">
                 <div class="preview-empty-state">
-                    <p>트리를 선택해보세요.</p>
+                    <p>러브트리를 고르면 이어진 순간의 흐름이 여기에 열려요.</p>
                 </div>
             </div>
             <div id="previewDetails">


### PR DESCRIPTION
## Summary
- Cleans the Browse selected hub empty and initial preview treatment.
- Clarifies placeholder/count copy so empty states do not read as real social metrics.
- Preserves existing selected hub populated behavior and flow expand/collapse behavior.
- Keeps #766 selectable moment behavior out of scope.

## Changed files
- `pages/search.html`
- `css/search/preview-sidebar.css`
- `js/i18n/i18n-search.js`
- `js/search/search-preview-renderer.js`
- `js/search/search-ui.js`

## Scope
- Browse selected hub empty/initial state copy only.
- Selected preview placeholder hierarchy only.
- Minor selected hub visual spacing for empty guidance.

## Non-goals
- No backend/API/Auth/DB/package/workflow changes.
- No selectable moment behavior.
- No broad Browse redesign.
- No #903 heading rework.
- No #768 flow visual rollback.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/i18n/i18n-search.js`: PASS
- `node --check js/search/search-preview-renderer.js`: PASS
- `node --check js/search/search-ui.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser/UI verification
Post-merge/deploy screenshot review should confirm:
- empty selected hub reads as a gentle selection guide, not dashboard filler;
- count/social placeholder copy is not misleading;
- initial selected-tree preview behavior is clear;
- populated selected hub flow remains readable;
- expand/collapse behavior still works;
- desktop and mobile 375px have no overlap or horizontal overflow;
- no fatal console errors;
- no secret/private exposure.

Refs #904
Refs #455
Refs #605
Refs #800
Refs #681
