### PR TITLE
ui(search): add tree-first Browse card preview

### DIFF
--- a/css/search/search-base.css
+++ b/css/search/search-base.css
@@ -1,12 +1,18 @@
 /* LoveBud Search page styles. Page-specific only. */
 
 .search-container {
+    width: min(100%, var(--page-shell-max));
     max-width: var(--page-shell-max);
     margin: 0 auto;
     padding: 28px var(--page-pad-desktop) 58px;
     display: grid;
-    grid-template-columns: minmax(0, 1.62fr) 420px;
+    grid-template-columns: minmax(0, 1fr) minmax(360px, 400px);
     gap: var(--hero-gap);
+    box-sizing: border-box;
+}
+
+.search-container > * {
+    min-width: 0;
 }
 
 .search-container .material-symbols-outlined {

--- a/css/search/search-controls.css
+++ b/css/search/search-controls.css
@@ -42,6 +42,8 @@
 }
 
 .tag-chip {
+    box-sizing: border-box;
+    max-width: 100%;
     padding: 8px 14px;
     border-radius: 99px;
     background: rgba(255,255,255,0.76);
@@ -80,6 +82,20 @@
     background: rgba(255, 255, 255, 0.48);
     box-shadow: 0 14px 32px rgba(75, 64, 57, 0.035);
     min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+#browseSortControls {
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
+#browseSortControls > div {
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
 }
 
 .browse-scroll-load-sentinel {
@@ -140,6 +156,11 @@
         font-size: 11px;
         white-space: nowrap;
         flex-shrink: 0;
+    }
+
+    #browseSortControls > div {
+        width: 100%;
+        justify-content: flex-start;
     }
 
     .browse-utility-row {

--- a/css/search/search-hero-controls.css
+++ b/css/search/search-hero-controls.css
@@ -79,6 +79,15 @@
     border-top: 1px solid rgba(144, 73, 81, 0.09);
 }
 
+.browse-results-head > * {
+    min-width: 0;
+}
+
+.browse-head-right {
+    min-width: 0;
+    max-width: 100%;
+}
+
 .browse-results-head h3 {
     margin: 0;
     font-size: 1.22rem;
@@ -119,8 +128,9 @@
     }
 
     .browse-head-right {
-        align-self: flex-end;
+        align-self: stretch;
         width: 100%;
+        align-items: flex-start !important;
     }
 
     .browse-results-head h3 {
@@ -128,7 +138,10 @@
     }
 
     #browseSortControls {
-        justify-content: flex-start;
+        width: 100% !important;
+        max-width: 100%;
+        min-width: 0;
+        justify-content: flex-start !important;
     }
 
     #browseSortControls .tag-chip {

--- a/css/search/search-preview-sidebar.css
+++ b/css/search/search-preview-sidebar.css
@@ -2,6 +2,8 @@
     position: sticky;
     top: 96px;
     height: fit-content;
+    width: 100%;
+    max-width: 100%;
     background:
         radial-gradient(circle at 28% 12%, rgba(255, 248, 246, 0.96), transparent 38%),
         radial-gradient(circle at 80% 22%, rgba(242, 234, 228, 0.72), transparent 28%),
@@ -14,6 +16,7 @@
         inset 0 1px 0 rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(14px);
     min-width: 0;
+    box-sizing: border-box;
 }
 
 .preview-sidebar h3 {
@@ -319,7 +322,7 @@
 }
 
 .preview-sidebar::before {
-    content: '';
+    content: none;
     position: absolute;
     top: 92px;
     right: 20px;
@@ -366,6 +369,9 @@
 
 .video-container {
     position: relative;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
     box-shadow: 0 16px 38px rgba(75, 64, 57, 0.10);
 }
 

--- a/css/search/search-preview-sidebar.css
+++ b/css/search/search-preview-sidebar.css
@@ -404,17 +404,19 @@
     content: '';
     position: absolute;
     left: 18px;
-    top: 16px;
-    width: 58px;
-    height: 42px;
+    top: 15px;
+    width: 76px;
+    height: 50px;
     border-radius: 999px;
     background:
-        radial-gradient(circle at 68% 26%, rgba(144, 73, 81, 0.50) 0 4px, transparent 5px),
-        radial-gradient(circle at 32% 48%, rgba(122, 139, 110, 0.42) 0 4px, transparent 5px),
-        linear-gradient(32deg, transparent 41%, rgba(144, 73, 81, 0.34) 42% 47%, transparent 48%),
+        radial-gradient(circle at 70% 25%, rgba(144, 73, 81, 0.70) 0 5px, transparent 6px),
+        radial-gradient(circle at 36% 48%, rgba(122, 139, 110, 0.62) 0 5px, transparent 6px),
+        radial-gradient(circle at 50% 28%, rgba(200, 116, 128, 0.56) 0 4px, transparent 5px),
+        linear-gradient(32deg, transparent 39%, rgba(144, 73, 81, 0.48) 40% 44%, transparent 45%),
+        linear-gradient(150deg, transparent 43%, rgba(122, 139, 110, 0.36) 44% 48%, transparent 49%),
         rgba(255, 255, 255, 0.82);
-    border: 1px solid rgba(255, 255, 255, 0.62);
-    box-shadow: 0 12px 24px rgba(50, 38, 35, 0.12);
+    border: 1px solid rgba(144, 73, 81, 0.14);
+    box-shadow: 0 12px 24px rgba(50, 38, 35, 0.14);
     pointer-events: none;
     z-index: 2;
 }

--- a/css/search/search-preview-sidebar.css
+++ b/css/search/search-preview-sidebar.css
@@ -338,7 +338,7 @@
 }
 
 .preview-sidebar::after {
-    content: '';
+    content: none;
     position: absolute;
     top: 146px;
     right: 72px;

--- a/css/search/search-responsive.css
+++ b/css/search/search-responsive.css
@@ -1,6 +1,6 @@
 @media (max-width: 1240px) {
     .search-container {
-        grid-template-columns: minmax(0, 1fr) 380px;
+        grid-template-columns: minmax(0, 1fr) minmax(340px, 380px);
         gap: 24px;
         padding: 24px var(--page-pad-tablet) 48px;
     }
@@ -159,6 +159,7 @@
     .search-container {
         padding: 20px var(--page-pad-mobile) 36px;
         gap: 22px;
+        width: 100%;
     }
 
     .browse-curation-shell {

--- a/css/search/search-responsive.css
+++ b/css/search/search-responsive.css
@@ -40,8 +40,8 @@
     }
 
     .tree-card-body {
-        grid-template-rows: 2.86rem 2.58rem auto;
-        row-gap: 8px;
+        grid-template-rows: 2.7rem 2.34rem 20px auto;
+        row-gap: 7px;
         padding: 4px;
     }
 
@@ -55,8 +55,19 @@
     .tree-subtitle {
         font-size: 0.88rem;
         line-height: 1.46;
-        min-height: 2.92em;
-        max-height: 2.92em;
+        min-height: 2.86em;
+        max-height: 2.86em;
+    }
+
+    .tree-card-flow-bridge {
+        height: 20px;
+        padding: 0 7px;
+    }
+
+    .tree-card-flow-node {
+        width: 6px;
+        height: 6px;
+        box-shadow: 0 0 0 3px rgba(200, 116, 128, 0.10);
     }
 
     .tree-meta-row {

--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -1,6 +1,9 @@
 .tree-card {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     padding: 14px;
     background:
         radial-gradient(circle at 30% 20%, rgba(255, 248, 245, 0.92), transparent 52%),
@@ -66,6 +69,9 @@
 
 .tree-card-media {
     position: relative;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     height: 136px;
     margin: 0 0 14px;
     overflow: hidden;
@@ -323,6 +329,9 @@
     row-gap: 7px;
     padding: 4px 6px 6px;
     flex: 1;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     min-width: 0;
     min-height: 0;
     overflow: hidden;
@@ -380,6 +389,9 @@
     align-items: center;
     gap: 0;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     height: 22px;
     padding: 0 8px;
     border-radius: 999px;
@@ -401,6 +413,7 @@
 
 .tree-card-flow-node {
     position: relative;
+    flex: 0 0 auto;
     z-index: 1;
     width: 7px;
     height: 7px;

--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -319,8 +319,8 @@
 
 .tree-card-body {
     display: grid;
-    grid-template-rows: 3.22rem 2.74rem auto;
-    row-gap: 8px;
+    grid-template-rows: 2.98rem 2.46rem 22px auto;
+    row-gap: 7px;
     padding: 4px 6px 6px;
     flex: 1;
     min-width: 0;
@@ -372,6 +372,59 @@
 .tree-subtitle-fallback {
     color: rgba(108, 89, 83, 0.72);
     font-weight: 650;
+}
+
+.tree-card-flow-bridge {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    width: 100%;
+    height: 22px;
+    padding: 0 8px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(255, 248, 245, 0.64), rgba(244, 248, 238, 0.58));
+    border: 1px solid rgba(144, 73, 81, 0.07);
+    overflow: hidden;
+}
+
+.tree-card-flow-line {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    top: 50%;
+    height: 2px;
+    border-radius: 999px;
+    transform: translateY(-50%);
+    background: linear-gradient(90deg, rgba(144, 73, 81, 0.34), rgba(122, 139, 110, 0.30));
+}
+
+.tree-card-flow-node {
+    position: relative;
+    z-index: 1;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #c87480;
+    box-shadow: 0 0 0 4px rgba(200, 116, 128, 0.10);
+}
+
+.tree-card-flow-node + .tree-card-flow-node {
+    margin-left: auto;
+}
+
+.tree-card-flow-node-root {
+    background: #904951;
+}
+
+.tree-card-flow-node-end {
+    background: #7a8b6e;
+    box-shadow: 0 0 0 4px rgba(122, 139, 110, 0.12);
+}
+
+.tree-card-flow-count-1 .tree-card-flow-line {
+    right: 50%;
+    opacity: 0.28;
 }
 
 .tree-meta-row {

--- a/js/i18n/i18n-search.js
+++ b/js/i18n/i18n-search.js
@@ -10,8 +10,8 @@
 
   window.i18nSearch = {
     'search.eyebrow': {
-      ko: '공개 러브트리',
-      en: 'Public LoveTrees'
+      ko: '러브트리 둘러보기',
+      en: 'Browse LoveTrees'
     },
     'search.title': {
       ko: '<span class="title-accent">러브트리</span> 둘러보기',
@@ -22,8 +22,8 @@
       en: 'Lightly explore the flow of moments others have shared.'
     },
     'search.resultsHeading': {
-      ko: '공개 러브트리',
-      en: 'Public LoveTrees'
+      ko: '둘러볼 러브트리',
+      en: 'LoveTrees to browse'
     },
     'search.resultsPopularHeading': {
       ko: '많이 감상한 러브트리',
@@ -236,6 +236,10 @@
     'search.previewOpenTreeCta': {
       ko: '트리 열기',
       en: 'Open tree'
+    },
+    'search.previewFallbackMomentCount': {
+      ko: '{count}개의 순간이 이어져 있어요.',
+      en: '{count} moments are connected.'
     },
     'search.previewSummaryThemeStart': {
       ko: '<strong style="color:var(--on-surface);">{title}</strong>는 <strong style="color:var(--on-surface);">{theme}</strong>와 함께 막 시작된 러브트리예요.',

--- a/js/search/index.js
+++ b/js/search/index.js
@@ -135,12 +135,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             return null;
         };
 
-        const selectTree = (tree, activeCard) => {
+        const selectTree = (tree, activeCard, options = {}) => {
             if (!tree) return;
+            const { openMobilePreview = true } = options;
             state.selectedTreeId = tree.id;
             ui.markActiveCard(activeCard);
 
-            if (ui.isMobilePreviewMode()) {
+            if (openMobilePreview && ui.isMobilePreviewMode()) {
                 ui.setMobilePreviewOpen(true);
             }
 
@@ -161,7 +162,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const targetTree = state.allTrees.find(t => t.id === treeId) || state.growingTrees.find(t => t.id === treeId);
             if (!targetTree) return;
 
-            selectTree(targetTree, findRenderedTreeCard(treeId));
+            selectTree(targetTree, findRenderedTreeCard(treeId), { openMobilePreview: false });
             state.initialTreeDeepLinkApplied = true;
         };
 
@@ -214,7 +215,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (!state.selectedTreeId && resetPreviewWhenNoSelection && filtered.length > 0) {
             const firstTree = filtered[0];
             const firstCard = findRenderedTreeCard(firstTree.id);
-            previewController.selectTree(firstTree, firstCard);
+            previewController.selectTree(firstTree, firstCard, { openMobilePreview: false });
             return;
         }
 

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -156,6 +156,31 @@
         `;
     }
 
+    function renderTreeFlowBridge(tree) {
+        const memoryCount = getDisplayMemoryCount(tree?.memoryCount);
+        const nodeCount = Math.max(1, Math.min(memoryCount || 1, 5));
+        const flowNodes = Array.from({ length: nodeCount }, (_, index) => {
+            const isFirst = index === 0;
+            const isLast = index === nodeCount - 1;
+            const nodeClass = [
+                'tree-card-flow-node',
+                isFirst ? 'tree-card-flow-node-root' : '',
+                isLast && nodeCount > 1 ? 'tree-card-flow-node-end' : ''
+            ].filter(Boolean).join(' ');
+            return `<span class="${nodeClass}"></span>`;
+        }).join('');
+        const label = memoryCount > 0
+            ? `${memoryCount}개의 순간이 이어진 러브트리 흐름`
+            : '이어질 순간을 기다리는 러브트리 흐름';
+
+        return `
+            <div class="tree-card-flow-bridge tree-card-flow-count-${nodeCount}" role="img" aria-label="${escapeHtml(label)}">
+                <span class="tree-card-flow-line"></span>
+                ${flowNodes}
+            </div>
+        `;
+    }
+
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
         const treeStage = tree?.stage || 'empty';
@@ -248,6 +273,7 @@
                  <div class="tree-card-body">
                      <div class="tree-title">${safeTitle}</div>
                      <p class="${subtitleClass}">${escapeHtml(softMoodLine)}</p>
+                     ${renderTreeFlowBridge(tree)}
                      <div class="tree-meta-row">
                          <div class="tree-meta-left">
                              <span class="tree-meta-chip">

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -101,7 +101,7 @@
             'Open viewing'
         );
         return `
-            <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
+            <a href="${escapeHtml(href)}" class="btn-round preview-secondary-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:13px;font-weight:700;gap:6px;background:transparent;color:var(--primary);border:1px solid var(--outline-variant);">
                 <span class="material-symbols-outlined" style="font-size:18px;">play_circle</span>
                 ${escapeHtml(label)}
             </a>
@@ -135,14 +135,14 @@
      */
     function renderOpenTreeButton(tree) {
         if (!tree?.id) return '';
-        const href = `${getBasePath()}detail.html?tree=${encodeURIComponent(tree.id)}`;
+        const href = `${getBasePath()}tree.html?treeId=${encodeURIComponent(tree.id)}`;
         const label = getSearchCopy(
             'search.previewOpenTreeCta',
             '트리 열기',
             'Open tree'
         );
         return `
-            <a href="${escapeHtml(href)}" class="btn-round preview-secondary-action" style="width:100%;margin-top:12px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:13px;font-weight:700;gap:6px;background:transparent;color:var(--primary);border:1px solid var(--outline-variant);">
+            <a href="${escapeHtml(href)}" class="btn-round btn-primary preview-primary-action" style="width:100%;margin-top:18px;min-height:50px;display:inline-flex;align-items:center;justify-content:center;text-decoration:none;font-size:14px;font-weight:800;gap:8px;">
                 <span class="material-symbols-outlined" style="font-size:16px;">account_tree</span>
                 ${escapeHtml(label)}
             </a>

--- a/js/search/search-preview-controller.js
+++ b/js/search/search-preview-controller.js
@@ -31,12 +31,13 @@
             return null;
         }
 
-        function selectTree(tree, activeCard) {
+        function selectTree(tree, activeCard, options = {}) {
             if (!tree) return;
+            const { openMobilePreview = true } = options;
             state.selectedTreeId = tree.id;
             ui.markActiveCard(activeCard);
 
-            if (ui.isMobilePreviewMode()) {
+            if (openMobilePreview && ui.isMobilePreviewMode()) {
                 ui.setMobilePreviewOpen(true);
             }
 
@@ -69,7 +70,7 @@
                 return;
             }
 
-            selectTree(targetTree, findRenderedTreeCard(treeId));
+            selectTree(targetTree, findRenderedTreeCard(treeId), { openMobilePreview: false });
             state.initialTreeDeepLinkApplied = true;
         }
 

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -334,6 +334,25 @@
         `;
     }
 
+    function renderSelectedTreeMediaFallback(treeTitle, memoryCount) {
+        const countLabel = memoryCount > 0
+            ? formatSearchCopy(
+                'search.previewFallbackMomentCount',
+                { count: memoryCount },
+                '{count}개의 순간이 이어져 있어요.',
+                '{count} moments are connected.'
+            )
+            : getSearchCopy('search.previewStatsPending', '첫 순간을 기다리는 중', 'Waiting for the first moment');
+
+        return `
+            <div class="preview-media-fallback preview-media-fallback-selected" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
+                <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">account_tree</span>
+                <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${treeTitle}</div>
+                <p style="margin:0;font-size:13px;line-height:1.6;">${escapeHtml(countLabel)}</p>
+            </div>
+        `;
+    }
+
     function showPreviewImageFallback(img) {
         const helper = window.LoveBudSearchPreviewMediaHelper;
         if (helper?.showPreviewImageFallback) {
@@ -393,7 +412,7 @@
                 const safeSourceUrl = sanitizeUrl(mediaMem?.sourceUrl || '');
                 const safeThumbnail = sanitizeUrl(mediaMem?.thumbnail || '');
                 const safeMediaMemTitle = escapeHtml(getMomentLabel(mediaMem || firstMem));
-                previewState = safeSourceUrl ? 'media' : (safeThumbnail ? 'thumbnail' : 'empty');
+                previewState = safeSourceUrl ? 'media' : 'thumbnail';
 
                 const mediaHelper = window.LoveBudSearchPreviewMediaHelper;
                 if (mediaHelper?.renderPreviewIframe && safeSourceUrl) {
@@ -414,7 +433,9 @@
                                 <div style="font-size:12px;opacity:0.7;">${safeMediaMemTitle}</div>
                             </div>
                         </div>
-                    ` : (safeThumbnail ? renderPreviewThumbnailMedia(safeThumbnail, safeMediaMemTitle, safeTreeTitle) : renderPlaceholder());
+                    ` : (safeThumbnail
+                        ? renderPreviewThumbnailMedia(safeThumbnail, safeMediaMemTitle, safeTreeTitle)
+                        : renderSelectedTreeMediaFallback(safeTreeTitle, displayMemoryCount));
                 }
             }
             setPreviewState(previewState);
@@ -462,8 +483,8 @@
                         <span style="color:var(--primary);font-weight:700;">${noRecordsLine}</span>
                         ${renderInfoCallout('info', getSearchCopy('search.previewNewTreeInfo', '이제 막 감상이 시작될 공개 러브트리예요.', 'This public LoveTree is just about to begin.'))}
                     </div>
-                    ${renderPreviewActionButton(tree)}
                     ${renderOpenTreeButton(tree)}
+                    ${renderPreviewActionButton(tree)}
                     ${renderShareButton(tree)}
                 `;
             } else {
@@ -491,8 +512,8 @@
                         ${renderInfoCallout('favorite', `${firstMomentLabel}에서 시작해 ${lastMomentLabel}까지 이어진 감정의 흐름이에요.`)}
                         ${renderInfoCallout('touch_app', getSearchCopy('search.previewJourneyCta', '이곳에서 대표 순간과 이어진 감정을 훑어보고, 마음이 머무는 순간으로 들어가 보세요.', 'Scan the featured moment and connected feelings here, then open the moment that draws you in.'), 'primary')}
                     </div>
-                    ${renderPreviewActionButton(tree)}
                     ${renderOpenTreeButton(tree)}
+                    ${renderPreviewActionButton(tree)}
                     ${renderShareButton(tree)}
                 `;
             }

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -66,6 +66,7 @@
                 sheetOverlay.remove();
                 sheetOverlay = null;
             }
+            document.querySelectorAll('.preview-sheet-overlay').forEach((overlay) => overlay.remove());
 
             // Release scroll lock: clear class and inline top BEFORE scrollTo
             document.body.classList.remove('preview-sheet-open');
@@ -99,7 +100,8 @@
         function syncPreviewVisibility() {
             if (!previewSidebar) return;
             if (isMobilePreviewMode()) {
-                setMobilePreviewOpen(Boolean(state.selectedTreeId));
+                const shouldStayOpen = previewSidebar.classList.contains('is-open') && Boolean(state.selectedTreeId);
+                setMobilePreviewOpen(shouldStayOpen);
                 return;
             }
             // Desktop / resize from mobile: clean up overlay + scroll lock safely
@@ -129,7 +131,7 @@
 
         const SORT_COPY = {
             latest: {
-                title: () => getSearchCopy('search.resultsHeading', '공개 러브트리', 'Public LoveTrees')
+                title: () => getSearchCopy('search.resultsHeading', '둘러볼 러브트리', 'LoveTrees to browse')
             },
             popular: {
                 title: () => getSearchCopy('search.resultsPopularHeading', '많이 감상한 러브트리', 'Popular LoveTrees')
@@ -143,7 +145,7 @@
 
             const eyebrow = document.querySelector('.search-panel-eyebrow span:last-child');
             if (eyebrow) {
-                eyebrow.textContent = getSearchCopy('search.eyebrow', '오늘의 공개 감상', 'Today\'s Public Picks');
+                eyebrow.textContent = getSearchCopy('search.eyebrow', '러브트리 둘러보기', 'Browse LoveTrees');
             }
 
             if (refs.searchInput) {

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260508-618-rev1">
+    <link rel="stylesheet" href="../css/search.css?v=20260508-618-rev2">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>

--- a/pages/search.html
+++ b/pages/search.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>공개 러브트리 둘러보기 | 러브트리</title>
+    <title>러브트리 둘러보기 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260504-778">
+    <link rel="stylesheet" href="../css/search.css?v=20260508-618-rev1">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -21,7 +21,7 @@
         <section>
             <div class="browse-curation-shell reveal-up">
                 <div class="search-panel-header">
-                    <div class="search-panel-eyebrow"><span data-i18n="search.eyebrow">공개 러브트리</span></div>
+                    <div class="search-panel-eyebrow"><span data-i18n="search.eyebrow">러브트리 둘러보기</span></div>
                     <h1 class="headline" data-i18n="search.title" data-i18n-html><span class="title-accent">러브트리</span> 둘러보기</h1>
                     <p data-i18n="search.subtitle">다른 사람이 남긴 순간의 흐름을 가볍게 살펴보세요.</p>
                 </div>
@@ -130,19 +130,19 @@
     <script src="../js/search/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search/search-data-adapter.js?v=20260422-1"></script>
     <script src="../js/search/search-shared-utils.js?v=20260428-1"></script>
-    <script src="../js/search/search-card-renderer.js?v=20260503-618"></script>
+    <script src="../js/search/search-card-renderer.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
-    <script src="../js/search/search-preview-action-helper.js?v=20260505-605"></script>
+    <script src="../js/search/search-preview-action-helper.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-renderer-builders.js?v=20260505-1"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260505-605"></script>
+    <script src="../js/search/search-preview-renderer.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
-    <script src="../js/search/search-ui.js?v=20260504-777-2"></script>
+    <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>
      <script src="../js/search/search-controls.js?v=20260429-1"></script>
     <script src="../js/search/search-data.js?v=20260503-598-2"></script>
-     <script src="../js/search/search-preview-controller.js?v=20260429-1"></script>
-    <script src="../js/search/index.js?v=20260503-598-2"></script>
+     <script src="../js/search/search-preview-controller.js?v=20260508-618-rev1"></script>
+    <script src="../js/search/index.js?v=20260508-618-rev1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <script src="../js/firebase-config.js?v=20260417-31"></script>
@@ -150,7 +150,7 @@
     <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
     <script src="../js/i18n/i18n-login.js?v=20260419-2"></script>
     <script src="../js/i18n/i18n-intro.js?v=20260421-2"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260505-605"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260508-618-rev1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260421-9"></script>
     <script src="../js/i18n/i18n-my-trees.js?v=20260421-5"></script>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -115,7 +115,7 @@ test('search preview summary omits range phrase for missing time range labels', 
   assert.match(i18nSearch, /span style="color:var\(--primary\);font-weight:700;">\{count\}개의 순간<\/span>이 이어졌어요/);
 });
 
-test('browse selected hub primary and secondary CTA labels match detail viewing routes', () => {
+test('browse selected hub primary tree CTA and secondary viewing CTA keep truthful routes', () => {
   const actionHelper = read('js/search/search-preview-action-helper.js');
   const previewRenderer = read('js/search/search-preview-renderer.js');
   const i18nSearch = read('js/i18n/i18n-search.js');
@@ -123,11 +123,14 @@ test('browse selected hub primary and secondary CTA labels match detail viewing 
   assert.match(actionHelper, /detail\.html\?id=/);
   assert.match(actionHelper, /from=browse/);
   assert.match(actionHelper, /search\.previewOpenViewingCta/);
+  assert.match(actionHelper, /preview-secondary-action/);
   assert.match(previewRenderer, /helper\?\.renderPreviewActionButton/);
   assert.match(previewRenderer, /return '';/);
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
+  assert.match(actionHelper, /tree\.html\?treeId=/);
+  assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
   assert.match(i18nSearch, /'search\.previewOpenTreeCta'/);


### PR DESCRIPTION
## Summary
- Add compact mini tree-flow signal to Browse cards.
- Strengthen selected hub tree preview readability.
- Keep thumbnail as supporting representative context.
- Preserve media/fallback card grammar.
- Revision: keep mobile initial Browse free of preview-sheet dim overlay, keep selected hub preview state consistent, clean repeated "공개 러브트리" copy, and make `트리 열기` the primary tree-first CTA.
- Revision v2: remove the actual remaining floating vertical decorative pill source and tighten desktop/mobile Browse layout bounds so cards, sort controls, and the selected hub do not create horizontal overflow.

## Scope
- `js/search/search-card-renderer.js`
- `css/search/search-tree-card.css`
- `css/search/search-responsive.css`
- `css/search/search-preview-sidebar.css`
- `css/search/search-base.css`
- `css/search/search-controls.css`
- `css/search/search-hero-controls.css`
- `js/search/search-preview-renderer.js`
- `js/search/search-preview-action-helper.js`
- `js/search/search-preview-controller.js`
- `js/search/search-ui.js`
- `js/search/index.js`
- `js/i18n/i18n-search.js`
- `pages/search.html`
- `tests/routes/search-runtime-modules.test.js`

## Non-goals
- No backend/API/Auth/DB changes.
- No package/workflow changes.
- No full viewer implementation.
- No #766 selectable flow moment behavior.
- No CTA count increase.
- No fake/unlabeled overlay buttons.
- No broad Browse redesign.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/i18n/i18n-search.js js/search/index.js js/search/search-card-renderer.js js/search/search-preview-action-helper.js js/search/search-preview-controller.js js/search/search-preview-renderer.js js/search/search-ui.js`: PASS
- `npm run verify`: PASS
- `npm test`: PASS
- Local/static browser quick check: DESKTOP_HORIZONTAL_OVERFLOW=NO, MOBILE_375_HORIZONTAL_OVERFLOW=NO, FLOATING_VERTICAL_PILL_PRESENT=NO

## UI Review
- UI_REVIEW_REQUIRED
- CTO will judge desktop/mobile screenshots on the deployed preview.
- Draft remains intentionally not ready for merge.

Refs #618
