### PR TITLE
docs(engineering): audit JS filename convention risk

### DIFF
--- a/docs/engineering/JS_FILENAME_CONVENTION_AUDIT.md
+++ b/docs/engineering/JS_FILENAME_CONVENTION_AUDIT.md
@@ -1,0 +1,253 @@
+# JS Filename Convention Audit
+
+Refs #942
+Refs #931
+Refs #834
+Refs #656
+
+## Purpose
+
+This audit defines the pre-rename safety model for JavaScript filename convention cleanup.
+
+CSS filename convention cleanup can usually be verified through stylesheet import paths and visual review. JavaScript filename cleanup is higher risk because file paths participate in runtime loading, script ordering, test contracts, browser globals, Cloudflare static path resolution, and area-specific initialization behavior.
+
+This document is audit-only. It does not rename JavaScript files and does not authorize a broad JavaScript rename PR.
+
+## Current decision
+
+Do not create one broad JS rename PR.
+
+Use narrow implementation PRs after this audit, one runtime surface at a time. Each future rename PR should rename only a small group of files with one clear owner area, exact reference updates, static verification, and browser verification classification.
+
+## Risk model
+
+| Risk class | Meaning | Future PR requirement |
+| --- | --- | --- |
+| SAFE | File has local references only or clear path references with low runtime coupling. | May be renamed in a small docs-backed implementation PR after reference mapping. |
+| MEDIUM_RISK | File participates in HTML script order, browser globals, route tests, or user-visible runtime loading. | Rename only in a one-area PR with `node --check`, `npm run verify`, `npm test`, and browser verification classification. |
+| BLOCKED | File participates in unresolved duplicate source-of-truth, active open PR overlap, protected prototype paths, or unclear public/private runtime boundary. | Do not rename until blocker is resolved and the owner document is updated. |
+
+## Reference surfaces that must be checked
+
+Every future JS rename candidate must be mapped against:
+
+```text
+- HTML <script src> paths
+- ES module import/export paths
+- dynamic import or lazy-load paths
+- tests/routes runtime module expectations
+- docs/contracts mentioning the path
+- browser global names such as window.LoveBud...
+- event binding initialization order
+- Cloudflare Pages static path resolution
+- cache-key updates in pages/*.html when applicable
+```
+
+A rename is not complete when the file path changes. It is complete only when all known references and route contracts are updated and the affected runtime surface has a verification classification.
+
+## Candidate area inventory
+
+### 1. Search / Browse JS runtime modules
+
+Suggested owner docs:
+
+```text
+docs/engineering/SEARCH_RUNTIME_CONTRACT.md
+docs/engineering/SEARCH_ROOT_LEGACY_MOVE_PREFLIGHT_656.md
+docs/engineering/SEARCH_DUPLICATE_RENDERER_SOURCE_OF_TRUTH_656.md
+docs/engineering/LARGE_RUNTIME_DECOMPOSITION_STATUS_656.md
+```
+
+Observed risk pattern:
+
+```text
+- Search uses multiple js/search/* modules.
+- Search has runtime module expectation tests.
+- Search has recent path-contract history under #656 and #834.
+- Search pages depend on script order and browser globals.
+```
+
+Classification:
+
+```text
+MEDIUM_RISK by default
+```
+
+Recommended first rename type:
+
+```text
+Search low-risk helper modules only, 1-3 files maximum, after current active Browse/Search PR overlap is cleared.
+```
+
+Do not combine Search JS rename with Browse UI behavior, selected hub behavior, card layout, copy changes, API changes, or route changes.
+
+### 2. My Trees JS modules
+
+Suggested owner docs:
+
+```text
+docs/engineering/CORE_RUNTIME_BOUNDARY_MAP.md
+docs/ops/MEMBER_JOURNEY_QA_SUITE.md
+```
+
+Observed risk pattern:
+
+```text
+- My Trees is Auth and data dependent.
+- My Trees is part of returning-user member journey verification.
+- My Trees cards and actions can touch private/owner state.
+```
+
+Classification:
+
+```text
+MEDIUM_RISK
+```
+
+Recommended first rename type:
+
+```text
+Non-entry helper-only files after reference mapping.
+```
+
+Browser verification classification is required for any renamed file loaded by My Trees route HTML or involved in Auth-gated rendering.
+
+### 3. Editor JS modules
+
+Suggested owner docs:
+
+```text
+docs/engineering/EDITOR_ENTRYPOINT_ORCHESTRATION_BOUNDARY.md
+docs/engineering/EDITOR_DETAIL_UI_RESPONSIBILITY_AUDIT.md
+docs/engineering/AUTH_EDITOR_RUNTIME_INVENTORY_834.md
+```
+
+Observed risk pattern:
+
+```text
+- Editor is Auth/data/runtime sensitive.
+- Editor has many stateful interactions and compatibility globals.
+- Editor route depends on script order and selected tree/moment state.
+```
+
+Classification:
+
+```text
+MEDIUM_RISK to BLOCKED depending on file
+```
+
+Recommended first rename type:
+
+```text
+Audit-only until the target file is proven helper-only and outside active Editor decomposition work.
+```
+
+Do not rename Editor entrypoint or compatibility/global state files as part of filename convention cleanup without a separate runtime boundary plan.
+
+### 4. Shared / Header / Auth modules
+
+Suggested owner docs:
+
+```text
+docs/engineering/SCRIPT_LOAD_ORDER.md
+docs/engineering/AUTH_BOOTSTRAP_COMPATIBILITY_BOUNDARY.md
+docs/engineering/AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md
+docs/engineering/SHARED_HEADER_CONFIG_HELPER_DECISION.md
+```
+
+Observed risk pattern:
+
+```text
+- Shared header and Auth files can affect every route.
+- Script ordering and cached globals are part of the runtime contract.
+- Auth state mistakes can expose private route content or break login routing.
+```
+
+Classification:
+
+```text
+BLOCKED for broad rename
+MEDIUM_RISK for proven helper-only rename
+```
+
+Recommended first rename type:
+
+```text
+Do not start here. Rename only after Search/My Trees lower-risk slices prove the process.
+```
+
+### 5. Detail / Public Viewer modules
+
+Suggested owner docs:
+
+```text
+docs/engineering/DETAIL_RUNTIME_BOUNDARY_PLAN.md
+docs/product/READ_ONLY_LOVETREE_VIEWER_PLAN.md
+```
+
+Observed risk pattern:
+
+```text
+- Public/private data boundary matters.
+- Read-only viewer work is still evolving.
+- Route shell and public-safe payload boundary may introduce new viewer-specific modules.
+```
+
+Classification:
+
+```text
+MEDIUM_RISK for existing detail route modules
+BLOCKED for viewer modules until the first viewer route shell stabilizes
+```
+
+Recommended first rename type:
+
+```text
+Defer until viewer route naming and module ownership are stable.
+```
+
+## Recommended PR split after audit
+
+Use narrow PRs only:
+
+```text
+PR-JS-A: Search helper-only filename convention cleanup
+PR-JS-B: My Trees helper-only filename convention cleanup
+PR-JS-C: Editor helper-only filename convention cleanup, only after runtime boundary confirmation
+PR-JS-D: Shared/Auth/Header cleanup, only after previous slices pass and script-order risk is re-reviewed
+```
+
+Each implementation PR must include:
+
+```text
+- exact changed file list
+- old path -> new path mapping
+- reference update table
+- script/import/test update summary
+- node --check for changed JS
+- npm run verify
+- npm test
+- browser/fixed-slot verification requirement classification
+- PR #7 untouched confirmation
+- prototype/reference/demo/variant untouched confirmation
+- secret/private exposure: NO
+```
+
+## Explicit non-goals
+
+```text
+- No JS file rename in this audit document.
+- No CSS cleanup.
+- No runtime behavior change.
+- No Browse/Search UI change.
+- No Auth/API/backend/DB change.
+- No package or workflow change.
+- No PR #7 change.
+- No prototype/reference/demo/variant change.
+```
+
+## Initial recommendation
+
+Start with Search only after active Browse/Search overlap is cleared. Even then, rename only low-risk helper modules with complete reference mapping. Do not rename entrypoints, route-loaded files, or files listed in runtime module expectation tests unless the PR explicitly updates tests and has a browser verification classification.
+
+The safest immediate next action is not a rename PR. It is a concrete Search JS reference map that names candidate files and blocks unsafe targets before any path changes occur.

--- a/docs/engineering/engineering_index.md
+++ b/docs/engineering/engineering_index.md
@@ -20,21 +20,22 @@
 2. [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 3. [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) - module size, thin entrypoint, browser-global split, large file refactor safety policy
 4. [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) - #428 core runtime module owner domains, runtime boundaries, verification requirements
-5. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
-6. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
-7. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
-8. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
-9. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
-10. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
-11. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
-12. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
-13. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
-14. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
-15. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
-16. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
-17. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
-18. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
-19. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
+5. [JS_FILENAME_CONVENTION_AUDIT.md](./JS_FILENAME_CONVENTION_AUDIT.md) - #942 JS filename convention rename risk model, candidate areas, reference surfaces, and safe PR split
+6. [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) - stylesheet import hub, split ownership, visual verification 기준
+7. [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) - pages/*.html script order runtime contract, Auth/Login dependency order, reorder checklist
+8. [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) - Search/Browse runtime script order, globals, submodule boundary
+9. [AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md](./AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md) - Auth/Login active provider transition 단계, 금지 조합, fixed test slot 검증 기준
+10. [TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md](./TECHNICAL_DEBT_CHECKLIST_DISPOSITION.md) - #224 technical-debt checklist disposition map
+11. [CSS_HTML_CLEANUP_STATUS_MAP.md](./CSS_HTML_CLEANUP_STATUS_MAP.md) - #137 CSS/HTML cleanup backlog 상태와 잔여 작업 순서
+12. [EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md](./EDITOR_FALLBACK_GLOBAL_STATE_AUDIT.md) - Editor fallback factories와 global state cleanup path 감사 계획
+13. [AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md](./AUTH_EDITOR_FALLBACK_CHECKLIST_MAPPING.md) - #224 Auth/Editor fallback findings의 #78/#223/#225 ownership mapping
+14. [STAGED_RUNTIME_CLEANUP_DISPOSITION.md](./STAGED_RUNTIME_CLEANUP_DISPOSITION.md) - #225 staged runtime cleanup items disposition map
+15. [SHARED_HEADER_CONFIG_HELPER_DECISION.md](./SHARED_HEADER_CONFIG_HELPER_DECISION.md) - Shared header config/helper extraction defer 결정과 follow-up trigger
+16. [REVIEW_GUARDRAILS.md](./REVIEW_GUARDRAILS.md) - 반복 false positive 방지 규칙
+17. [RECENT_REFACTORING.md](./RECENT_REFACTORING.md) - 최근 리팩터링 기록
+18. [EDITOR_OVERRIDES_RELOCATION_AUDIT.md](./EDITOR_OVERRIDES_RELOCATION_AUDIT.md) - css/editor/overrides.css role-based relocation 사전 audit (구현 없음, #137 종속)
+19. [REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md](./REPOSITORY_STRUCTURE_FOLLOWUP_STATUS_MAP.md) - Issue #223 repository structure follow-up bucket disposition, active blockers, and closure conditions
+20. [PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md](./PUBLIC_TREE_ADAPTER_BOUNDARY_AUDIT.md) - #412 public tree adapter helper boundaries, export contract, loading-order risk, preview implications audit
 
 ---
 
@@ -46,6 +47,7 @@
 | [BROWSE_FILTER_VS_PUBLICATION_GUARD.md](./BROWSE_FILTER_VS_PUBLICATION_GUARD.md) | browse 표시 정책과 publication guard 분리 기준 |
 | [CODE_ARCHITECTURE.md](./CODE_ARCHITECTURE.md) | 파일 크기, thin entrypoint, browser-global module split, 대형 파일 리팩터링 안전 정책 |
 | [CORE_RUNTIME_BOUNDARY_MAP.md](./CORE_RUNTIME_BOUNDARY_MAP.md) | Issue #428 core runtime module ownership, frontend/backend/runtime boundaries, namespace and verification requirements |
+| [JS_FILENAME_CONVENTION_AUDIT.md](./JS_FILENAME_CONVENTION_AUDIT.md) | Issue #942 JS filename convention rename risk model, reference surfaces, candidate area classification, and follow-up PR split |
 | [CSS_ARCHITECTURE.md](./CSS_ARCHITECTURE.md) | CSS import hub, split ownership, import order, visual verification 기준 |
 | [SCRIPT_LOAD_ORDER.md](./SCRIPT_LOAD_ORDER.md) | pages/*.html script load order runtime contract, Auth/Login dependency order, reorder checklist |
 | [SEARCH_RUNTIME_CONTRACT.md](./SEARCH_RUNTIME_CONTRACT.md) | Search/Browse runtime script order, globals, submodule boundary, smoke checklist |
@@ -79,6 +81,7 @@
 - 런타임 / 배포 판단은 `../ops/OPERATIONS.md`와 `../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md`의 현재 기준을 우선합니다.
 - 반복되는 오판 방지는 `REVIEW_GUARDRAILS.md`를 기준으로 합니다.
 - 신규 코드 구조, thin entrypoint, browser-global split, 대형 파일 리팩터링 순서는 `CODE_ARCHITECTURE.md`를 기준으로 합니다.
+- JS filename convention cleanup은 `JS_FILENAME_CONVENTION_AUDIT.md`의 risk class, reference surfaces, and future PR split을 먼저 확인합니다.
 - core runtime owner domain, namespace contract, and verification boundary decisions start from `CORE_RUNTIME_BOUNDARY_MAP.md`.
 - pages/*.html script order 변경 판단은 `SCRIPT_LOAD_ORDER.md`를 먼저 보고, Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`와 함께 봅니다.
 - Auth/Login active provider 전환은 `AUTH_LOGIN_ACTIVE_PROVIDER_TRANSITION_PLAN.md`의 phase gate와 금지 조합을 기준으로 합니다.


### PR DESCRIPTION
## Summary
- Add a JS filename convention audit before any runtime module rename work.
- Classify JS rename risk by area: Search, My Trees, Editor, Shared/Auth/Header, and Detail/Public Viewer.
- Define required reference surfaces for future rename PRs.
- Recommend narrow future PR splits and block broad JS rename work.
- Index the audit in the engineering docs.

## Scope
- Docs-only.
- `docs/engineering/JS_FILENAME_CONVENTION_AUDIT.md`
- `docs/engineering/engineering_index.md`

## Non-goals
- No JavaScript rename.
- No runtime behavior change.
- No HTML/CSS/API/Auth/backend/DB/package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- GitHub API file create/update: PASS
- Changed files limited to docs/engineering: PASS
- Runtime/browser verification: NOT_REQUIRED for docs-only audit
- Secret/private exposure: NO

Refs #942
Refs #931
Refs #834
Refs #656