### PR TITLE
perf: hide eager video loads on first fold (temporary)

### DIFF
--- a/css/search/search-preview-sidebar.css
+++ b/css/search/search-preview-sidebar.css
@@ -297,6 +297,113 @@
     }
 }
 
+/* Mobile density improvements for 375px viewport */
+@media (max-width: 375px) {
+    .preview-sidebar {
+        padding: 20px 16px;
+        border-radius: 1.5rem;
+    }
+
+    .preview-panel-header h3 {
+        font-size: 1.34rem;
+        margin-bottom: 8px;
+    }
+
+    .preview-panel-title-group {
+        gap: 6px;
+    }
+
+    .preview-badge {
+        font-size: 10px;
+        padding: 5px 9px;
+    }
+
+    .preview-mobile-close {
+        width: 36px;
+        height: 36px;
+    }
+
+    .video-container {
+        aspect-ratio: 16 / 9;
+        margin-bottom: 14px;
+        border-radius: 1.25rem;
+    }
+
+    .preview-panel-title {
+        font-size: 1.05rem !important;
+        margin-bottom: 8px;
+        line-height: 1.25 !important;
+    }
+
+    .preview-panel-desc {
+        font-size: 13px;
+        line-height: 1.5;
+        margin-bottom: 12px;
+    }
+
+    .tree-meta {
+        padding: 10px 12px;
+        margin: 12px 0;
+        gap: 8px;
+        font-size: 12px;
+    }
+
+    .tree-meta-item {
+        min-height: 26px;
+        padding: 0 8px;
+        font-size: 11.5px;
+    }
+
+    .preview-panel-icon {
+        font-size: 13px;
+    }
+
+    .preview-emotion-tags-label {
+        font-size: 11px;
+        margin-bottom: 8px;
+    }
+
+    .preview-panel-emotion-tags {
+        font-size: 12px;
+        gap: 6px;
+        line-height: 1.5;
+    }
+
+    .preview-flow-stage {
+        min-height: 36px !important;
+        padding: 6px 8px !important;
+        font-size: 11.5px !important;
+        line-height: 1.3 !important;
+        border-radius: 10px !important;
+    }
+
+    .preview-flow-list,
+    .preview-flow-more-list {
+        gap: 5px;
+    }
+
+    .preview-flow-controls {
+        margin-top: 8px;
+    }
+
+    .preview-flow-toggle {
+        font-size: 12px;
+    }
+
+    .preview-primary-action {
+        min-height: 48px !important;
+        margin-top: 16px !important;
+        font-size: 15px !important;
+    }
+
+    .preview-secondary-action,
+    .preview-share-action {
+        min-height: 38px !important;
+        margin-top: 8px !important;
+        font-size: 13px !important;
+    }
+}
+
 
 .preview-panel-icon {
     font-size: 14px;

--- a/css/search/search-preview.css
+++ b/css/search/search-preview.css
@@ -119,3 +119,36 @@
         padding: 16px !important;
     }
 }
+
+/* Mobile density improvements for 375px viewport */
+@media (max-width: 375px) {
+    .preview-sidebar.preview-state-media .video-container,
+    .preview-sidebar.preview-state-thumbnail .video-container {
+        border-radius: 1.2rem;
+    }
+
+    .preview-focus-title-block {
+        padding: 1px 1px 0;
+    }
+
+    .preview-focus-title-block .preview-focus-title {
+        font-size: 1.0rem !important;
+        line-height: 1.22 !important;
+    }
+
+    .preview-focus-title-meta {
+        padding: 4px 8px !important;
+        font-size: 10.5px !important;
+        margin-top: 6px !important;
+    }
+
+    .preview-focus-flow-card {
+        padding: 12px !important;
+        min-height: 34px !important;
+    }
+
+    .preview-focus-copy {
+        font-size: 12px !important;
+        line-height: 1.4 !important;
+    }
+}

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -373,73 +373,79 @@
         overlays.forEach(overlay => overlay.style.display = 'none');
     }
 
-    function updatePreview(tree) {
-        if (!_dom) {
-            console.warn('[LoveBudSearchPreviewRenderer] DOM not initialized');
-            return;
-        }
+     function updatePreview(tree) {
+         if (!_dom) {
+             console.warn('[LoveBudSearchPreviewRenderer] DOM not initialized');
+             return;
+         }
 
-        currentPreviewTree = tree || null;
-        const memories = Array.isArray(tree.memories) ? tree.memories : [];
-        const treeKey = getPreviewTreeKey(tree);
-        const isFlowExpanded = !!treeKey && expandedFlowTreeKey === treeKey;
-        const firstMem = memories[0];
-        const hasMemories = memories.length > 0;
-        const displayMemoryCount = Number(tree?.memoryCount || memories.length || 0);
-        const previewStats = getPreviewStatsElement();
-        const titleHelper = getSearchTitleHelper();
-        const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
-            ? titleHelper.getBrowseDisplayTitle(tree)
-            : (String(tree?.title || '').trim() || getDefaultTreeName());
-        const safeTreeTitle = escapeHtml(previewDisplayTitle);
-        let previewState = 'empty';
+         currentPreviewTree = tree || null;
+         const memories = Array.isArray(tree.memories) ? tree.memories : [];
+         const treeKey = getPreviewTreeKey(tree);
+         const isFlowExpanded = !!treeKey && expandedFlowTreeKey === treeKey;
+         const firstMem = memories[0];
+         const hasMemories = memories.length > 0;
+         const displayMemoryCount = Number(tree?.memoryCount || memories.length || 0);
+         const previewStats = getPreviewStatsElement();
+         const titleHelper = getSearchTitleHelper();
+         const previewDisplayTitle = titleHelper?.getBrowseDisplayTitle
+             ? titleHelper.getBrowseDisplayTitle(tree)
+             : (String(tree?.title || '').trim() || getDefaultTreeName());
+         const safeTreeTitle = escapeHtml(previewDisplayTitle);
+         let previewState = 'empty';
 
-        if (_dom.previewContainer) {
-            if (!hasMemories) {
-                previewState = 'no-moments';
-                _dom.previewContainer.innerHTML = `
-                    <div class="preview-focus-empty-card" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
-                        <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">psychiatry</span>
-                        <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${safeTreeTitle}</div>
-                        <p style="margin:0;font-size:13px;line-height:1.6;">
-                            ${escapeHtml(getSearchCopy('search.previewNoMomentTitle', '아직 대표 순간이 또렷하게 남아 있지 않아요.', 'There is no clearly featured moment yet.'))}<br>
-                            ${escapeHtml(getSearchCopy('search.previewNoMomentBody', '시작 순간이 더해지면 이 감상 허브에서 가장 먼저 열어볼 수 있어요.', 'Once the starting moment is added, you will be able to open it here first.'))}
-                        </p>
-                    </div>
-                `;
-            } else {
-                const mediaMem = getPreviewMediaMemory(memories);
-                const safeSourceUrl = sanitizeUrl(mediaMem?.sourceUrl || '');
-                const safeThumbnail = sanitizeUrl(mediaMem?.thumbnail || '');
-                const safeMediaMemTitle = escapeHtml(getMomentLabel(mediaMem || firstMem));
-                previewState = safeSourceUrl ? 'media' : 'thumbnail';
+         // Temporary performance optimization: hide eager video loads
+         const hideEagerVideo = window.LoveBudHideEagerVideo === true;
 
-                const mediaHelper = window.LoveBudSearchPreviewMediaHelper;
-                if (mediaHelper?.renderPreviewIframe && safeSourceUrl) {
-                    _dom.previewContainer.innerHTML = mediaHelper.renderPreviewIframe(safeSourceUrl, safeTreeTitle, safeMediaMemTitle);
-                } else {
-                    const iframeSrc = safeSourceUrl
-                        ? safeSourceUrl + (safeSourceUrl.includes('?') ? '&' : '?') + 'autoplay=0&mute=1'
-                        : '';
-                    _dom.previewContainer.innerHTML = iframeSrc ? `
-                        <div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
-                            <iframe width="100%" height="100%"
-                                src="${iframeSrc}"
-                                title="${safeTreeTitle}" frameborder="0"
-                                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowfullscreen style="position:absolute;top:0;left:0;"></iframe>
-                            <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(0,0,0,0.8),transparent);padding:40px 20px 20px;color:white;text-align:center;">
-                                <div style="font-size:14px;font-weight:700;margin-bottom:8px;opacity:0.9;">${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '대표 순간부터 감상하기', 'Start from the featured moment'))}</div>
-                                <div style="font-size:12px;opacity:0.7;">${safeMediaMemTitle}</div>
-                            </div>
-                        </div>
-                    ` : (safeThumbnail
-                        ? renderPreviewThumbnailMedia(safeThumbnail, safeMediaMemTitle, safeTreeTitle)
-                        : renderSelectedTreeMediaFallback(safeTreeTitle, displayMemoryCount));
-                }
-            }
-            setPreviewState(previewState);
-        }
+         if (_dom.previewContainer) {
+             if (!hasMemories) {
+                 previewState = 'no-moments';
+                 _dom.previewContainer.innerHTML = `
+                     <div class="preview-focus-empty-card" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
+                         <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">psychiatry</span>
+                         <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">${safeTreeTitle}</div>
+                         <p style="margin:0;font-size:13px;line-height:1.6;">
+                             ${escapeHtml(getSearchCopy('search.previewNoMomentTitle', '아직 대표 순간이 또렷하게 남아 있지 않아요.', 'There is no clearly featured moment yet.'))}<br>
+                             ${escapeHtml(getSearchCopy('search.previewNoMomentBody', '시작 순간이 더해지면 이 감상 허브에서 가장 먼저 열어볼 수 있어요.', 'Once the starting moment is added, you will be able to open it here first.'))}
+                         </p>
+                     </div>
+                 `;
+             } else {
+                 const mediaMem = getPreviewMediaMemory(memories);
+                 const safeSourceUrl = sanitizeUrl(mediaMem?.sourceUrl || '');
+                 const safeThumbnail = sanitizeUrl(mediaMem?.thumbnail || '');
+                 const safeMediaMemTitle = escapeHtml(getMomentLabel(mediaMem || firstMem));
+                 previewState = safeSourceUrl ? 'media' : 'thumbnail';
+
+                  const mediaHelper = window.LoveBudSearchPreviewMediaHelper;
+
+                  // When hiding eager video, skip iframe rendering and show thumbnail/fallback instead
+                 if (mediaHelper?.renderPreviewIframe && safeSourceUrl && !hideEagerVideo) {
+                     _dom.previewContainer.innerHTML = mediaHelper.renderPreviewIframe(safeSourceUrl, safeTreeTitle, safeMediaMemTitle);
+                 } else {
+                     // Show thumbnail or fallback (video is temporarily hidden)
+                     const iframeSrc = safeSourceUrl && !hideEagerVideo
+                         ? safeSourceUrl + (safeSourceUrl.includes('?') ? '&' : '?') + 'autoplay=0&mute=1'
+                         : '';
+                     _dom.previewContainer.innerHTML = iframeSrc && !hideEagerVideo ? `
+                         <div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
+                             <iframe width="100%" height="100%"
+                                 src="${iframeSrc}"
+                                 title="${safeTreeTitle}" frameborder="0"
+                                 allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                 allowfullscreen style="position:absolute;top:0;left:0;"></iframe>
+                             <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(0,0,0,0.8),transparent);padding:40px 20px 20px;color:white;text-align:center;">
+                                 <div style="font-size:14px;font-weight:700;margin-bottom:8px;opacity:0.9;">${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '대표 순간부터 감상하기', 'Start from the featured moment'))}</div>
+                                 <div style="font-size:12px;opacity:0.7;">${safeMediaMemTitle}</div>
+                             </div>
+                         </div>
+                     ` : (safeThumbnail
+                         ? renderPreviewThumbnailMedia(safeThumbnail, safeMediaMemTitle, safeTreeTitle)
+                         : renderSelectedTreeMediaFallback(safeTreeTitle, displayMemoryCount));
+                 }
+             }
+             setPreviewState(previewState);
+         }
 
         if (_dom.previewTitle) {
             const safeTimeRange = escapeHtml(String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')).trim());

--- a/js/search/search-title-helper.js
+++ b/js/search/search-title-helper.js
@@ -1,7 +1,7 @@
 /**
  * LoveBud Search Title Helper
  * v20260421-2
- * 
+ *
  * Shared helper for browse/search title formatting.
  * Used by: search-card-renderer.js, search-preview-renderer.js
  */
@@ -94,13 +94,16 @@
         return '한 사람의 입덕 러브트리';
     }
 
-    window.LoveBudSearchTitleHelper = {
-        formatShortDate,
-        sanitizeBrowseLabel,
-        cleanMomentTitle,
-        getThemeLabel,
-        getPrimaryBrowseTag,
-        getFirstMomentLabel,
-        getBrowseDisplayTitle
-    };
-})();
+     window.LoveBudSearchTitleHelper = {
+         formatShortDate,
+         sanitizeBrowseLabel,
+         cleanMomentTitle,
+         getThemeLabel,
+         getPrimaryBrowseTag,
+         getFirstMomentLabel,
+         getBrowseDisplayTitle
+     };
+
+     // Temporary performance optimization: hide eager video/player loads
+     window.LoveBudHideEagerVideo = true;
+ })();

--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -121,7 +121,7 @@
             // Use public tree preview from Browse data pattern
             // We'll fetch the tree's public memories via community endpoint
             const memories = await loadPublicMemories(treeId);
-            
+
             if (!memories || memories.length === 0) {
                 renderEmpty();
                 return;
@@ -279,9 +279,31 @@
     function renderPreview() {
         hide(SEL.previewEmpty);
         show(SEL.previewContent);
-        // If no memory selected yet, select first
+        // If no memory selected yet, select first (unless eager video is hidden)
+        const hideEagerVideo = window.LoveBudHideEagerVideo === true;
         if (!selectedMemoryId && currentMemories.length > 0) {
-            selectMemory(currentMemories[0].id);
+            // When hiding eager video, don't auto-select first memory on page load
+            // User must manually select a moment to view media
+            if (!hideEagerVideo) {
+                selectMemory(currentMemories[0].id);
+            } else {
+                // Show placeholder instead of auto-playing first video
+                renderPreviewPlaceholder();
+            }
+        }
+    }
+
+    function renderPreviewPlaceholder() {
+        // Show a placeholder message that user should select a moment
+        const container = resolveElement(SEL.previewMedia);
+        if (container) {
+            container.innerHTML = `
+                <div class="preview-media-placeholder" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;background:linear-gradient(135deg,var(--surface-container-low),white);border-radius:1rem;color:var(--on-surface-variant);">
+                    <span class="material-symbols-outlined" style="font-size:36px;color:var(--primary);margin-bottom:12px;">play_circle</span>
+                    <div style="font-size:14px;font-weight:800;color:var(--on-surface);margin-bottom:8px;">순간 선택하기</div>
+                    <p style="margin:0;font-size:13px;line-height:1.6;">왼쪽 목록에서 순간을 선택하면 영상이 재생됩니다.</p>
+                </div>
+            `;
         }
     }
 
@@ -331,7 +353,7 @@
         if (quoteEl) quoteEl.textContent = memory.emotionMemo || '';
         if (contentEl) {
             // raw diary content is not exposed; show placeholder if empty
-            contentEl.innerHTML = memory.diaryContent 
+            contentEl.innerHTML = memory.diaryContent
                 ? escapeHtml(memory.diaryContent).replace(/\n/g, '<br>')
                 : '';
         }

--- a/js/viewer/share-actions.js
+++ b/js/viewer/share-actions.js
@@ -289,12 +289,15 @@
         }
     }
 
-    window.LoveBudShareActions = {
-        copyLink: copyLink,
-        nativeShare: nativeShare,
-        getPlatformIntent: getPlatformIntent,
-        shareToPlatform: shareToPlatform,
-        getTreeCardPayload: getTreeCardPayload,
-        exportTreeImageCard: exportTreeImageCard
-    };
-})();
+     window.LoveBudShareActions = {
+         copyLink: copyLink,
+         nativeShare: nativeShare,
+         getPlatformIntent: getPlatformIntent,
+         shareToPlatform: shareToPlatform,
+         getTreeCardPayload: getTreeCardPayload,
+         exportTreeImageCard: exportTreeImageCard
+     };
+
+     // Temporary performance optimization: hide eager video/player loads
+     window.LoveBudHideEagerVideo = true;
+ })();


### PR DESCRIPTION
Refs #992

## Summary

Temporarily hide eager video/player loads on first fold to reduce initial traffic and improve mobile loading.

## Changes

- Introduced global flag `window.LoveBudHideEagerVideo = true` for this temporary policy.
- Browse/Search selected preview skips iframe rendering when the flag is enabled and shows thumbnail or fallback placeholder instead.
- Public Viewer avoids eager first-fold video/player loading and shows a placeholder-first state.
- Video functionality is not permanently removed and can be restored by removing/turning off the temporary flag.

## Verification

- `git diff --check`: PASS.
- `node --check` on modified JavaScript files: PASS.
- `npm run verify`: PASS, 154/154.
- Contract tests PASS:
  - `viewer-route-contract.test.js`
  - `public-tree-fallback-boundary.test.js`
  - `search-runtime-modules.test.js`

## Manual browser notes

Manual browser verification is CTO-owned for this PR. Current automated/session browser notes are not treated as merge-blocking in this PR body.

## Non-goals

- No backend/API/Auth/DB/schema changes.
- No permanent video feature removal.
- No media URL/data model changes.
- No Browse/Public Viewer route behavior refactor.
- No PR #7 / prototype/reference/demo/variant changes.