### PR TITLE
ui(search): compact Browse hub flow layout

### DIFF
--- a/css/search/preview-sidebar.css
+++ b/css/search/preview-sidebar.css
@@ -196,22 +196,35 @@
 .preview-flow-list,
 .preview-flow-more-list {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 7px;
     min-width: 0;
     max-width: 100%;
+    align-items: stretch;
 }
 
 .preview-flow-more-list {
-    margin-top: 8px;
+    margin-top: 7px;
 }
 
 .preview-flow-stage {
+    display: flex !important;
+    align-items: center !important;
+    gap: 6px !important;
     min-width: 0;
     max-width: 100%;
-    min-height: 36px;
+    min-height: 42px !important;
     justify-content: flex-start;
     overflow: hidden;
+    width: 100%;
+    padding: 8px 10px !important;
+    border-radius: 12px !important;
+    background: rgba(255, 255, 255, 0.56) !important;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66);
+    color: var(--on-surface-variant) !important;
+    font-size: 12.5px !important;
+    line-height: 1.35;
 }
 
 /* Issue #602: label text clamped to 2 lines with ellipsis; full label preserved in title attribute */
@@ -227,7 +240,7 @@
 }
 
 .preview-flow-controls {
-    margin-top: 10px;
+    margin-top: 11px;
 }
 
 .preview-flow-toggle {
@@ -262,6 +275,20 @@
     .preview-flow-list,
     .preview-flow-more-list {
         grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media (min-width: 1025px) {
+    .preview-flow-list,
+    .preview-flow-more-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .preview-flow-stage {
+        min-height: 40px !important;
+        padding: 8px 9px !important;
     }
 }
 

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -469,7 +469,7 @@
             } else {
                 const visibleMemories = memories.slice(0, VISIBLE_FLOW_MOMENT_COUNT);
                 const hiddenMemories = memories.slice(VISIBLE_FLOW_MOMENT_COUNT);
-                const pathStages = renderPathStages(visibleMemories);
+                const pathStages = renderPathStages(visibleMemories, 0, false);
                 const flowToggle = renderFlowToggleButton(hiddenMemories.length, isFlowExpanded);
                 const hiddenStages = renderHiddenPathStages(hiddenMemories, VISIBLE_FLOW_MOMENT_COUNT, isFlowExpanded);
                 const firstMomentLabel = getMomentLabel(firstMem, '시작 순간', 'Starting moment');


### PR DESCRIPTION
## Summary
- Refines the Browse selected hub connected-flow layout into a compact, stable visible moment presentation.
- Uses a two-column layout where hub width allows and a safe one-column layout on mobile.
- Preserves #601 expand/collapse behavior and #768 quiet text-style expand control.
- Keeps #766 selectable moment behavior out of scope.

## Changed files
- `css/search/preview-sidebar.css`
- `js/search/search-preview-renderer.js`

## Scope
- Browse selected hub connected-flow layout only.
- CSS-first compact/two-column flow treatment.
- Minimal renderer call adjustment so visible flow moments do not render arrow separators as grid items.

## Non-goals
- No backend/API/Auth/DB/package/workflow changes.
- No selectable moment behavior.
- No full read-only viewer.
- No Browse card grid redesign.
- No Search/filter behavior changes.
- No #903 heading rollback.
- No #904 empty/copy rollback.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/search/search-preview-renderer.js`: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Browser/UI verification
Post-merge/deploy screenshot review should confirm:
- collapsed selected hub flow is compact and readable;
- visible moments use stable shape and rhythm;
- two-column layout appears only where it improves readability;
- expanded flow remains readable;
- text-style expand/collapse still works;
- mobile 375px has no overlap or horizontal overflow;
- no fatal console errors;
- no restricted data exposure.

Refs #603
Refs #455
Refs #502
Refs #599
Refs #601
Refs #602
Refs #681
