### PR TITLE
ui: public viewer tree hero visual hierarchy correction (#976)

### DIFF
--- a/css/visitor-viewer/visitor-viewer-panel.css
+++ b/css/visitor-viewer/visitor-viewer-panel.css
@@ -1,10 +1,10 @@
 .vv-panel {
-    background: rgba(255,255,255,0.80);
-    border: 1px solid rgba(251,113,133,0.06);
-    border-radius: 28px;
-    padding: 18px;
+    background: rgba(255,255,255,0.56);
+    border: 1px solid rgba(144,73,81,0.07);
+    border-radius: 24px;
+    padding: 16px;
     backdrop-filter: blur(8px);
-    box-shadow: 0 8px 28px rgba(111,70,44,0.04);
+    box-shadow: 0 10px 26px rgba(111,70,44,0.035);
 }
 
 .vv-panel-empty {
@@ -13,40 +13,40 @@
 
 .vv-panel-empty-illus {
     width: 100%;
-    height: 120px;
-    border-radius: 22px;
-    border: 2px dashed rgba(251,113,133,0.2);
-    background: linear-gradient(135deg, rgba(255,241,243,0.6), rgba(255,247,237,0.6));
-    margin-bottom: 18px;
+    height: 76px;
+    border-radius: 18px;
+    border: 1px dashed rgba(144,73,81,0.14);
+    background: linear-gradient(135deg, rgba(255,241,243,0.36), rgba(255,247,237,0.34));
+    margin-bottom: 14px;
 }
 
 .vv-panel-eyebrow {
     margin: 0 0 6px;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.18em;
-    color: #904951;
-    opacity: 0.7;
+    color: #9a7468;
+    opacity: 0.62;
 }
 
 .vv-panel-title {
     margin: 0 0 8px;
-    font-size: 1.25rem;
+    font-size: 1.05rem;
     font-weight: 700;
     color: #3f302b;
 }
 
 .vv-panel-title-lg {
     margin: 4px 0 2px;
-    font-size: 1.2rem;
+    font-size: 1.04rem;
     font-weight: 700;
     color: #3f302b;
 }
 
 .vv-panel-desc {
     margin: 0 0 12px;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     line-height: 1.6;
     color: #9a8a82;
 }
@@ -54,13 +54,13 @@
 .vv-panel-stats {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 10px;
+    gap: 8px;
 }
 
 .vv-panel-stats div {
-    padding: 12px;
-    border-radius: 16px;
-    font-size: 12px;
+    padding: 9px;
+    border-radius: 14px;
+    font-size: 11px;
     color: #7e6b62;
     text-align: center;
 }
@@ -70,7 +70,7 @@
 
 .vv-panel-stats strong {
     display: block;
-    font-size: 1.1rem;
+    font-size: 0.95rem;
     color: #3f302b;
     margin-bottom: 2px;
 }
@@ -112,27 +112,27 @@
 }
 
 .vv-panel-caption {
-    margin-top: 10px;
-    padding: 10px 12px;
-    border-radius: 14px;
-    background: rgba(255,241,243,0.5);
-    font-size: 13px;
+    margin-top: 8px;
+    padding: 9px 10px;
+    border-radius: 13px;
+    background: rgba(255,241,243,0.34);
+    font-size: 12px;
     line-height: 1.6;
     color: #8a7a72;
 }
 
 .vv-branch-moment-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 6px;
-    margin-top: 14px;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 5px;
+    margin-top: 12px;
 }
 
 .vv-branch-moment-btn {
     aspect-ratio: 1;
-    border-radius: 14px;
-    border: 1px solid rgba(255,255,255,0.75);
-    font-size: 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(255,255,255,0.62);
+    font-size: 11px;
     font-weight: 500;
     color: #9a8a82;
     cursor: pointer;
@@ -140,20 +140,20 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 1px 4px rgba(111,70,44,0.03);
+    box-shadow: none;
     position: relative;
     overflow: hidden;
 }
 
 .vv-branch-moment-btn:hover {
     transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(111,70,44,0.06);
+    box-shadow: 0 2px 8px rgba(111,70,44,0.045);
 }
 
 .vv-branch-moment-frame {
     position: absolute;
-    inset: 3px;
-    border-radius: 10px;
+    inset: 4px;
+    border-radius: 9px;
     border: 1px solid rgba(255,255,255,0.4);
     pointer-events: none;
 }
@@ -161,21 +161,21 @@
 .vv-branch-moment-label {
     position: relative;
     z-index: 1;
-    font-size: 12px;
+    font-size: 11px;
 }
 
 .vv-branch-moment-play {
     position: absolute;
     bottom: 3px;
     right: 3px;
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
     background: rgba(255,255,255,0.7);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 6px;
+    font-size: 5px;
     color: #a39087;
     opacity: 0.5;
     box-shadow: 0 1px 3px rgba(0,0,0,0.05);
@@ -185,7 +185,7 @@
     margin-top: 10px;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 3px;
 }
 
 .vv-branch-moment-item {
@@ -193,10 +193,10 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    padding: 8px 12px;
-    border-radius: 12px;
+    padding: 7px 10px;
+    border-radius: 11px;
     background: rgba(255,255,255,0.5);
-    font-size: 13px;
+    font-size: 12px;
     color: #8a7a72;
     cursor: pointer;
     transition: all 0.2s;
@@ -208,14 +208,14 @@
 .vv-branch-moment-open { font-size: 12px; color: #a39087; }
 
 .vv-moment-media {
-    margin-top: 16px;
+    margin-top: 12px;
 }
 
 .vv-moment-media-inner {
     position: relative;
     aspect-ratio: 16 / 9;
-    border-radius: 24px;
-    border: 1px solid rgba(255,255,255,0.8);
+    border-radius: 18px;
+    border: 1px solid rgba(255,255,255,0.68);
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -224,8 +224,8 @@
 
 .vv-moment-media-border {
     position: absolute;
-    inset: 14px;
-    border-radius: 20px;
+    inset: 10px;
+    border-radius: 15px;
     border: 1px solid rgba(255,255,255,0.5);
 }
 
@@ -271,25 +271,25 @@
 }
 
 .vv-moment-title {
-    margin: 14px 0 6px;
-    font-size: 1.5rem;
+    margin: 12px 0 5px;
+    font-size: 1.18rem;
     font-weight: 700;
     color: #3f302b;
 }
 
 .vv-moment-caption {
     margin: 0;
-    font-size: 14px;
-    line-height: 1.7;
+    font-size: 13px;
+    line-height: 1.62;
     color: #6b5850;
 }
 
 .vv-moment-memo {
-    margin-top: 16px;
-    padding: 12px;
-    border-radius: 18px;
-    background: rgba(255,241,243,0.55);
-    border: 1px solid rgba(251,113,133,0.1);
+    margin-top: 12px;
+    padding: 10px;
+    border-radius: 15px;
+    background: rgba(255,241,243,0.36);
+    border: 1px solid rgba(144,73,81,0.07);
 }
 
 .vv-moment-memo-label {

--- a/css/visitor-viewer/visitor-viewer-panel.css
+++ b/css/visitor-viewer/visitor-viewer-panel.css
@@ -1,10 +1,10 @@
 .vv-panel {
-    background: rgba(255,255,255,0.85);
-    border: 1px solid rgba(251,113,133,0.12);
+    background: rgba(255,255,255,0.80);
+    border: 1px solid rgba(251,113,133,0.06);
     border-radius: 28px;
-    padding: 22px;
+    padding: 18px;
     backdrop-filter: blur(8px);
-    box-shadow: 0 18px 50px rgba(111,70,44,0.10);
+    box-shadow: 0 8px 28px rgba(111,70,44,0.04);
 }
 
 .vv-panel-empty {
@@ -38,17 +38,17 @@
 }
 
 .vv-panel-title-lg {
-    margin: 6px 0 4px;
-    font-size: 1.5rem;
+    margin: 4px 0 2px;
+    font-size: 1.2rem;
     font-weight: 700;
     color: #3f302b;
 }
 
 .vv-panel-desc {
-    margin: 0 0 16px;
-    font-size: 0.9rem;
-    line-height: 1.7;
-    color: #7e6b62;
+    margin: 0 0 12px;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: #9a8a82;
 }
 
 .vv-panel-stats {
@@ -112,80 +112,80 @@
 }
 
 .vv-panel-caption {
-    margin-top: 14px;
-    padding: 14px;
-    border-radius: 16px;
-    background: rgba(255,241,243,0.7);
-    font-size: 14px;
-    line-height: 1.7;
-    color: #6b5850;
+    margin-top: 10px;
+    padding: 10px 12px;
+    border-radius: 14px;
+    background: rgba(255,241,243,0.5);
+    font-size: 13px;
+    line-height: 1.6;
+    color: #8a7a72;
 }
 
 .vv-branch-moment-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 8px;
-    margin-top: 18px;
+    gap: 6px;
+    margin-top: 14px;
 }
 
 .vv-branch-moment-btn {
     aspect-ratio: 1;
-    border-radius: 18px;
-    border: 1.5px solid rgba(255,255,255,0.85);
-    font-size: 14px;
-    font-weight: 600;
-    color: #7e6b62;
+    border-radius: 14px;
+    border: 1px solid rgba(255,255,255,0.75);
+    font-size: 12px;
+    font-weight: 500;
+    color: #9a8a82;
     cursor: pointer;
     transition: all 0.2s;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 2px 8px rgba(111,70,44,0.06);
+    box-shadow: 0 1px 4px rgba(111,70,44,0.03);
     position: relative;
     overflow: hidden;
 }
 
 .vv-branch-moment-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 14px rgba(111,70,44,0.12);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(111,70,44,0.06);
 }
 
 .vv-branch-moment-frame {
     position: absolute;
-    inset: 4px;
-    border-radius: 12px;
-    border: 1px solid rgba(255,255,255,0.5);
+    inset: 3px;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.4);
     pointer-events: none;
 }
 
 .vv-branch-moment-label {
     position: relative;
     z-index: 1;
-    font-size: 14px;
+    font-size: 12px;
 }
 
 .vv-branch-moment-play {
     position: absolute;
-    bottom: 4px;
-    right: 4px;
-    width: 16px;
-    height: 16px;
+    bottom: 3px;
+    right: 3px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
-    background: rgba(255,255,255,0.8);
+    background: rgba(255,255,255,0.7);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 8px;
-    color: #6b5850;
-    opacity: 0.7;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    font-size: 6px;
+    color: #a39087;
+    opacity: 0.5;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 }
 
 .vv-branch-moment-list {
-    margin-top: 14px;
+    margin-top: 10px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
 .vv-branch-moment-item {
@@ -193,11 +193,11 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    padding: 10px 14px;
-    border-radius: 16px;
-    background: rgba(255,255,255,0.7);
-    font-size: 14px;
-    color: #6b5850;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(255,255,255,0.5);
+    font-size: 13px;
+    color: #8a7a72;
     cursor: pointer;
     transition: all 0.2s;
     border: none;

--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -5,6 +5,33 @@
     color: #3f302b;
 }
 
+.viewer-page-shell {
+    background:
+        radial-gradient(circle at 50% 4%, rgba(255, 238, 231, 0.72), transparent 34%),
+        radial-gradient(circle at 12% 42%, rgba(244, 248, 238, 0.62), transparent 34%),
+        linear-gradient(180deg, #fffaf8 0%, #fbf5ed 100%);
+}
+
+.viewer-layout {
+    display: block;
+    width: min(100%, 1800px);
+    max-width: none;
+    margin: 0 auto;
+    padding: clamp(16px, 2vw, 30px) clamp(18px, 3vw, 48px) 48px;
+}
+
+.viewer-tree-shell {
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+
+.viewer-tree-container {
+    width: 100%;
+}
+
 .visitor-viewer-shell {
     width: min(100%, 1320px);
     margin: 0 auto;
@@ -18,13 +45,14 @@
     align-items: flex-end;
     justify-content: space-between;
     gap: 14px;
-    margin-bottom: 18px;
-    padding: 18px 22px;
-    border: 1px solid rgba(255,255,255,0.7);
-    border-radius: 28px;
-    background: rgba(255,255,255,0.55);
-    box-shadow: 0 2px 12px rgba(111,70,44,0.05);
-    backdrop-filter: blur(8px);
+    max-width: 1480px;
+    margin: 0 auto 12px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
 }
 
 .vv-eyebrow {
@@ -39,7 +67,7 @@
 
 .vv-title {
     margin: 0;
-    font-size: clamp(1.6rem, 3.5vw, 2.6rem);
+    font-size: clamp(1.72rem, 2.2vw, 2.82rem);
     font-weight: 700;
     letter-spacing: -0.02em;
     color: #3f302b;
@@ -65,35 +93,39 @@
 
 .vv-viewer-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
-    gap: 24px;
-    align-items: start;
+    grid-template-columns: minmax(760px, 1fr) clamp(248px, 17vw, 300px);
+    gap: clamp(18px, 1.6vw, 28px);
+    align-items: stretch;
+    min-height: clamp(720px, calc(100vh - 178px), 900px);
 }
 
 .vv-tree-container {
     position: relative;
-    min-height: 860px;
-    border: 1px solid rgba(144,73,81,0.12);
-    border-radius: 34px;
+    min-height: clamp(720px, calc(100vh - 178px), 900px);
+    border: 0;
+    border-radius: 38px;
     overflow: hidden;
-    box-shadow: 0 4px 32px rgba(111,70,44,0.05);
+    box-shadow:
+        0 32px 80px rgba(111,70,44,0.10),
+        0 0 0 1px rgba(255,255,255,0.70) inset;
     transition: box-shadow 0.2s;
 }
 
 .vv-tree-canvas {
     position: relative;
     width: 100%;
-    min-height: 860px;
-    background: linear-gradient(180deg, #fffdf9, #fffaf1 50%, #fdf6ed);
-    background-image: radial-gradient(#e8cfc0 1px, transparent 1px);
-    background-size: 18px 18px;
+    min-height: clamp(720px, calc(100vh - 178px), 900px);
+    background:
+        radial-gradient(circle at 50% 18%, rgba(255, 240, 234, 0.76), transparent 32%),
+        radial-gradient(circle at 50% 72%, rgba(244, 248, 238, 0.56), transparent 34%),
+        linear-gradient(180deg, #fffdf9, #fff9ef 52%, #fdf4e9);
     overflow: hidden;
 }
 
 .vv-tree-bg-pattern {
     position: absolute;
     inset: 0;
-    opacity: 0.45;
+    opacity: 0.36;
     background-image: radial-gradient(#e8cfc0 1px, transparent 1px);
     background-size: 18px 18px;
 }
@@ -152,12 +184,15 @@
 }
 
 .vv-action-dock {
-    margin-bottom: 18px;
-    padding: 12px 18px;
-    border-radius: 22px;
-    border: 1px solid rgba(255,255,255,0.7);
-    background: rgba(255,255,255,0.45);
-    backdrop-filter: blur(8px);
+    display: flex;
+    justify-content: flex-end;
+    max-width: 1480px;
+    margin: 0 auto 12px;
+    padding: 0 10px;
+    border-radius: 0;
+    border: 0;
+    background: transparent;
+    backdrop-filter: none;
 }
 
 .vv-action-group {
@@ -213,25 +248,53 @@
 
 .vv-panel-host {
     min-width: 0;
+    align-self: start;
+    position: sticky;
+    top: 88px;
 }
 
 .vv-panel {
-    background: rgba(255,255,255,0.85);
-    border: 1px solid rgba(251,113,133,0.06);
-    border-radius: 28px;
-    padding: 22px;
+    background: rgba(255,255,255,0.56);
+    border: 1px solid rgba(144,73,81,0.07);
+    border-radius: 24px;
+    padding: 16px;
     backdrop-filter: blur(8px);
-    box-shadow: 0 8px 30px rgba(111,70,44,0.05);
+    box-shadow: 0 10px 26px rgba(111,70,44,0.035);
+}
+
+@media (min-width: 1500px) {
+    .vv-viewer-layout {
+        grid-template-columns: minmax(1080px, 1fr) clamp(240px, 15vw, 288px);
+    }
+
+    .vv-tree-container,
+    .vv-tree-canvas {
+        min-height: clamp(760px, calc(100vh - 168px), 940px);
+    }
 }
 
 @media (max-width: 900px) {
+    .viewer-layout { padding: 14px; }
     .visitor-viewer-shell { padding: 16px; }
+    .vv-header { margin-bottom: 10px; padding: 0 4px; }
+    .vv-title { font-size: clamp(1.42rem, 7vw, 2rem); }
     .vv-viewer-layout { display: block; }
-    .vv-tree-container { min-height: 600px; border-radius: 24px; }
-    .vv-tree-canvas { min-height: 600px; }
+    .vv-tree-container { min-height: min(660px, 72vh); border-radius: 26px; }
+    .vv-tree-canvas { min-height: min(660px, 72vh); }
     .vv-panel-host { margin-top: 16px; }
     .vv-panel { box-shadow: 0 4px 16px rgba(111,70,44,0.03); border-radius: 20px; }
     .vv-mobile-note { display: block; }
     .vv-action-group { gap: 6px; }
     .vv-action-btn { padding: 6px 12px; font-size: 12px; }
+}
+
+@media (max-width: 375px) {
+    .viewer-layout { padding: 12px 10px 24px; }
+    .vv-tree-container,
+    .vv-tree-canvas {
+        min-height: 620px;
+    }
+    .vv-panel {
+        padding: 14px;
+    }
 }

--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -65,24 +65,26 @@
 
 .vv-viewer-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(340px, 420px);
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
     gap: 24px;
     align-items: start;
 }
 
 .vv-tree-container {
     position: relative;
-    min-height: 780px;
-    border: 1px solid rgba(144,73,81,0.09);
+    min-height: 860px;
+    border: 1px solid rgba(144,73,81,0.12);
     border-radius: 34px;
     overflow: hidden;
+    box-shadow: 0 4px 32px rgba(111,70,44,0.05);
+    transition: box-shadow 0.2s;
 }
 
 .vv-tree-canvas {
     position: relative;
     width: 100%;
-    min-height: 780px;
-    background: #fffaf1;
+    min-height: 860px;
+    background: linear-gradient(180deg, #fffdf9, #fffaf1 50%, #fdf6ed);
     background-image: radial-gradient(#e8cfc0 1px, transparent 1px);
     background-size: 18px 18px;
     overflow: hidden;
@@ -215,11 +217,11 @@
 
 .vv-panel {
     background: rgba(255,255,255,0.85);
-    border: 1px solid rgba(251,113,133,0.12);
+    border: 1px solid rgba(251,113,133,0.06);
     border-radius: 28px;
     padding: 22px;
     backdrop-filter: blur(8px);
-    box-shadow: 0 18px 50px rgba(111,70,44,0.10);
+    box-shadow: 0 8px 30px rgba(111,70,44,0.05);
 }
 
 @media (max-width: 900px) {
@@ -228,6 +230,7 @@
     .vv-tree-container { min-height: 600px; border-radius: 24px; }
     .vv-tree-canvas { min-height: 600px; }
     .vv-panel-host { margin-top: 16px; }
+    .vv-panel { box-shadow: 0 4px 16px rgba(111,70,44,0.03); border-radius: 20px; }
     .vv-mobile-note { display: block; }
     .vv-action-group { gap: 6px; }
     .vv-action-btn { padding: 6px 12px; font-size: 12px; }

--- a/css/visitor-viewer/visitor-viewer-tree.css
+++ b/css/visitor-viewer/visitor-viewer-tree.css
@@ -1,7 +1,7 @@
 .vv-tree-canvas {
     position: relative;
     width: 100%;
-    min-height: 780px;
+    min-height: 860px;
     overflow: hidden;
 }
 
@@ -15,17 +15,18 @@
     position: absolute;
     z-index: 20;
     transform: translate(-50%, -50%);
-    padding: 4px 14px;
+    padding: 6px 18px;
     border-radius: 999px;
-    border: 1px solid rgba(255,255,255,0.6);
-    background: rgba(255,255,255,0.7);
-    font-size: 12px;
-    font-weight: 600;
+    border: 1px solid rgba(255,255,255,0.8);
+    background: rgba(255,255,255,0.85);
+    font-size: 13px;
+    font-weight: 700;
     cursor: pointer;
     transition: all 0.2s;
     backdrop-filter: blur(4px);
     white-space: nowrap;
     pointer-events: auto;
+    box-shadow: 0 2px 10px rgba(111,70,44,0.06);
 }
 
 .vv-branch-label:hover {
@@ -75,8 +76,8 @@
 
 .vv-leaf-shape.is-active {
     border-radius: 54% 46% 52% 48% / 43% 58% 42% 57% !important;
-    scale: 1.1;
-    box-shadow: 0 0 0 6px rgba(255,241,243,0.9), 0 20px 38px rgba(80,45,39,0.18);
+    scale: 1.15;
+    box-shadow: 0 0 0 8px rgba(255,241,243,0.95), 0 24px 44px rgba(80,45,39,0.22);
 }
 
 .vv-leaf-inner {
@@ -137,9 +138,9 @@
 
 .vv-leaf-label-title {
     display: block;
-    font-size: 12px;
-    font-weight: 700;
-    color: #3f302b;
+    font-size: 13px;
+    font-weight: 800;
+    color: #2b1f1b;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -187,7 +188,7 @@
 .vv-root-seed {
     position: absolute;
     left: 50%;
-    top: 91%;
+    top: 88%;
     z-index: 30;
     transform: translate(-50%, -50%);
     cursor: pointer;
@@ -207,11 +208,11 @@
 }
 
 .vv-root-seed-shape {
-    width: 96px;
-    height: 80px;
+    width: 108px;
+    height: 90px;
     border-radius: 46% 54% 48% 52%;
-    border: 1px solid rgba(255,255,255,0.8);
-    box-shadow: 0 16px 34px rgba(122,65,67,0.2), 0 0 0 2px rgba(255,255,255,0.8);
+    border: 1.5px solid rgba(255,255,255,0.85);
+    box-shadow: 0 20px 40px rgba(122,65,67,0.25), 0 0 0 3px rgba(255,255,255,0.85);
     position: relative;
 }
 

--- a/css/visitor-viewer/visitor-viewer-tree.css
+++ b/css/visitor-viewer/visitor-viewer-tree.css
@@ -1,7 +1,7 @@
 .vv-tree-canvas {
     position: relative;
     width: 100%;
-    min-height: 860px;
+    min-height: clamp(720px, calc(100vh - 178px), 900px);
     overflow: hidden;
 }
 
@@ -15,18 +15,18 @@
     position: absolute;
     z-index: 20;
     transform: translate(-50%, -50%);
-    padding: 6px 18px;
+    padding: 7px 20px;
     border-radius: 999px;
     border: 1px solid rgba(255,255,255,0.8);
-    background: rgba(255,255,255,0.85);
-    font-size: 13px;
+    background: rgba(255,255,255,0.78);
+    font-size: 14px;
     font-weight: 700;
     cursor: pointer;
     transition: all 0.2s;
     backdrop-filter: blur(4px);
     white-space: nowrap;
     pointer-events: auto;
-    box-shadow: 0 2px 10px rgba(111,70,44,0.06);
+    box-shadow: 0 8px 18px rgba(111,70,44,0.08);
 }
 
 .vv-branch-label:hover {
@@ -54,8 +54,8 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: 28px;
-    height: 2px;
+    width: 34px;
+    height: 3px;
     border-radius: 999px;
     background: #cbb8b0;
     transform-origin: left center;
@@ -63,7 +63,7 @@
 
 .vv-leaf-shape {
     position: relative;
-    border: 3px solid #fff;
+    border: 4px solid rgba(255,255,255,0.96);
     border-radius: 54% 46% 52% 48% / 43% 58% 42% 57%;
     cursor: pointer;
     transition: all 0.2s;
@@ -90,23 +90,23 @@
 .vv-leaf-emoji {
     position: relative;
     z-index: 1;
-    font-size: 18px;
+    font-size: 22px;
     line-height: 1;
     color: rgba(97,61,38,0.6);
 }
 
 .vv-leaf-play {
     position: absolute;
-    bottom: 5px;
-    right: 5px;
-    width: 14px;
-    height: 14px;
+    bottom: 6px;
+    right: 6px;
+    width: 17px;
+    height: 17px;
     border-radius: 50%;
     background: rgba(255,255,255,0.75);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 7px;
+    font-size: 8px;
     color: #6b5850;
     z-index: 2;
     opacity: 0.7;
@@ -161,8 +161,8 @@
 
 .vv-cluster-leaf {
     position: absolute;
-    width: 44px;
-    height: 44px;
+    width: 56px;
+    height: 56px;
     border-radius: 48% 52% 45% 55%;
     box-shadow: 0 2px 8px rgba(111,70,44,0.1);
     border: 1px solid rgba(255,255,255,0.6);
@@ -174,15 +174,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 13px;
+    font-size: 15px;
     font-weight: 700;
     color: #6b5850;
     z-index: 2;
 }
 
 .vv-cluster-lg .vv-cluster-leaf {
-    width: 50px;
-    height: 50px;
+    width: 64px;
+    height: 64px;
 }
 
 .vv-root-seed {
@@ -208,8 +208,8 @@
 }
 
 .vv-root-seed-shape {
-    width: 108px;
-    height: 90px;
+    width: 132px;
+    height: 108px;
     border-radius: 46% 54% 48% 52%;
     border: 1.5px solid rgba(255,255,255,0.85);
     box-shadow: 0 20px 40px rgba(122,65,67,0.25), 0 0 0 3px rgba(255,255,255,0.85);
@@ -236,14 +236,14 @@
     position: absolute;
     bottom: 8px;
     right: 8px;
-    width: 22px;
-    height: 22px;
+    width: 26px;
+    height: 26px;
     border-radius: 50%;
     background: rgba(255,255,255,0.85);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 10px;
+    font-size: 11px;
     color: #6b5850;
     z-index: 2;
     box-shadow: 0 2px 6px rgba(0,0,0,0.08);
@@ -255,14 +255,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 28px;
+    font-size: 34px;
     color: rgba(127,68,70,0.75);
     z-index: 1;
 }
 
 .vv-root-seed-label {
     position: absolute;
-    bottom: -24px;
+    bottom: -26px;
     left: 50%;
     transform: translateX(-50%);
     white-space: nowrap;
@@ -270,7 +270,7 @@
     border-radius: 999px;
     border: 1px solid rgba(251,113,133,0.25);
     background: rgba(255,255,255,0.85);
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
     color: #881337;
     box-shadow: 0 2px 8px rgba(136,19,55,0.08);

--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -47,9 +47,9 @@
             var bPalette = paletteColor(branch);
             var d = 'M50 ' + branch.startY + ' C' + branch.curveA + ' ' + (branch.startY - 8) + ', ' + branch.curveB + ' ' + (branch.endY + 8) + ', ' + branch.endX + ' ' + branch.endY;
 
-            svg += '<path d="' + d + '" stroke="rgba(113,76,60,.14)" stroke-width="' + (selected ? '4.35' : '3.05') + '" stroke-linecap="round" fill="none" opacity="' + (muted ? '0.18' : '1') + '" />';
-            svg += '<path d="' + d + '" stroke="' + bPalette.stroke + '" stroke-width="' + (selected ? '2.45' : '1.65') + '" stroke-linecap="round" fill="none" opacity="' + (muted ? '0.25' : '1') + '" />';
-            svg += '<path d="' + d + '" stroke="rgba(255,255,255,.70)" stroke-width=".48" stroke-linecap="round" fill="none" />';
+            svg += '<path d="' + d + '" stroke="rgba(113,76,60,.14)" stroke-width="' + (selected ? '5.1' : '3.65') + '" stroke-linecap="round" fill="none" opacity="' + (muted ? '0.18' : '1') + '" />';
+            svg += '<path d="' + d + '" stroke="' + bPalette.stroke + '" stroke-width="' + (selected ? '2.95' : '1.95') + '" stroke-linecap="round" fill="none" opacity="' + (muted ? '0.25' : '1') + '" />';
+            svg += '<path d="' + d + '" stroke="rgba(255,255,255,.70)" stroke-width=".62" stroke-linecap="round" fill="none" />';
             svg += '<circle cx="50" cy="' + branch.startY + '" r="' + (selected ? '1.65' : '1.18') + '" fill="' + bPalette.stroke + '" opacity="' + (muted ? '.25' : '.82') + '" />';
 
             var labelPoint = curvePoint(branch, 0.78);
@@ -82,8 +82,8 @@
             '  <div class="vv-tree-glow-bottom"></div>' +
             '  <svg class="vv-tree-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">' +
             '    <defs><filter id="trunkShadow"><feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="#7c4a3f" floodOpacity="0.16" /></filter></defs>' +
-            '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#9f745b" stroke-width="3.9" stroke-linecap="round" fill="none" opacity="0.34" />' +
-            '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#7f5b47" stroke-width="1.55" stroke-linecap="round" fill="none" opacity="0.86" />' +
+            '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#9f745b" stroke-width="5.35" stroke-linecap="round" fill="none" opacity="0.34" />' +
+            '    <path d="M50 91 C48 78, 52 66, 50 54 C48 43, 52 32, 50 12" stroke="#7f5b47" stroke-width="2.15" stroke-linecap="round" fill="none" opacity="0.86" />' +
             svg +
             '  </svg>' +
             '  <div class="vv-tree-organs">' + branchNames + mediaLeafs + rootEl + '</div>' +
@@ -109,8 +109,8 @@
         }
 
         var stemAngle = branch.side === 'left' ? -18 : 18;
-        var leafW = (branchSelected || selected) ? '64px' : '52px';
-        var leafH = (branchSelected || selected) ? '80px' : '68px';
+        var leafW = (branchSelected || selected) ? 'clamp(66px, 5vw, 88px)' : 'clamp(56px, 4vw, 74px)';
+        var leafH = (branchSelected || selected) ? 'clamp(84px, 6vw, 112px)' : 'clamp(72px, 5vw, 94px)';
         var leafShape = 'style="width:' + leafW + ';height:' + leafH + ';border-radius:54% 46% 52% 48% / 43% 58% 42% 57%;background:' + leafGrad(branch) + ';box-shadow:' + (selected ? '0 0 0 6px rgba(255,241,243,0.9),0 20px 38px rgba(80,45,39,0.18)' : (branchSelected ? '0 10px 28px rgba(97,61,38,0.2)' : '0 8px 20px rgba(97,61,38,0.10)')) + ';"';
 
         var p = paletteColorFn(branch);

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
     <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260508-923-1">
-    <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260509-976-1">
+    <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260509-976-2">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="paper-grain viewer-body">
@@ -60,7 +60,7 @@
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>
-    <script src="../js/visitor-viewer/visitor-viewer-render-tree.js?v=20260508-955-1"></script>
+    <script src="../js/visitor-viewer/visitor-viewer-render-tree.js?v=20260509-976-2"></script>
     <script src="../js/visitor-viewer/visitor-viewer-panels.js?v=20260509-957-1"></script>
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260415-10">
     <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260508-923-1">
-    <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260508-951-2">
+    <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260509-976-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
 <body class="paper-grain viewer-body">


### PR DESCRIPTION
## Summary

Vertical tree hero visual hierarchy correction for the public viewer. The tree is now clearly the primary hero object on first view.

## Changes

### css/visitor-viewer/visitor-viewer-shell.css
- Panel column narrowed from `minmax(340px, 420px)` to `minmax(260px, 320px)`
- Tree container gets subtle box-shadow for hero elevation
- Tree canvas background enhanced with depth gradient
- Panel shadow reduced, border contrast lowered
- Mobile: panel shadow and border-radius reduced

### css/visitor-viewer/visitor-viewer-panel.css
- Panel shadow drastically reduced, border/padding toned down
- Branch panel title font reduced (1.5rem → 1.2rem)
- Moment grid gap reduced (8px → 6px), button size/shadow reduced
- Play indicator made smaller and lower opacity
- Branch moment list spacing/contrast reduced

### css/visitor-viewer/visitor-viewer-tree.css
- Canvas min-height increased (780px → 860px)
- Branch labels: larger padding, bolder font, subtle shadow
- Selected leaf active state: stronger scale/glow
- Root seed: larger (96×80 → 108×90), stronger shadow
- Leaf label title: darker, bolder

## Verification
- git diff --check: clean
- node --check all JS: pass
- npm run verify: 154/154
- npm test: 253/253
- No backend/API/Auth/DB changes
- No Browse/My Trees changes
- No PR #7 touched