### PR TITLE
ui(search): add Browse card tree-first bridge

### DIFF
--- a/css/search/search-responsive.css
+++ b/css/search/search-responsive.css
@@ -73,12 +73,37 @@
     .tree-meta-row {
         padding-top: 10px;
         font-size: 12px;
+        gap: 7px;
     }
 
     .tree-meta-chip {
         font-size: 11px;
         padding: 0 8px;
         min-height: 24px;
+    }
+
+    .tree-meta-left {
+        flex: 0 1 auto;
+        max-width: 42%;
+    }
+
+    .tree-meta-right {
+        gap: 5px;
+        min-width: 0;
+    }
+
+    .tree-moment-count {
+        font-size: 11px;
+    }
+
+    .tree-card-open-link {
+        min-height: 24px;
+        padding: 0 7px;
+        font-size: 10.5px;
+    }
+
+    .tree-card-open-link .material-symbols-outlined {
+        font-size: 13px;
     }
 
     .tree-card-media-fallback {

--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -56,6 +56,12 @@
         0 0 0 1px rgba(255, 255, 255, 0.42) inset;
 }
 
+.tree-card.is-active .tree-card-open-link {
+    background: rgba(144, 73, 81, 0.92);
+    border-color: rgba(144, 73, 81, 0.22);
+    color: #fffaf8;
+}
+
 .tree-card:hover::before,
 .tree-card.is-active::before {
     opacity: 1;
@@ -444,7 +450,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
+    gap: 10px;
     padding-top: 10px;
     border-top: 1px solid rgba(144,73,81,0.08);
     font-size: 13px;
@@ -464,6 +470,8 @@
 .tree-meta-right {
     justify-content: flex-end;
     overflow: hidden;
+    flex: 1 1 auto;
+    gap: 6px;
 }
 
 .tree-meta-chip {
@@ -482,6 +490,54 @@
 
 .tree-meta-chip .material-symbols-outlined {
     font-size: 14px;
+}
+
+.tree-moment-count {
+    color: var(--on-surface-variant);
+    font-size: 12.5px;
+    font-weight: 720;
+    line-height: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tree-card-open-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    flex: 0 0 auto;
+    min-height: 28px;
+    padding: 0 9px;
+    border-radius: 999px;
+    border: 1px solid rgba(144, 73, 81, 0.14);
+    background: rgba(255, 250, 248, 0.84);
+    color: var(--primary);
+    font-size: 11.5px;
+    font-weight: 850;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.tree-card-open-link .material-symbols-outlined {
+    font-size: 14px;
+}
+
+.tree-card-open-link:hover,
+.tree-card-open-link:focus-visible {
+    background: rgba(144, 73, 81, 0.92);
+    border-color: rgba(144, 73, 81, 0.24);
+    color: #fffaf8;
+    transform: translateY(-1px);
+}
+
+.tree-card-open-link:focus-visible {
+    outline: 2px solid rgba(144, 73, 81, 0.30);
+    outline-offset: 2px;
 }
 
 /* Issue #455 PR B: representative media and fallback tree preview polish. */

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -134,6 +134,11 @@
         return Number.isFinite(count) && count > 0 ? count : 0;
     }
 
+    function getTreeViewerHref(tree) {
+        if (!tree?.id) return '';
+        return `${getBasePath()}tree.html?treeId=${encodeURIComponent(tree.id)}`;
+    }
+
     function getTreePreviewTone(tree) {
         const memoryCount = getDisplayMemoryCount(tree?.memoryCount);
         if (memoryCount >= 6) return 'full';
@@ -255,6 +260,9 @@
          const safeTitle = escapeHtml(displayTitleRaw);
          const emotionTag = renderEmotionTags(tree.emotionTags);
          const countLabel = memoryCount > 0 ? `${memoryCount}개의 순간` : '대표 순간 준비 중';
+         const viewerHref = getTreeViewerHref(tree);
+         const cardSelectLabel = `${displayTitleRaw} 러브트리를 감상 허브에서 미리보기`;
+         const viewerLabel = `${displayTitleRaw} 러브트리 열기`;
          const hasDerivedDescription = Boolean(displayTheme || primaryTag);
          const softMoodLine = displayTheme
              ? `${displayTheme}와 함께 시작된 마음`
@@ -268,7 +276,7 @@
              : 'tree-subtitle tree-subtitle-fallback';
 
          return `
-             <div class="tree-card ${index === 0 ? 'tree-card-featured' : ''}" id="tree-card-${safeTreeId}" data-tree-id="${safeTreeId}" style="animation-delay: ${index * 0.05}s;">
+             <div class="tree-card ${index === 0 ? 'tree-card-featured' : ''}" id="tree-card-${safeTreeId}" data-tree-id="${safeTreeId}" aria-label="${escapeHtml(cardSelectLabel)}" style="animation-delay: ${index * 0.05}s;">
                  ${renderRepresentativeMedia(tree, firstMem, displayTitleRaw)}
                  <div class="tree-card-body">
                      <div class="tree-title">${safeTitle}</div>
@@ -282,8 +290,14 @@
                              </span>
                          </div>
                          <div class="tree-meta-right">
-                             <span style="font-size:13px;color:var(--on-surface-variant);white-space:nowrap;">${escapeHtml(countLabel)}</span>
+                             <span class="tree-moment-count">${escapeHtml(countLabel)}</span>
                              ${emotionTag}
+                             ${viewerHref ? `
+                                 <a href="${escapeHtml(viewerHref)}" class="tree-card-open-link" aria-label="${escapeHtml(viewerLabel)}">
+                                     <span class="material-symbols-outlined" aria-hidden="true">account_tree</span>
+                                     트리 열기
+                                 </a>
+                             ` : ''}
                          </div>
                      </div>
                  </div>
@@ -428,6 +442,7 @@
         getTreeIcon: getTreeIcon,
         renderEmotionTags: renderEmotionTags,
         getBasePath: getBasePath,
+        getTreeViewerHref: getTreeViewerHref,
         showImageFallback: showImageFallback,
         handleImageLoad: (img) => {
             if (isSuspiciousYouTubeThumbnailImage(img)) {

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-    <link rel="stylesheet" href="../css/search.css?v=20260508-966-1">
+    <link rel="stylesheet" href="../css/search.css?v=20260509-963-1">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -87,15 +87,28 @@ test('browse filter and sort changes reset pagination state without changing fee
 
 test('search UI module implements card accessibility and event delegation', () => {
   const uiModule = read('js/search/search-ui.js');
+  const cardRenderer = read('js/search/search-card-renderer.js');
   
   // Verify accessibility attributes are set
   assert.match(uiModule, /card\.setAttribute\(['"]tabindex['"],\s*['"]0['"]\)/);
   assert.match(uiModule, /card\.setAttribute\(['"]role['"],\s*['"]button['"]\)/);
+  assert.match(cardRenderer, /aria-label="\$\{escapeHtml\(cardSelectLabel\)\}"/);
   
   // Verify event delegation pattern
   assert.match(uiModule, /container\.addEventListener\(['"]click['"]/);
   assert.match(uiModule, /container\.addEventListener\(['"]keydown['"]/);
   assert.match(uiModule, /event\.target\.closest\(['"]\.tree-card\[data-tree-id\]['"]\)/);
+  assert.match(uiModule, /const interactiveSelector = ['"]a, button,/);
+});
+
+test('browse cards expose a truthful public tree viewer bridge', () => {
+  const cardRenderer = read('js/search/search-card-renderer.js');
+
+  assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
+  assert.match(cardRenderer, /tree\.html\?treeId=/);
+  assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
+  assert.match(cardRenderer, /tree-card-open-link/);
+  assert.match(cardRenderer, /트리 열기/);
 });
 
 test('search preview summary omits range phrase for missing time range labels', () => {


### PR DESCRIPTION
## Summary
- Adds a compact `트리 열기` bridge inside Browse cards that routes to the public viewer route.
- Keeps the existing card tap behavior focused on selected preview / 감상 허브 selection.
- Reinforces the card as a LoveTree object with tree-flow structure, moment count, and viewer bridge instead of relying only on media thumbnail identity.
- Covers fallback/no-thumbnail cards through the existing shared card grammar.

## Scope
- Browse/Search card renderer markup only.
- Browse card visual/action bridge CSS only.
- Search stylesheet cache key update.
- Static route/card contract test update.

## Non-goals
- No #966 work.
- No #967 work.
- No Public Viewer implementation.
- No backend/API/Auth/DB/package/workflow changes.
- No full Browse redesign.
- No Browse internal moment selection behavior.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/search/search-card-renderer.js`: PASS
- `node --test tests/routes/search-runtime-modules.test.js tests/routes/viewer-route-contract.test.js`: PASS
- `npm run verify`: PASS
- `npm test`: PASS

## Reasoning report
- Desktop Browse card row: existing card grid and selected preview selection remain intact; only the card meta/action area gains the public tree route link.
- Media-backed card: representative media remains, but the card now has visible LoveTree flow and public tree route affordance.
- Fallback/no-thumbnail card: fallback media still uses the same tree preview grammar and receives the same card-level public viewer bridge.
- Selected preview: card click still delegates to `callbacks.selectTree`; nested link clicks are ignored by the existing interactive-child guard.
- Mobile 375px: local static smoke with a mock card showed `scrollWidth === innerWidth`; link and flow fit within the card width.
- Mobile selected/tapped card: active card styling now also emphasizes the tree-open bridge while preserving selected preview semantics.
- Fatal console/network blocker introduced: NO by code inspection; no API/feed loading code changed.

## UI Review
- UI_REVIEW_REQUIRED on Cloudflare Preview for final visual acceptance.

Refs #963