### PR TITLE
ui(editor): simplify first moment modal structure

### DIFF
--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -60,6 +60,150 @@
     color: var(--on-surface-variant);
 }
 
+.canvas-area.is-memory-form-open .editor-canvas-empty-guide,
+.editor-canvas-empty-guide-form-suppressed {
+    display: none;
+}
+
+.editor-memory-form-modal.is-open {
+    display: flex !important;
+    flex-direction: column;
+    gap: 0;
+    position: fixed;
+    left: 50%;
+    top: clamp(18px, 6vh, 42px);
+    transform: translateX(-50%);
+    width: min(620px, calc(100vw - 32px));
+    max-width: 620px;
+    max-height: calc(100vh - clamp(36px, 12vh, 84px));
+    padding: 0;
+    overflow: hidden;
+    z-index: 24;
+    border-radius: 30px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.995), rgba(250,246,244,0.985));
+    border: 1px solid rgba(144,73,81,0.12);
+    box-shadow: 0 26px 68px rgba(75,64,57,0.18);
+}
+
+.editor-memory-form-body {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 0;
+    padding: 24px 26px 14px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.editor-memory-form-modal .editor-modal-eyebrow,
+.editor-memory-form-modal .editor-form-label {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    min-height: 26px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: rgba(144, 73, 81, 0.08);
+    border: 1px solid rgba(144, 73, 81, 0.12);
+    color: var(--primary, #904951);
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: .02em;
+}
+
+.editor-memory-form-modal .editor-form-field,
+.editor-memory-form-modal .editor-form-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editor-memory-form-modal .editor-memory-mode-group {
+    margin: 0 0 2px;
+}
+
+.editor-memory-form-modal .editor-form-field-grid {
+    gap: 12px;
+}
+
+.editor-memory-form-modal .editor-form-input,
+.editor-memory-form-modal .editor-form-textarea {
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 400;
+}
+
+.editor-memory-form-modal .editor-form-input::placeholder,
+.editor-memory-form-modal .editor-form-textarea::placeholder {
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 400;
+    color: rgba(75, 64, 57, 0.45);
+}
+
+.editor-memory-form-modal .editor-form-textarea {
+    min-height: 92px;
+    resize: vertical;
+}
+
+.editor-memory-form-modal .editor-form-help {
+    margin: -2px 0 0;
+    font-size: 11px;
+    font-weight: 700;
+    color: rgba(144, 73, 81, 0.62);
+    line-height: 1.35;
+}
+
+.editor-video-segment-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    align-items: start;
+}
+
+.editor-video-segment-field {
+    min-width: 0;
+}
+
+.editor-memory-form-modal .memory-link-preview.is-enhanced {
+    max-height: 58px;
+}
+
+.editor-memory-form-modal .editor-form-actions {
+    flex-shrink: 0;
+    margin-top: 0;
+    padding: 12px 26px 16px;
+    border-top: 1px solid rgba(144, 73, 81, 0.10);
+    background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(250,246,244,0.995));
+    box-shadow: 0 -10px 22px rgba(75,64,57,0.06);
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+}
+
+@media (max-width: 560px) {
+    .editor-memory-form-modal.is-open {
+        top: 12px;
+        width: calc(100vw - 20px);
+        max-height: calc(100vh - 24px);
+        border-radius: 22px;
+    }
+
+    .editor-memory-form-body {
+        padding: 18px 16px 12px;
+    }
+
+    .editor-video-segment-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .editor-memory-form-modal .editor-form-actions {
+        padding: 10px 16px 14px;
+    }
+}
+
 .memory-node {
     position: absolute;
     z-index: 2;

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -198,11 +198,13 @@
 }
 
 .editor-video-segment-field {
-    display: grid !important;
-    grid-template-rows: 26px 42px;
-    gap: 7px;
+    display: flex !important;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: 8px;
     min-width: 0;
-    padding: 9px;
+    min-height: 92px;
+    padding: 10px;
     border: 1px solid rgba(144,73,81,0.08);
     border-radius: 14px;
     background: rgba(255,255,255,0.68);
@@ -210,12 +212,15 @@
 }
 
 .editor-video-segment-field .editor-form-label {
-    align-self: start;
+    align-self: flex-start;
+    margin: 0;
 }
 
 .editor-video-segment-field .editor-form-input {
     width: 100%;
     height: 42px;
+    min-height: 42px;
+    margin: 0;
 }
 
 .editor-video-segment-help {
@@ -263,7 +268,8 @@
     }
 
     .editor-video-segment-field {
-        padding: 8px;
+        min-height: 90px;
+        padding: 9px;
     }
 
     .editor-memory-form-modal .editor-form-actions {

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -189,7 +189,7 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     column-gap: 10px;
-    row-gap: 8px;
+    row-gap: 7px;
     align-items: start;
     padding: 9px;
     border: 1px solid rgba(144,73,81,0.08);
@@ -198,21 +198,22 @@
 }
 
 .editor-video-segment-field {
-    display: flex !important;
-    flex-direction: column;
-    justify-content: flex-start;
-    gap: 8px;
+    display: grid !important;
+    grid-template-rows: 26px 42px;
+    row-gap: 6px;
     min-width: 0;
-    min-height: 92px;
+    height: 94px;
+    min-height: 94px;
     padding: 10px;
-    border: 1px solid rgba(144,73,81,0.08);
+    border: 1px solid rgba(144,73,81,0.07);
     border-radius: 14px;
-    background: rgba(255,255,255,0.68);
+    background: rgba(255,255,255,0.50);
     box-sizing: border-box;
 }
 
 .editor-video-segment-field .editor-form-label {
-    align-self: flex-start;
+    align-self: start;
+    justify-self: start;
     margin: 0;
 }
 
@@ -220,15 +221,20 @@
     width: 100%;
     height: 42px;
     min-height: 42px;
+    max-height: 42px;
     margin: 0;
+    box-sizing: border-box;
 }
 
 .editor-video-segment-help {
     grid-column: 1 / -1;
     margin: 0;
-    padding: 0 3px 1px;
+    padding: 6px 8px;
+    border-radius: 12px;
+    background: rgba(255,255,255,0.42);
     color: rgba(75, 64, 57, 0.52);
     font-weight: 600;
+    text-align: center;
     line-height: 1.3;
 }
 
@@ -268,7 +274,8 @@
     }
 
     .editor-video-segment-field {
-        min-height: 90px;
+        height: 92px;
+        min-height: 92px;
         padding: 9px;
     }
 

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -78,11 +78,11 @@
     position: absolute;
     left: 50%;
     top: clamp(18px, 4vh, 30px);
-    bottom: clamp(18px, 4vh, 30px);
+    bottom: auto;
     transform: translateX(-50%);
     width: min(620px, calc(100% - 32px));
     max-width: 620px;
-    max-height: none;
+    max-height: calc(100% - 36px);
     padding: 0;
     overflow: hidden;
     z-index: 30;
@@ -96,11 +96,11 @@
 
 .editor-memory-form-body {
     display: flex;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     flex-direction: column;
-    gap: 10px;
+    gap: 9px;
     min-height: 0;
-    padding: 20px 24px 12px;
+    padding: 18px 24px 10px;
     overflow-y: auto;
     overscroll-behavior: contain;
     scrollbar-width: thin;
@@ -189,8 +189,12 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     column-gap: 12px;
-    row-gap: 7px;
+    row-gap: 8px;
     align-items: start;
+    padding: 10px;
+    border: 1px solid rgba(144,73,81,0.08);
+    border-radius: 16px;
+    background: rgba(255, 250, 247, 0.62);
 }
 
 .editor-video-segment-field {
@@ -212,10 +216,14 @@
 .editor-video-segment-help {
     grid-column: 1 / -1;
     margin: 0;
+    padding: 1px 2px 0;
+    color: rgba(75, 64, 57, 0.52);
+    font-weight: 600;
 }
 
 .editor-memory-form-modal .memory-link-preview.is-enhanced {
-    max-height: 58px;
+    max-height: 54px;
+    margin-top: 0 !important;
 }
 
 .editor-memory-form-modal .editor-form-actions {
@@ -233,17 +241,19 @@
 @media (max-width: 560px) {
     #addMemoryForm.editor-memory-form-modal.is-open {
         top: 10px;
-        bottom: 10px;
+        bottom: auto;
         width: calc(100% - 20px);
+        max-height: calc(100% - 20px);
         border-radius: 22px;
     }
 
     .editor-memory-form-body {
-        padding: 16px 14px 10px;
+        padding: 16px 14px 9px;
     }
 
     .editor-video-segment-grid {
         grid-template-columns: 1fr;
+        padding: 9px;
     }
 
     .editor-memory-form-modal .editor-form-actions {

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -65,35 +65,59 @@
     display: none;
 }
 
-.editor-memory-form-modal.is-open {
+.canvas-area.is-memory-form-open .editor-canvas-topbar {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+}
+
+#addMemoryForm.editor-memory-form-modal.is-open {
     display: flex !important;
     flex-direction: column;
     gap: 0;
-    position: fixed;
+    position: absolute;
     left: 50%;
-    top: clamp(18px, 6vh, 42px);
+    top: clamp(18px, 4vh, 30px);
+    bottom: clamp(18px, 4vh, 30px);
     transform: translateX(-50%);
-    width: min(620px, calc(100vw - 32px));
+    width: min(620px, calc(100% - 32px));
     max-width: 620px;
-    max-height: calc(100vh - clamp(36px, 12vh, 84px));
+    max-height: none;
     padding: 0;
     overflow: hidden;
-    z-index: 24;
+    z-index: 30;
     border-radius: 30px;
     background: linear-gradient(180deg, rgba(255,255,255,0.995), rgba(250,246,244,0.985));
     border: 1px solid rgba(144,73,81,0.12);
     box-shadow: 0 26px 68px rgba(75,64,57,0.18);
+    cursor: default;
+    user-select: text;
 }
 
 .editor-memory-form-body {
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     min-height: 0;
-    padding: 24px 26px 14px;
+    padding: 20px 24px 12px;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(144,73,81,0.22) transparent;
+}
+
+.editor-memory-form-body::-webkit-scrollbar {
+    width: 8px;
+}
+
+.editor-memory-form-body::-webkit-scrollbar-thumb {
+    background: rgba(144,73,81,0.18);
+    border-radius: 999px;
+}
+
+.editor-memory-form-body::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .editor-memory-form-modal .editor-modal-eyebrow,
@@ -117,7 +141,7 @@
 .editor-memory-form-modal .editor-form-stack {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 
 .editor-memory-form-modal .editor-memory-mode-group {
@@ -133,6 +157,7 @@
     font-family: inherit;
     font-size: 14px;
     font-weight: 400;
+    min-height: 42px;
 }
 
 .editor-memory-form-modal .editor-form-input::placeholder,
@@ -144,7 +169,8 @@
 }
 
 .editor-memory-form-modal .editor-form-textarea {
-    min-height: 92px;
+    min-height: 72px;
+    max-height: 112px;
     resize: vertical;
 }
 
@@ -153,7 +179,7 @@
     font-size: 11px;
     font-weight: 700;
     color: rgba(144, 73, 81, 0.62);
-    line-height: 1.35;
+    line-height: 1.25;
 }
 
 .editor-video-segment-grid {
@@ -174,7 +200,7 @@
 .editor-memory-form-modal .editor-form-actions {
     flex-shrink: 0;
     margin-top: 0;
-    padding: 12px 26px 16px;
+    padding: 12px 24px 16px;
     border-top: 1px solid rgba(144, 73, 81, 0.10);
     background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(250,246,244,0.995));
     box-shadow: 0 -10px 22px rgba(75,64,57,0.06);
@@ -184,15 +210,15 @@
 }
 
 @media (max-width: 560px) {
-    .editor-memory-form-modal.is-open {
-        top: 12px;
-        width: calc(100vw - 20px);
-        max-height: calc(100vh - 24px);
+    #addMemoryForm.editor-memory-form-modal.is-open {
+        top: 10px;
+        bottom: 10px;
+        width: calc(100% - 20px);
         border-radius: 22px;
     }
 
     .editor-memory-form-body {
-        padding: 18px 16px 12px;
+        padding: 16px 14px 10px;
     }
 
     .editor-video-segment-grid {

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -125,6 +125,7 @@
     display: inline-flex;
     align-items: center;
     width: fit-content;
+    height: 26px;
     min-height: 26px;
     padding: 5px 10px;
     border-radius: 999px;
@@ -135,6 +136,7 @@
     font-weight: 800;
     line-height: 1;
     letter-spacing: .02em;
+    box-sizing: border-box;
 }
 
 .editor-memory-form-modal .editor-form-field,
@@ -158,6 +160,7 @@
     font-size: 14px;
     font-weight: 400;
     min-height: 42px;
+    box-sizing: border-box;
 }
 
 .editor-memory-form-modal .editor-form-input::placeholder,
@@ -185,12 +188,30 @@
 .editor-video-segment-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
+    column-gap: 12px;
+    row-gap: 7px;
     align-items: start;
 }
 
 .editor-video-segment-field {
+    display: grid !important;
+    grid-template-rows: 26px 42px;
+    gap: 7px;
     min-width: 0;
+}
+
+.editor-video-segment-field .editor-form-label {
+    align-self: start;
+}
+
+.editor-video-segment-field .editor-form-input {
+    width: 100%;
+    height: 42px;
+}
+
+.editor-video-segment-help {
+    grid-column: 1 / -1;
+    margin: 0;
 }
 
 .editor-memory-form-modal .memory-link-preview.is-enhanced {

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -188,13 +188,13 @@
 .editor-video-segment-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 12px;
+    column-gap: 10px;
     row-gap: 8px;
     align-items: start;
-    padding: 10px;
+    padding: 9px;
     border: 1px solid rgba(144,73,81,0.08);
     border-radius: 16px;
-    background: rgba(255, 250, 247, 0.62);
+    background: rgba(255, 250, 247, 0.52);
 }
 
 .editor-video-segment-field {
@@ -202,6 +202,11 @@
     grid-template-rows: 26px 42px;
     gap: 7px;
     min-width: 0;
+    padding: 9px;
+    border: 1px solid rgba(144,73,81,0.08);
+    border-radius: 14px;
+    background: rgba(255,255,255,0.68);
+    box-sizing: border-box;
 }
 
 .editor-video-segment-field .editor-form-label {
@@ -216,9 +221,10 @@
 .editor-video-segment-help {
     grid-column: 1 / -1;
     margin: 0;
-    padding: 1px 2px 0;
+    padding: 0 3px 1px;
     color: rgba(75, 64, 57, 0.52);
     font-weight: 600;
+    line-height: 1.3;
 }
 
 .editor-memory-form-modal .memory-link-preview.is-enhanced {
@@ -254,6 +260,10 @@
     .editor-video-segment-grid {
         grid-template-columns: 1fr;
         padding: 9px;
+    }
+
+    .editor-video-segment-field {
+        padding: 8px;
     }
 
     .editor-memory-form-modal .editor-form-actions {

--- a/js/editor/editor-memory-form-mode.js
+++ b/js/editor/editor-memory-form-mode.js
@@ -22,10 +22,15 @@
         if (refs?.startTimeField) refs.startTimeField.style.display = linkMode ? 'block' : 'none';
         if (refs?.videoSegmentGrid) refs.videoSegmentGrid.style.display = linkMode ? 'grid' : 'none';
 
+        const linkModeText = refs?.modeLinkBtn?.querySelector('span:last-child');
+        if (linkModeText) linkModeText.textContent = '영상으로 시작';
+        const textModeText = refs?.modeTextBtn?.querySelector('span:last-child');
+        if (textModeText) textModeText.textContent = '텍스트로 시작';
+
         if (refs?.urlInput) {
             refs.urlInput.placeholder = linkMode
-                ? 'https://www.youtube.com/watch?v=...'
-                : (i18n('editor_link_optional_placeholder') || '링크가 있다면 나중에 붙여도 괜찮아요');
+                ? 'YouTube 링크를 붙여넣으세요'
+                : (i18n('editor_link_optional_placeholder') || '링크는 나중에 붙여도 괜찮아요');
         }
 
         setText(refs?.urlLabel, linkMode
@@ -33,15 +38,8 @@
             : (i18n('editor_optional_link') || '참고 링크 (선택)'));
 
         if (refs?.formIntro) {
-            if (linkMode) {
-                refs.formIntro.textContent = isFirstMoment
-                    ? (i18n('editor_add_first_memory_intro') || '링크와 짧은 메모를 남기면 이 장면에서 러브트리가 시작돼요.')
-                    : (i18n('editor_add_next_memory_intro') || '현재 마음에서 이어진 장면을 붙여 트리를 더 자라게 해보세요.');
-            } else {
-                refs.formIntro.textContent = isFirstMoment
-                    ? (i18n('editor_add_first_memory_text_intro') || '링크 없이도 제목과 메모만으로 첫 순간을 심을 수 있어요.')
-                    : (i18n('editor_add_next_memory_text_intro') || '짧은 제목과 메모만으로도 이어진 순간을 남길 수 있어요.');
-            }
+            refs.formIntro.textContent = '';
+            refs.formIntro.style.display = 'none';
         }
 
         setText(refs?.supportNoteText, linkMode

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -149,9 +149,7 @@
         }
 
         if (refs?.startTimeHint) {
-            refs.startTimeHint.textContent = formatted
-                ? `${formatted}부터 재생돼요.`
-                : '시작시간 포함 링크는 자동 입력돼요.';
+            refs.startTimeHint.textContent = '순간의 시작과 끝 시간을 입력하세요.';
         }
     }
 

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -6,25 +6,24 @@
         if (!preview) return;
         preview.classList.add('is-enhanced');
         preview.style.display = 'flex';
-        preview.style.alignItems = 'stretch';
-        preview.style.gap = '14px';
-        preview.style.padding = '14px';
-        preview.style.borderRadius = '20px';
-        preview.style.background = 'linear-gradient(180deg, rgba(245, 241, 238, 0.98), rgba(255,255,255,0.98))';
-        preview.style.border = '1px solid rgba(144,73,81,0.10)';
-        preview.style.marginTop = '8px';
-        preview.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+        preview.style.alignItems = 'center';
+        preview.style.gap = '10px';
+        preview.style.padding = '8px 10px';
+        preview.style.borderRadius = '14px';
+        preview.style.background = 'rgba(144, 73, 81, 0.045)';
+        preview.style.border = '1px solid rgba(144,73,81,0.08)';
+        preview.style.marginTop = '6px';
 
         const thumbWrap = refs?.thumbWrap || preview.querySelector('.memory-link-preview__thumb-wrap');
         if (thumbWrap) {
             thumbWrap.style.position = 'relative';
-            thumbWrap.style.width = '136px';
-            thumbWrap.style.minWidth = '136px';
-            thumbWrap.style.height = '76px';
-            thumbWrap.style.borderRadius = '14px';
+            thumbWrap.style.width = '72px';
+            thumbWrap.style.minWidth = '72px';
+            thumbWrap.style.height = '40px';
+            thumbWrap.style.borderRadius = '10px';
             thumbWrap.style.overflow = 'hidden';
             thumbWrap.style.background = 'var(--surface-container, #ece9e5)';
-            thumbWrap.style.boxShadow = '0 8px 20px rgba(75,64,57,0.08)';
+            thumbWrap.style.boxShadow = 'none';
         }
 
         if (refs?.thumb) {
@@ -55,34 +54,23 @@
         }
 
         if (refs?.badge) {
-            refs.badge.style.display = 'inline-flex';
-            refs.badge.style.alignItems = 'center';
-            refs.badge.style.padding = '4px 9px';
-            refs.badge.style.borderRadius = '999px';
-            refs.badge.style.background = 'rgba(144, 73, 81, 0.1)';
-            refs.badge.style.color = 'var(--primary, #904951)';
-            refs.badge.style.fontSize = '10px';
-            refs.badge.style.fontWeight = '700';
-            refs.badge.style.letterSpacing = '0.03em';
-            refs.badge.style.textTransform = 'uppercase';
-            refs.badge.style.width = 'fit-content';
+            refs.badge.style.display = 'none';
         }
 
         if (refs?.previewTitle) {
-            refs.previewTitle.style.fontSize = '0.95rem';
+            refs.previewTitle.textContent = '영상 링크 확인됨';
+            refs.previewTitle.style.fontSize = '0.78rem';
             refs.previewTitle.style.fontWeight = '700';
-            refs.previewTitle.style.color = 'var(--on-surface, #333)';
-            refs.previewTitle.style.lineHeight = '1.4';
+            refs.previewTitle.style.color = 'rgba(144, 73, 81, 0.72)';
+            refs.previewTitle.style.lineHeight = '1.35';
             refs.previewTitle.style.overflow = 'hidden';
             refs.previewTitle.style.textOverflow = 'ellipsis';
             refs.previewTitle.style.whiteSpace = 'nowrap';
         }
 
         if (refs?.previewHint) {
-            refs.previewHint.style.fontSize = '0.8rem';
-            refs.previewHint.style.color = 'var(--on-surface-variant, #666)';
-            refs.previewHint.style.lineHeight = '1.6';
-            refs.previewHint.style.margin = '0';
+            refs.previewHint.textContent = '';
+            refs.previewHint.style.display = 'none';
         }
     }
 

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -7,19 +7,19 @@
         preview.classList.add('is-enhanced');
         preview.style.display = 'flex';
         preview.style.alignItems = 'center';
-        preview.style.gap = '10px';
-        preview.style.padding = '8px 10px';
+        preview.style.gap = '9px';
+        preview.style.padding = '8px 9px';
         preview.style.borderRadius = '14px';
-        preview.style.background = 'rgba(144, 73, 81, 0.045)';
-        preview.style.border = '1px solid rgba(144,73,81,0.08)';
-        preview.style.marginTop = '6px';
+        preview.style.background = 'rgba(144, 73, 81, 0.04)';
+        preview.style.border = '1px solid rgba(144,73,81,0.075)';
+        preview.style.marginTop = '0';
 
         const thumbWrap = refs?.thumbWrap || preview.querySelector('.memory-link-preview__thumb-wrap');
         if (thumbWrap) {
             thumbWrap.style.position = 'relative';
-            thumbWrap.style.width = '72px';
-            thumbWrap.style.minWidth = '72px';
-            thumbWrap.style.height = '40px';
+            thumbWrap.style.width = '52px';
+            thumbWrap.style.minWidth = '52px';
+            thumbWrap.style.height = '34px';
             thumbWrap.style.borderRadius = '10px';
             thumbWrap.style.overflow = 'hidden';
             thumbWrap.style.background = 'var(--surface-container, #ece9e5)';
@@ -38,7 +38,7 @@
             playIcon.style.top = '50%';
             playIcon.style.left = '50%';
             playIcon.style.transform = 'translate(-50%, -50%)';
-            playIcon.style.fontSize = '32px';
+            playIcon.style.fontSize = '23px';
             playIcon.style.color = '#fff';
             playIcon.style.opacity = '0.92';
             playIcon.style.textShadow = '0 2px 8px rgba(0,0,0,0.3)';
@@ -49,8 +49,9 @@
             body.style.flex = '1';
             body.style.display = 'flex';
             body.style.flexDirection = 'column';
-            body.style.gap = '6px';
+            body.style.gap = '2px';
             body.style.minWidth = '0';
+            body.style.justifyContent = 'center';
         }
 
         if (refs?.badge) {
@@ -69,8 +70,16 @@
         }
 
         if (refs?.previewHint) {
-            refs.previewHint.textContent = '';
-            refs.previewHint.style.display = 'none';
+            refs.previewHint.textContent = '제목과 메모를 다듬어 주세요.';
+            refs.previewHint.style.display = 'block';
+            refs.previewHint.style.margin = '0';
+            refs.previewHint.style.fontSize = '0.72rem';
+            refs.previewHint.style.fontWeight = '600';
+            refs.previewHint.style.lineHeight = '1.25';
+            refs.previewHint.style.color = 'rgba(75, 64, 57, 0.54)';
+            refs.previewHint.style.whiteSpace = 'nowrap';
+            refs.previewHint.style.overflow = 'hidden';
+            refs.previewHint.style.textOverflow = 'ellipsis';
         }
     }
 
@@ -134,15 +143,15 @@
             : '';
 
         if (refs?.previewHint && formatted) {
-            refs.previewHint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
+            refs.previewHint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 주세요.`;
         } else if (refs?.previewHint) {
-            refs.previewHint.textContent = '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
+            refs.previewHint.textContent = '제목과 메모를 다듬어 주세요.';
         }
 
         if (refs?.startTimeHint) {
             refs.startTimeHint.textContent = formatted
                 ? `${formatted}부터 재생돼요.`
-                : '공유 링크의 시작 시간이 자동 입력돼요.';
+                : '시작시간 포함 링크는 자동 입력돼요.';
         }
     }
 

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -141,8 +141,8 @@
 
         if (refs?.startTimeHint) {
             refs.startTimeHint.textContent = formatted
-                ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
-                : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
+                ? `${formatted}부터 재생돼요.`
+                : '공유 링크의 시작 시간이 자동 입력돼요.';
         }
     }
 

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -55,6 +55,7 @@ function createEditorMemoryForm(deps) {
         startTimeInput: document.getElementById('memoryStartTimeInput'),
         startTimeHint: document.getElementById('memoryStartTimeHint'),
         endTimeInput: document.getElementById('memoryEndTimeInput'),
+        canvasEmptyGuide: document.getElementById('canvasEmptyGuide'),
         formEyebrow: document.getElementById('addMemoryFormEyebrow'),
         formTitle: document.getElementById('addMemoryFormTitle'),
         formIntro: document.getElementById('addMemoryFormIntro'),
@@ -91,19 +92,25 @@ function createEditorMemoryForm(deps) {
         if (!form) return;
         form.style.display = 'block';
         form.classList.add('is-open');
-        form.style.position = 'absolute';
-        form.style.left = '50%';
-        form.style.top = '42px';
-        form.style.transform = 'translateX(-50%)';
-        form.style.width = 'min(620px, calc(100% - 48px))';
-        form.style.maxWidth = '620px';
-        form.style.padding = '28px 28px 24px';
-        form.style.borderRadius = '30px';
-        form.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.985), rgba(250,246,244,0.97))';
-        form.style.boxShadow = '0 24px 56px rgba(75,64,57,0.14)';
-        form.style.border = '1px solid rgba(144,73,81,0.10)';
-        form.style.zIndex = '8';
-        form.style.backdropFilter = 'blur(12px)';
+    }
+
+    function setEmptyGuideSuppressed(isSuppressed) {
+        const canvasArea = refs.addMemoryForm?.closest('.canvas-area');
+        if (canvasArea) canvasArea.classList.toggle('is-memory-form-open', isSuppressed);
+        if (!refs.canvasEmptyGuide) return;
+        refs.canvasEmptyGuide.classList.toggle('editor-canvas-empty-guide-form-suppressed', isSuppressed);
+        if (isSuppressed) {
+            refs.canvasEmptyGuide.dataset.previousAriaHidden = refs.canvasEmptyGuide.getAttribute('aria-hidden') || '';
+            refs.canvasEmptyGuide.setAttribute('aria-hidden', 'true');
+            return;
+        }
+        const previousAriaHidden = refs.canvasEmptyGuide.dataset.previousAriaHidden;
+        if (previousAriaHidden) {
+            refs.canvasEmptyGuide.setAttribute('aria-hidden', previousAriaHidden);
+        } else {
+            refs.canvasEmptyGuide.removeAttribute('aria-hidden');
+        }
+        delete refs.canvasEmptyGuide.dataset.previousAriaHidden;
     }
 
     function hideLinkPreview() {
@@ -224,6 +231,7 @@ function createEditorMemoryForm(deps) {
         if (!form) return;
         resetFormValues();
         applyFormOpenStyles();
+        setEmptyGuideSuppressed(true);
         isFormOpen = true;
 
         const memories = getTreeMemories();
@@ -264,6 +272,7 @@ function createEditorMemoryForm(deps) {
         if (!form) return;
         form.style.display = 'none';
         form.classList.remove('is-open');
+        setEmptyGuideSuppressed(false);
         isFormOpen = false;
 
         document.removeEventListener('keydown', focusTrap);

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -56,6 +56,7 @@ function createEditorMemoryForm(deps) {
         startTimeHint: document.getElementById('memoryStartTimeHint'),
         endTimeInput: document.getElementById('memoryEndTimeInput'),
         canvasEmptyGuide: document.getElementById('canvasEmptyGuide'),
+        canvasTopbar: document.querySelector('.editor-canvas-topbar'),
         formEyebrow: document.getElementById('addMemoryFormEyebrow'),
         formTitle: document.getElementById('addMemoryFormTitle'),
         formIntro: document.getElementById('addMemoryFormIntro'),
@@ -97,6 +98,20 @@ function createEditorMemoryForm(deps) {
     function setEmptyGuideSuppressed(isSuppressed) {
         const canvasArea = refs.addMemoryForm?.closest('.canvas-area');
         if (canvasArea) canvasArea.classList.toggle('is-memory-form-open', isSuppressed);
+        if (refs.canvasTopbar) {
+            if (isSuppressed) {
+                refs.canvasTopbar.dataset.previousAriaHidden = refs.canvasTopbar.getAttribute('aria-hidden') || '';
+                refs.canvasTopbar.setAttribute('aria-hidden', 'true');
+            } else {
+                const previousTopbarAriaHidden = refs.canvasTopbar.dataset.previousAriaHidden;
+                if (previousTopbarAriaHidden) {
+                    refs.canvasTopbar.setAttribute('aria-hidden', previousTopbarAriaHidden);
+                } else {
+                    refs.canvasTopbar.removeAttribute('aria-hidden');
+                }
+                delete refs.canvasTopbar.dataset.previousAriaHidden;
+            }
+        }
         if (!refs.canvasEmptyGuide) return;
         refs.canvasEmptyGuide.classList.toggle('editor-canvas-empty-guide-form-suppressed', isSuppressed);
         if (isSuppressed) {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-999">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1000">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -279,10 +279,10 @@
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
     <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>
-    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-999"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1000"></script>
     <script src="../js/editor/editor-memory-form-time.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1004"></script>
-    <script src="../js/editor/editor-memory-form.js?v=20260510-999"></script>
+    <script src="../js/editor/editor-memory-form.js?v=20260510-1000"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260504-624">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-999">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -93,51 +93,59 @@
             </div>
 
             <div id="addMemoryForm" class="memory-create-section editor-memory-form-modal" style="display:none;">
-                <div class="editor-modal-eyebrow" id="addMemoryFormEyebrow">첫 순간 시작</div>
-                <h3 class="headline editor-modal-title" id="addMemoryFormTitle">...</h3>
-                <p id="addMemoryFormIntro" class="editor-modal-intro">...</p>
-                <div class="editor-memory-mode-group" id="memoryInputModeGroup" aria-label="순간 입력 방식">
-                    <button type="button" class="editor-memory-mode-chip is-active" id="memoryModeLinkBtn" data-mode="link">
-                        <span class="material-symbols-outlined">smart_display</span>
-                        <span>링크로 시작</span>
-                    </button>
-                    <button type="button" class="editor-memory-mode-chip" id="memoryModeTextBtn" data-mode="text">
-                        <span class="material-symbols-outlined">edit_note</span>
-                        <span>텍스트로 시작</span>
-                    </button>
-                </div>
-                <div class="editor-form-support-note editor-form-support-note-hidden" id="memoryFormSupportNote" aria-hidden="true">
-                    <span class="material-symbols-outlined">info</span>
-                    <span id="memoryFormSupportNoteText">YouTube 링크가 있으면 대표 장면이 잡히고, 링크가 없어도 제목과 메모만으로 첫 순간을 시작할 수 있어요.</span>
-                </div>
-                <div class="editor-form-field editor-form-field-primary" id="memoryUrlField">
-                    <label id="memoryUrlLabel" class="editor-form-label">...</label>
-                    <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
-                </div>
-                <div class="editor-form-field" id="memoryStartTimeField">
-                    <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">입덕 순간 시간</label>
-                    <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23 또는 83초" class="editor-form-input">
-                    <p id="memoryStartTimeHint" class="editor-form-help">유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.</p>
-                </div>
-                <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
-                    <div class="memory-link-preview__thumb-wrap">
-                        <img class="memory-link-preview__thumb" id="memoryPreviewThumb" alt="">
-                        <div class="memory-link-preview__play-icon material-symbols-outlined">play_circle</div>
+                <div class="editor-memory-form-body">
+                    <div class="editor-modal-eyebrow" id="addMemoryFormEyebrow">첫 순간 시작</div>
+                    <h3 class="headline editor-modal-title" id="addMemoryFormTitle">...</h3>
+                    <p id="addMemoryFormIntro" class="editor-modal-intro">...</p>
+                    <div class="editor-memory-mode-group" id="memoryInputModeGroup" aria-label="순간 입력 방식">
+                        <button type="button" class="editor-memory-mode-chip is-active" id="memoryModeLinkBtn" data-mode="link">
+                            <span class="material-symbols-outlined">smart_display</span>
+                            <span>링크로 시작</span>
+                        </button>
+                        <button type="button" class="editor-memory-mode-chip" id="memoryModeTextBtn" data-mode="text">
+                            <span class="material-symbols-outlined">edit_note</span>
+                            <span>텍스트로 시작</span>
+                        </button>
                     </div>
-                    <div class="memory-link-preview__body">
-                        <span class="memory-link-preview__badge" id="memoryPreviewBadge">YouTube</span>
-                        <strong class="memory-link-preview__title" id="memoryPreviewTitle">영상 링크가 확인됐어요</strong>
-                        <p class="memory-link-preview__hint" id="memoryPreviewHint">이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.</p>
+                    <div class="editor-form-support-note editor-form-support-note-hidden" id="memoryFormSupportNote" aria-hidden="true">
+                        <span class="material-symbols-outlined">info</span>
+                        <span id="memoryFormSupportNoteText">YouTube 링크가 있으면 대표 장면이 잡히고, 링크가 없어도 제목과 메모만으로 첫 순간을 시작할 수 있어요.</span>
                     </div>
-                </div>
-                <div class="editor-form-field editor-form-field-grid">
-                    <div class="editor-form-stack editor-form-stack-compact">
-                        <label id="memoryTitleLabel" class="editor-form-label">...</label>
-                        <input type="text" id="memoryTitleInput" placeholder="..." class="editor-form-input">
+                    <div class="editor-form-field editor-form-field-primary" id="memoryUrlField">
+                        <label id="memoryUrlLabel" class="editor-form-label">...</label>
+                        <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
                     </div>
-                    <div class="editor-form-stack editor-form-stack-roomy">
-                        <label id="memoryMemoLabel" class="editor-form-label">...</label>
-                        <textarea id="memoryMemoInput" placeholder="..." rows="5" class="editor-form-textarea"></textarea>
+                    <div class="editor-video-segment-grid" id="memoryVideoSegmentGrid">
+                        <div class="editor-form-field editor-video-segment-field" id="memoryStartTimeField">
+                            <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">시작</label>
+                            <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23" class="editor-form-input">
+                            <p id="memoryStartTimeHint" class="editor-form-help">시작시간 자동 인식</p>
+                        </div>
+                        <div class="editor-form-field editor-video-segment-field" id="memoryEndTimeField">
+                            <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
+                            <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
+                        </div>
+                    </div>
+                    <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
+                        <div class="memory-link-preview__thumb-wrap">
+                            <img class="memory-link-preview__thumb" id="memoryPreviewThumb" alt="">
+                            <div class="memory-link-preview__play-icon material-symbols-outlined">play_circle</div>
+                        </div>
+                        <div class="memory-link-preview__body">
+                            <span class="memory-link-preview__badge" id="memoryPreviewBadge">YouTube</span>
+                            <strong class="memory-link-preview__title" id="memoryPreviewTitle">영상 링크가 확인됐어요</strong>
+                            <p class="memory-link-preview__hint" id="memoryPreviewHint">이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.</p>
+                        </div>
+                    </div>
+                    <div class="editor-form-field editor-form-field-grid">
+                        <div class="editor-form-stack editor-form-stack-compact">
+                            <label id="memoryTitleLabel" class="editor-form-label">...</label>
+                            <input type="text" id="memoryTitleInput" placeholder="..." class="editor-form-input">
+                        </div>
+                        <div class="editor-form-stack editor-form-stack-roomy">
+                            <label id="memoryMemoLabel" class="editor-form-label">...</label>
+                            <textarea id="memoryMemoInput" placeholder="..." rows="5" class="editor-form-textarea"></textarea>
+                        </div>
                     </div>
                 </div>
                 <div class="editor-form-actions">
@@ -270,11 +278,11 @@
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
-    <script src="../js/editor/editor-memory-form-mode.js?v=20260510-1004"></script>
-    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-999"></script>
     <script src="../js/editor/editor-memory-form-time.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1004"></script>
-    <script src="../js/editor/editor-memory-form.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form.js?v=20260510-999"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1004">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1005">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1001">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1002">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -124,7 +124,7 @@
                             <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
                             <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
                         </div>
-                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">공유 링크의 시작 시간이 자동 입력돼요.</p>
+                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">시작시간 포함 링크는 자동 입력돼요.</p>
                     </div>
                     <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
                         <div class="memory-link-preview__thumb-wrap">
@@ -279,7 +279,7 @@
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
     <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>
-    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1000"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1002"></script>
     <script src="../js/editor/editor-memory-form-time.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260510-1000"></script>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1002">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1003">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -124,7 +124,7 @@
                             <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
                             <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
                         </div>
-                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">시작시간 포함 링크는 자동 입력돼요.</p>
+                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">순간의 시작과 끝 시간을 입력하세요.</p>
                     </div>
                     <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
                         <div class="memory-link-preview__thumb-wrap">
@@ -279,7 +279,7 @@
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
     <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>
-    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1002"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1003"></script>
     <script src="../js/editor/editor-memory-form-time.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1004"></script>
     <script src="../js/editor/editor-memory-form.js?v=20260510-1000"></script>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1000">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1001">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -119,12 +119,12 @@
                         <div class="editor-form-field editor-video-segment-field" id="memoryStartTimeField">
                             <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">시작</label>
                             <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23" class="editor-form-input">
-                            <p id="memoryStartTimeHint" class="editor-form-help">시작시간 자동 인식</p>
                         </div>
                         <div class="editor-form-field editor-video-segment-field" id="memoryEndTimeField">
                             <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
                             <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
                         </div>
+                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">공유 링크의 시작 시간이 자동 입력돼요.</p>
                     </div>
                     <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
                         <div class="memory-link-preview__thumb-wrap">

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1003">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1004">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
## Summary

Refs #999

Simplifies the Editor first-moment modal UX:

- collapses redundant modal heading/intro copy at runtime
- changes the primary mode label from link wording to `영상으로 시작`
- keeps `텍스트로 시작` as the text mode
- applies pill-style visual treatment to modal section labels
- changes the video confirmation preview into a smaller, lower-emphasis `영상 링크 확인됨` state
- replaces the single start-time field presentation with a compact start/end video segment pair
- keeps end time optional and validates that it is later than the start time when both are present
- normalizes placeholder styling between inputs and textarea
- reduces modal padding/spacing to improve viewport fit

## Notes

The i18n source file was not changed in this PR. Runtime text is adjusted inside the Editor memory form module for the currently targeted Korean first-moment modal cleanup. A later i18n-only cleanup can move the new copy into translation entries if needed.

## Verification needed

- Browser verification required before ready/merge.
- Verify default empty video mode.
- Verify valid YouTube link state.
- Verify text mode.
- Verify start/end segment validation.
- Verify desktop viewport fit and mobile no-overflow smoke.

## Guardrails

- PR #7 untouched.
- prototype/reference/demo/variant paths untouched.
- No backend/API/DB/schema changes intended.