### PR TITLE
fix(viewer): correct viewer state visibility rendering on production route

### DIFF
--- a/css/viewer/public-tree-viewer.css
+++ b/css/viewer/public-tree-viewer.css
@@ -303,6 +303,10 @@
     min-height: 300px;
 }
 
+.viewer-tree-shell [hidden] {
+    display: none !important;
+}
+
 .viewer-state-content {
     text-align: center;
     color: var(--on-surface-variant);

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -38,13 +38,13 @@
     function show() {
         for (var i = 0; i < arguments.length; i++) {
             var el = qs(arguments[i]);
-            if (el) el.removeAttribute('hidden');
+            if (el) el.style.display = '';
         }
     }
     function hide() {
         for (var i = 0; i < arguments.length; i++) {
             var el = qs(arguments[i]);
-            if (el) el.setAttribute('hidden', '');
+            if (el) el.style.display = 'none';
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes production `/pages/tree?treeId=...` viewer state rendering so loading/empty/error states properly hide/show instead of being simultaneously visible.

## Root cause
The `hide()`/`show()` functions used `setAttribute('hidden', '')` / `removeAttribute('hidden')` to toggle state visibility. However, `.viewer-state { display: flex; }` in the CSS overrode the browser's default `[hidden]` behavior, causing all states (loading, empty, error) to remain visible at the same time.

## Fixes
1. **JS**: Changed `hide()` to use `el.style.display = 'none'` and `show()` to use `el.style.display = ''` — robust, no CSS dependency.
2. **CSS**: Added `.viewer-tree-shell [hidden] { display: none !important; }` as a safety net for any other `hidden` attribute usage in the viewer.

## Data fetch path
The viewer correctly uses `apiClient.communityApi.getCachedCommunityMemories()` which exists in production. The `treeId` parameter from URL is passed directly. The API returns 400 for invalid/non-existent treeIds (expected). For a valid public treeId, the flow should succeed and render the Canvas v4 tree.

## Changed files
- `css/viewer/public-tree-viewer.css` — Added `[hidden]` CSS override for viewer shell
- `js/viewer/tree-viewer.js` — Changed `show()`/`hide()` to use `style.display` instead of `hidden` attribute

## Verification
- `git diff --check`: PASS
- `node --check js/viewer/tree-viewer.js`: PASS
- `npm test`: PASS 233/233
- `npm run verify`: PASS (152/152)
- Route-local moment DOM IDs preserved (`moment-0`, `moment-1`, `moment-root`)
- No raw API memory IDs exposed
- No Editor/Builder controls or scripts

## Browser verification
Fixed slot or production deploy required to confirm:
- Loading/empty/error states properly hide/show
- Valid treeId renders Canvas v4 tree with branch/moment interaction
- API error for invalid treeId shows only error state

Refs #955
Refs #923