### PR TITLE
docs(product): update v0.1 UI trust pass status

### DIFF
--- a/docs/product/V0_1_UI_TRUST_PASS_STATUS.md
+++ b/docs/product/V0_1_UI_TRUST_PASS_STATUS.md
@@ -1,0 +1,187 @@
+# v0.1 UI Trust Pass Status
+
+**Issue**: #681
+**Status**: Coordination / Release Gate Documentation
+**Last Updated**: 2026-05-08
+
+## Purpose
+
+This document tracks the v0.1 release gate status for UI Trust Pass. It separates implemented work from browser-verified work, and coordinates remaining verification, audit, and deferred items.
+
+This is NOT an implementation issue — it is a release gate coordination tracker.
+
+## Current v0.1 UI Trust Pass Snapshot
+
+### Recently Merged Implementation PRs
+
+| PR | Issue | Description | Browser Verification Issue |
+|----|-------|------------|----------------------------|
+| #928 | #903 | Browse heading brand alignment | #913 |
+| #929 | #904 | Browse selected hub empty/copy cleanup | #930 |
+| #932 | #901 | Intro LoveTree label anchor regression fix | #914 |
+| #933 | #897 | Editor canvas edge rendering helper extraction | #915 |
+| #934 | #603 | Browse hub flow compact/two-column layout | #935 |
+
+### Classification Legend
+
+- **IMPLEMENTED_PENDING_BROWSER_VERIFICATION**: Code merged, awaiting browser verification
+- **IMPLEMENTED_AND_TRACKED**: Implementation merged and browser verification complete
+- **COORDINATION_ONLY**: Issue for coordination/tracking, not implementation
+- **AUDIT_REQUIRED**: Requires security/visibility audit before release
+- **DEFERRED**: Moved to v0.2 or later
+- **BLOCKED**: Blocker that must be resolved before release
+
+## Completed Implementation PRs
+
+### Browse Screen
+
+| Issue | PR | Implementation Status | Browser Verification |
+|-------|-----|---------------------|----------------------|
+| #903 | #928 | Merged | Tracked by #913 |
+| #904 | #929 | Merged | Tracked by #930 |
+| #603 | #934 | Merged | Tracked by #935 |
+| #618 | Open | Deferred | — |
+
+### Intro/Login Screen
+
+| Issue | PR | Implementation Status | Browser Verification |
+|-------|-----|---------------------|----------------------|
+| #901 | #932 | Merged | Tracked by #914 |
+
+### Editor Screen
+
+| Issue | PR | Implementation Status | Browser Verification |
+|-------|-----|---------------------|----------------------|
+| #897 | #933 | Merged | Tracked by #915 |
+
+### My Trees Screen
+
+Status: Not part of current v0.1 PR batch.
+
+## Browser Verification Tracking Issues
+
+| Issue | Status | Description |
+|-------|--------|-------------|
+| #913 | OPEN | Browse heading brand alignment verification |
+| #930 | OPEN | Browse selected hub empty/copy verification |
+| #914 | OPEN | Intro LoveTree anchor verification |
+| #915 | OPEN | Editor canvas edge rendering verification |
+| #935 | OPEN | Browse hub flow layout verification |
+
+## Remaining Release-Gate Blockers
+
+### Infrastructure
+
+| Issue | Status | Risk |
+|-------|--------|-----|
+| #668 | OPEN | Fixed test slot / Cloudflare Preview URL binding audit incomplete |
+
+**Risk Note**: Without #668 resolution, the reliability of fixed test slot and preview URL bindings for browser verification cannot be confirmed.
+
+### Product Trust
+
+| Issue | Status | Risk |
+|-------|--------|-----|
+| #674 | OPEN | Public-by-default visibility audit not completed |
+| #872 | OPEN | Security red-team source review (unless already completed) |
+
+**Risk Note**: #674 is critical for product trust. Requires read-only audit before release, no DB mutation needed.
+
+## Deferred v0.2 Candidates
+
+| Issue | Status | Description |
+|-------|--------|-------------|
+| #618 | DEFERRED | Browse hybrid card design/planning candidate (after #603) |
+| #931 | OPEN | CSS folder-prefixed filename convention cleanup |
+
+**Notes**:
+- #618 is not a hard blocker for v0.1 release
+- If cards still appear as media-tiles, consider as v0.1 polish candidate
+- #931 is a CSS naming cleanup, not critical for v0.1
+
+## Screen-by-Screen Status
+
+### Browse
+
+- **Status**: IMPLEMENTED_PENDING_BROWSER_VERIFICATION
+- **Recent PRs**: #928, #929, #934
+- **Pending Verification**: #913, #930, #935
+- **Notes**: Hub flow layout complete, heading brand alignment applied. Awaiting browser verification evidence.
+
+### Intro/Login
+
+- **Status**: IMPLEMENTED_PENDING_BROWSER_VERIFICATION
+- **Recent PRs**: #932
+- **Pending Verification**: #914
+- **Notes**: LoveTree label anchor regression fixed. Awaiting browser verification evidence.
+
+### Editor
+
+- **Status**: IMPLEMENTED_PENDING_BROWSER_VERIFICATION
+- **Recent PRs**: #933
+- **Pending Verification**: #915
+- **Notes**: Canvas edge rendering helper extracted. Awaiting browser verification evidence.
+
+### My Trees
+
+- **Status**: NOT_IN_V0_1_SCOPE
+- **Notes**: Not part of current v0.1 implementation batch.
+
+### Auth/API/DB-related Trust Items
+
+- **Status**: AUDIT_REQUIRED
+- **Pending**: #674 (visibility), #872 (security red-team)
+- **Notes**: Read-only audit needed, no DB mutation required for #674
+
+## Go / No-Go Checklist for v0.1 UI Trust
+
+### Must Have (Release Blockers)
+
+- [ ] Browse browser verification (#913, #930, #935)
+- [ ] Intro browser verification (#914)
+- [ ] Editor browser verification (#915)
+- [ ] #674 visibility audit complete
+- [ ] #872 security review complete OR confirmed out of scope
+
+### Should Have (Recommended)
+
+- [ ] #668 infrastructure audit complete
+- [ ] #931 CSS naming follow-up complete
+
+### Could Have (Nice to Have)
+
+- [ ] #618 design spike for hybrid cards
+
+### Won't Have (Explicitly Deferred)
+
+- [ ] My Trees improvements (deferred to v0.2)
+- [ ] Advanced auth flows (deferred to v0.2)
+
+## Non-Goals and Guardrails
+
+- **No implementation in this documentation**: This is coordination-only
+- **No browser verification claims**: Separate from implementation
+- **No Auth/API/DB mutation**: For visibility audit (#674)
+- **No PR #7 changes**: experiment/gpt-svg-tree-prototype untouched
+- **No prototype/reference/demo/variant changes**
+- **No secret/token/credential exposure**
+
+## References
+
+- Implementation PRs: #928, #929, #932, #933, #934
+- Browser Verification Issues: #913, #914, #915, #930, #935
+- Tracking Issues: #931, #668, #674, #618, #872
+
+## v0.1 Release Decision
+
+**Current Status**: IMPLEMENTED_PENDING_BROWSER_VERIFICATION
+
+**Next Steps**:
+1. Complete browser verification for #913, #930, #935 (Browse)
+2. Complete browser verification for #914 (Intro)
+3. Complete browser verification for #915 (Editor)
+4. Conduct #674 visibility audit (read-only)
+5. Confirm #872 security review status
+6. Decide on #668 infrastructure audit necessity
+
+**Release Gate Criterion**: All IMPLEMENTED_PENDING_BROWSER_VERIFICATION items must be verified or explicitly tracked before v0.1 UI Trust Pass.


### PR DESCRIPTION
## Summary
- Records the current v0.1 UI Trust Pass status after recent Browse, Intro, and Editor implementation PRs.
- Separates implemented work from browser-verified work.
- Lists remaining browser verification, infra audit, visibility audit, and deferred UI candidates.
- Keeps this as coordination documentation only.

## Changed files
- docs/product/V0_1_UI_TRUST_PASS_STATUS.md (new file)

## Scope
- Docs/status update only.
- v0.1 UI Trust Pass release-gate coordination.
- No runtime implementation.

## Non-goals
- No code/CSS/JS/HTML changes.
- No browser verification claim.
- No Auth/API/DB mutation.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- Docs-only: YES
- Secret/private exposure: NO

Refs #681
Refs #903
Refs #904
Refs #901
Refs #897
Refs #603
Refs #913
Refs #914
Refs #915
Refs #930
Refs #935
Refs #931
Refs #668
Refs #674
Refs #618
Refs #872