### PR TITLE
ui(my-trees): align card preview grammar

### DIFF
--- a/css/my-trees/my-trees-cards.css
+++ b/css/my-trees/my-trees-cards.css
@@ -2,17 +2,25 @@
 .tree-card { display: block; position: relative; background: var(--lovetree-soft-surface); border-radius: var(--lovetree-card-radius); padding: 0; box-shadow: var(--lovetree-card-shadow); border: 1px solid var(--lovetree-soft-surface-border); overflow: hidden; cursor: pointer; transition: border-color 0.12s ease, box-shadow 0.12s ease; text-decoration: none; color: inherit; }
 .tree-card:hover { box-shadow: 0 20px 50px rgba(144, 73, 81, 0.12); border-color: var(--primary-soft); }
 .tree-card-thumb { width: 100%; height: 184px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; padding: 18px; }
+.tree-card-thumb::after { content: ""; position: absolute; inset: auto 0 0; height: 44%; background: linear-gradient(to top, rgba(75,64,57,0.18), transparent); pointer-events: none; z-index: 1; }
 .tree-card-thumb-glow { position: absolute; inset: auto auto 18px 18px; width: 128px; height: 128px; border-radius: 50%; filter: blur(10px); }
 .tree-card-thumb-initial { position: absolute; top: 16px; left: 16px; width: 42px; height: 42px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 17px; font-weight: 800; background: rgba(255,255,255,0.72); border: 1px solid rgba(255,255,255,0.55); backdrop-filter: blur(6px); z-index: 2; }
 .tree-card-thumb-topline { position: absolute; top: 16px; right: 16px; z-index: 2; }
 .tree-card-thumb-art { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; }
 .tree-card-thumb svg { width: 84%; height: 84%; opacity: 0.95; }
 .tree-card-thumb-image { width: calc(100% + 36px); height: calc(100% + 36px); margin: -18px; object-fit: cover; display: block; }
-.tree-card-text-visual { width: calc(100% - 20px); min-height: 126px; display: flex; flex-direction: column; justify-content: center; gap: 8px; padding: 16px 18px; border-radius: 24px; border: 1px solid; box-shadow: 0 14px 34px rgba(75, 64, 57, 0.07); backdrop-filter: blur(10px); }
+.tree-card-text-visual { position: relative; width: calc(100% - 20px); min-height: 126px; display: flex; flex-direction: column; justify-content: center; gap: 8px; padding: 16px 18px; border-radius: 24px; border: 1px solid; box-shadow: 0 14px 34px rgba(75, 64, 57, 0.07); backdrop-filter: blur(10px); z-index: 1; }
 .tree-card-text-kicker { font-size: 10px; font-weight: 900; letter-spacing: 0.08em; text-transform: uppercase; }
 .tree-card-text-title { font-size: 1rem; font-weight: 800; line-height: 1.4; color: var(--on-surface); word-break: keep-all; }
 .tree-card-text-memo { font-size: 12px; line-height: 1.55; color: var(--on-surface-variant); display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; word-break: keep-all; }
-.tree-card-thumb-caption { position: absolute; left: 16px; right: 16px; bottom: 14px; padding: 10px 12px; border-radius: 999px; background: rgba(255,255,255,0.78); backdrop-filter: blur(8px); font-size: 12px; font-weight: 700; color: var(--on-surface); text-align: center; }
+.tree-card-thumb-caption { position: absolute; left: 16px; right: 16px; bottom: 12px; padding: 8px 12px; border-radius: 999px; background: rgba(255,255,255,0.82); backdrop-filter: blur(8px); font-size: 12px; font-weight: 700; color: var(--on-surface); text-align: center; z-index: 3; }
+.tree-card-flow-bridge { position: absolute; left: 18px; right: 18px; bottom: 50px; z-index: 3; display: flex; align-items: center; height: 22px; padding: 0 8px; border-radius: 999px; background: linear-gradient(90deg, rgba(255,248,245,0.72), rgba(244,248,238,0.62)); border: 1px solid rgba(144,73,81,0.08); box-sizing: border-box; overflow: hidden; pointer-events: none; }
+.tree-card-flow-line { position: absolute; left: 16px; right: 16px; top: 50%; height: 2px; border-radius: 999px; transform: translateY(-50%); background: linear-gradient(90deg, rgba(144,73,81,0.34), rgba(122,139,110,0.30)); }
+.tree-card-flow-node { position: relative; z-index: 1; flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: #c87480; box-shadow: 0 0 0 4px rgba(200,116,128,0.10); }
+.tree-card-flow-node + .tree-card-flow-node { margin-left: auto; }
+.tree-card-flow-node-root { background: #904951; }
+.tree-card-flow-node-end { background: #7a8b6e; box-shadow: 0 0 0 4px rgba(122,139,110,0.12); }
+.tree-card-flow-count-1 .tree-card-flow-line { right: 50%; opacity: 0.28; }
 .tree-card-info { padding: 18px 18px 22px; display: flex; flex-direction: column; gap: 7px; min-height: 114px; }
 .tree-card-title-row { display: flex; align-items: flex-start; gap: 10px; justify-content: space-between; }
 .tree-card-title { font-size: 1.04rem; font-weight: 700; color: var(--on-surface); line-height: 1.3; flex: 1; overflow-wrap: anywhere; }

--- a/css/my-trees/my-trees-responsive.css
+++ b/css/my-trees/my-trees-responsive.css
@@ -17,6 +17,9 @@
 .trees-skeleton-grid { grid-template-columns: 1fr; gap: 20px; }
 .empty-state { padding: 60px 24px; }
 .tree-card-thumb { height: 176px; }
+.tree-card-flow-bridge { left: 16px; right: 16px; bottom: 48px; height: 20px; }
+.tree-card-flow-node { width: 6px; height: 6px; box-shadow: 0 0 0 3px rgba(200,116,128,0.10); }
+.tree-card-thumb-caption { bottom: 11px; padding: 7px 10px; }
 .create-tree-modal-backdrop { padding: 16px; }
 .create-tree-modal { padding: 22px 20px; border-radius: 24px; }
 .create-tree-visibility { grid-template-columns: 1fr; }

--- a/js/i18n/i18n-my-trees.js
+++ b/js/i18n/i18n-my-trees.js
@@ -51,6 +51,8 @@
     'myTrees.card_selected': { ko: '보고 있는 트리', en: 'Current tree' },
     'myTrees.card_open': { ko: '다시 열기', en: 'Open again' },
     'myTrees.card_menu': { ko: '트리 메뉴 열기', en: 'Open tree menu' },
+    'myTrees.card_flow_label': { ko: '이어진 순간 흐름', en: 'Connected moment flow' },
+    'myTrees.card_flow_empty_label': { ko: '첫 순간을 기다리는 러브트리 흐름', en: 'LoveTree flow waiting for the first moment' },
     'myTrees.card_waiting': { ko: '첫 순간을 기다리는 중', en: 'Waiting for the first moment' },
     'myTrees.card_growing': { ko: '차곡차곡 자라는 중', en: 'Growing layer by layer' },
     'myTrees.moment_count_compact': { ko: '순간 {count}개', en: '{count} moments' },

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -138,6 +138,28 @@
     ].join('');
   }
 
+  function buildTreeFlowBridge(tree, i18n) {
+    var momentCount = getTreeMomentCount(tree);
+    var nodeCount = Math.max(1, Math.min(momentCount || 1, 5));
+    var nodes = [];
+    for (var i = 0; i < nodeCount; i++) {
+      var nodeClass = 'tree-card-flow-node';
+      if (i === 0) nodeClass += ' tree-card-flow-node-root';
+      if (i === nodeCount - 1 && nodeCount > 1) nodeClass += ' tree-card-flow-node-end';
+      nodes.push('<span class="' + nodeClass + '"></span>');
+    }
+    var label = momentCount > 0
+      ? (i18n('myTrees.card_flow_label') || '이어진 순간 흐름')
+      : (i18n('myTrees.card_flow_empty_label') || '첫 순간을 기다리는 러브트리 흐름');
+
+    return [
+      '<div class="tree-card-flow-bridge tree-card-flow-count-' + nodeCount + '" role="img" aria-label="' + escapeHtml(label) + '">',
+        '<span class="tree-card-flow-line"></span>',
+        nodes.join(''),
+      '</div>'
+    ].join('');
+  }
+
   function getRepresentativeThumbnail(tree) {
     if (!tree) return '';
     return tree.representativeThumbnail || tree.representative_thumbnail || tree.thumbnail || '';
@@ -198,6 +220,7 @@
             : (textVisual || buildMiniTreeSVG(tree)),
         '</div>',
         (momentCount > 0 ? '<div class="tree-card-thumb-topline"><span class="tree-card-moment-badge" data-count="' + momentCount + '">' + (i18n('myTrees.moment_count_compact') || '순간 {count}개').replace('{count}', String(momentCount)) + '</span></div>' : ''),
+        buildTreeFlowBridge(tree, i18n),
         (momentCount > 0 ? '<div class="tree-card-thumb-caption">' + moodLabel + '</div>' : ''),
       '</div>'
     ].join('');

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="stylesheet" href="../css/global.css?v=20260415-10">
-  <link rel="stylesheet" href="../css/my-trees.css?v=20260509-910-1">
+  <link rel="stylesheet" href="../css/my-trees.css?v=20260509-910-2">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -141,7 +141,7 @@
   <script src="../js/api/auth-policy.js?v=20260420-1"></script>
   <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
   <script src="../js/postgres-client.js?v=20260422-1"></script>
-  <script src="../js/my-trees/my-trees-ui.js?v=20260422-2"></script>
+  <script src="../js/my-trees/my-trees-ui.js?v=20260509-910-2"></script>
   <script src="../js/my-trees/my-trees-actions.js?v=20260427-1"></script>
   <script src="../js/my-trees/my-trees-data.js?v=20260422-4"></script>
   <script src="../js/my-trees/my-trees-state.js?v=20260421-4"></script>
@@ -159,7 +159,7 @@
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260421-9"></script>
-    <script src="../js/i18n/i18n-my-trees.js?v=20260509-910-1"></script>
+    <script src="../js/i18n/i18n-my-trees.js?v=20260509-910-2"></script>
     <script src="../js/i18n/i18n-index.js?v=20260421-1"></script>
   <script src="../js/i18n.js?v=20260419-2"></script>
   <script src="../js/shared-header.js?v=20260421-2"></script>


### PR DESCRIPTION
## Summary
- Adds a compact, non-interactive LoveTree flow bridge inside My Trees card previews.
- Brings My Trees owner cards closer to the Browse LoveTree preview grammar without matching Browse one-for-one.
- Improves fallback/no-thumbnail previews so they read as LoveTree objects, not plain placeholders.
- Keeps owner card navigation, menu actions, sorting, and data behavior unchanged.

## Scope
- My Trees card preview renderer markup only.
- My Trees card preview CSS and mobile sizing only.
- Tiny My Trees i18n labels for the non-interactive flow cue.
- My Trees page cache keys for the touched assets.

## Non-goals
- No header/heading work.
- No Auth/API/backend/DB/package/workflow changes.
- No create/edit/delete/open behavior changes.
- No menu behavior changes.
- No Browse changes.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check js/my-trees/my-trees-ui.js js/i18n/i18n-my-trees.js`: PASS
- `npm run verify`: PASS
- `npm test`: PASS

## Reasoning Report
- Mobile 375px mock-render smoke: card and flow bridge stayed within viewport and card bounds.
- Desktop mock-render smoke: card grid and flow bridge stayed within viewport and card bounds.
- Owner open/menu behavior: existing event handlers are preserved; mock smoke confirmed menu click does not trigger card navigation and card body click still triggers navigation handler.
- Auth/data behavior: no auth, data, loader, or API files changed.

## UI Review
- UI_REVIEW_REQUIRED on an auth-capable Cloudflare Preview or assigned test slot.

Refs #910
Refs #681
