### PR TITLE
docs(qa): reconcile member journey suite status

### DIFF
--- a/docs/ops/MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md
+++ b/docs/ops/MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md
@@ -1,0 +1,162 @@
+# Member Journey QA Status Reconciliation
+
+Refs #838
+Refs #839
+Refs #840
+Refs #841
+Refs #842
+Refs #843
+Refs #844
+Refs #846
+Refs #849
+Refs #851
+Refs #861
+Refs #863
+Refs #871
+Refs #873
+Refs #877
+
+## Purpose
+
+This document reconciles the current documentation and execution status of the LoveBud member journey QA suite.
+
+The core QA suite and related operating policies already exist in repository docs. The remaining work is not another broad QA-suite document. The remaining work is to keep a clear separation between:
+
+```text
+- reusable docs/policy already recorded in the repository;
+- browser execution that still needs fixed-slot or production-smoke evidence;
+- credential/evidence inventory work that must remain secret-safe;
+- future narrow implementation PRs created only when verification finds a defect.
+```
+
+## Current source-of-truth documents
+
+| Area | Source document | Status |
+| --- | --- | --- |
+| Member journey suite | `docs/ops/MEMBER_JOURNEY_QA_SUITE.md` | DOC_PRESENT |
+| Personas | `docs/ops/MEMBER_JOURNEY_PERSONAS.md` | DOC_PRESENT |
+| Synthetic actor/account strategy | `docs/ops/SYNTHETIC_ACTOR_ACCOUNT_STRATEGY.md` | DOC_PRESENT |
+| PR checklist guidance | `docs/ops/PR_CHECKLIST.md` | DOC_PRESENT |
+| Credential and local secret handling | `docs/ops/AGENTS.md`, `docs/ops/AGENT_SECURITY.md`, credential-specific docs | DOC_PRESENT |
+| Browser verification URL and slot policy | `docs/ops/BROWSER_VERIFICATION_URL_POLICY.md`, `docs/ops/BROWSER_VERIFICATION_SLOT_GATE.md`, `docs/ops/CLOUDFLARE_PREVIEW_PROVENANCE_RUNBOOK.md` | DOC_PRESENT |
+
+## Issue reconciliation
+
+### Suite definition issues
+
+| Issue | Scope | Reconciled status | Remaining action |
+| --- | --- | --- | --- |
+| #838 | Define end-to-end member journey verification suite | DOC_PRESENT / EXECUTION_PENDING | Use the suite for future runtime-sensitive verification; no new broad docs PR needed unless policy changes. |
+| #839 | Auth signup/login checklist | DOC_PRESENT / EXECUTION_PENDING | Run fixed-slot Auth journey when assigned; record report on the issue. |
+| #840 | First tree creation checklist | DOC_PRESENT / EXECUTION_PENDING | Run fixed-slot first-create journey when assigned; record report on the issue. |
+| #841 | Returning user My Trees checklist | DOC_PRESENT / EXECUTION_PENDING | Run fixed-slot returning-user journey when assigned; record report on the issue. |
+| #842 | Editor moment editing checklist | DOC_PRESENT / EXECUTION_PENDING | Run fixed-slot Editor journey when assigned; record report on the issue. |
+| #843 | Public viewer read-only checklist | DOC_PRESENT / EXECUTION_PENDING | Run public/read-only viewer journey after a target route/deploy is available. |
+| #844 | Mobile and error recovery matrix | DOC_PRESENT / EXECUTION_PENDING | Run mobile/error recovery checks as part of target PR or batch verification. |
+
+### Persona and account strategy issues
+
+| Issue | Scope | Reconciled status | Remaining action |
+| --- | --- | --- | --- |
+| #846 | Member personas | DOC_PRESENT | Select personas in runtime-sensitive verification prompts. |
+| #849 | Three-track synthetic actor strategy | DOC_PRESENT / OPS_EXECUTION_PENDING | Keep QA/test, user-behavior, and AI activity separated in reports and credentials. |
+| #851 | Initial free password manager account set | DOC_PRESENT / OPS_EXECUTION_PENDING | CTO-managed password manager registration still needs safe status inventory. |
+| #861 | Multi-machine QA credential file handoff | DOC_PRESENT / OPS_EXECUTION_PENDING | Local credential files and USB handoff remain execution-only, not repository material. |
+| #863 | Verification report to fix/retest lifecycle | DOC_PRESENT | Use issue comments for per-run reports, not repository docs. |
+
+### Evidence and credential inventory issues
+
+| Issue | Scope | Reconciled status | Remaining action |
+| --- | --- | --- | --- |
+| #871 | Browser screenshot evidence inventory | OPS_EXECUTION_PENDING | Collect safe metadata and classify screenshots as SAFE_TO_UPLOAD / LOCAL_ONLY / DELETE_RECOMMENDED / MISSING. |
+| #873 | Register QA/AI accounts in password manager | OPS_EXECUTION_PENDING | Record only safe inventory rows in GitHub; actual credentials remain outside GitHub. |
+| #877 | Require screenshot evidence and credential inventory for future batches | DOC_PRESENT / EXECUTION_RULE_ACTIVE | Future browser prompts should include evidence and credential preservation requirements. |
+
+## What should not be duplicated
+
+Do not create another broad replacement for `MEMBER_JOURNEY_QA_SUITE.md` unless the actual operating policy changes.
+
+Do not turn repository docs into an incident log. Per-run results belong in issue comments or PR comments. Docs should hold stable templates and reusable policy only.
+
+Do not store screenshot artifacts, local credential file contents, raw browser logs, request/response payloads, private URLs, IDs, or credentials in repository docs.
+
+## Recommended next work split
+
+### Workstream A — Execution batch planning
+
+Use issue comments or an ops tracker comment to assign:
+
+```text
+- target issue or PR
+- persona
+- journey
+- fixed slot or production-smoke target
+- expected deployed SHA
+- account label and credential key only
+- report destination
+```
+
+No repository change is required unless the process changes.
+
+### Workstream B — Evidence inventory
+
+For #871 and #877, collect only safe screenshot metadata:
+
+```text
+- screenshot filename or artifact label
+- local artifact location label
+- journey or verification scope
+- viewport
+- PASS/FAIL context
+- SAFE_TO_UPLOAD / LOCAL_ONLY / DELETE_RECOMMENDED / MISSING
+```
+
+Do not upload or paste screenshots until they are manually reviewed for secret/private exposure.
+
+### Workstream C — Credential inventory
+
+For #873, record only GitHub-safe metadata:
+
+```text
+- Account label
+- Track
+- Persona or AI role
+- Credential key
+- Credential location label
+- Status
+- Secret values exposed: NO
+```
+
+Actual credential values must remain in the approved password manager or approved local credential file and must not be committed, pasted, screenshotted, or logged.
+
+### Workstream D — Defect-to-PR lifecycle
+
+Create a new narrow implementation issue or PR only when verification finds a defect.
+
+Use this sequence:
+
+```text
+verification report
+-> finding classification
+-> narrow fix issue if code change is needed
+-> implementation PR with Refs only
+-> fixed-slot retest
+-> final disposition
+```
+
+## Completion interpretation
+
+The QA suite documentation layer is present enough for future execution. The open status of the QA issues should be interpreted as execution tracking unless a specific missing policy is identified.
+
+A future issue may be closed or moved forward only after CTO review confirms whether the required documentation and/or execution evidence is sufficient. This document does not close any issue.
+
+## Guardrails
+
+```text
+- Use Refs only in PRs and comments unless CTO explicitly approves closure wording.
+- Do not push directly to main.
+- Do not touch PR #7.
+- Do not modify prototype/reference/demo/variant paths.
+- Do not expose actual email, password, token, session, cookie, request header, private UID, tree ID, owner ID, memory ID, copied tree ID, DB row value, raw private URL, raw request/response payload, or credential file contents.
+- Do not claim browser PASS from docs-only reconciliation.
+```

--- a/docs/ops/ops_index.md
+++ b/docs/ops/ops_index.md
@@ -19,25 +19,27 @@
 1. [OPERATIONS.md](OPERATIONS.md) - 현재 운영 전략과 계층 정의
 2. [PARALLEL_WORKTREE_AGENT_POLICY.md](PARALLEL_WORKTREE_AGENT_POLICY.md) - 병렬 모델/worktree/검증 모델 운영 기준
 3. [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) - 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준
-4. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
-5. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
-6. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
-7. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
-8. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
-9. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
-10. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
-11. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
-12. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
-13. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
-14. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
-15. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
-16. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
-17. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
-18. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
-19. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
-20. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
-21. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
-22. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
+4. [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md) - end-to-end member journey verification suite
+5. [MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md](MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md) - #838 계열 QA 문서/실행/증거/credential 잔여 상태 정리
+6. [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) - Issue #464 agent startup checklist, fixed-slot verification, dirty worktree stop, token-safe reporting 기준
+7. [AGENTS.md](AGENTS.md) - ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준
+8. [AGENT_SECURITY.md](AGENT_SECURITY.md) - agent secret handling policy, approved local paths, forbidden value exposure 기준
+9. [GITHUB_AUTH_TOKEN_USAGE.md](GITHUB_AUTH_TOKEN_USAGE.md) - GitHub CLI/browser login/connector 인증 및 token/credential 취급 기준
+10. [BROWSER_VERIFICATION_URL_POLICY.md](BROWSER_VERIFICATION_URL_POLICY.md) - 브라우저 검증 URL 출처, PR Preview, fixed test slot 사용 기준
+11. [TEST_PREVIEW_SLOTS.md](TEST_PREVIEW_SLOTS.md) - 고정 테스트 Preview 슬롯 운영 기준
+12. [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) - 배포 전/후 체크리스트
+13. [RUNBOOK.md](RUNBOOK.md) - 운영 / 장애 대응 기준
+14. [MODAL_BROWSE_RUNTIME.md](MODAL_BROWSE_RUNTIME.md) - browse summary의 Modal 우선 read path 기준
+15. [KNOWN_CI_E2E_BLOCKERS.md](KNOWN_CI_E2E_BLOCKERS.md) - 반복 CI/E2E blocker 원인 분리 및 exception merge 판단 기준
+16. [E2E_SMOKE_COVERAGE_POLICY.md](E2E_SMOKE_COVERAGE_POLICY.md) - Issue #413 E2E smoke coverage 분류, CI/manual/Cloudflare Preview/fixed test slot 실행 정책, evidence 기준
+17. [ACTIVE_WORK_BOARD_POLICY.md](ACTIVE_WORK_BOARD_POLICY.md) - Issue #426 병렬 AI/workstation 작업 충돌 방지, active work board 필드, 상태 정의, 중복 prompt 방지, overlap warning 규칙, handoff/report 형식
+18. [BRANCH_CLEANUP_PLAN.md](BRANCH_CLEANUP_PLAN.md) - merged/stale branch cleanup 후보와 보존 branch 분류 기준
+19. [../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md](../migration/VERCEL_MODAL_MIGRATION_RUNBOOK.md) - 전환 현황과 남은 과제
+20. [ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md](ENV_NAMING_RUNTIME_TERMINOLOGY_AUDIT.md) - Issue #431 환경변수 명명 및 runtime terminology 감사, NETLIFY_DATABASE_URL 사용 현황, Cloudflare + Modal + Neon active runtime 정리
+21. [LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md](LOCAL_FILE_HYGIENE_PG_DEPENDENCY_AUDIT.md) - Issue #429 local file hygiene 및 pg dependency usage 감사, .local/ tracked-file safety boundary, secret-safe local file handling, Cloudflare Functions vs local script dependency boundary
+22. [OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md](OBSERVABILITY_RUNTIME_LOGGING_AUDIT.md) - Issue #415 observability 및 runtime logging strategy 감사, Cloudflare/Modal/browser 디버깅 경로, redaction-safe logging boundary, follow-up implementation issue plan (A/B/C)
+23. [MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md](MODAL_RUNTIME_DIAGNOSTICS_WORKFLOW.md) - Issue #473 Modal runtime diagnostics workflow, Cloudflare ↔ Modal verification 절차, request ID correlation, blocked-state 보고 기준
+24. [../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md](../engineering/BROWSE_FILTER_VS_PUBLICATION_GUARD.md) - browse filter / publication guard 구분
 
 ---
 
@@ -60,6 +62,8 @@
 | [DEPLOY_CHECKLIST.md](DEPLOY_CHECKLIST.md) | 배포 전/후 검증 체크리스트 |
 | [RUNBOOK.md](RUNBOOK.md) | 운영 및 장애 대응 런북 |
 | [LOCAL_BROWSER_VERIFICATION_STARTUP.md](LOCAL_BROWSER_VERIFICATION_STARTUP.md) | 로컬/브라우저 검증 시작 전 공통 preflight, URL provenance, evidence, PR checklist 기준 |
+| [MEMBER_JOURNEY_QA_SUITE.md](MEMBER_JOURNEY_QA_SUITE.md) | Persona-first end-to-end member journey QA suite, fixed-slot vs production-smoke boundary, journey report templates |
+| [MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md](MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md) | #838 계열 journey/persona/account/evidence issue 상태 reconcile 및 execution-pending 분리 |
 | [AGENT_STARTUP_VERIFICATION_RULES.md](AGENT_STARTUP_VERIFICATION_RULES.md) | agent startup checklist, fixed-slot verification, dirty worktree stop, PASS/NOT_VERIFIED/BLOCKED reporting 기준 |
 | [AGENTS.md](AGENTS.md) | ops agent secret/path-only handling, PR/Issue safety, CTO merge approval 기준 |
 | [AGENT_SECURITY.md](AGENT_SECURITY.md) | agent secret handling policy, approved local paths, forbidden value exposure 기준 |


### PR DESCRIPTION
## Summary
- Add a QA status reconciliation document for the member journey issue family.
- Separate existing reusable docs from remaining execution, evidence inventory, and credential inventory work.
- Clarify that #838-series issues are primarily execution tracking unless a specific missing policy is identified.
- Index the reconciliation document in ops docs.

## Scope
- Docs-only.
- `docs/ops/MEMBER_JOURNEY_QA_STATUS_RECONCILIATION.md`
- `docs/ops/ops_index.md`

## Non-goals
- No runtime implementation.
- No browser verification claim.
- No credential values or local credential file contents.
- No Auth/API/backend/DB/package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- GitHub API file create/update: PASS
- Changed files limited to docs/ops: PASS
- Runtime/browser verification: NOT_REQUIRED for docs-only reconciliation
- Secret/private exposure: NO

Refs #838
Refs #839
Refs #840
Refs #841
Refs #842
Refs #843
Refs #844
Refs #846
Refs #849
Refs #851
Refs #861
Refs #863
Refs #871
Refs #873
Refs #877