### PR TITLE
Browse card-to-stage visual bridge polish

### DIFF
--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -35,12 +35,36 @@
     transition: opacity 0.3s;
 }
 
+.tree-card::after {
+    content: '';
+    position: absolute;
+    top: 26px;
+    right: 0;
+    bottom: 26px;
+    width: 4px;
+    border-radius: 999px 0 0 999px;
+    background: linear-gradient(180deg, rgba(144, 73, 81, 0.80), rgba(122, 139, 110, 0.68));
+    box-shadow:
+        -10px 0 22px rgba(144, 73, 81, 0.12),
+        -4px 0 12px rgba(122, 139, 110, 0.10);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(4px);
+    transition: opacity 0.24s ease, transform 0.24s ease;
+}
+
 .tree-card:hover {
     transform: translateY(-3px);
     border-color: rgba(144,73,81,0.16);
     box-shadow:
         0 24px 56px rgba(75, 64, 57, 0.14),
         0 0 0 1px rgba(255, 255, 255, 0.82) inset;
+}
+
+.tree-card:focus-visible {
+    outline: 2px solid rgba(122, 139, 110, 0.48);
+    outline-offset: 4px;
+    border-color: rgba(122, 139, 110, 0.24);
 }
 
 .tree-card:hover .tree-card-media::before,
@@ -50,10 +74,20 @@
 }
 
 .tree-card.is-active {
+    background:
+        radial-gradient(circle at 30% 20%, rgba(255, 248, 245, 0.96), transparent 52%),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.90), rgba(255, 246, 243, 0.76)),
+        rgba(255, 255, 255, 0.86);
     border-color: rgba(144, 73, 81, 0.22);
     box-shadow:
-        0 26px 60px rgba(144, 73, 81, 0.12),
-        0 0 0 1px rgba(255, 255, 255, 0.42) inset;
+        0 26px 60px rgba(144, 73, 81, 0.13),
+        0 0 0 1px rgba(255, 255, 255, 0.52) inset,
+        0 0 0 3px rgba(200, 116, 128, 0.10);
+}
+
+.tree-card.is-active::after {
+    opacity: 1;
+    transform: translateX(0);
 }
 
 .tree-card.is-active .tree-card-open-link {
@@ -404,6 +438,15 @@
     background: linear-gradient(90deg, rgba(255, 248, 245, 0.64), rgba(244, 248, 238, 0.58));
     border: 1px solid rgba(144, 73, 81, 0.07);
     overflow: hidden;
+    transition: background 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease;
+}
+
+.tree-card.is-active .tree-card-flow-bridge {
+    background: linear-gradient(90deg, rgba(255, 241, 239, 0.88), rgba(244, 249, 238, 0.82));
+    border-color: rgba(144, 73, 81, 0.16);
+    box-shadow:
+        0 8px 18px rgba(144, 73, 81, 0.08),
+        0 0 0 1px rgba(255, 255, 255, 0.62) inset;
 }
 
 .tree-card-flow-line {
@@ -415,6 +458,11 @@
     border-radius: 999px;
     transform: translateY(-50%);
     background: linear-gradient(90deg, rgba(144, 73, 81, 0.34), rgba(122, 139, 110, 0.30));
+    transition: background 0.24s ease;
+}
+
+.tree-card.is-active .tree-card-flow-line {
+    background: linear-gradient(90deg, rgba(144, 73, 81, 0.58), rgba(122, 139, 110, 0.48));
 }
 
 .tree-card-flow-node {
@@ -426,6 +474,13 @@
     border-radius: 50%;
     background: #c87480;
     box-shadow: 0 0 0 4px rgba(200, 116, 128, 0.10);
+    transition: box-shadow 0.24s ease;
+}
+
+.tree-card.is-active .tree-card-flow-node {
+    box-shadow:
+        0 0 0 4px rgba(200, 116, 128, 0.16),
+        0 4px 10px rgba(144, 73, 81, 0.12);
 }
 
 .tree-card-flow-node + .tree-card-flow-node {


### PR DESCRIPTION
Refs #907

Summary:
- Adds a warmer selected-card ring and right-edge bridge cue for Browse cards.
- Strengthens the in-card flow bridge when a card is selected.
- Keeps keyboard focus-visible styling distinct from selected state.

Verification:
- git diff --check
- npm run verify
- npm test

Non-goals:
- no API/data fetching changes
- no card click behavior changes
- no selected hub behavior changes
- no `트리 열기` behavior changes
- no share-copy behavior changes
- no focus-stage hub restructure
- no mobile bottom-sheet density pass
- no Public Viewer route/API changes
- no PR #7 / prototype/reference/demo/variant changes