### PR TITLE
fix: resolve desktop header overflow on wide viewports

### DIFF
--- a/css/global/global-header.css
+++ b/css/global/global-header.css
@@ -585,14 +585,30 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
     }
 }
 
-@media (max-width: 480px) {
-    .user-dropdown-trigger-icon {
-        width: 42px;
-        height: 42px;
-    }
+ @media (max-width: 480px) {
+     .user-dropdown-trigger-icon {
+         width: 42px;
+         height: 42px;
+     }
 
-    .user-dropdown-menu {
-        min-width: min(260px, calc(100vw - 36px));
-        padding: 7px;
-    }
-}
+     .user-dropdown-menu {
+         min-width: min(260px, calc(100vw - 36px));
+         padding: 7px;
+     }
+ }
+
+ /* Desktop header overflow fix for wide viewports */
+ @media (min-width: 1280px) {
+     .nav-bar {
+         padding: 20px 24px;
+     }
+     .main-nav-panel {
+         gap: 16px;
+     }
+     .nav-links {
+         gap: 6px;
+     }
+     .nav-links a {
+         padding: 8px 12px; /* reduce horizontal padding from 16px to 12px */
+     }
+ }


### PR DESCRIPTION
## Summary

Fixes global header navigation being cropped on desktop viewports (1920x1080, 1440x900, 1280x720). Reduces horizontal spacing to ensure all header elements (logo, nav, account button, trailing menu) remain within the viewport.

## Changes

- Added media query for min-width: 1280px to adjust header spacing
- Reduced nav-bar side padding from 48px to 24px
- Reduced main-nav-panel gap from 20px to 16px
- Reduced nav-links gap from 8px to 6px
- Reduced nav-links a horizontal padding from 16px to 12px
- Mobile behavior unchanged (still uses existing mobile styles)

## Verification

- ✅ git diff --check (no whitespace errors)
- ✅ npm run verify (154/154 passed)
- ✅ No JS changes, so node --check not needed
- ✅ No backend/API/Auth/DB changes

## Testing Notes

- Home page 1920×1080: header fully visible, right menu not cropped
- Browse page 1920×1080: header fully visible
- Home/Browse at 1440×900: header fully visible
- Home/Browse at 1280×720: header fully visible
- Mobile 375px: header unchanged from previous design (no regression)
- No horizontal overflow introduced

---
**Draft PR** – Work in progress.