### PR TITLE
Fix Modal compute package bundling

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -82,6 +82,7 @@ image = (
         "PyJWT[crypto]==2.10.1",
         "psycopg[binary,pool]==3.2.9",
     )
+    .add_local_python_source("modal_compute")
 )
 
 web_app = FastAPI(

--- a/tests/contracts/modal-package-bundling-contract.test.js
+++ b/tests/contracts/modal-package-bundling-contract.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const MODAL_APP = path.join(ROOT, 'modal_compute', 'app.py');
+
+function readModalApp() {
+  return fs.readFileSync(MODAL_APP, 'utf8').replace(/\r\n/g, '\n');
+}
+
+test('modal image includes the local modal_compute package source', () => {
+  const content = readModalApp();
+  const imageDefinition = content.slice(
+    content.indexOf('image = ('),
+    content.indexOf('web_app = FastAPI(')
+  );
+
+  assert.ok(
+    imageDefinition.includes('.add_local_python_source("modal_compute")'),
+    'Modal image must include modal_compute sibling modules in deployed containers'
+  );
+});


### PR DESCRIPTION
Refs #985
Refs #983

Summary:
- include the local `modal_compute` package in the Modal image with `add_local_python_source("modal_compute")`
- add a contract test that keeps the Modal package bundling expectation explicit

Verification:
- `git diff --check`
- `python3 -m py_compile modal_compute/*.py`
- `/tmp/lovebud-modal-cli-venv/bin/python -c "import modal_compute.app; print('IMPORT_SMOKE: PASS')"`
- `node --test tests/contracts/modal-package-bundling-contract.test.js`
- `npm test`
- `npm run verify`
- Modal deploy from branch: PASS
- direct Modal `/modal/health` smoke: PASS
- direct Modal public summary smoke: PASS
- production/test6/test7 public data route smoke: PASS

Non-goals:
- no UI changes
- no API behavior refactor
- no DB/schema changes
- no Auth behavior changes
- no Cloudflare env changes
- no PR #7 / prototype/reference/demo/variant changes
