### PR TITLE
refactor(editor): extract canvas edge rendering helper

### DIFF
--- a/js/editor/editor-canvas-edges.js
+++ b/js/editor/editor-canvas-edges.js
@@ -5,6 +5,10 @@
             canvasViewport = {}
         } = options || {};
 
+        const clearBranches = () => {
+            svg.querySelectorAll('.branch-line').forEach((line) => line.remove());
+        };
+
         const drawBranch = (startPos, endPos) => {
             if (typeof canvasViewport.drawBranch === 'function') {
                 canvasViewport.drawBranch(svg, startPos, endPos);
@@ -23,8 +27,26 @@
             svg.appendChild(path);
         };
 
+        const drawBranchForMemory = (node, context) => {
+            const {
+                treeMemories = [],
+                canonicalRootId,
+                calcPosition
+            } = context || {};
+
+            if (!node || typeof calcPosition !== 'function') return;
+
+            const parentId = node.parentId || canonicalRootId;
+            const parent = treeMemories.find((memory) => memory.id === parentId);
+            if (parent) {
+                drawBranch(calcPosition(parent), calcPosition(node));
+            }
+        };
+
         return {
-            drawBranch
+            clearBranches,
+            drawBranch,
+            drawBranchForMemory
         };
     }
 

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -191,7 +191,15 @@ function isNodeWithinSafeViewport(pos) {
         });
     }
 
-    const { drawBranch } = canvasEdges;
+    const requireCanvasEdgeMethod = (name) => {
+        if (typeof canvasEdges[name] !== 'function') {
+            throw new Error(`LoveBudEditorCanvasEdges.${name} is required`);
+        }
+        return canvasEdges[name];
+    };
+    const drawBranch = requireCanvasEdgeMethod('drawBranch');
+    const clearBranches = requireCanvasEdgeMethod('clearBranches');
+    const drawBranchForMemory = requireCanvasEdgeMethod('drawBranchForMemory');
     const NODE_TAP_SELECT_THRESHOLD = 8;
 
     function bindNodeDrag(nodeEl, mem) {
@@ -371,7 +379,7 @@ function isNodeWithinSafeViewport(pos) {
 
         canvas.querySelectorAll('.memory-node').forEach((node) => node.remove());
         canvas.querySelectorAll('#emptyTreeMessage').forEach((el) => el.remove());
-        svg.querySelectorAll('.branch-line').forEach((line) => line.remove());
+        clearBranches();
         clearGrowthAffordance();
 
         setDetailEmptyState(!hasVisibleNodes);
@@ -383,11 +391,11 @@ function isNodeWithinSafeViewport(pos) {
 
         drawableMemories.forEach((node) => {
             drawNode(node);
-            const parentId = node.parentId || canonicalRootId;
-            const parent = treeMemories.find((m) => m.id === parentId);
-            if (parent) {
-                drawBranch(calcPosition(parent), calcPosition(node));
-            }
+            drawBranchForMemory(node, {
+                treeMemories,
+                canonicalRootId,
+                calcPosition
+            });
         });
 
         if (hasVisibleNodes) {

--- a/tests/contracts/editor-script-order-contract.test.js
+++ b/tests/contracts/editor-script-order-contract.test.js
@@ -46,6 +46,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-canvas-interaction.js',
     'js/editor/editor-canvas-interaction-helpers.js',
     'js/editor/editor-canvas-viewport.js',
+    'js/editor/editor-canvas-edges.js',
     'js/editor/editor-canvas-state-boundary.js',
     'js/editor/editor-canvas-growth-affordance.js',
     'js/editor/editor-canvas.js',
@@ -96,6 +97,16 @@ test('canvas state boundary loads before canvas runtime', () => {
   assertLoadedBefore(
     sources,
     'js/editor/editor-canvas-state-boundary.js',
+    'js/editor/editor-canvas.js'
+  );
+});
+
+test('canvas edge helper loads before canvas runtime', () => {
+  const sources = scriptSources(editorHtml());
+
+  assertLoadedBefore(
+    sources,
+    'js/editor/editor-canvas-edges.js',
     'js/editor/editor-canvas.js'
   );
 });


### PR DESCRIPTION
## Summary
- Extracts one narrow Editor canvas rendering responsibility from `js/editor/editor-canvas.js`.
- Moves branch cleanup and memory-to-parent branch rendering into the existing canvas edge helper.
- Preserves existing canvas visual output and interaction behavior.
- Keeps browser-global script loading; no ES module conversion.
- Leaves remaining canvas decomposition as follow-up under #897/#656.

## Changed files
- `js/editor/editor-canvas.js`
- `js/editor/editor-canvas-edges.js`
- `tests/contracts/editor-script-order-contract.test.js`

## Scope
- Editor canvas edge rendering helper extraction only.
- Behavior-equivalent refactor.
- Script include/test expectation updates only where required; `pages/editor.html` already loaded the edge helper before canvas runtime.

## Non-goals
- No broad Editor rewrite.
- No detail panel refactor.
- No editor CSS redesign.
- No API/Auth/backend/DB/package/workflow changes.
- No Browse/Intro/My Trees changes.
- No ES module conversion.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/editor/editor-canvas.js js/editor/editor-canvas-edges.js tests/contracts/editor-script-order-contract.test.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser verification
Post-merge/deploy browser verification is tracked by #915 and should confirm:
- Editor route loads after deployed SHA match;
- existing tree canvas renders;
- nodes and edges render as before;
- selection interaction still works;
- viewport/zoom/pan behavior remains safe if touched;
- no fatal console errors;
- no restricted data exposure in reports.

Refs #897
Refs #656
Refs #658
Refs #895
Refs #915
