### PR TITLE
feat(viewer): add read-only LoveTree viewer route with Canvas v4 media-leaf tree

### DIFF
--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -80,7 +80,7 @@
         // Group memories by parentId or create a flat single-branch structure
         var moments = memories.map(function(m, i) {
             return {
-                id: m.id,
+                id: 'moment-' + i,
                 title: m.title || m.emotionMemo || '',
                 tag: (m.emotionTags && m.emotionTags[0]) || '',
                 caption: m.emotionMemo || m.title || '',
@@ -111,7 +111,7 @@
                 caption: memories.length + t('viewer.momentsConnected', '개의 순간이 이어져 있어요', ' connected moments'),
                 count: memories.length,
                 rootSeed: {
-                    id: 'root-' + (memories[0] && memories[0].id || treeId),
+                    id: 'moment-root',
                     branchId: 'main',
                     title: memories[0] && memories[0].title || t('viewer.rootMoment', '시작된 순간', 'Starting moment'),
                     tag: t('viewer.start', '시작', 'Start'),
@@ -285,18 +285,20 @@
             };
 
             container.addEventListener('click', function(e) {
-                var branchBtn = e.target.closest('[data-branch-id]');
-                if (branchBtn) { handler.onSelectBranch(branchBtn.dataset.branchId); return; }
+                var action = e.target.closest('[data-action]');
+                if (action) {
+                    var a = action.dataset.action;
+                    if (a === 'close-moment') handler.closeMoment();
+                    else if (a === 'close-panel') handler.closePanel();
+                    else if (a === 'toggle-like') handler.toggleLike();
+                    else if (a === 'open-tree-comments') handler.openPanel('tree-comments');
+                    else if (a === 'open-share') handler.openPanel('share');
+                    return;
+                }
                 var momentBtn = e.target.closest('[data-moment-id]');
                 if (momentBtn) { handler.onSelectMoment(momentBtn.dataset.momentId, momentBtn.dataset.branchId); return; }
-                var action = e.target.closest('[data-action]');
-                if (!action) return;
-                var a = action.dataset.action;
-                if (a === 'close-moment') handler.closeMoment();
-                else if (a === 'close-panel') handler.closePanel();
-                else if (a === 'toggle-like') handler.toggleLike();
-                else if (a === 'open-tree-comments') handler.openPanel('tree-comments');
-                else if (a === 'open-share') handler.openPanel('share');
+                var branchBtn = e.target.closest('.vv-branch-label[data-branch-id]');
+                if (branchBtn) { handler.onSelectBranch(branchBtn.dataset.branchId); return; }
             });
 
             state.selectedBranchId = 'main';

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -1,0 +1,349 @@
+(function() {
+    'use strict';
+
+    var MARKER = 'LoveBudTreeViewerLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    var SEL = {
+        shell: '#viewerTreeShell',
+        loading: '#viewerLoadingState',
+        empty: '#viewerEmptyState',
+        error: '#viewerErrorState',
+        treeContainer: '#viewerTreeContainer',
+        treeTitle: '#viewerTreeTitle',
+        treeMeta: '#viewerTreeMeta'
+    };
+
+    var currentTreeId = null;
+    var viewerState = {};
+
+    // i18n helper
+    function t(key, fallbackKo, fallbackEn) {
+        var dict = window.i18nViewer && window.i18nViewer[key];
+        if (dict && typeof dict === 'object') {
+            var locale = (window.i18n && window.i18n.currentLang || 'ko').toLowerCase();
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return dict || fallbackKo || fallbackEn || key;
+    }
+
+    function escapeHtml(v) {
+        return String(v == null ? '' : v).replace(/[&<>"']/g, function(c) {
+            return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+        });
+    }
+
+    function qs(sel) { return document.querySelector(sel); }
+    function show() {
+        for (var i = 0; i < arguments.length; i++) {
+            var el = qs(arguments[i]);
+            if (el) el.removeAttribute('hidden');
+        }
+    }
+    function hide() {
+        for (var i = 0; i < arguments.length; i++) {
+            var el = qs(arguments[i]);
+            if (el) el.setAttribute('hidden', '');
+        }
+    }
+
+    function getCurrentLocale() {
+        var locale = window.i18n && window.i18n.currentLang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    function formatDate(raw) {
+        if (!raw) return '';
+        try {
+            return new Date(raw).toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR');
+        } catch(e) { return raw; }
+    }
+
+    function showLoading() {
+        hide(SEL.treeContainer, SEL.empty, SEL.error);
+        show(SEL.loading);
+    }
+
+    function renderEmpty() {
+        hide(SEL.treeContainer, SEL.loading, SEL.error);
+        show(SEL.empty);
+    }
+
+    function renderError() {
+        hide(SEL.treeContainer, SEL.loading, SEL.empty);
+        show(SEL.error);
+    }
+
+    function transformToRenderFormat(treeId, memories) {
+        // Convert flat memory list to branch/moment structure for Canvas v4 renderer
+        // Group memories by parentId or create a flat single-branch structure
+        var moments = memories.map(function(m, i) {
+            return {
+                id: m.id,
+                title: m.title || m.emotionMemo || '',
+                tag: (m.emotionTags && m.emotionTags[0]) || '',
+                caption: m.emotionMemo || m.title || '',
+                color: 'from-rose-100 via-rose-50 to-white',
+                emoji: '✦',
+                t: (i + 0.5) / Math.max(memories.length, 1)
+            };
+        });
+
+        return {
+            tree: {
+                id: treeId,
+                title: memories[0] && memories[0].treeTitle || t('viewer.treeTitle', '러브트리', 'LoveTree'),
+                memoryCount: memories.length,
+                creator: '@lovetree_viewer',
+                meta: memories.length + '개의 순간 · 꾸민 트리'
+            },
+            branch: {
+                id: 'main',
+                name: t('viewer.mainBranch', '전체 흐름', 'Full Flow'),
+                side: 'left',
+                color: 'rose',
+                startY: 77,
+                endY: 16,
+                endX: 22,
+                curveA: 38,
+                curveB: 28,
+                caption: memories.length + t('viewer.momentsConnected', '개의 순간이 이어져 있어요', ' connected moments'),
+                count: memories.length,
+                rootSeed: {
+                    id: 'root-' + (memories[0] && memories[0].id || treeId),
+                    branchId: 'main',
+                    title: memories[0] && memories[0].title || t('viewer.rootMoment', '시작된 순간', 'Starting moment'),
+                    tag: t('viewer.start', '시작', 'Start'),
+                    caption: memories[0] && memories[0].emotionMemo || '',
+                    color: 'from-rose-200 via-rose-100 to-amber-50',
+                    emoji: '✦'
+                },
+                moments: moments
+            }
+        };
+    }
+
+    async function loadPublicData(treeId) {
+        var getMemories = window.apiClient &&
+            (window.apiClient.communityApi && window.apiClient.communityApi.getCachedCommunityMemories ||
+             window.apiClient.getCachedCommunityMemories);
+
+        if (typeof getMemories !== 'function') {
+            throw new Error('Community API not available');
+        }
+
+        var memories = await getMemories({ treeId: treeId, limit: 100 });
+        return Array.isArray(memories) ? memories.filter(function(m) { return m && m.visibility === 'public'; }) : [];
+    }
+
+    async function initViewer() {
+        var params = new URLSearchParams(window.location.search);
+        var treeId = params.get('treeId');
+        if (!treeId) {
+            renderEmpty();
+            return;
+        }
+
+        currentTreeId = treeId;
+        showLoading();
+
+        try {
+            var memories = await loadPublicData(treeId);
+            if (!memories || memories.length === 0) {
+                renderEmpty();
+                return;
+            }
+
+            var renderData = transformToRenderFormat(treeId, memories);
+
+            // Set up the viewer state using the #953 renderer modules
+            var RenderTree = window.LoveBudVisitorViewerRenderTree;
+            var Panels = window.LoveBudVisitorViewerPanels;
+
+            if (!RenderTree || !Panels) {
+                // Fallback: show simple tree list if Canvas modules not loaded
+                renderSimpleTree(renderData);
+                return;
+            }
+
+            // Build the Canvas v4 tree shell
+            show(SEL.treeContainer);
+            hide(SEL.loading, SEL.empty, SEL.error);
+
+            var container = qs('#viewerTreeContainer');
+            if (!container) return;
+
+            // Set tree identity
+            var titleEl = qs(SEL.treeTitle);
+            var metaEl = qs(SEL.treeMeta);
+            if (titleEl) titleEl.textContent = renderData.tree.title;
+            if (metaEl) metaEl.textContent = renderData.tree.meta;
+
+            // Inject Canvas v4 structure
+            container.innerHTML =
+                '<div class="vv-viewer-layout">' +
+                '  <div class="vv-tree-container"></div>' +
+                '  <div class="vv-panel-host"></div>' +
+                '</div>';
+
+            // Set up the global data object the #953 modules expect
+            window.__viewerTreeData = {
+                palette: window.LoveBudVisitorViewerData && window.LoveBudVisitorViewerData.palette || {
+                    rose: { stroke:'#e99aac', soft:'#fff1f3', text:'#be123c', dim:'rgba(251,113,133,.16)' }
+                },
+                branches: [renderData.branch],
+                rootSeed: renderData.branch.rootSeed,
+                curvePoint: function(branch, t) {
+                    var x0=50, y0=branch.startY;
+                    var x1=branch.curveA, y1=branch.startY-8;
+                    var x2=branch.curveB, y2=branch.endY+8;
+                    var x3=branch.endX, y3=branch.endY;
+                    var mt=1-t;
+                    return {
+                        x: mt*mt*mt*x0 + 3*mt*mt*t*x1 + 3*mt*t*t*x2 + t*t*t*x3,
+                        y: mt*mt*mt*y0 + 3*mt*mt*t*y1 + 3*mt*t*t*y2 + t*t*t*y3
+                    };
+                }
+            };
+
+            var state = {
+                selectedBranchId: null,
+                selectedMomentId: null,
+                activePanel: 'empty',
+                likedTree: false
+            };
+
+            function getAllMoments() {
+                var results = [];
+                var rs = renderData.branch.rootSeed;
+                results.push({ id: rs.id, branchId: 'main', title: rs.title, tag: rs.tag, caption: rs.caption, color: rs.color, emoji: rs.emoji });
+                renderData.branch.moments.forEach(function(m) {
+                    results.push({ id: m.id, branchId: 'main', title: m.title, tag: m.tag, caption: m.caption, color: m.color, emoji: m.emoji });
+                });
+                return results;
+            }
+
+            var allMoments = getAllMoments();
+
+            function refresh() {
+                var branch = renderData.branch;
+                var moment = allMoments.find(function(m) { return m.id === state.selectedMomentId; });
+                state.selectedBranch = branch;
+                state.selectedMoment = moment;
+                state.panelBranch = branch;
+
+                var treeBox = container.querySelector('.vv-tree-container');
+                if (treeBox && RenderTree) {
+                    // Patch data temporarily for renderer
+                    var origData = window.LoveBudVisitorViewerData;
+                    window.LoveBudVisitorViewerData = window.__viewerTreeData;
+                    RenderTree.renderTree(treeBox, state, handler);
+                    window.LoveBudVisitorViewerData = origData;
+                }
+
+                var panelHost = container.querySelector('.vv-panel-host');
+                if (panelHost && Panels) {
+                    var origData2 = window.LoveBudVisitorViewerData;
+                    window.LoveBudVisitorViewerData = window.__viewerTreeData;
+                    panelHost.innerHTML = Panels.renderPanel(state, handler);
+                    window.LoveBudVisitorViewerData = origData2;
+                }
+            }
+
+            var handler = {
+                onSelectBranch: function(branchId) {
+                    state.selectedBranchId = branchId;
+                    state.selectedMomentId = null;
+                    state.activePanel = 'branch';
+                    refresh();
+                },
+                onSelectMoment: function(momentId, branchId) {
+                    state.selectedBranchId = branchId;
+                    state.selectedMomentId = momentId;
+                    state.activePanel = 'moment';
+                    refresh();
+                },
+                closeMoment: function() {
+                    state.selectedMomentId = null;
+                    state.activePanel = 'branch';
+                    refresh();
+                },
+                openPanel: function(panel) {
+                    state.activePanel = panel;
+                    refresh();
+                },
+                closePanel: function() {
+                    if (state.selectedMomentId) { state.activePanel = 'moment'; }
+                    else if (state.selectedBranchId) { state.activePanel = 'branch'; }
+                    else { state.activePanel = 'empty'; }
+                    refresh();
+                },
+                toggleLike: function() {
+                    state.likedTree = !state.likedTree;
+                }
+            };
+
+            container.addEventListener('click', function(e) {
+                var branchBtn = e.target.closest('[data-branch-id]');
+                if (branchBtn) { handler.onSelectBranch(branchBtn.dataset.branchId); return; }
+                var momentBtn = e.target.closest('[data-moment-id]');
+                if (momentBtn) { handler.onSelectMoment(momentBtn.dataset.momentId, momentBtn.dataset.branchId); return; }
+                var action = e.target.closest('[data-action]');
+                if (!action) return;
+                var a = action.dataset.action;
+                if (a === 'close-moment') handler.closeMoment();
+                else if (a === 'close-panel') handler.closePanel();
+                else if (a === 'toggle-like') handler.toggleLike();
+                else if (a === 'open-tree-comments') handler.openPanel('tree-comments');
+                else if (a === 'open-share') handler.openPanel('share');
+            });
+
+            state.selectedBranchId = 'main';
+            state.activePanel = 'empty';
+            refresh();
+
+        } catch (error) {
+            console.error('[tree-viewer] load failed:', error);
+            renderError();
+        }
+    }
+
+    function renderSimpleTree(renderData) {
+        show(SEL.treeContainer);
+        hide(SEL.loading, SEL.empty, SEL.error);
+        var titleEl = qs(SEL.treeTitle);
+        var metaEl = qs(SEL.treeMeta);
+        if (titleEl) titleEl.textContent = renderData.tree.title;
+        if (metaEl) metaEl.textContent = renderData.tree.meta;
+        var container = qs('#viewerTreeContainer');
+        if (!container) return;
+        container.innerHTML = '';
+        var list = document.createElement('div');
+        list.className = 'viewer-nodes-list';
+        renderData.branch.moments.forEach(function(m) {
+            var node = document.createElement('div');
+            node.className = 'viewer-node';
+            node.innerHTML = '<span class="viewer-node-title">' + escapeHtml(m.title) + '</span>' +
+                (m.tag ? '<span class="viewer-node-tag">' + escapeHtml(m.tag) + '</span>' : '');
+            list.appendChild(node);
+        });
+        container.appendChild(list);
+    }
+
+    function setupRetry() {
+        var btn = document.getElementById('viewerRetryBtn');
+        if (btn) {
+            btn.addEventListener('click', function() {
+                if (currentTreeId) initViewer();
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function() { setupRetry(); initViewer(); });
+    } else {
+        setupRetry();
+        initViewer();
+    }
+})();

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -7,17 +7,14 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260505-802-1">
+    <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260508-923-1">
+    <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260508-951-2">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
-<body class="paper-grain">
+<body class="paper-grain viewer-body">
     <div class="noise-overlay"></div>
-
-    <!-- Shared Header (public, non-auth-gated) -->
     <div id="shared-header"></div>
-
     <div class="viewer-page-shell page-transition-enter">
-        <!-- Topbar -->
         <div class="viewer-topbar">
             <a id="backButton" class="viewer-back-link" href="../pages/search.html">
                 <span class="material-symbols-outlined">arrow_back</span>
@@ -28,93 +25,48 @@
                 <span data-i18n="viewer.public">공개</span>
             </div>
         </div>
-
         <main class="viewer-layout">
-            <!-- Tree Area (Left/Top) -->
-            <section class="viewer-tree-section">
-                <div id="viewerTreeShell" class="viewer-tree-shell">
-                    <!-- Loading / Empty / Error states -->
-                    <div id="viewerLoadingState" class="viewer-state" hidden>
-                        <div class="viewer-state-content">
-                            <span class="material-symbols-outlined refresh-symbol">progress_activity</span>
-                            <p data-i18n="viewer.loading">러브트리를 불러오는 중이에요</p>
-                        </div>
-                    </div>
-
-                    <div id="viewerEmptyState" class="viewer-state" hidden>
-                        <div class="viewer-state-content">
-                            <span class="material-symbols-outlined">sentiment_dissatisfied</span>
-                            <p data-i18n="viewer.empty">아직 공개된 순간이 없어요</p>
-                        </div>
-                    </div>
-
-                    <div id="viewerErrorState" class="viewer-state" hidden>
-                        <div class="viewer-state-content">
-                            <span class="material-symbols-outlined">error_outline</span>
-                            <p data-i18n="viewer.error">러브트리를 불러오지 못했어요. 다시 시도해 주세요.</p>
-                            <button type="button" id="viewerRetryBtn" class="btn-round btn-outline" data-i18n="viewer.retry">
-                                다시 시도
-                            </button>
-                        </div>
-                    </div>
-
-                    <!-- Tree Nodes Container -->
-                    <div id="viewerTreeContainer" class="viewer-tree-container" hidden>
-                        <!-- Tree title/meta -->
-                        <div class="viewer-tree-header">
-                            <h2 id="viewerTreeTitle" class="viewer-tree-title"></h2>
-                            <div id="viewerTreeMeta" class="viewer-tree-meta"></div>
-                        </div>
-
-                        <!-- Tree nodes vertical flow -->
-                        <div id="viewerNodesList" class="viewer-nodes-list"></div>
+            <div id="viewerTreeShell" class="viewer-tree-shell">
+                <div id="viewerLoadingState" class="viewer-state" hidden>
+                    <div class="viewer-state-content">
+                        <span class="material-symbols-outlined refresh-symbol">progress_activity</span>
+                        <p data-i18n="viewer.loading">러브트리를 불러오는 중이에요</p>
                     </div>
                 </div>
-            </section>
-
-            <!-- Moment Preview Panel (Right/Bottom) -->
-            <aside class="viewer-preview-section">
-                <div class="viewer-preview-sticky">
-                    <div class="viewer-preview-header">
-                        <h3 data-i18n="viewer.selectedMoment">선택한 순간</h3>
-                    </div>
-
-                    <div id="viewerPreviewContainer" class="viewer-preview-container">
-                        <!-- Empty state -->
-                        <div id="viewerPreviewEmpty" class="viewer-preview-empty">
-                            <p data-i18n="viewer.previewPlaceholder">순간을 선택하면 여기에 표시돼요</p>
-                        </div>
-
-                        <!-- Moment content -->
-                        <div id="viewerPreviewContent" class="viewer-preview-content" hidden>
-                            <div id="viewerPreviewMedia" class="viewer-preview-media"></div>
-                            <div class="viewer-preview-details">
-                                <h4 id="viewerMomentTitle" class="viewer-moment-title"></h4>
-                                <div id="viewerMomentTags" class="viewer-moment-tags"></div>
-                                <div id="viewerMomentMeta" class="viewer-moment-meta"></div>
-                                <div id="viewerMomentDiary" class="viewer-moment-diary">
-                                    <p id="viewerDiaryQuote" class="viewer-diary-quote"></p>
-                                    <div id="viewerDiaryContent" class="viewer-diary-content"></div>
-                                </div>
-                            </div>
-                        </div>
+                <div id="viewerEmptyState" class="viewer-state" hidden>
+                    <div class="viewer-state-content">
+                        <span class="material-symbols-outlined">sentiment_dissatisfied</span>
+                        <p data-i18n="viewer.empty">아직 공개된 순간이 없어요</p>
                     </div>
                 </div>
-            </aside>
+                <div id="viewerErrorState" class="viewer-state" hidden>
+                    <div class="viewer-state-content">
+                        <span class="material-symbols-outlined">error_outline</span>
+                        <p data-i18n="viewer.error">러브트리를 불러오지 못했어요. 다시 시도해 주세요.</p>
+                        <button type="button" id="viewerRetryBtn" class="btn-round btn-outline" data-i18n="viewer.retry">다시 시도</button>
+                    </div>
+                </div>
+                <div id="viewerTreeContainer" class="viewer-tree-container" hidden>
+                    <div class="viewer-tree-header">
+                        <h2 id="viewerTreeTitle" class="viewer-tree-title"></h2>
+                        <div id="viewerTreeMeta" class="viewer-tree-meta"></div>
+                    </div>
+                </div>
+            </div>
         </main>
     </div>
-
-    <!-- Scripts (minimal auth policy for base-api-fetch) -->
     <script src="../js/cache-utils.js?v=20260418-1"></script>
     <script src="../js/utils/normalize.js?v=20260422-1"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>
-    <script src="../js/search/search-preview-renderer.js?v=20260504-1"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-data.js?v=20260508-951-1"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-render-tree.js?v=20260508-951-2"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-panels.js?v=20260508-951-4"></script>
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
-    <script src="../js/i18n/i18n-viewer.js?v=20260505-802-1"></script>
+    <script src="../js/i18n/i18n-viewer.js?v=20260508-923-1"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
-    <script src="../js/viewer/public-tree-viewer.js?v=20260505-802-1"></script>
+    <script src="../js/viewer/tree-viewer.js?v=20260508-923-1"></script>
 </body>
 </html>

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -1,0 +1,72 @@
+/**
+ * LoveBud Viewer Route Contract Tests
+ * Issue #923 — First slice of read-only LoveTree viewer route
+ *
+ * Verifies:
+ * - Viewer route (pages/tree.html) exists
+ * - Viewer JS does not expose Editor/Builder controls
+ * - Viewer does not load Editor entry script
+ * - Browse "트리 열기" targets tree.html (not editor or detail)
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+test('tree viewer route page exists', () => {
+    assert.ok(fs.existsSync('pages/tree.html'), 'pages/tree.html must exist');
+});
+
+test('tree viewer orchestrator JS exists', () => {
+    assert.ok(fs.existsSync('js/viewer/tree-viewer.js'), 'js/viewer/tree-viewer.js must exist');
+});
+
+test('tree viewer route does not load editor entry script', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const noEditorScript = !html.includes('js/editor.js') && !html.includes('pages/editor.html');
+    assert.ok(noEditorScript, 'tree.html must not load editor entry script');
+});
+
+test('tree viewer JS does not contain editing affordances', () => {
+    const content = fs.readFileSync('js/viewer/tree-viewer.js', 'utf8');
+    const forbidden = ['contentEditable', 'edit-control', 'edit-btn', 'delete-btn', 'add-moment', 'drag-handle'];
+    const violations = forbidden.filter(f => content.includes(f));
+    assert.equal(violations.length, 0, 'tree-viewer.js must not contain editing affordances: ' + violations.join(', '));
+});
+
+test('tree viewer route does not reference Editor/Builder page', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const noEditorPage = !html.includes('editor.html') && !html.includes('js/editor/') && !html.includes('js/editor.js');
+    assert.ok(noEditorPage, 'tree.html must not load any Editor module');
+});
+
+test('Browse tree-open CTA targets tree.html with treeId param', () => {
+    const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
+    const hasTreeUrl = helper.includes('tree.html?treeId=');
+    assert.ok(hasTreeUrl, 'search-preview-action-helper.js must use tree.html?treeId= for tree-open CTA');
+    const noDetailUrl = !helper.includes('detail.html?tree=');
+    assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
+});
+
+test('tree viewer loads Canvas v4 modules', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const hasVisitorModules = html.includes('visitor-viewer/visitor-viewer-data.js') &&
+        html.includes('visitor-viewer/visitor-viewer-render-tree.js') &&
+        html.includes('visitor-viewer/visitor-viewer-panels.js');
+    assert.ok(hasVisitorModules, 'tree.html must load visitor-viewer Canvas v4 modules');
+});
+
+test('tree viewer does not load mock visitor-viewer orchestrator', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const noMockOrch = !html.includes('visitor-viewer/visitor-viewer.js');
+    assert.ok(noMockOrch, 'tree.html must not load visitor-viewer.js (mock data orchestrator)');
+});
+
+test('tree viewer scripts are scoped as viewer code', () => {
+    const content = fs.readFileSync('js/viewer/tree-viewer.js', 'utf8');
+    const marker = content.includes('LoveBudTreeViewerLoaded');
+    assert.ok(marker, 'tree-viewer.js must have a unique loaded marker');
+    const noEditorMarkers = !content.includes('editorCanvas') && !content.includes('nodeContextMenu') && !content.includes('addMemory');
+    assert.ok(noEditorMarkers, 'tree-viewer.js must not reference Editor internals');
+});


### PR DESCRIPTION
## Summary
Adds a dedicated read-only LoveTree viewer route (pages/tree.html) that uses the Canvas v4 media-leaf tree visualization from PR #953, powered by public-safe API data.

Browse's "트리 열기" CTA now targets this viewer route with treeId parameter instead of the detail/moment page.

## Route decision
pages/tree.html is used rather than repurposing pages/editor.html because:
- The editor page includes owner-mode controls and conflicts with read-only viewing.
- The viewer route explicitly avoids loading any Editor/Builder scripts.
- The existing pages/tree.html from PR #953 was a shell; this PR wires it with real data loading and Canvas v4 rendering.

## Public-safe data boundary
- Uses apiClient.communityApi.getCachedCommunityMemories() which returns only public memories.
- Displays: public tree title, moment titles, emotion tags, public metadata counts.
- Uses public route treeId from URL only. No raw API memory IDs are exposed in DOM attributes, labels, logs, or reports. Memory IDs are transformed to route-local identifiers (moment-0, moment-1, ...).
- Does NOT expose: owner IDs, memory IDs, copied tree IDs, DB rows, private identifiers, source URLs, or private fields.
- Falls back to loading/empty/error states if API is unavailable or no data.

## Viewer/editor boundary proof
- pages/tree.html does NOT load js/editor.js or any js/editor/ module.
- js/viewer/tree-viewer.js has a unique LoveBudTreeViewerLoaded marker and does NOT reference editor internals.
- No editing affordances, delete buttons, drag handles, or add-moment controls.
- Uses the same Canvas v4 renderer modules as the visitor viewer shell (#953), which are read-only by design.
- Falls back to a simple text list if Canvas v4 modules fail to load (safe degraded state).

## Click delegation order
The event handler processes actions first (close-moment, close-panel, toggle-like, etc.), then moment selection ([data-moment-id]), then branch selection (.vv-branch-label[data-branch-id]). This prevents moment clicks from being intercepted by branch selection handlers.

## Changed files
- pages/tree.html - Updated to load Canvas v4 modules and tree-viewer orchestrator
- js/viewer/tree-viewer.js - New viewer orchestrator with data loading, Canvas v4 rendering, state management, route-local IDs
- js/search/search-preview-action-helper.js - Wire tree open CTA to tree.html?treeId= instead of detail.html?tree=
- tests/routes/viewer-route-contract.test.js - 9 contract tests covering route existence, editor boundary, CTA wiring

## Non-goals
- No Editor/Builder owner-mode changes
- No API/Auth/DB/backend schema changes
- No comment/reaction persistence
- No Browse redesign
- No My Trees redesign
- No PR #7 or prototype/reference/demo/variant changes
- No broad Browse redesign
- No #766 selectable moment behavior

## Verification
- git diff --check: PASS
- node --check: PASS (viewer JS files)
- npm test: PASS 233/233 (9 new viewer route tests)
- npm run verify: PASS (152/152)
- Viewer route does not load Editor/Builder entry or modules
- Viewer JS contains no editing affordances
- No raw API memory IDs exposed in DOM

## Browser verification note
Browser screenshot/UI verification is separated under current operating rules. This first slice focuses on code/CI/scope/product-direction validation.

Refs #923