### PR TITLE
ui(search): simplify mobile Browse controls

### DIFF
--- a/css/search/search-controls.css
+++ b/css/search/search-controls.css
@@ -139,12 +139,13 @@
 /* Issue #911: Mobile filter density reduction */
 @media (max-width: 480px) {
     .filter-row {
-        gap: 6px;
+        width: 100%;
+        gap: 5px;
         justify-content: flex-start;
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none;
-        padding-bottom: 4px;
+        padding-bottom: 0;
     }
 
     .filter-row::-webkit-scrollbar {
@@ -152,20 +153,37 @@
     }
 
     .tag-chip {
-        padding: 6px 10px;
-        font-size: 11px;
+        display: inline-flex;
+        align-items: center;
+        min-height: 26px;
+        padding: 4px 8px;
+        font-size: 10.5px;
+        line-height: 1;
         white-space: nowrap;
         flex-shrink: 0;
+        border-color: rgba(144, 73, 81, 0.06);
+        background: rgba(255, 255, 255, 0.58);
+    }
+
+    .tag-chip.active {
+        background: rgba(144, 73, 81, 0.10);
+        border-color: rgba(144, 73, 81, 0.14);
     }
 
     #browseSortControls > div {
         width: 100%;
+        gap: 6px !important;
         justify-content: flex-start;
     }
 
     .browse-utility-row {
         flex-wrap: wrap;
-        gap: 12px;
+        gap: 8px;
+        margin-bottom: 12px;
+        padding: 10px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.34);
+        box-shadow: none;
     }
 
     .search-input-wrapper {
@@ -174,8 +192,9 @@
     }
 
     .search-input {
-        padding: 12px 14px 12px 40px;
-        font-size: 0.9rem;
+        min-height: 40px;
+        padding: 10px 12px 10px 38px;
+        font-size: 0.86rem;
     }
 
     .search-icon {

--- a/css/search/search-hero-controls.css
+++ b/css/search/search-hero-controls.css
@@ -119,12 +119,18 @@
     box-shadow: 0 8px 18px rgba(75,64,57,0.03);
 }
 
+.browse-results-badge[hidden] {
+    display: none !important;
+}
+
 /* Issue #911: Mobile sort hierarchy improvement */
 @media (max-width: 480px) {
     .browse-results-head {
         flex-direction: column;
         align-items: flex-start;
-        gap: 12px;
+        gap: 8px;
+        margin: 2px 0 12px;
+        padding-top: 14px;
     }
 
     .browse-head-right {
@@ -142,10 +148,12 @@
         max-width: 100%;
         min-width: 0;
         justify-content: flex-start !important;
+        gap: 6px !important;
     }
 
     #browseSortControls .tag-chip {
-        padding: 5px 10px;
-        font-size: 11px;
+        min-height: 26px;
+        padding: 4px 8px;
+        font-size: 10.5px;
     }
 }

--- a/css/search/search-responsive.css
+++ b/css/search/search-responsive.css
@@ -354,16 +354,39 @@
     .browse-results-head {
         align-items: flex-start;
         flex-direction: column;
-        gap: 10px;
+        gap: 8px;
+        margin-bottom: 12px;
+        padding-top: 14px;
     }
 
     .browse-results-head h3 {
-        font-size: 1.12rem;
+        font-size: 1.08rem;
     }
 
     .browse-utility-row {
-        gap: 10px;
-        margin-top: 14px;
-        padding: 12px;
+        gap: 8px;
+        margin-top: 12px;
+        padding: 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .tag-chip,
+    #browseSortControls .tag-chip {
+        display: inline-flex;
+        align-items: center;
+        min-height: 26px;
+        padding: 4px 8px;
+        font-size: 10.5px;
+        line-height: 1;
+    }
+
+    .filter-row {
+        gap: 5px;
+        padding-bottom: 0;
+    }
+
+    .browse-results-head p {
+        display: none;
     }
 }

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260508-618-rev2">
+    <link rel="stylesheet" href="../css/search.css?v=20260508-966-1">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
## Summary
- Reduces mobile Browse control density for the search/filter block and results sort row.
- Keeps filter and sort behavior intact while making chips smaller and lighter on narrow screens.
- Connects sort controls more closely to the results heading without changing feed loading or card behavior.
- Preserves desktop layout and existing Browse runtime structure.

## Scope
- Mobile-focused Search/Browse CSS density tuning.
- Search stylesheet cache key update in `pages/search.html`.
- No JavaScript behavior changes.

## Non-goals
- No Browse card tap response or tree-open bridge work.
- No sentinel or marker cleanup work.
- No backend/API/Auth/DB/package/workflow changes.
- No Browse redesign.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check`: SKIPPED (no JS changed)
- `npm run verify`: PASS
- `npm test`: PASS

## Mobile/Desktop Reasoning
- Mobile 375px local static smoke showed `document.documentElement.scrollWidth === window.innerWidth`.
- Mobile filter chips now render as compact one-line controls with reduced chip height and spacing.
- Sort controls stay in the results heading area with compact mobile chip sizing.
- Desktop selectors remain outside the changed mobile media queries except the hidden-result-badge guard.

## UI Review
- UI_REVIEW_REQUIRED for Cloudflare Preview/mobile screenshot acceptance.

Refs #966