### PR TITLE
fix(viewer): integrate #953 Canvas v4 viewer shell with production route and dynamic data

### DIFF
--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -154,6 +154,11 @@
             var treeMetaText = viewerData.tree.meta;
 
             container.innerHTML =
+                '<header class="vv-header">' +
+                '  <div><p class="vv-eyebrow">Public LoveTree Viewer</p>' +
+                '  <h1 class="vv-title">' + escapeHtml(treeTitle) + '</h1>' +
+                '  <div class="vv-meta-row"><span>' + escapeHtml(viewerData.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(treeMetaText) + '</span></div></div>' +
+                '</header>' +
                 '<div class="vv-viewer-layout">' +
                 '  <div class="vv-tree-container"></div>' +
                 '  <div class="vv-panel-host"></div>' +

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -36,7 +36,7 @@
     function show() {
         for (var i = 0; i < arguments.length; i++) {
             var el = qs(arguments[i]);
-            if (el) el.style.display = '';
+            if (el) { el.style.display = ''; el.removeAttribute('hidden'); }
         }
     }
     function hide() {

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -16,9 +16,7 @@
     };
 
     var currentTreeId = null;
-    var viewerState = {};
 
-    // i18n helper
     function t(key, fallbackKo, fallbackEn) {
         var dict = window.i18nViewer && window.i18nViewer[key];
         if (dict && typeof dict === 'object') {
@@ -38,188 +36,134 @@
     function show() {
         for (var i = 0; i < arguments.length; i++) {
             var el = qs(arguments[i]);
-            if (el) el.removeAttribute('hidden');
+            if (el) el.style.display = '';
         }
     }
     function hide() {
         for (var i = 0; i < arguments.length; i++) {
             var el = qs(arguments[i]);
-            if (el) el.setAttribute('hidden', '');
+            if (el) el.style.display = 'none';
         }
     }
 
-    function getCurrentLocale() {
-        var locale = window.i18n && window.i18n.currentLang || 'ko';
-        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
-    }
-
-    function formatDate(raw) {
-        if (!raw) return '';
-        try {
-            return new Date(raw).toLocaleDateString(getCurrentLocale() === 'en' ? 'en-US' : 'ko-KR');
-        } catch(e) { return raw; }
-    }
-
-    function showLoading() {
-        hide(SEL.treeContainer, SEL.empty, SEL.error);
-        show(SEL.loading);
-    }
-
-    function renderEmpty() {
-        hide(SEL.treeContainer, SEL.loading, SEL.error);
-        show(SEL.empty);
-    }
-
-    function renderError() {
-        hide(SEL.treeContainer, SEL.loading, SEL.empty);
-        show(SEL.error);
-    }
-
-    function transformToRenderFormat(treeId, memories) {
-        // Convert flat memory list to branch/moment structure for Canvas v4 renderer
-        // Group memories by parentId or create a flat single-branch structure
-        var moments = memories.map(function(m, i) {
-            return {
-                id: 'moment-' + i,
-                title: m.title || m.emotionMemo || '',
-                tag: (m.emotionTags && m.emotionTags[0]) || '',
-                caption: m.emotionMemo || m.title || '',
-                color: 'from-rose-100 via-rose-50 to-white',
-                emoji: '✦',
-                t: (i + 0.5) / Math.max(memories.length, 1)
-            };
-        });
-
-        return {
-            tree: {
-                id: treeId,
-                title: memories[0] && memories[0].treeTitle || t('viewer.treeTitle', '러브트리', 'LoveTree'),
-                memoryCount: memories.length,
-                creator: '@lovetree_viewer',
-                meta: memories.length + '개의 순간 · 꾸민 트리'
-            },
-            branch: {
-                id: 'main',
-                name: t('viewer.mainBranch', '전체 흐름', 'Full Flow'),
-                side: 'left',
-                color: 'rose',
-                startY: 77,
-                endY: 16,
-                endX: 22,
-                curveA: 38,
-                curveB: 28,
-                caption: memories.length + t('viewer.momentsConnected', '개의 순간이 이어져 있어요', ' connected moments'),
-                count: memories.length,
-                rootSeed: {
-                    id: 'moment-root',
-                    branchId: 'main',
-                    title: memories[0] && memories[0].title || t('viewer.rootMoment', '시작된 순간', 'Starting moment'),
-                    tag: t('viewer.start', '시작', 'Start'),
-                    caption: memories[0] && memories[0].emotionMemo || '',
-                    color: 'from-rose-200 via-rose-100 to-amber-50',
-                    emoji: '✦'
-                },
-                moments: moments
-            }
-        };
-    }
+    function showLoading() { hide(SEL.treeContainer, SEL.empty, SEL.error); show(SEL.loading); }
+    function renderEmpty() { hide(SEL.treeContainer, SEL.loading, SEL.error); show(SEL.empty); }
+    function renderError() { hide(SEL.treeContainer, SEL.loading, SEL.empty); show(SEL.error); }
 
     async function loadPublicData(treeId) {
         var getMemories = window.apiClient &&
             (window.apiClient.communityApi && window.apiClient.communityApi.getCachedCommunityMemories ||
              window.apiClient.getCachedCommunityMemories);
 
-        if (typeof getMemories !== 'function') {
-            throw new Error('Community API not available');
-        }
+        if (typeof getMemories !== 'function') throw new Error('Community API not available');
 
         var memories = await getMemories({ treeId: treeId, limit: 100 });
         return Array.isArray(memories) ? memories.filter(function(m) { return m && m.visibility === 'public'; }) : [];
     }
 
+    function buildBranches(memories) {
+        // Group moments into a single main branch with computed positions
+        var moments = memories.map(function(m, i) {
+            return {
+                id: 'moment-' + i,
+                title: m.title || m.emotionMemo || '',
+                tag: (m.emotionTags && m.emotionTags[0]) || '',
+                caption: m.emotionMemo || m.title || '',
+                emoji: '✦',
+                t: (i + 0.5) / Math.max(memories.length, 1)
+            };
+        });
+
+        var branch = {
+            id: 'main',
+            name: t('viewer.mainBranch', '전체 흐름', 'Full Flow'),
+            side: 'left',
+            color: 'rose',
+            startY: 77,
+            endY: 16,
+            endX: 22,
+            curveA: 38,
+            curveB: 28,
+            caption: memories.length + t('viewer.momentsConnected', '개의 순간이 이어져 있어요', ' connected moments'),
+            count: memories.length,
+            moments: moments
+        };
+
+        var rootSeed = {
+            id: 'moment-root',
+            branchId: 'main',
+            title: (memories[0] && memories[0].title) || t('viewer.rootMoment', '시작된 순간', 'Starting moment'),
+            tag: t('viewer.start', '시작', 'Start'),
+            caption: (memories[0] && memories[0].emotionMemo) || '',
+            color: 'from-rose-200 via-rose-100 to-amber-50',
+            emoji: '✦'
+        };
+
+        return {
+            branches: [branch],
+            rootSeed: rootSeed,
+            palette: { rose: { stroke:'#e99aac', soft:'#fff1f3', text:'#be123c', dim:'rgba(251,113,133,.16)' } },
+            curvePoint: function(branch, t) {
+                var x0=50, y0=branch.startY;
+                var x1=branch.curveA, y1=branch.startY-8;
+                var x2=branch.curveB, y2=branch.endY+8;
+                var x3=branch.endX, y3=branch.endY;
+                var mt=1-t;
+                return { x: mt*mt*mt*x0 + 3*mt*mt*t*x1 + 3*mt*t*t*x2 + t*t*t*x3,
+                         y: mt*mt*mt*y0 + 3*mt*mt*t*y1 + 3*mt*t*t*y2 + t*t*t*y3 };
+            },
+            tree: {
+                title: (memories[0] && memories[0].treeTitle) || t('viewer.treeTitle', '러브트리', 'LoveTree'),
+                creator: (memories[0] && memories[0].artist ? '@' + memories[0].artist : '@lovetree_viewer') || '',
+                meta: memories.length + t('viewer.metaMoments', '개의 순간 · 공개 러브트리', ' moments · public LoveTree')
+            },
+            treeComments: [],
+            momentComments: {}
+        };
+    }
+
     async function initViewer() {
         var params = new URLSearchParams(window.location.search);
         var treeId = params.get('treeId');
-        if (!treeId) {
-            renderEmpty();
-            return;
-        }
-
+        if (!treeId) { renderEmpty(); return; }
         currentTreeId = treeId;
         showLoading();
 
         try {
             var memories = await loadPublicData(treeId);
-            if (!memories || memories.length === 0) {
-                renderEmpty();
-                return;
-            }
+            if (!memories || memories.length === 0) { renderEmpty(); return; }
 
-            var renderData = transformToRenderFormat(treeId, memories);
+            var viewerData = buildBranches(memories);
 
-            // Set up the viewer state using the #953 renderer modules
+            // Set data for #953 modules
+            window.LoveBudVisitorViewerData = viewerData;
+
             var RenderTree = window.LoveBudVisitorViewerRenderTree;
             var Panels = window.LoveBudVisitorViewerPanels;
 
-            if (!RenderTree || !Panels) {
-                // Fallback: show simple tree list if Canvas modules not loaded
-                renderSimpleTree(renderData);
-                return;
-            }
+            // Render state
+            var state = { selectedBranchId: 'main', selectedMomentId: null, activePanel: 'empty', likedTree: false };
 
-            // Build the Canvas v4 tree shell
             show(SEL.treeContainer);
             hide(SEL.loading, SEL.empty, SEL.error);
 
             var container = qs('#viewerTreeContainer');
             if (!container) return;
 
-            // Set tree identity
-            var titleEl = qs(SEL.treeTitle);
-            var metaEl = qs(SEL.treeMeta);
-            if (titleEl) titleEl.textContent = renderData.tree.title;
-            if (metaEl) metaEl.textContent = renderData.tree.meta;
+            var treeTitle = viewerData.tree.title;
+            var treeMetaText = viewerData.tree.meta;
 
-            // Inject Canvas v4 structure
             container.innerHTML =
                 '<div class="vv-viewer-layout">' +
                 '  <div class="vv-tree-container"></div>' +
                 '  <div class="vv-panel-host"></div>' +
                 '</div>';
 
-            // Set up the global data object the #953 modules expect
-            window.__viewerTreeData = {
-                palette: window.LoveBudVisitorViewerData && window.LoveBudVisitorViewerData.palette || {
-                    rose: { stroke:'#e99aac', soft:'#fff1f3', text:'#be123c', dim:'rgba(251,113,133,.16)' }
-                },
-                branches: [renderData.branch],
-                rootSeed: renderData.branch.rootSeed,
-                curvePoint: function(branch, t) {
-                    var x0=50, y0=branch.startY;
-                    var x1=branch.curveA, y1=branch.startY-8;
-                    var x2=branch.curveB, y2=branch.endY+8;
-                    var x3=branch.endX, y3=branch.endY;
-                    var mt=1-t;
-                    return {
-                        x: mt*mt*mt*x0 + 3*mt*mt*t*x1 + 3*mt*t*t*x2 + t*t*t*x3,
-                        y: mt*mt*mt*y0 + 3*mt*mt*t*y1 + 3*mt*t*t*y2 + t*t*t*y3
-                    };
-                }
-            };
-
-            var state = {
-                selectedBranchId: null,
-                selectedMomentId: null,
-                activePanel: 'empty',
-                likedTree: false
-            };
-
             function getAllMoments() {
                 var results = [];
-                var rs = renderData.branch.rootSeed;
-                results.push({ id: rs.id, branchId: 'main', title: rs.title, tag: rs.tag, caption: rs.caption, color: rs.color, emoji: rs.emoji });
-                renderData.branch.moments.forEach(function(m) {
-                    results.push({ id: m.id, branchId: 'main', title: m.title, tag: m.tag, caption: m.caption, color: m.color, emoji: m.emoji });
+                results.push({ id: viewerData.rootSeed.id, branchId: 'main', title: viewerData.rootSeed.title, tag: viewerData.rootSeed.tag, caption: viewerData.rootSeed.caption, emoji: viewerData.rootSeed.emoji });
+                viewerData.branches[0].moments.forEach(function(m) {
+                    results.push({ id: m.id, branchId: 'main', title: m.title, tag: m.tag, caption: m.caption, emoji: m.emoji });
                 });
                 return results;
             }
@@ -227,28 +171,17 @@
             var allMoments = getAllMoments();
 
             function refresh() {
-                var branch = renderData.branch;
+                var branch = viewerData.branches[0];
                 var moment = allMoments.find(function(m) { return m.id === state.selectedMomentId; });
                 state.selectedBranch = branch;
                 state.selectedMoment = moment;
                 state.panelBranch = branch;
 
                 var treeBox = container.querySelector('.vv-tree-container');
-                if (treeBox && RenderTree) {
-                    // Patch data temporarily for renderer
-                    var origData = window.LoveBudVisitorViewerData;
-                    window.LoveBudVisitorViewerData = window.__viewerTreeData;
-                    RenderTree.renderTree(treeBox, state, handler);
-                    window.LoveBudVisitorViewerData = origData;
-                }
+                if (treeBox && RenderTree) RenderTree.renderTree(treeBox, state, handler);
 
                 var panelHost = container.querySelector('.vv-panel-host');
-                if (panelHost && Panels) {
-                    var origData2 = window.LoveBudVisitorViewerData;
-                    window.LoveBudVisitorViewerData = window.__viewerTreeData;
-                    panelHost.innerHTML = Panels.renderPanel(state, handler);
-                    window.LoveBudVisitorViewerData = origData2;
-                }
+                if (panelHost && Panels) panelHost.innerHTML = Panels.renderPanel(state, handler);
             }
 
             var handler = {
@@ -269,19 +202,14 @@
                     state.activePanel = 'branch';
                     refresh();
                 },
-                openPanel: function(panel) {
-                    state.activePanel = panel;
-                    refresh();
-                },
+                openPanel: function(panel) { state.activePanel = panel; refresh(); },
                 closePanel: function() {
-                    if (state.selectedMomentId) { state.activePanel = 'moment'; }
-                    else if (state.selectedBranchId) { state.activePanel = 'branch'; }
-                    else { state.activePanel = 'empty'; }
+                    if (state.selectedMomentId) state.activePanel = 'moment';
+                    else if (state.selectedBranchId) state.activePanel = 'branch';
+                    else state.activePanel = 'empty';
                     refresh();
                 },
-                toggleLike: function() {
-                    state.likedTree = !state.likedTree;
-                }
+                toggleLike: function() { state.likedTree = !state.likedTree; }
             };
 
             container.addEventListener('click', function(e) {
@@ -311,35 +239,9 @@
         }
     }
 
-    function renderSimpleTree(renderData) {
-        show(SEL.treeContainer);
-        hide(SEL.loading, SEL.empty, SEL.error);
-        var titleEl = qs(SEL.treeTitle);
-        var metaEl = qs(SEL.treeMeta);
-        if (titleEl) titleEl.textContent = renderData.tree.title;
-        if (metaEl) metaEl.textContent = renderData.tree.meta;
-        var container = qs('#viewerTreeContainer');
-        if (!container) return;
-        container.innerHTML = '';
-        var list = document.createElement('div');
-        list.className = 'viewer-nodes-list';
-        renderData.branch.moments.forEach(function(m) {
-            var node = document.createElement('div');
-            node.className = 'viewer-node';
-            node.innerHTML = '<span class="viewer-node-title">' + escapeHtml(m.title) + '</span>' +
-                (m.tag ? '<span class="viewer-node-tag">' + escapeHtml(m.tag) + '</span>' : '');
-            list.appendChild(node);
-        });
-        container.appendChild(list);
-    }
-
     function setupRetry() {
         var btn = document.getElementById('viewerRetryBtn');
-        if (btn) {
-            btn.addEventListener('click', function() {
-                if (currentTreeId) initViewer();
-            });
-        }
+        if (btn) btn.addEventListener('click', function() { if (currentTreeId) initViewer(); });
     }
 
     if (document.readyState === 'loading') {

--- a/js/visitor-viewer/visitor-viewer-panels.js
+++ b/js/visitor-viewer/visitor-viewer-panels.js
@@ -14,7 +14,14 @@
         eye: '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12Z" stroke="currentColor" stroke-width="1.7"/><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.7"/></svg>'
     };
 
-    function escape(str) { return String(str == null ? '' : str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    function escape(str) {
+        return String(str == null ? '' : str)
+            .replace(/&/g,'&amp;')
+            .replace(/</g,'&lt;')
+            .replace(/>/g,'&gt;')
+            .replace(/"/g,'&quot;')
+            .replace(/'/g,'&#39;');
+    }
 
     function momentGrad(moment, branch) {
         var pal = getData('palette');
@@ -31,10 +38,10 @@
             '<div class="vv-comment-header">' +
             '  <div class="vv-comment-avatar" style="background:linear-gradient(135deg,var(--rose-200),var(--amber-100))"><span>' + escape(comment.author).slice(1, 3).toUpperCase() + '</span></div>' +
             '  <div class="vv-comment-author"><span class="vv-comment-name">' + escape(comment.author) + '</span><span class="vv-comment-time">' + escape(comment.time) + '</span></div>' +
-            '  <button type="button" class="vv-comment-like-btn" data-action="comment-like">' + Icon.heart + ' <span>' + comment.likes + '</span></button>' +
+            '  <button type="button" class="vv-comment-like-btn" data-action="comment-like">' + Icon.heart + ' <span>' + escape(comment.likes) + '</span></button>' +
             '</div>' +
             '<p class="vv-comment-body">' + escape(comment.body) + '</p>' +
-            (comment.replies > 0 ? '<button type="button" class="vv-comment-replies-btn" data-action="show-replies">답글 ' + comment.replies + '개 보기</button>' : '') +
+            (comment.replies > 0 ? '<button type="button" class="vv-comment-replies-btn" data-action="show-replies">답글 ' + escape(comment.replies) + '개 보기</button>' : '') +
             '</article>';
     }
 
@@ -63,7 +70,7 @@
                 var bg = m.cluster ? '' : momentBg(m, branch);
                 return '<button type="button" class="vv-branch-moment-btn" style="' + bg + '" data-moment-id="' + escape(m.id) + '" data-branch-id="' + escape(branch.id) + '" title="' + escape(m.title) + '">' +
                     '<span class="vv-branch-moment-frame"></span>' +
-                    (m.cluster ? '<span class="vv-branch-moment-label">+' + m.cluster + '</span>' : '<span class="vv-branch-moment-label">' + m.emoji + '</span>') +
+                    (m.cluster ? '<span class="vv-branch-moment-label">+' + escape(m.cluster) + '</span>' : '<span class="vv-branch-moment-label">' + escape(m.emoji) + '</span>') +
                     (m.cluster ? '' : '<span class="vv-branch-moment-play">▶</span>') +
                     '</button>';
             }).join('') +
@@ -91,14 +98,14 @@
             '    <div class="vv-moment-media-border"></div>' +
             '    <span class="vv-moment-media-badge">moment media</span>' +
             '    <button type="button" class="vv-moment-play-btn" aria-label="미디어 재생">▶</button>' +
-            '    <span class="vv-moment-media-emoji">' + moment.emoji + '</span></div></div>' +
+            '    <span class="vv-moment-media-emoji">' + escape(moment.emoji) + '</span></div></div>' +
             '<div class="vv-moment-tags"><span class="vv-moment-tag-branch" style="background:' + (getData('palette') && (getData('palette')[branch.id] || {}).soft || '#fff1f3') + ';color:' + (getData('palette') && (getData('palette')[branch.id] || {}).text || '#be123c') + '">' + escape(branch.name) + '</span>' + (moment.tag ? '<span class="vv-moment-tag-default">' + escape(moment.tag) + '</span>' : '') + '</div>' +
             '<h2 class="vv-moment-title">' + escape(moment.title) + '</h2>' +
             '<p class="vv-moment-caption">' + escape(moment.caption) + '</p>' +
             '<div class="vv-moment-memo"><p class="vv-moment-memo-label">creator memo</p><p class="vv-moment-memo-text">처음으로 이 트리에 꽂아둔, 오래 남은 장면.</p></div>' +
             '<div class="vv-moment-actions">' +
             '  <button type="button" class="vv-moment-action-btn" data-action="moment-like">' + Icon.heart + ' 좋아요 1.2k</button>' +
-            '  <button type="button" class="vv-moment-action-btn" data-action="moment-comment">' + Icon.message + ' 순간 댓글 ' + comments.length + '</button>' +
+            '  <button type="button" class="vv-moment-action-btn" data-action="moment-comment">' + Icon.message + ' 순간 댓글 ' + escape(comments.length) + '</button>' +
             '  <button type="button" class="vv-moment-action-btn" data-action="moment-share">' + Icon.share + ' 공유</button></div>' +
             '<div class="vv-moment-comments-section">' +
             '  <div class="vv-moment-comments-header"><div><p class="vv-panel-eyebrow">Moment comments</p><h3 class="vv-moment-comments-title">이 순간에 남긴 댓글</h3></div>' +

--- a/js/visitor-viewer/visitor-viewer-panels.js
+++ b/js/visitor-viewer/visitor-viewer-panels.js
@@ -1,8 +1,10 @@
 (function() {
     'use strict';
 
-    var data = window.LoveBudVisitorViewerData;
-    if (!data) return;
+    function getData(key) {
+        var d = window.LoveBudVisitorViewerData;
+        return d ? d[key] : null;
+    }
 
     var Icon = {
         heart: '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M12 20.2s-7.2-4.42-9.4-9.08C.92 7.58 2.68 4.3 6.15 4.3c2.02 0 3.38 1.12 3.98 2.02.58-.9 1.96-2.02 3.98-2.02 3.46 0 5.22 3.28 3.55 6.82C15.45 15.78 12 20.2 12 20.2Z" fill="currentColor"/></svg>',
@@ -15,13 +17,13 @@
     function escape(str) { return String(str == null ? '' : str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
     function momentGrad(moment, branch) {
-        var pal = data.palette[branch && branch.color] || data.palette.rose;
-        return 'linear-gradient(135deg,' + pal.soft + ',' + pal.stroke + ' 40%,white)';
+        var pal = getData('palette');
+        var p = pal && (pal[branch && branch.color] || pal.rose) || { soft:'#fff1f3', stroke:'#e99aac' };
+        return 'linear-gradient(135deg,' + p.soft + ',' + p.stroke + ' 40%,white)';
     }
 
     function momentBg(moment, branch) {
-        var pal = data.palette[branch && branch.color] || data.palette.rose;
-        return 'background:linear-gradient(135deg,' + pal.soft + ',' + pal.stroke + ' 45%,white)';
+        return 'background:' + momentGrad(moment, branch);
     }
 
     function CommentRow(comment) {
@@ -70,13 +72,13 @@
             moments.slice(0, 3).map(function(m) {
                 return '<button type="button" class="vv-branch-moment-item" data-moment-id="' + escape(m.id) + '" data-branch-id="' + escape(branch.id) + '"><span>' + escape(m.title) + '</span><span class="vv-branch-moment-open">열기</span></button>';
             }).join('') +
-            '</div>' +
-            '</aside>';
+            '</div></aside>';
     }
 
     function renderMomentPanel(moment, branch, handlers) {
         if (!moment || !branch) return '';
-        var comments = data.momentComments[moment.id] || [
+        var momentComments = getData('momentComments') || {};
+        var comments = momentComments[moment.id] || [
             { id: 'mc-empty', author: '@lovetree_viewer', body: '이 장면에 대한 댓글이 이곳에 모입니다.', time: '예시', likes: 0, replies: 0 }
         ];
         return '<aside class="vv-panel vv-panel-moment">' +
@@ -89,34 +91,26 @@
             '    <div class="vv-moment-media-border"></div>' +
             '    <span class="vv-moment-media-badge">moment media</span>' +
             '    <button type="button" class="vv-moment-play-btn" aria-label="미디어 재생">▶</button>' +
-            '    <span class="vv-moment-media-emoji">' + moment.emoji + '</span>' +
-            '  </div>' +
-            '</div>' +
-            '<div class="vv-moment-tags"><span class="vv-moment-tag-branch" style="background:' + (data.palette[branch.id] && data.palette[branch.id].soft || '#fff1f3') + ';color:' + (data.palette[branch.id] && data.palette[branch.id].text || '#be123c') + '">' + escape(branch.name) + '</span>' + (moment.tag ? '<span class="vv-moment-tag-default">' + escape(moment.tag) + '</span>' : '') + '</div>' +
+            '    <span class="vv-moment-media-emoji">' + moment.emoji + '</span></div></div>' +
+            '<div class="vv-moment-tags"><span class="vv-moment-tag-branch" style="background:' + (getData('palette') && (getData('palette')[branch.id] || {}).soft || '#fff1f3') + ';color:' + (getData('palette') && (getData('palette')[branch.id] || {}).text || '#be123c') + '">' + escape(branch.name) + '</span>' + (moment.tag ? '<span class="vv-moment-tag-default">' + escape(moment.tag) + '</span>' : '') + '</div>' +
             '<h2 class="vv-moment-title">' + escape(moment.title) + '</h2>' +
             '<p class="vv-moment-caption">' + escape(moment.caption) + '</p>' +
-            '<div class="vv-moment-memo">' +
-            '  <p class="vv-moment-memo-label">creator memo</p>' +
-            '  <p class="vv-moment-memo-text">처음으로 이 트리에 꽂아둔, 오래 남은 장면.</p>' +
-            '</div>' +
+            '<div class="vv-moment-memo"><p class="vv-moment-memo-label">creator memo</p><p class="vv-moment-memo-text">처음으로 이 트리에 꽂아둔, 오래 남은 장면.</p></div>' +
             '<div class="vv-moment-actions">' +
             '  <button type="button" class="vv-moment-action-btn" data-action="moment-like">' + Icon.heart + ' 좋아요 1.2k</button>' +
             '  <button type="button" class="vv-moment-action-btn" data-action="moment-comment">' + Icon.message + ' 순간 댓글 ' + comments.length + '</button>' +
-            '  <button type="button" class="vv-moment-action-btn" data-action="moment-share">' + Icon.share + ' 공유</button>' +
-            '</div>' +
+            '  <button type="button" class="vv-moment-action-btn" data-action="moment-share">' + Icon.share + ' 공유</button></div>' +
             '<div class="vv-moment-comments-section">' +
             '  <div class="vv-moment-comments-header"><div><p class="vv-panel-eyebrow">Moment comments</p><h3 class="vv-moment-comments-title">이 순간에 남긴 댓글</h3></div>' +
-            '    <button type="button" class="vv-sort-btn">최신순</button>' +
-            '  </div>' +
+            '    <button type="button" class="vv-sort-btn">최신순</button></div>' +
             '  <div class="vv-comment-input"><div class="vv-comment-input-avatar"></div><input type="text" class="vv-comment-input-field" placeholder="이 순간에 댓글 남기기" /><button type="button" class="vv-comment-submit">게시</button></div>' +
-            '  <div class="vv-comment-list">' + comments.map(CommentRow).join('') + '</div>' +
-            '</div>' +
+            '  <div class="vv-comment-list">' + comments.map(CommentRow).join('') + '</div></div>' +
             '<div class="vv-moment-nav"><button type="button" data-action="prev-moment">← 이전 순간</button><button type="button" data-action="next-moment">다음 순간 →</button></div>' +
-            '<p class="vv-moment-close-hint">닫으면 같은 가지 선택 상태로 돌아갑니다.</p>' +
-            '</aside>';
+            '<p class="vv-moment-close-hint">닫으면 같은 가지 선택 상태로 돌아갑니다.</p></aside>';
     }
 
     function renderTreeCommentsPanel(handlers) {
+        var treeComments = getData('treeComments') || [];
         return '<aside class="vv-panel vv-panel-tree-comments">' +
             '<div class="vv-panel-header">' +
             '  <div><p class="vv-panel-eyebrow">Tree comments</p><h2 class="vv-panel-title-lg">트리 전체 댓글</h2></div>' +
@@ -125,22 +119,21 @@
             '<div class="vv-scope-notice"><p class="vv-scope-notice-label">comment scope</p><p class="vv-scope-notice-text">트리 전체 댓글은 흐름, 큐레이션, 만든 사람의 기억에 대한 반응입니다.</p></div>' +
             '<div class="vv-sort-tabs"><button type="button" class="vv-sort-tab is-active">인기순</button><button type="button" class="vv-sort-tab">최신순</button></div>' +
             '<div class="vv-comment-input"><div class="vv-comment-input-avatar"></div><input type="text" class="vv-comment-input-field" placeholder="트리 전체에 댓글 남기기" /><button type="button" class="vv-comment-submit">게시</button></div>' +
-            '<div class="vv-comment-list">' + data.treeComments.map(CommentRow).join('') + '</div>' +
-            '</aside>';
+            '<div class="vv-comment-list">' + treeComments.map(CommentRow).join('') + '</div></aside>';
     }
 
     function renderSharePanel(handlers) {
+        var tree = getData('tree') || {};
         return '<aside class="vv-panel vv-panel-share">' +
             '<div class="vv-panel-header">' +
             '  <div><p class="vv-panel-eyebrow">Share tree</p><h2 class="vv-panel-title-lg">트리 공유</h2></div>' +
             '  <button type="button" class="vv-panel-close" data-action="close-panel" aria-label="공유 패널 닫기">' + Icon.close + '</button>' +
             '</div>' +
-            '<div class="vv-share-preview"><div class="vv-share-icon">🌳</div><h3 class="vv-share-title">' + escape(data.tree.title) + '</h3><p class="vv-share-creator">' + escape(data.tree.creator) + '</p></div>' +
+            '<div class="vv-share-preview"><div class="vv-share-icon">🌳</div><h3 class="vv-share-title">' + escape(tree.title || '') + '</h3><p class="vv-share-creator">' + escape(tree.creator || '') + '</p></div>' +
             '<div class="vv-share-actions"><button type="button" class="vv-share-btn vv-share-btn-primary">링크 복사 <span>copy</span></button>' +
             '<button type="button" class="vv-share-btn vv-share-btn-secondary">Browse에 공유 <span>public</span></button>' +
             '<button type="button" class="vv-share-btn vv-share-btn-secondary">이미지 카드로 저장 <span>later</span></button></div>' +
-            '<p class="vv-share-note">공유 액션은 나중에 실제 URL 복사, 네이티브 공유, 공개 범위 확인과 연결하면 됩니다.</p>' +
-            '</aside>';
+            '<p class="vv-share-note">공유 액션은 나중에 실제 URL 복사, 네이티브 공유, 공개 범위 확인과 연결하면 됩니다.</p></aside>';
     }
 
     function renderPanel(state, handlers) {

--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -1,33 +1,44 @@
 (function() {
     'use strict';
 
-    var data = window.LoveBudVisitorViewerData;
-    if (!data) return;
-    var palette = data.palette;
-    var branches = data.branches;
-    var rootSeed = data.rootSeed;
-    var curvePoint = data.curvePoint;
+    function getData(key) {
+        var d = window.LoveBudVisitorViewerData;
+        return d ? d[key] : null;
+    }
+
+    function paletteColor(branch) {
+        var pal = getData('palette');
+        if (!pal) return { stroke:'#e99aac', soft:'#fff1f3', text:'#be123c', dim:'rgba(251,113,133,.16)' };
+        return pal[branch && branch.color] || pal.rose;
+    }
 
     function leafGrad(branch) {
-        var p = palette[branch && branch.color] || palette.rose;
+        var p = paletteColor(branch);
         return 'linear-gradient(135deg,' + p.soft + ',' + p.stroke + ' 40%,white)';
     }
 
     function renderTree(container, state, handlers) {
         if (!container) return;
+        var branches = getData('branches') || [];
+        var rootSeed = getData('rootSeed');
+        var paletteObj = getData('palette') || {};
+        var curvePoint = getData('curvePoint') || function(b,t) {
+            var x0=50,y0=b.startY,x1=b.curveA,y1=b.startY-8,x2=b.curveB,y2=b.endY+8,x3=b.endX,y3=b.endY,mt=1-t;
+            return {x:mt*mt*mt*x0+3*mt*mt*t*x1+3*mt*t*t*x2+t*t*t*x3,y:mt*mt*mt*y0+3*mt*mt*t*y1+3*mt*t*t*y2+t*t*t*y3};
+        };
+
         var selectedBranchId = state.selectedBranchId;
         var selectedMomentId = state.selectedMomentId;
         var hasSelection = Boolean(selectedBranchId || selectedMomentId);
 
         var svg = '';
-        var branchEls = '';
         var branchNames = '';
         var mediaLeafs = '';
 
         branches.forEach(function(branch) {
             var selected = selectedBranchId === branch.id;
             var muted = hasSelection && !selected;
-            var bPalette = palette[branch.color];
+            var bPalette = paletteColor(branch);
             var d = 'M50 ' + branch.startY + ' C' + branch.curveA + ' ' + (branch.startY - 8) + ', ' + branch.curveB + ' ' + (branch.endY + 8) + ', ' + branch.endX + ' ' + branch.endY;
 
             svg += '<path d="' + d + '" stroke="rgba(113,76,60,.14)" stroke-width="' + (selected ? '4.35' : '3.05') + '" stroke-linecap="round" fill="none" opacity="' + (muted ? '0.18' : '1') + '" />';
@@ -42,19 +53,21 @@
             branch.moments.forEach(function(moment) {
                 var point = curvePoint(branch, moment.t);
                 var bSelected = selectedMomentId === moment.id;
-                mediaLeafs += renderLeaf(moment, branch, point, bSelected, selected, muted, handlers);
+                mediaLeafs += renderLeaf(moment, branch, point, bSelected, selected, muted, curvePoint, paletteColor);
             });
         });
 
-        var rootSelected = selectedMomentId === rootSeed.id;
-        var rootEl = '<button type="button" class="vv-root-seed ' + (rootSelected ? 'is-selected' : '') + '" data-moment-id="' + rootSeed.id + '" data-branch-id="' + rootSeed.branchId + '" aria-label="시작된 순간 열기">' +
-            '<div class="vv-root-seed-shape" style="background:linear-gradient(135deg,' + palette.rose.soft + ',' + palette.rose.stroke + ' 40%,white)">' +
-            '<div class="vv-root-seed-inner"></div>' +
-            '<span class="vv-root-seed-emoji">' + rootSeed.emoji + '</span>' +
-            '<span class="vv-root-seed-play">▶</span>' +
-            '</div>' +
-            '<span class="vv-root-seed-label">시작된 순간</span>' +
-            '</button>';
+        var rootEl = '';
+        if (rootSeed) {
+            rootEl = '<button type="button" class="vv-root-seed ' + (selectedMomentId === rootSeed.id ? 'is-selected' : '') + '" data-moment-id="' + rootSeed.id + '" data-branch-id="' + rootSeed.branchId + '" aria-label="시작된 순간 열기">' +
+                '<div class="vv-root-seed-shape" style="background:linear-gradient(135deg,' + (paletteObj.rose || {soft:'#fff1f3',stroke:'#e99aac'}).soft + ',' + (paletteObj.rose || {}).stroke + ' 40%,white)">' +
+                '<div class="vv-root-seed-inner"></div>' +
+                '<span class="vv-root-seed-emoji">' + rootSeed.emoji + '</span>' +
+                '<span class="vv-root-seed-play">▶</span>' +
+                '</div>' +
+                '<span class="vv-root-seed-label">시작된 순간</span>' +
+                '</button>';
+        }
 
         container.innerHTML =
             '<div class="vv-tree-canvas" data-has-selection="' + hasSelection + '">' +
@@ -62,25 +75,17 @@
             '  <div class="vv-tree-glow-top"></div>' +
             '  <div class="vv-tree-glow-bottom"></div>' +
             '  <svg class="vv-tree-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">' +
-            '    <defs>' +
-            '      <filter id="trunkShadow"><feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="#7c4a3f" floodOpacity="0.16" /></filter>' +
-            '    </defs>' +
+            '    <defs><filter id="trunkShadow"><feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="#7c4a3f" floodOpacity="0.16" /></filter></defs>' +
             '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#9f745b" stroke-width="3.9" stroke-linecap="round" fill="none" opacity="0.34" />' +
             '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#7f5b47" stroke-width="1.55" stroke-linecap="round" fill="none" opacity="0.86" />' +
             svg +
             '  </svg>' +
-            '  <div class="vv-tree-organs">' +
-            branchNames +
-            mediaLeafs +
-            rootEl +
-            '  </div>' +
+            '  <div class="vv-tree-organs">' + branchNames + mediaLeafs + rootEl + '</div>' +
             '  <div class="vv-tree-badge">완성된 공개 러브트리</div>' +
             '</div>';
-
-        // Event delegation is handled by container in visitor-viewer.js
     }
 
-    function renderLeaf(moment, branch, point, selected, branchSelected, muted, handlers) {
+    function renderLeaf(moment, branch, point, selected, branchSelected, muted, curvePoint, paletteColorFn) {
         var cluster = moment.cluster;
         var leafClasses = 'vv-media-leaf ' + (selected ? 'is-selected' : '') + ' ' + (muted ? 'is-dimmed' : '');
         var labelPoint = curvePoint(branch, 0.78);
@@ -88,14 +93,13 @@
         var showLabel = branchSelected && !cluster;
 
         if (cluster) {
-            var pal = palette[branch.color];
+            var pal = paletteColorFn(branch);
             var sizeClass = branchSelected || selected ? 'vv-cluster-lg' : 'vv-cluster-sm';
             return '<div class="' + leafClasses + ' vv-cluster ' + sizeClass + '" data-moment-id="' + moment.id + '" data-branch-id="' + branch.id + '" style="left:' + point.x + '%;top:' + point.y + '%" aria-label="' + moment.title + '">' +
                 '<span class="vv-cluster-leaf" style="left:16%;top:18%;background:' + leafGrad(branch) + '"></span>' +
                 '<span class="vv-cluster-leaf" style="left:28%;top:0%;background:' + leafGrad(branch) + '"></span>' +
                 '<span class="vv-cluster-leaf" style="left:0%;top:5%;background:' + leafGrad(branch) + '"></span>' +
-                '<span class="vv-cluster-label">+' + moment.cluster + '</span>' +
-                '</div>';
+                '<span class="vv-cluster-label">+' + moment.cluster + '</span></div>';
         }
 
         var stemAngle = branch.side === 'left' ? -18 : 18;
@@ -103,14 +107,14 @@
         var leafH = (branchSelected || selected) ? '80px' : '68px';
         var leafShape = 'style="width:' + leafW + ';height:' + leafH + ';border-radius:54% 46% 52% 48% / 43% 58% 42% 57%;background:' + leafGrad(branch) + ';box-shadow:' + (selected ? '0 0 0 6px rgba(255,241,243,0.9),0 20px 38px rgba(80,45,39,0.18)' : (branchSelected ? '0 10px 28px rgba(97,61,38,0.2)' : '0 8px 20px rgba(97,61,38,0.10)')) + ';"';
 
+        var p = paletteColorFn(branch);
         return '<div class="' + leafClasses + '" data-moment-id="' + moment.id + '" data-branch-id="' + branch.id + '" style="left:' + point.x + '%;top:' + point.y + '%">' +
             '<span class="vv-leaf-stem" style="transform:rotate(' + stemAngle + 'deg);opacity:' + (branchSelected || selected ? '0.75' : '0.38') + '"></span>' +
             '<button type="button" class="vv-leaf-shape ' + (selected ? 'is-active' : '') + '" ' + leafShape + ' aria-label="' + moment.title + '">' +
             '  <span class="vv-leaf-inner"></span>' +
             '  <span class="vv-leaf-emoji">' + moment.emoji + '</span>' +
-            '  <span class="vv-leaf-play">▶</span>' +
-            '</button>' +
-            (showLabel ? '<div class="vv-leaf-label ' + labelSide + '"><span class="vv-leaf-label-title">' + moment.title + '</span><span class="vv-leaf-label-tag" style="background:' + palette[branch.color].soft + ';color:' + palette[branch.color].text + '">' + moment.tag + '</span></div>' : '') +
+            '  <span class="vv-leaf-play">▶</span></button>' +
+            (showLabel ? '<div class="vv-leaf-label ' + labelSide + '"><span class="vv-leaf-label-title">' + moment.title + '</span><span class="vv-leaf-label-tag" style="background:' + p.soft + ';color:' + p.text + '">' + moment.tag + '</span></div>' : '') +
             '</div>';
     }
 

--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -17,6 +17,12 @@
         return 'linear-gradient(135deg,' + p.soft + ',' + p.stroke + ' 40%,white)';
     }
 
+    function escapeHtml(value) {
+        return String(value == null ? '' : value).replace(/[&<>"']/g, function(char) {
+            return { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[char];
+        });
+    }
+
     function renderTree(container, state, handlers) {
         if (!container) return;
         var branches = getData('branches') || [];
@@ -48,7 +54,7 @@
 
             var labelPoint = curvePoint(branch, 0.78);
 
-            branchNames += '<button type="button" class="vv-branch-label ' + (selected ? 'is-selected' : '') + '" data-branch-id="' + branch.id + '" style="left:' + labelPoint.x + '%;top:' + labelPoint.y + '%;color:' + bPalette.text + '">' + branch.name + '</button>';
+            branchNames += '<button type="button" class="vv-branch-label ' + (selected ? 'is-selected' : '') + '" data-branch-id="' + escapeHtml(branch.id) + '" style="left:' + labelPoint.x + '%;top:' + labelPoint.y + '%;color:' + bPalette.text + '">' + escapeHtml(branch.name) + '</button>';
 
             branch.moments.forEach(function(moment) {
                 var point = curvePoint(branch, moment.t);
@@ -59,10 +65,10 @@
 
         var rootEl = '';
         if (rootSeed) {
-            rootEl = '<button type="button" class="vv-root-seed ' + (selectedMomentId === rootSeed.id ? 'is-selected' : '') + '" data-moment-id="' + rootSeed.id + '" data-branch-id="' + rootSeed.branchId + '" aria-label="시작된 순간 열기">' +
+            rootEl = '<button type="button" class="vv-root-seed ' + (selectedMomentId === rootSeed.id ? 'is-selected' : '') + '" data-moment-id="' + escapeHtml(rootSeed.id) + '" data-branch-id="' + escapeHtml(rootSeed.branchId) + '" aria-label="시작된 순간 열기">' +
                 '<div class="vv-root-seed-shape" style="background:linear-gradient(135deg,' + (paletteObj.rose || {soft:'#fff1f3',stroke:'#e99aac'}).soft + ',' + (paletteObj.rose || {}).stroke + ' 40%,white)">' +
                 '<div class="vv-root-seed-inner"></div>' +
-                '<span class="vv-root-seed-emoji">' + rootSeed.emoji + '</span>' +
+                '<span class="vv-root-seed-emoji">' + escapeHtml(rootSeed.emoji) + '</span>' +
                 '<span class="vv-root-seed-play">▶</span>' +
                 '</div>' +
                 '<span class="vv-root-seed-label">시작된 순간</span>' +
@@ -95,11 +101,11 @@
         if (cluster) {
             var pal = paletteColorFn(branch);
             var sizeClass = branchSelected || selected ? 'vv-cluster-lg' : 'vv-cluster-sm';
-            return '<div class="' + leafClasses + ' vv-cluster ' + sizeClass + '" data-moment-id="' + moment.id + '" data-branch-id="' + branch.id + '" style="left:' + point.x + '%;top:' + point.y + '%" aria-label="' + moment.title + '">' +
+            return '<div class="' + leafClasses + ' vv-cluster ' + sizeClass + '" data-moment-id="' + escapeHtml(moment.id) + '" data-branch-id="' + escapeHtml(branch.id) + '" style="left:' + point.x + '%;top:' + point.y + '%" aria-label="' + escapeHtml(moment.title) + '">' +
                 '<span class="vv-cluster-leaf" style="left:16%;top:18%;background:' + leafGrad(branch) + '"></span>' +
                 '<span class="vv-cluster-leaf" style="left:28%;top:0%;background:' + leafGrad(branch) + '"></span>' +
                 '<span class="vv-cluster-leaf" style="left:0%;top:5%;background:' + leafGrad(branch) + '"></span>' +
-                '<span class="vv-cluster-label">+' + moment.cluster + '</span></div>';
+                '<span class="vv-cluster-label">+' + escapeHtml(moment.cluster) + '</span></div>';
         }
 
         var stemAngle = branch.side === 'left' ? -18 : 18;
@@ -108,13 +114,13 @@
         var leafShape = 'style="width:' + leafW + ';height:' + leafH + ';border-radius:54% 46% 52% 48% / 43% 58% 42% 57%;background:' + leafGrad(branch) + ';box-shadow:' + (selected ? '0 0 0 6px rgba(255,241,243,0.9),0 20px 38px rgba(80,45,39,0.18)' : (branchSelected ? '0 10px 28px rgba(97,61,38,0.2)' : '0 8px 20px rgba(97,61,38,0.10)')) + ';"';
 
         var p = paletteColorFn(branch);
-        return '<div class="' + leafClasses + '" data-moment-id="' + moment.id + '" data-branch-id="' + branch.id + '" style="left:' + point.x + '%;top:' + point.y + '%">' +
+        return '<div class="' + leafClasses + '" data-moment-id="' + escapeHtml(moment.id) + '" data-branch-id="' + escapeHtml(branch.id) + '" style="left:' + point.x + '%;top:' + point.y + '%">' +
             '<span class="vv-leaf-stem" style="transform:rotate(' + stemAngle + 'deg);opacity:' + (branchSelected || selected ? '0.75' : '0.38') + '"></span>' +
-            '<button type="button" class="vv-leaf-shape ' + (selected ? 'is-active' : '') + '" ' + leafShape + ' aria-label="' + moment.title + '">' +
+            '<button type="button" class="vv-leaf-shape ' + (selected ? 'is-active' : '') + '" ' + leafShape + ' aria-label="' + escapeHtml(moment.title) + '">' +
             '  <span class="vv-leaf-inner"></span>' +
-            '  <span class="vv-leaf-emoji">' + moment.emoji + '</span>' +
+            '  <span class="vv-leaf-emoji">' + escapeHtml(moment.emoji) + '</span>' +
             '  <span class="vv-leaf-play">▶</span></button>' +
-            (showLabel ? '<div class="vv-leaf-label ' + labelSide + '"><span class="vv-leaf-label-title">' + moment.title + '</span><span class="vv-leaf-label-tag" style="background:' + p.soft + ';color:' + p.text + '">' + moment.tag + '</span></div>' : '') +
+            (showLabel ? '<div class="vv-leaf-label ' + labelSide + '"><span class="vv-leaf-label-title">' + escapeHtml(moment.title) + '</span><span class="vv-leaf-label-tag" style="background:' + p.soft + ';color:' + p.text + '">' + escapeHtml(moment.tag) + '</span></div>' : '') +
             '</div>';
     }
 

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -60,13 +60,12 @@
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>
-    <script src="../js/visitor-viewer/visitor-viewer-data.js?v=20260508-951-1"></script>
-    <script src="../js/visitor-viewer/visitor-viewer-render-tree.js?v=20260508-951-2"></script>
-    <script src="../js/visitor-viewer/visitor-viewer-panels.js?v=20260508-951-4"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-render-tree.js?v=20260508-955-1"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-panels.js?v=20260508-955-1"></script>
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-viewer.js?v=20260508-923-1"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
-    <script src="../js/viewer/tree-viewer.js?v=20260508-923-1"></script>
+    <script src="../js/viewer/tree-viewer.js?v=20260508-955-1"></script>
 </body>
 </html>

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -51,10 +51,10 @@ test('Browse tree-open CTA targets tree.html with treeId param', () => {
 
 test('tree viewer loads Canvas v4 modules', () => {
     const html = fs.readFileSync('pages/tree.html', 'utf8');
-    const hasVisitorModules = html.includes('visitor-viewer/visitor-viewer-data.js') &&
-        html.includes('visitor-viewer/visitor-viewer-render-tree.js') &&
-        html.includes('visitor-viewer/visitor-viewer-panels.js');
-    assert.ok(hasVisitorModules, 'tree.html must load visitor-viewer Canvas v4 modules');
+    const hasRenderer = html.includes('visitor-viewer/visitor-viewer-render-tree.js');
+    const hasPanels = html.includes('visitor-viewer/visitor-viewer-panels.js');
+    const noMockData = !html.includes('visitor-viewer/visitor-viewer-data.js');
+    assert.ok(hasRenderer && hasPanels && noMockData, 'tree.html must load render-tree and panels but NOT visitor-viewer-data.js');
 });
 
 test('tree viewer does not load mock visitor-viewer orchestrator', () => {


### PR DESCRIPTION
## Summary
Integrates the #953 Canvas v4 public visitor viewer shell with the production `/pages/tree?treeId=...` route, fixing the full public-data Canvas rendering failure.

## Root cause
The #953 `visitor-viewer-render-tree.js` and `visitor-viewer-panels.js` modules capture `window.LoveBudVisitorViewerData` at module load time. The tree-viewer orchestrator tried to update this data after module load, but the modules always used the original mock data. This caused:
- Loading/empty/error states appearing simultaneously (CSS `[hidden]` override by `display: flex`)
- Canvas tree rendering with stale mock data instead of real API data
- Partial/empty panels visible during error states

## Changes

### Core fix: dynamic data reading
Both `visitor-viewer-render-tree.js` and `visitor-viewer-panels.js` now read from `window.LoveBudVisitorViewerData` on each render call instead of capturing at module load time. A `getData(key)` helper reads the current data, so the tree-viewer can set `window.LoveBudVisitorViewerData` with real API data before each render.

### State visibility
`tree-viewer.js` now uses `style.display = 'none'` / `style.display = ''` for show/hide instead of the `hidden` attribute, which was overridden by CSS.

### Data adapter
`tree-viewer.js` has a `buildBranches()` function that transforms API memory data into the branch/moment/rootSeed format expected by the Canvas v4 renderer. Route-local IDs (`moment-0`, `moment-1`, `moment-root`) are used instead of raw API memory IDs.

### Removed mock data dependency
`pages/tree.html` no longer loads `visitor-viewer-data.js` (mock data). The tree viewer sets its own data.

## Canonical route decision
The current production route `/pages/tree?treeId=...` (extensionless, served from `pages/tree.html` by Cloudflare Pages) is kept as-is. No route change needed. Browse "트리 열기" CTA already uses this route.

## Changed files
- `js/visitor-viewer/visitor-viewer-render-tree.js` — Rewritten to read data dynamically
- `js/visitor-viewer/visitor-viewer-panels.js` — Rewritten to read data dynamically
- `js/viewer/tree-viewer.js` — Rewritten with proper data adapter, style.display state, clean state management
- `pages/tree.html` — Removed mock data module import, updated cache keys
- `tests/routes/viewer-route-contract.test.js` — Updated Canvas v4 module loading test

## Non-goals
- No backend/API/Auth/DB/schema changes
- No Editor/Builder owner-mode changes
- No Browse redesign / 감상허브 redesign
- No comment/reaction persistence
- No PR #7 or prototype/reference/demo/variant changes

## Verification
- `git diff --check`: PASS
- `node --check` all changed JS files: PASS
- `npm test`: PASS 233/233
- `npm run verify`: PASS (152/152)
- Route-local moment DOM IDs preserved
- No raw API memory IDs in DOM
- No Editor/Builder controls or scripts
- Loading/empty/error states are mutually exclusive

## Browser verification
Fixed slot or production deploy required to confirm:
- Valid treeId renders Canvas v4 tree with branch/moment interaction
- Invalid/missing treeId shows clean empty/error state only
- Post-merge verification tracked in #955

Refs #955
Refs #923