### PR TITLE
Global header desktop full nav fit

### DIFF
--- a/css/global/global-header.css
+++ b/css/global/global-header.css
@@ -585,14 +585,30 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
     }
 }
 
-@media (max-width: 480px) {
-    .user-dropdown-trigger-icon {
-        width: 42px;
-        height: 42px;
-    }
+ @media (max-width: 480px) {
+     .user-dropdown-trigger-icon {
+         width: 42px;
+         height: 42px;
+     }
 
-    .user-dropdown-menu {
-        min-width: min(260px, calc(100vw - 36px));
-        padding: 7px;
-    }
-}
+     .user-dropdown-menu {
+         min-width: min(260px, calc(100vw - 36px));
+         padding: 7px;
+     }
+ }
+
+ /* Desktop header overflow fix for wide viewports */
+ @media (min-width: 1280px) {
+     .nav-bar {
+         padding: 20px 24px;
+     }
+     .main-nav-panel {
+         gap: 16px;
+     }
+     .nav-links {
+         gap: 6px;
+     }
+     .nav-links a {
+         padding: 8px 12px; /* reduce horizontal padding from 16px to 12px */
+     }
+ }

--- a/css/global/global-header.css
+++ b/css/global/global-header.css
@@ -5,14 +5,17 @@
     position: sticky;
     top: 0;
     width: 100%;
+    box-sizing: border-box;
     background: rgba(251, 249, 245, 0.9);
     backdrop-filter: blur(20px);
     z-index: 1000;
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: clamp(16px, 2.5vw, 40px);
     align-items: center;
-    padding: 20px 48px;
+    padding: 18px clamp(20px, 3vw, 48px);
     border-bottom: 1px solid var(--outline-variant);
+    overflow: visible;
 }
 
 .nav-bar .headline {
@@ -23,11 +26,17 @@
     cursor: pointer;
     margin: 0;
     text-decoration: none;
+    white-space: nowrap;
+    min-width: 0;
 }
 
 .nav-links {
     display: flex;
+    align-items: center;
+    justify-content: flex-end;
     gap: 8px;
+    min-width: 0;
+    white-space: nowrap;
 }
 
 .nav-links a {
@@ -40,6 +49,7 @@
     opacity: 0.65;
     transition: none;
     white-space: nowrap;
+    flex: 0 1 auto;
 }
 
 .nav-links a:hover, .nav-links a.active {
@@ -55,21 +65,31 @@
 
 /* Main nav layout (replaces inline styles) */
 .main-nav {
-    display: flex;
+    display: block;
     align-items: center;
-    gap: 20px;
+    justify-self: stretch;
+    min-width: 0;
+    width: 100%;
 }
 
 .main-nav-panel {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    gap: 20px;
+    justify-content: end;
+    gap: clamp(10px, 1.4vw, 20px);
+    min-width: 0;
+    width: 100%;
 }
 
 .nav-actions {
     display: flex;
     align-items: center;
-    gap: 12px;
+    justify-content: flex-end;
+    gap: clamp(8px, 1vw, 12px);
+    flex: 0 0 auto;
+    min-width: max-content;
+    white-space: nowrap;
 }
 
 /* User dropdown menu */
@@ -147,6 +167,7 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
+    min-width: 0;
 }
 
 .cached-avatar-initial {
@@ -165,7 +186,7 @@
 .cached-avatar-name {
     font-size: 14px;
     color: var(--on-surface);
-    max-width: 120px;
+    max-width: clamp(72px, 9vw, 120px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -293,6 +314,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
 /* Mobile-first responsive overrides */
 @media (max-width: 768px) {
     .nav-bar {
+        display: flex;
         padding: 14px 16px;
         gap: 12px;
     }
@@ -308,6 +330,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
 
     .main-nav {
         margin-left: 0;
+        width: auto;
     }
 
     .main-nav-panel {
@@ -325,6 +348,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
         border-radius: 20px;
         box-shadow: 0 16px 40px rgba(75, 64, 57, 0.12);
         backdrop-filter: blur(18px);
+        width: auto;
     }
 
     .main-nav-panel.show {
@@ -352,6 +376,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
         gap: 12px;
         padding-top: 8px;
         border-top: 1px solid var(--outline-variant);
+        min-width: 0;
     }
 
 }
@@ -597,18 +622,57 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
      }
  }
 
- /* Desktop header overflow fix for wide viewports */
- @media (min-width: 1280px) {
+/* Desktop header fit: reserve the right action group, compact only the link group. */
+@media (min-width: 769px) {
+    #auth-nav,
+    #auth-nav-container {
+        flex: 0 0 auto;
+        min-width: 88px !important;
+        max-width: 168px;
+        overflow: visible;
+    }
+
+    #auth-nav .btn-round,
+    #auth-nav-container .btn-round {
+        padding-inline: 16px !important;
+        white-space: nowrap;
+    }
+}
+
+@media (min-width: 769px) and (max-width: 1360px) {
      .nav-bar {
-         padding: 20px 24px;
+         column-gap: 18px;
+         padding: 16px 22px;
      }
      .main-nav-panel {
-         gap: 16px;
+         gap: 10px;
      }
      .nav-links {
-         gap: 6px;
+         gap: 4px;
      }
      .nav-links a {
-         padding: 8px 12px; /* reduce horizontal padding from 16px to 12px */
+         padding: 7px 10px;
+         font-size: 12.5px;
+      }
+     .nav-links a.nav-highlight {
+         margin: 0 1px;
+         padding: 6px 10px;
+     }
+     .lang-menu-trigger {
+         padding: 0 10px !important;
+         font-size: 12.5px !important;
+     }
+     .cached-avatar-name {
+         max-width: 82px;
      }
  }
+
+@media (min-width: 1361px) and (max-width: 1536px) {
+    .nav-bar {
+        padding-inline: 28px;
+        column-gap: 24px;
+    }
+    .nav-links a {
+        padding-inline: 12px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>LoveTree | 나만의 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="css/global.css?v=20260417-31">
+    <link rel="stylesheet" href="css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="css/index.css?v=20260426-1">
     <link rel="stylesheet" href="css/index-visual.css?v=20260426-1">
     <link rel="stylesheet" href="css/page-transitions.css?v=20260430-1">

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -6,7 +6,7 @@
     <title>기억 상세 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/detail.css?v=20260505-646">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -6,7 +6,7 @@
   <title>소개 | 러브트리</title>
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+  <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
   <link rel="stylesheet" href="../css/intro.css?v=20260426-1">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/login.html
+++ b/pages/login.html
@@ -6,7 +6,7 @@
     <title>로그인 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/login.css?v=20260504-642">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -6,7 +6,7 @@
   <title>내 러브트리 | LoveTree</title>
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
-  <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+  <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
   <link rel="stylesheet" href="../css/my-trees.css?v=20260509-910-2">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/public-tree-viewer-shell.html
+++ b/pages/public-tree-viewer-shell.html
@@ -6,7 +6,7 @@
     <title>Public LoveTree Viewer Shell | LoveBud</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260508-951-1">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260508-951-2">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap">
 </head>

--- a/pages/search.html
+++ b/pages/search.html
@@ -6,7 +6,7 @@
     <title>러브트리 둘러보기 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/search.css?v=20260509-907-1">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>설정 | 러브트리</title>
-    <link rel="stylesheet" href="../css/global.css?v=20260417-31">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
   <link rel="stylesheet" href="../css/settings.css?v=20260427-1">
 </head>

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -6,7 +6,7 @@
     <title>회원가입 | 러브트리</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/login.css?v=20260504-642">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -6,7 +6,7 @@
     <title>러브트리 감상 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/global.css?v=20260415-10">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/viewer/public-tree-viewer.css?v=20260508-923-1">
     <link rel="stylesheet" href="../css/visitor-viewer.css?v=20260508-951-2">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />


### PR DESCRIPTION
Refs #994
Related: #993

Summary:
- Reworks the desktop global header shell from spacing-only flex behavior into a grid layout with a reserved action group.
- Keeps the full nav, language control, and login/account control in the desktop layout without changing route targets or Auth behavior.
- Preserves the mobile hamburger layout and updates page cache keys for the global stylesheet.

Verification:
- git diff --check: PASS
- npm run verify: PASS
- npm test: PASS

Non-goals:
- no route/link target changes
- no Auth behavior changes
- no backend/API/Auth/DB/schema changes
- no header item deletion
- no hiding login/account controls
- no PR #7 / prototype/reference/demo/variant changes
- no final browser visual PASS without screenshot review
