### PR TITLE
feat(viewer): add public LoveTree share actions

### DIFF
--- a/css/visitor-viewer/visitor-viewer-panel.css
+++ b/css/visitor-viewer/visitor-viewer-panel.css
@@ -649,6 +649,26 @@
     color: #a8a29e;
 }
 
+.vv-share-status {
+    margin-top: 10px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+    text-align: center;
+    min-height: 18px;
+}
+
+.vv-share-status.is-success {
+    background: rgba(220,252,231,0.7);
+    color: #166534;
+}
+
+.vv-share-status.is-error {
+    background: rgba(254,226,226,0.7);
+    color: #991b1b;
+}
+
 .vv-icon {
     width: 14px;
     height: 14px;

--- a/js/viewer/share-actions.js
+++ b/js/viewer/share-actions.js
@@ -1,0 +1,69 @@
+(function() {
+    'use strict';
+
+    var MARKER = 'LoveBudShareActionsLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    function getCurrentUrl() {
+        return window.location.href;
+    }
+
+    function getShareData(handlers) {
+        var tree = window.LoveBudVisitorViewerData && window.LoveBudVisitorViewerData.tree;
+        return {
+            title: (tree && tree.title) || document.title || '러브트리',
+            url: (handlers && handlers.getShareUrl) ? handlers.getShareUrl() : getCurrentUrl()
+        };
+    }
+
+    function copyLink(handlers) {
+        var data = getShareData(handlers);
+        if (!navigator.clipboard) {
+            // Fallback: select and copy via textarea
+            try {
+                var ta = document.createElement('textarea');
+                ta.value = data.url;
+                ta.style.position = 'fixed';
+                ta.style.left = '-9999px';
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                document.body.removeChild(ta);
+                return { success: true, message: '링크를 복사했어요' };
+            } catch(e) {
+                return { success: false, message: '복사하지 못했어요' };
+            }
+        }
+        return navigator.clipboard.writeText(data.url).then(function() {
+            return { success: true, message: '링크를 복사했어요' };
+        }).catch(function() {
+            return { success: false, message: '복사하지 못했어요' };
+        });
+    }
+
+    function nativeShare(handlers) {
+        var data = getShareData(handlers);
+        if (typeof navigator.share !== 'function') {
+            // Fallback to link copy
+            return copyLink(handlers);
+        }
+        return navigator.share({
+            title: data.title,
+            text: data.title,
+            url: data.url
+        }).then(function() {
+            return { success: true, message: '공유를 열었어요' };
+        }).catch(function(err) {
+            if (err.name === 'AbortError') {
+                return { success: false, message: '' }; // User cancelled, no feedback needed
+            }
+            return { success: false, message: '공유하지 못했어요' };
+        });
+    }
+
+    window.LoveBudShareActions = {
+        copyLink: copyLink,
+        nativeShare: nativeShare
+    };
+})();

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -190,6 +190,7 @@
             }
 
             var handler = {
+                getShareUrl: function() { return window.location.href; },
                 onSelectBranch: function(branchId) {
                     state.selectedBranchId = branchId;
                     state.selectedMomentId = null;
@@ -214,8 +215,34 @@
                     else state.activePanel = 'empty';
                     refresh();
                 },
-                toggleLike: function() { state.likedTree = !state.likedTree; }
+                toggleLike: function() { state.likedTree = !state.likedTree; },
+                copyLink: function() {
+                    var Share = window.LoveBudShareActions;
+                    if (!Share) return;
+                    var result = Share.copyLink(handler);
+                    showShareStatus(result);
+                },
+                nativeShare: function() {
+                    var Share = window.LoveBudShareActions;
+                    if (!Share) return;
+                    Share.nativeShare(handler).then(function(result) {
+                        showShareStatus(result);
+                    });
+                }
             };
+
+            function showShareStatus(result) {
+                if (!result || !result.message) return;
+                var statusEl = document.getElementById('vvShareStatus');
+                if (!statusEl) return;
+                statusEl.textContent = result.message;
+                statusEl.className = 'vv-share-status ' + (result.success ? 'is-success' : 'is-error');
+                clearTimeout(statusEl._hideTimer);
+                statusEl._hideTimer = setTimeout(function() {
+                    statusEl.textContent = '';
+                    statusEl.className = 'vv-share-status';
+                }, 3000);
+            }
 
             container.addEventListener('click', function(e) {
                 var action = e.target.closest('[data-action]');
@@ -226,6 +253,8 @@
                     else if (a === 'toggle-like') handler.toggleLike();
                     else if (a === 'open-tree-comments') handler.openPanel('tree-comments');
                     else if (a === 'open-share') handler.openPanel('share');
+                    else if (a === 'copy-link') handler.copyLink();
+                    else if (a === 'native-share') handler.nativeShare();
                     return;
                 }
                 var momentBtn = e.target.closest('[data-moment-id]');

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -159,6 +159,13 @@
                 '  <h1 class="vv-title">' + escapeHtml(treeTitle) + '</h1>' +
                 '  <div class="vv-meta-row"><span>' + escapeHtml(viewerData.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(treeMetaText) + '</span></div></div>' +
                 '</header>' +
+                '<div class="vv-action-dock">' +
+                '  <div class="vv-action-group">' +
+                '    <button type="button" class="vv-action-btn" data-action="open-share"><span class="vv-action-icon">' +
+                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M8.1 12.7 15.9 17M15.9 7 8.1 11.3M6.4 14.6a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm10.9-5a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm0 10a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg></span>' +
+                '    공유</button>' +
+                '  </div>' +
+                '</div>' +
                 '<div class="vv-viewer-layout">' +
                 '  <div class="vv-tree-container"></div>' +
                 '  <div class="vv-panel-host"></div>' +

--- a/js/visitor-viewer/visitor-viewer-panels.js
+++ b/js/visitor-viewer/visitor-viewer-panels.js
@@ -137,9 +137,11 @@
             '  <button type="button" class="vv-panel-close" data-action="close-panel" aria-label="공유 패널 닫기">' + Icon.close + '</button>' +
             '</div>' +
             '<div class="vv-share-preview"><div class="vv-share-icon">🌳</div><h3 class="vv-share-title">' + escape(tree.title || '') + '</h3><p class="vv-share-creator">' + escape(tree.creator || '') + '</p></div>' +
-            '<div class="vv-share-actions"><button type="button" class="vv-share-btn vv-share-btn-primary">링크 복사 <span>copy</span></button>' +
-            '<button type="button" class="vv-share-btn vv-share-btn-secondary">Browse에 공유 <span>public</span></button>' +
-            '<button type="button" class="vv-share-btn vv-share-btn-secondary">이미지 카드로 저장 <span>later</span></button></div>' +
+            '<div class="vv-share-actions">' +
+            '<button type="button" class="vv-share-btn vv-share-btn-primary" data-action="copy-link">링크 복사 <span>copy</span></button>' +
+            '<button type="button" class="vv-share-btn vv-share-btn-secondary" data-action="native-share">공유하기 <span>share</span></button>' +
+            '<button type="button" class="vv-share-btn vv-share-btn-secondary" data-action="close-panel">나중에 하기 <span>close</span></button></div>' +
+            '<div id="vvShareStatus" class="vv-share-status" aria-live="polite"></div>' +
             '<p class="vv-share-note">공유 액션은 나중에 실제 URL 복사, 네이티브 공유, 공개 범위 확인과 연결하면 됩니다.</p></aside>';
     }
 

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -66,6 +66,7 @@
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-viewer.js?v=20260508-923-1"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
+    <script src="../js/viewer/share-actions.js?v=20260508-956-1"></script>
     <script src="../js/viewer/tree-viewer.js?v=20260508-955-1"></script>
 </body>
 </html>

--- a/tests/routes/viewer-share-contract.test.js
+++ b/tests/routes/viewer-share-contract.test.js
@@ -21,6 +21,15 @@ test('share panel has actionable buttons', () => {
     assert.ok(panels.includes('vvShareStatus'), 'share panel must have status area');
 });
 
+test('tree route loads share actions before tree viewer', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const shareActionsIndex = html.indexOf('../js/viewer/share-actions.js');
+    const treeViewerIndex = html.indexOf('../js/viewer/tree-viewer.js');
+    assert.notEqual(shareActionsIndex, -1, 'tree.html must load share-actions.js');
+    assert.notEqual(treeViewerIndex, -1, 'tree.html must load tree-viewer.js');
+    assert.ok(shareActionsIndex < treeViewerIndex, 'share-actions.js must load before tree-viewer.js');
+});
+
 test('tree-viewer handles share actions', () => {
     const viewer = fs.readFileSync('js/viewer/tree-viewer.js', 'utf8');
     assert.ok(viewer.includes('copy-link') || viewer.includes('copyLink'), 'tree-viewer must handle copy-link');

--- a/tests/routes/viewer-share-contract.test.js
+++ b/tests/routes/viewer-share-contract.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('share actions module exists', () => {
+    assert.ok(fs.existsSync('js/viewer/share-actions.js'), 'js/viewer/share-actions.js must exist');
+});
+
+test('share actions module has expected API', () => {
+    const content = fs.readFileSync('js/viewer/share-actions.js', 'utf8');
+    assert.ok(content.includes('LoveBudShareActions'), 'must expose LoveBudShareActions');
+    assert.ok(content.includes('copyLink'), 'must expose copyLink');
+    assert.ok(content.includes('nativeShare'), 'must expose nativeShare');
+    assert.ok(content.includes('navigator.clipboard') || content.includes('execCommand'), 'must handle clipboard');
+});
+
+test('share panel has actionable buttons', () => {
+    const panels = fs.readFileSync('js/visitor-viewer/visitor-viewer-panels.js', 'utf8');
+    assert.ok(panels.includes('data-action="copy-link"'), 'share panel must have copy-link button');
+    assert.ok(panels.includes('data-action="native-share"'), 'share panel must have native-share button');
+    assert.ok(panels.includes('vvShareStatus'), 'share panel must have status area');
+});
+
+test('tree-viewer handles share actions', () => {
+    const viewer = fs.readFileSync('js/viewer/tree-viewer.js', 'utf8');
+    assert.ok(viewer.includes('copy-link') || viewer.includes('copyLink'), 'tree-viewer must handle copy-link');
+    assert.ok(viewer.includes('native-share') || viewer.includes('nativeShare'), 'tree-viewer must handle native-share');
+    assert.ok(viewer.includes('showShareStatus'), 'tree-viewer must have share status feedback');
+});
+
+test('share actions module does not expose private identifiers', () => {
+    const content = fs.readFileSync('js/viewer/share-actions.js', 'utf8');
+    const privatePatterns = ['ownerId', 'owner_id', 'memoryId', 'memory_id', 'treeId', 'tree_id'];
+    const matches = privatePatterns.filter(p => content.match(new RegExp(p, 'i')));
+    assert.equal(matches.length, 0, 'share actions must not reference private identifiers: ' + matches.join(', '));
+});
+
+test('viewer route does not load Editor/Builder scripts', () => {
+    const html = fs.readFileSync('pages/tree.html', 'utf8');
+    const noEditorScript = !html.includes('js/editor.js') && !html.includes('pages/editor.html');
+    assert.ok(noEditorScript, 'tree.html must not load editor entry script');
+});
+
+test('share module uses window.location.href without exposing raw values', () => {
+    const content = fs.readFileSync('js/viewer/share-actions.js', 'utf8');
+    assert.ok(content.includes('window.location.href'), 'share module must use current page URL');
+    assert.ok(!content.includes('treeId='), 'share module must not hardcode treeId in source');
+});


### PR DESCRIPTION
## Summary
Adds functional share actions to the public LoveTree viewer route (`/pages/tree?treeId=...`), replacing the previous static placeholder buttons.

## Changes
- **`js/viewer/share-actions.js`** (new): Share actions module with `copyLink()` (clipboard API + execCommand fallback) and `nativeShare()` (Web Share API + fallback to copy). Both return status `{ success, message }`.
- **`js/visitor-viewer/visitor-viewer-panels.js`**: Share panel now renders `data-action="copy-link"` and `data-action="native-share"` buttons, plus a `#vvShareStatus` aria-live area for status feedback. Removed old `Browse에 공유`/`이미지 카드로 저장` placeholders.
- **`js/viewer/tree-viewer.js`**: Added `copyLink()` and `nativeShare()` handlers wired to the share actions module, `showShareStatus()` for timed feedback, and click delegation for the new actions.
- **`css/visitor-viewer/visitor-viewer-panel.css`**: Added `.vv-share-status` styles with `.is-success` / `.is-error` states.
- **`tests/routes/viewer-share-contract.test.js`** (new): 7 tests covering module existence, API shape, button wiring, private identifier protection, and Editor/Builder boundary.

## Non-goals
- No backend/API/Auth/DB/schema changes
- No comment/reaction persistence
- No Editor/Builder owner-mode changes
- No Browse redesign
- No PR #7 or prototype/reference/demo/variant changes

## Verification
- `git diff --check`: PASS
- `node --check` all changed JS files: PASS
- `npm test`: PASS 240/240 (7 new share contract tests)
- `npm run verify`: PASS (152/152)
- Share URL is `window.location.href` (current route, no private identifiers)
- No raw API memory IDs in share DOM
- No Editor/Builder scripts or controls

Refs #956