### PR TITLE
editor: persist source URL memory updates

### DIFF
--- a/modal_compute/owner_writes.py
+++ b/modal_compute/owner_writes.py
@@ -231,6 +231,22 @@ def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) 
         updates.append("memo = %s")
         params.append(validate_optional_string(payload.get("memo"), 5000))
 
+    if "source" in payload:
+        updates.append("source = %s")
+        params.append(validate_optional_string(payload.get("source"), 200))
+
+    if "sourceUrl" in payload:
+        updates.append("source_url = %s")
+        params.append(validate_optional_string(payload.get("sourceUrl"), 1000))
+
+    if "sourceType" in payload:
+        updates.append("source_type = %s")
+        params.append(validate_optional_string(payload.get("sourceType"), 50) or "youtube")
+
+    if "thumbnail" in payload:
+        updates.append("thumbnail = %s")
+        params.append(validate_optional_string(payload.get("thumbnail"), 500))
+
     if "emotionTags" in payload:
         emotion_tags = payload.get("emotionTags") if isinstance(payload.get("emotionTags"), list) else []
         if len(emotion_tags) > 20:

--- a/tests/contracts/modal-owner-write-route-contract.test.js
+++ b/tests/contracts/modal-owner-write-route-contract.test.js
@@ -555,6 +555,30 @@ test('update_owner_memory only allows specific update fields', () => {
 
   assert.match(
     normalized,
+    /source.*in.*payload/i,
+    'update_owner_memory must check source in payload'
+  );
+
+  assert.match(
+    normalized,
+    /sourceurl.*in.*payload/i,
+    'update_owner_memory must check sourceUrl in payload'
+  );
+
+  assert.match(
+    normalized,
+    /sourcetype.*in.*payload/i,
+    'update_owner_memory must check sourceType in payload'
+  );
+
+  assert.match(
+    normalized,
+    /thumbnail.*in.*payload/i,
+    'update_owner_memory must check thumbnail in payload'
+  );
+
+  assert.match(
+    normalized,
     /emotiontags.*in.*payload/i,
     'update_owner_memory must check emotionTags in payload'
   );
@@ -563,6 +587,30 @@ test('update_owner_memory only allows specific update fields', () => {
     normalized,
     /visibility.*in.*payload/i,
     'update_owner_memory must check visibility in payload'
+  );
+});
+
+test('update_owner_memory maps source URL payload fields to DB columns', () => {
+  const source = readOwnerWrites();
+  const body = getFunctionBody(source, 'update_owner_memory');
+  const normalized = compact(body);
+
+  assert.match(
+    normalized,
+    /updates\.append\("source_url=%s"\).*validate_optional_string\(payload\.get\("sourceurl"\),1000\)/i,
+    'update_owner_memory must map sourceUrl to source_url with the source URL limit'
+  );
+
+  assert.match(
+    normalized,
+    /updates\.append\("source_type=%s"\).*validate_optional_string\(payload\.get\("sourcetype"\),50\)/i,
+    'update_owner_memory must map sourceType to source_type with the source type limit'
+  );
+
+  assert.match(
+    normalized,
+    /updates\.append\("thumbnail=%s"\).*validate_optional_string\(payload\.get\("thumbnail"\),500\)/i,
+    'update_owner_memory must map thumbnail with the thumbnail limit'
   );
 });
 


### PR DESCRIPTION
## Summary
- Identifies the source URL persistence break as a Modal owner memory update mapping gap.
- Lets owner memory updates persist `sourceUrl`, `sourceType`, `thumbnail`, and `source` through the existing private memory update route.
- Keeps Editor UI payload construction, Cloudflare routing, response normalization, and schema unchanged.
- Adds a contract test for source URL payload-to-DB column mapping.

## Investigation
- Editor edit mode writes `sourceUrl` into the update payload when the source link changes.
- The browser API client sends that payload with `PUT /api/memories/:memoryId`.
- Cloudflare maps that write route to Modal private memory update.
- Modal read normalization already returns DB `source_url` as `sourceUrl`.
- The missing piece was `update_owner_memory()`, which previously allowed title/memo/tags/visibility but ignored source media fields.

## Changed files
- `modal_compute/owner_writes.py`
- `tests/contracts/modal-owner-write-route-contract.test.js`

## Non-goals
- No fixture creation.
- No production data mutation.
- No broad Editor refactor.
- No unrelated memory field changes.
- No schema migration.
- No PR #7 or prototype/reference/demo/variant changes.

## Verification
- `git diff --check`: PASS
- `node --check tests/contracts/modal-owner-write-route-contract.test.js`: PASS
- `python3 -m py_compile modal_compute/owner_writes.py`: PASS
- `node --test tests/contracts/modal-owner-write-route-contract.test.js`: PASS
- `npm run verify`: PASS
- `npm test`: PASS

Refs #979
Refs #974
