### PR TITLE
refactor(editor): split memory form helpers

### DIFF
--- a/js/editor/editor-memory-form-mode.js
+++ b/js/editor/editor-memory-form-mode.js
@@ -1,0 +1,70 @@
+(function() {
+    'use strict';
+
+    function setText(el, text) {
+        if (el) el.textContent = text;
+    }
+
+    function setInputMode(options) {
+        const {
+            mode,
+            isFirstMoment,
+            refs,
+            i18n,
+            hidePreview
+        } = options || {};
+        const currentMode = mode === 'text' ? 'text' : 'link';
+        const linkMode = currentMode === 'link';
+
+        if (refs?.modeLinkBtn) refs.modeLinkBtn.classList.toggle('is-active', linkMode);
+        if (refs?.modeTextBtn) refs.modeTextBtn.classList.toggle('is-active', !linkMode);
+        if (refs?.urlField) refs.urlField.classList.toggle('is-deemphasized', !linkMode);
+        if (refs?.startTimeField) refs.startTimeField.style.display = linkMode ? 'block' : 'none';
+        if (refs?.videoSegmentGrid) refs.videoSegmentGrid.style.display = linkMode ? 'grid' : 'none';
+
+        if (refs?.urlInput) {
+            refs.urlInput.placeholder = linkMode
+                ? 'https://www.youtube.com/watch?v=...'
+                : (i18n('editor_link_optional_placeholder') || '링크가 있다면 나중에 붙여도 괜찮아요');
+        }
+
+        setText(refs?.urlLabel, linkMode
+            ? (i18n('editor_youtube_link') || 'YouTube 장면 링크')
+            : (i18n('editor_optional_link') || '참고 링크 (선택)'));
+
+        if (refs?.formIntro) {
+            if (linkMode) {
+                refs.formIntro.textContent = isFirstMoment
+                    ? (i18n('editor_add_first_memory_intro') || '링크와 짧은 메모를 남기면 이 장면에서 러브트리가 시작돼요.')
+                    : (i18n('editor_add_next_memory_intro') || '현재 마음에서 이어진 장면을 붙여 트리를 더 자라게 해보세요.');
+            } else {
+                refs.formIntro.textContent = isFirstMoment
+                    ? (i18n('editor_add_first_memory_text_intro') || '링크 없이도 제목과 메모만으로 첫 순간을 심을 수 있어요.')
+                    : (i18n('editor_add_next_memory_text_intro') || '짧은 제목과 메모만으로도 이어진 순간을 남길 수 있어요.');
+            }
+        }
+
+        setText(refs?.supportNoteText, linkMode
+            ? (i18n('editor_link_mode_help') || '링크가 있으면 대표 장면과 썸네일이 잡혀요. 제목은 자동 제안 후 직접 다듬을 수 있어요.')
+            : (i18n('editor_text_mode_help') || '링크가 없어도 제목과 메모만으로 저장할 수 있어요. 카드에는 텍스트형 대표 순간이 표시돼요.'));
+
+        if (refs?.confirmBtn) {
+            if (linkMode) {
+                refs.confirmBtn.textContent = isFirstMoment
+                    ? (i18n('editor_confirm_add_first') || '첫 순간 심기')
+                    : (i18n('editor_confirm_add_next') || '이 순간 이어가기');
+            } else {
+                refs.confirmBtn.textContent = isFirstMoment
+                    ? (i18n('editor_confirm_add_first_text') || '이 마음으로 시작하기')
+                    : (i18n('editor_confirm_add_next_text') || '이 메모 이어붙이기');
+            }
+        }
+
+        if (!linkMode && typeof hidePreview === 'function') hidePreview();
+        return currentMode;
+    }
+
+    window.LoveBudEditorMemoryFormMode = {
+        setInputMode
+    };
+})();

--- a/js/editor/editor-memory-form-payload.js
+++ b/js/editor/editor-memory-form-payload.js
@@ -1,0 +1,168 @@
+(function() {
+    'use strict';
+
+    function todayDateString() {
+        const today = new Date();
+        return `${today.getFullYear()}.${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`;
+    }
+
+    function buildFallbackYouTubeSource(rawUrl, getYouTubeInputErrorMessage) {
+        const match = rawUrl.match(/(?:v=|\/|youtu\.be\/)([0-9A-Za-z_-]{11})/);
+        if (!match) {
+            return {
+                ok: false,
+                message: getYouTubeInputErrorMessage(rawUrl),
+                level: 'error'
+            };
+        }
+        const videoId = match[1];
+        return {
+            ok: true,
+            embedUrl: `https://www.youtube.com/embed/${videoId}`,
+            thumbnailUrl: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+        };
+    }
+
+    function buildMediaSource(options) {
+        const {
+            rawUrl,
+            startValue,
+            endValue,
+            userHasEditedStartTime,
+            getYouTubeInputErrorMessage
+        } = options || {};
+        if (!rawUrl) {
+            return {
+                ok: true,
+                embedUrl: '',
+                thumbnailUrl: '',
+                sourceType: 'other',
+                sourceLabel: ''
+            };
+        }
+
+        const media = window.LoveBudMedia || {};
+        if (typeof media.extractYouTubeId !== 'function') {
+            console.warn('[editor] LoveBudMedia not loaded, using fallback YouTube parsing');
+            const fallback = buildFallbackYouTubeSource(rawUrl, getYouTubeInputErrorMessage);
+            if (!fallback.ok) return fallback;
+            return {
+                ...fallback,
+                sourceType: 'youtube',
+                sourceLabel: 'YouTube'
+            };
+        }
+
+        const videoId = media.extractYouTubeId(rawUrl);
+        if (!videoId) {
+            return {
+                ok: false,
+                message: getYouTubeInputErrorMessage(rawUrl),
+                level: 'error'
+            };
+        }
+
+        const time = window.LoveBudEditorMemoryFormTime || {};
+        const startSeconds = typeof time.resolveStartSeconds === 'function'
+            ? time.resolveStartSeconds({ rawUrl, startValue, userHasEditedStartTime })
+            : null;
+        const endCheck = typeof time.validateEndTime === 'function'
+            ? time.validateEndTime({ rawEndTime: endValue, startSeconds })
+            : { ok: true, endSeconds: null };
+        if (!endCheck.ok) {
+            return {
+                ok: false,
+                message: endCheck.message,
+                level: 'warn'
+            };
+        }
+
+        let embedUrl = media.getEmbedUrl(rawUrl, 'youtube', { startSeconds });
+        if (embedUrl && endCheck.endSeconds) {
+            const parsedEmbed = new URL(embedUrl);
+            parsedEmbed.searchParams.set('end', String(endCheck.endSeconds));
+            embedUrl = parsedEmbed.toString();
+        }
+
+        return {
+            ok: true,
+            embedUrl,
+            thumbnailUrl: media.getThumbnailUrl(rawUrl, 'youtube', 'mqdefault'),
+            sourceType: 'youtube',
+            sourceLabel: 'YouTube'
+        };
+    }
+
+    function buildMemoryPayload(options) {
+        const {
+            refs,
+            currentInputMode,
+            userHasEditedStartTime,
+            i18n,
+            treeId,
+            getYouTubeInputErrorMessage,
+            getTreeMemories,
+            resolveParentIdForCreate,
+            getSelectedNodeId,
+            getCanonicalRootId
+        } = options || {};
+        const rawUrl = refs?.urlInput ? refs.urlInput.value.trim() : '';
+        const titleValue = refs?.titleInput ? refs.titleInput.value.trim() : '';
+        const memoValue = refs?.memoInput ? refs.memoInput.value.trim() : '';
+        const usingLinkMode = currentInputMode === 'link';
+
+        if (usingLinkMode && !rawUrl) {
+            return {
+                ok: false,
+                message: i18n('enter_youtube'),
+                level: 'warn'
+            };
+        }
+
+        if (!usingLinkMode && !titleValue && !memoValue) {
+            return {
+                ok: false,
+                message: i18n('editor_enter_text_moment') || '제목이나 메모를 한 줄 이상 남겨 주세요.',
+                level: 'warn'
+            };
+        }
+
+        const mediaSource = buildMediaSource({
+            rawUrl,
+            startValue: refs?.startTimeInput?.value,
+            endValue: refs?.endTimeInput?.value,
+            userHasEditedStartTime,
+            getYouTubeInputErrorMessage
+        });
+        if (!mediaSource.ok) return mediaSource;
+
+        const memories = getTreeMemories();
+        const isFirstMoment = !memories || memories.length === 0;
+        const defaultTitle = isFirstMoment
+            ? (i18n('editor_default_first_title') || '첫 순간')
+            : (i18n('editor_default_next_title') || '이어진 순간');
+
+        return {
+            ok: true,
+            data: {
+                treeId,
+                title: titleValue || defaultTitle,
+                memo: memoValue || '',
+                timestamp: todayDateString(),
+                sourceUrl: mediaSource.embedUrl,
+                sourceType: mediaSource.sourceType,
+                emotionTags: [],
+                parentId: resolveParentIdForCreate(getSelectedNodeId(), getCanonicalRootId()),
+                thumbnail: mediaSource.thumbnailUrl,
+                artist: '',
+                source: mediaSource.sourceLabel,
+                visibility: 'public'
+            }
+        };
+    }
+
+    window.LoveBudEditorMemoryFormPayload = {
+        buildMediaSource,
+        buildMemoryPayload
+    };
+})();

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -1,0 +1,166 @@
+(function() {
+    'use strict';
+
+    function applyPreviewStyles(refs) {
+        const preview = refs?.preview || document.getElementById('memoryLinkPreview');
+        if (!preview) return;
+        preview.classList.add('is-enhanced');
+        preview.style.display = 'flex';
+        preview.style.alignItems = 'stretch';
+        preview.style.gap = '14px';
+        preview.style.padding = '14px';
+        preview.style.borderRadius = '20px';
+        preview.style.background = 'linear-gradient(180deg, rgba(245, 241, 238, 0.98), rgba(255,255,255,0.98))';
+        preview.style.border = '1px solid rgba(144,73,81,0.10)';
+        preview.style.marginTop = '8px';
+        preview.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+
+        const thumbWrap = refs?.thumbWrap || preview.querySelector('.memory-link-preview__thumb-wrap');
+        if (thumbWrap) {
+            thumbWrap.style.position = 'relative';
+            thumbWrap.style.width = '136px';
+            thumbWrap.style.minWidth = '136px';
+            thumbWrap.style.height = '76px';
+            thumbWrap.style.borderRadius = '14px';
+            thumbWrap.style.overflow = 'hidden';
+            thumbWrap.style.background = 'var(--surface-container, #ece9e5)';
+            thumbWrap.style.boxShadow = '0 8px 20px rgba(75,64,57,0.08)';
+        }
+
+        if (refs?.thumb) {
+            refs.thumb.style.width = '100%';
+            refs.thumb.style.height = '100%';
+            refs.thumb.style.objectFit = 'cover';
+        }
+
+        const playIcon = refs?.playIcon || preview.querySelector('.memory-link-preview__play-icon');
+        if (playIcon) {
+            playIcon.style.position = 'absolute';
+            playIcon.style.top = '50%';
+            playIcon.style.left = '50%';
+            playIcon.style.transform = 'translate(-50%, -50%)';
+            playIcon.style.fontSize = '32px';
+            playIcon.style.color = '#fff';
+            playIcon.style.opacity = '0.92';
+            playIcon.style.textShadow = '0 2px 8px rgba(0,0,0,0.3)';
+        }
+
+        const body = refs?.previewBody || preview.querySelector('.memory-link-preview__body');
+        if (body) {
+            body.style.flex = '1';
+            body.style.display = 'flex';
+            body.style.flexDirection = 'column';
+            body.style.gap = '6px';
+            body.style.minWidth = '0';
+        }
+
+        if (refs?.badge) {
+            refs.badge.style.display = 'inline-flex';
+            refs.badge.style.alignItems = 'center';
+            refs.badge.style.padding = '4px 9px';
+            refs.badge.style.borderRadius = '999px';
+            refs.badge.style.background = 'rgba(144, 73, 81, 0.1)';
+            refs.badge.style.color = 'var(--primary, #904951)';
+            refs.badge.style.fontSize = '10px';
+            refs.badge.style.fontWeight = '700';
+            refs.badge.style.letterSpacing = '0.03em';
+            refs.badge.style.textTransform = 'uppercase';
+            refs.badge.style.width = 'fit-content';
+        }
+
+        if (refs?.previewTitle) {
+            refs.previewTitle.style.fontSize = '0.95rem';
+            refs.previewTitle.style.fontWeight = '700';
+            refs.previewTitle.style.color = 'var(--on-surface, #333)';
+            refs.previewTitle.style.lineHeight = '1.4';
+            refs.previewTitle.style.overflow = 'hidden';
+            refs.previewTitle.style.textOverflow = 'ellipsis';
+            refs.previewTitle.style.whiteSpace = 'nowrap';
+        }
+
+        if (refs?.previewHint) {
+            refs.previewHint.style.fontSize = '0.8rem';
+            refs.previewHint.style.color = 'var(--on-surface-variant, #666)';
+            refs.previewHint.style.lineHeight = '1.6';
+            refs.previewHint.style.margin = '0';
+        }
+    }
+
+    function hide(refs) {
+        const preview = refs?.preview || document.getElementById('memoryLinkPreview');
+        if (!preview) return;
+        preview.classList.add('is-hidden');
+        preview.classList.remove('is-enhanced');
+    }
+
+    function update(options) {
+        const {
+            currentInputMode,
+            refs,
+            i18n,
+            isFirstMoment,
+            userHasEditedTitle,
+            userHasEditedStartTime
+        } = options || {};
+        if (currentInputMode !== 'link') {
+            hide(refs);
+            return;
+        }
+
+        const url = refs?.urlInput ? refs.urlInput.value.trim() : '';
+        const media = window.LoveBudMedia || {};
+        const videoId = typeof media.extractYouTubeId === 'function'
+            ? (media.extractYouTubeId(url) || '')
+            : '';
+
+        if (!videoId) {
+            hide(refs);
+            return;
+        }
+
+        if (refs?.preview) refs.preview.classList.remove('is-hidden');
+        applyPreviewStyles(refs);
+
+        if (refs?.thumb) {
+            refs.thumb.src = typeof media.getThumbnailUrl === 'function'
+                ? (media.getThumbnailUrl(url) || `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`)
+                : `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+        }
+
+        if (!userHasEditedTitle && refs?.titleInput) {
+            refs.titleInput.value = isFirstMoment
+                ? (i18n('editor_default_first_title') || '첫 순간')
+                : (i18n('editor_default_next_title') || '이어진 순간');
+        }
+
+        const time = window.LoveBudEditorMemoryFormTime || {};
+        const startSeconds = typeof time.resolveStartSeconds === 'function'
+            ? time.resolveStartSeconds({
+                rawUrl: url,
+                startValue: refs?.startTimeInput?.value,
+                userHasEditedStartTime
+            })
+            : null;
+        const formatted = typeof time.formatStartTime === 'function'
+            ? time.formatStartTime(startSeconds)
+            : '';
+
+        if (refs?.previewHint && formatted) {
+            refs.previewHint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
+        } else if (refs?.previewHint) {
+            refs.previewHint.textContent = i18n('editor_preview_hint') || '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
+        }
+
+        if (refs?.startTimeHint) {
+            refs.startTimeHint.textContent = formatted
+                ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
+                : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
+        }
+    }
+
+    window.LoveBudEditorMemoryFormPreview = {
+        applyPreviewStyles,
+        hide,
+        update
+    };
+})();

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -148,7 +148,7 @@
         if (refs?.previewHint && formatted) {
             refs.previewHint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
         } else if (refs?.previewHint) {
-            refs.previewHint.textContent = i18n('editor_preview_hint') || '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
+            refs.previewHint.textContent = '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
         }
 
         if (refs?.startTimeHint) {

--- a/js/editor/editor-memory-form-time.js
+++ b/js/editor/editor-memory-form-time.js
@@ -1,0 +1,72 @@
+(function() {
+    'use strict';
+
+    function getMedia() {
+        return window.LoveBudMedia || {};
+    }
+
+    function parseTime(value) {
+        const media = getMedia();
+        if (typeof media.parseYouTubeTimeToSeconds !== 'function') return null;
+        return media.parseYouTubeTimeToSeconds(value);
+    }
+
+    function extractStartSeconds(url) {
+        const media = getMedia();
+        if (typeof media.extractYouTubeStartSeconds !== 'function') return null;
+        return media.extractYouTubeStartSeconds(url);
+    }
+
+    function formatStartTime(seconds) {
+        const media = getMedia();
+        if (typeof media.formatYouTubeStartTime !== 'function') return '';
+        return media.formatYouTubeStartTime(seconds);
+    }
+
+    function resolveStartSeconds(options) {
+        const { rawUrl, startValue, userHasEditedStartTime } = options || {};
+        return userHasEditedStartTime ? parseTime(startValue) : extractStartSeconds(rawUrl);
+    }
+
+    function autofillStartFromUrl(options) {
+        const { rawUrl, startTimeInput, userHasEditedStartTime } = options || {};
+        if (!startTimeInput || userHasEditedStartTime) return;
+        const fromUrl = extractStartSeconds(rawUrl);
+        startTimeInput.value = fromUrl ? formatStartTime(fromUrl) : '';
+    }
+
+    function validateEndTime(options) {
+        const {
+            rawEndTime,
+            startSeconds,
+            invalidMessage,
+            rangeMessage
+        } = options || {};
+        const value = String(rawEndTime || '').trim();
+        if (!value) return { ok: true, endSeconds: null };
+
+        const endSeconds = parseTime(value);
+        if (!endSeconds) {
+            return {
+                ok: false,
+                message: invalidMessage || '끝 시간을 다시 확인해 주세요.'
+            };
+        }
+        if (startSeconds && endSeconds <= startSeconds) {
+            return {
+                ok: false,
+                message: rangeMessage || '끝 시간은 시작 시간보다 뒤여야 해요.'
+            };
+        }
+        return { ok: true, endSeconds };
+    }
+
+    window.LoveBudEditorMemoryFormTime = {
+        parseTime,
+        extractStartSeconds,
+        formatStartTime,
+        resolveStartSeconds,
+        autofillStartFromUrl,
+        validateEndTime
+    };
+})();

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -361,6 +361,12 @@ function createEditorMemoryForm(deps) {
     }
 
     const addMemoryFromForm = async () => {
+        if (!payloadHelper || typeof payloadHelper.buildMemoryPayload !== 'function') {
+            console.error('[editor] memory form payload helper is not loaded');
+            showToast(i18n('save_failed') || '저장 준비에 실패했어요. 페이지를 새로고침해 주세요.', 'error');
+            return;
+        }
+
         const payloadResult = payloadHelper.buildMemoryPayload({
             refs,
             currentInputMode,

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -13,7 +13,6 @@ function createEditorMemoryForm(deps) {
         getTreeMemories,
         setTreeMemories,
         setLocalSaveMode,
-        getLocalSaveMode,
         drawNode,
         drawBranch,
         calcPosition,
@@ -23,214 +22,126 @@ function createEditorMemoryForm(deps) {
         selectNode,
         treeMemories,
         setCachedMemories,
-        canvasArea,
         rerenderCanvas,
         focusNodeById
     } = deps;
+
+    const modeHelper = window.LoveBudEditorMemoryFormMode;
+    const previewHelper = window.LoveBudEditorMemoryFormPreview;
+    const timeHelper = window.LoveBudEditorMemoryFormTime;
+    const payloadHelper = window.LoveBudEditorMemoryFormPayload;
 
     let isFormOpen = false;
     let escHandler = null;
     let outsideClickHandler = null;
     let previewInputHandler = null;
     let startTimeInputHandler = null;
+    let endTimeInputHandler = null;
     let currentInputMode = 'link';
     let userHasEditedStartTime = false;
+    let userHasEditedTitle = false;
 
+    const refs = {
+        addMemoryForm: document.getElementById('addMemoryForm'),
+        urlInput: document.getElementById('memoryUrlInput'),
+        titleInput: document.getElementById('memoryTitleInput'),
+        memoInput: document.getElementById('memoryMemoInput'),
+        urlField: document.getElementById('memoryUrlField'),
+        modeLinkBtn: document.getElementById('memoryModeLinkBtn'),
+        modeTextBtn: document.getElementById('memoryModeTextBtn'),
+        supportNoteText: document.getElementById('memoryFormSupportNoteText'),
+        startTimeField: document.getElementById('memoryStartTimeField'),
+        videoSegmentGrid: document.getElementById('memoryVideoSegmentGrid'),
+        startTimeInput: document.getElementById('memoryStartTimeInput'),
+        startTimeHint: document.getElementById('memoryStartTimeHint'),
+        endTimeInput: document.getElementById('memoryEndTimeInput'),
+        formEyebrow: document.getElementById('addMemoryFormEyebrow'),
+        formTitle: document.getElementById('addMemoryFormTitle'),
+        formIntro: document.getElementById('addMemoryFormIntro'),
+        urlLabel: document.getElementById('memoryUrlLabel'),
+        titleLabel: document.getElementById('memoryTitleLabel'),
+        memoLabel: document.getElementById('memoryMemoLabel'),
+        confirmBtn: document.getElementById('confirmAddMemory'),
+        preview: document.getElementById('memoryLinkPreview'),
+        thumb: document.getElementById('memoryPreviewThumb'),
+        thumbWrap: document.querySelector('#memoryLinkPreview .memory-link-preview__thumb-wrap'),
+        playIcon: document.querySelector('#memoryLinkPreview .memory-link-preview__play-icon'),
+        previewBody: document.querySelector('#memoryLinkPreview .memory-link-preview__body'),
+        badge: document.getElementById('memoryPreviewBadge'),
+        previewTitle: document.getElementById('memoryPreviewTitle'),
+        previewHint: document.getElementById('memoryPreviewHint')
+    };
 
-    const addMemoryForm = document.getElementById('addMemoryForm');
-    const urlInput = document.getElementById('memoryUrlInput');
-    const titleInput = document.getElementById('memoryTitleInput');
-    const memoInput = document.getElementById('memoryMemoInput');
-    const urlField = document.getElementById('memoryUrlField');
-    const modeLinkBtn = document.getElementById('memoryModeLinkBtn');
-    const modeTextBtn = document.getElementById('memoryModeTextBtn');
-    const supportNoteText = document.getElementById('memoryFormSupportNoteText');
-    const startTimeField = document.getElementById('memoryStartTimeField');
-    const startTimeInput = document.getElementById('memoryStartTimeInput');
-    const startTimeHint = document.getElementById('memoryStartTimeHint');
-
-
-    const formInputs = [urlInput, startTimeInput, titleInput, memoInput].filter(Boolean);
-
-    function applyFormOpenStyles() {
-        if (!addMemoryForm) return;
-        addMemoryForm.style.display = 'block';
-        addMemoryForm.classList.add('is-open');
-        addMemoryForm.style.position = 'absolute';
-        addMemoryForm.style.left = '50%';
-        addMemoryForm.style.top = '42px';
-        addMemoryForm.style.transform = 'translateX(-50%)';
-        addMemoryForm.style.width = 'min(620px, calc(100% - 48px))';
-        addMemoryForm.style.maxWidth = '620px';
-        addMemoryForm.style.padding = '28px 28px 24px';
-        addMemoryForm.style.borderRadius = '30px';
-        addMemoryForm.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.985), rgba(250,246,244,0.97))';
-        addMemoryForm.style.boxShadow = '0 24px 56px rgba(75,64,57,0.14)';
-        addMemoryForm.style.border = '1px solid rgba(144,73,81,0.10)';
-        addMemoryForm.style.zIndex = '8';
-        addMemoryForm.style.backdropFilter = 'blur(12px)';
+    function getFormInputs() {
+        return [
+            refs.urlInput,
+            refs.startTimeInput,
+            refs.endTimeInput,
+            refs.titleInput,
+            refs.memoInput
+        ].filter(Boolean);
     }
 
-    function applyPreviewStyles() {
-        const preview = document.getElementById('memoryLinkPreview');
-        if (!preview) return;
-        preview.classList.add('is-enhanced');
-        preview.style.display = 'flex';
-        preview.style.alignItems = 'stretch';
-        preview.style.gap = '14px';
-        preview.style.padding = '14px';
-        preview.style.borderRadius = '20px';
-        preview.style.background = 'linear-gradient(180deg, rgba(245, 241, 238, 0.98), rgba(255,255,255,0.98))';
-        preview.style.border = '1px solid rgba(144,73,81,0.10)';
-        preview.style.marginTop = '8px';
-        preview.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+    function setText(el, text) {
+        if (el) el.textContent = text;
+    }
 
-        const thumbWrap = preview.querySelector('.memory-link-preview__thumb-wrap');
-        if (thumbWrap) {
-            thumbWrap.style.position = 'relative';
-            thumbWrap.style.width = '136px';
-            thumbWrap.style.minWidth = '136px';
-            thumbWrap.style.height = '76px';
-            thumbWrap.style.borderRadius = '14px';
-            thumbWrap.style.overflow = 'hidden';
-            thumbWrap.style.background = 'var(--surface-container, #ece9e5)';
-            thumbWrap.style.boxShadow = '0 8px 20px rgba(75,64,57,0.08)';
-        }
-
-        const thumb = document.getElementById('memoryPreviewThumb');
-        if (thumb) {
-            thumb.style.width = '100%';
-            thumb.style.height = '100%';
-            thumb.style.objectFit = 'cover';
-        }
-
-        const playIcon = preview.querySelector('.memory-link-preview__play-icon');
-        if (playIcon) {
-            playIcon.style.position = 'absolute';
-            playIcon.style.top = '50%';
-            playIcon.style.left = '50%';
-            playIcon.style.transform = 'translate(-50%, -50%)';
-            playIcon.style.fontSize = '32px';
-            playIcon.style.color = '#fff';
-            playIcon.style.opacity = '0.92';
-            playIcon.style.textShadow = '0 2px 8px rgba(0,0,0,0.3)';
-        }
-
-        const body = preview.querySelector('.memory-link-preview__body');
-        if (body) {
-            body.style.flex = '1';
-            body.style.display = 'flex';
-            body.style.flexDirection = 'column';
-            body.style.gap = '6px';
-            body.style.minWidth = '0';
-        }
-
-        const badge = document.getElementById('memoryPreviewBadge');
-        if (badge) {
-            badge.style.display = 'inline-flex';
-            badge.style.alignItems = 'center';
-            badge.style.padding = '4px 9px';
-            badge.style.borderRadius = '999px';
-            badge.style.background = 'rgba(144, 73, 81, 0.1)';
-            badge.style.color = 'var(--primary, #904951)';
-            badge.style.fontSize = '10px';
-            badge.style.fontWeight = '700';
-            badge.style.letterSpacing = '0.03em';
-            badge.style.textTransform = 'uppercase';
-            badge.style.width = 'fit-content';
-        }
-
-        const title = document.getElementById('memoryPreviewTitle');
-        if (title) {
-            title.style.fontSize = '0.95rem';
-            title.style.fontWeight = '700';
-            title.style.color = 'var(--on-surface, #333)';
-            title.style.lineHeight = '1.4';
-            title.style.overflow = 'hidden';
-            title.style.textOverflow = 'ellipsis';
-            title.style.whiteSpace = 'nowrap';
-        }
-
-        const hint = document.getElementById('memoryPreviewHint');
-        if (hint) {
-            hint.style.fontSize = '0.8rem';
-            hint.style.color = 'var(--on-surface-variant, #666)';
-            hint.style.lineHeight = '1.6';
-            hint.style.margin = '0';
-        }
+    function applyFormOpenStyles() {
+        const form = refs.addMemoryForm;
+        if (!form) return;
+        form.style.display = 'block';
+        form.classList.add('is-open');
+        form.style.position = 'absolute';
+        form.style.left = '50%';
+        form.style.top = '42px';
+        form.style.transform = 'translateX(-50%)';
+        form.style.width = 'min(620px, calc(100% - 48px))';
+        form.style.maxWidth = '620px';
+        form.style.padding = '28px 28px 24px';
+        form.style.borderRadius = '30px';
+        form.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.985), rgba(250,246,244,0.97))';
+        form.style.boxShadow = '0 24px 56px rgba(75,64,57,0.14)';
+        form.style.border = '1px solid rgba(144,73,81,0.10)';
+        form.style.zIndex = '8';
+        form.style.backdropFilter = 'blur(12px)';
     }
 
     function hideLinkPreview() {
-        const preview = document.getElementById('memoryLinkPreview');
-        if (preview) {
-            preview.classList.add('is-hidden');
-            preview.classList.remove('is-enhanced');
+        if (previewHelper && typeof previewHelper.hide === 'function') {
+            previewHelper.hide(refs);
+        }
+    }
+
+    function updatePreview(isFirstMoment) {
+        if (previewHelper && typeof previewHelper.update === 'function') {
+            previewHelper.update({
+                currentInputMode,
+                refs,
+                i18n,
+                isFirstMoment,
+                userHasEditedTitle,
+                userHasEditedStartTime
+            });
         }
     }
 
     function setInputMode(mode, isFirstMoment) {
+        if (modeHelper && typeof modeHelper.setInputMode === 'function') {
+            currentInputMode = modeHelper.setInputMode({
+                mode,
+                isFirstMoment,
+                refs,
+                i18n,
+                hidePreview: hideLinkPreview
+            });
+            return;
+        }
         currentInputMode = mode === 'text' ? 'text' : 'link';
-        const linkMode = currentInputMode === 'link';
-
-        if (modeLinkBtn) modeLinkBtn.classList.toggle('is-active', linkMode);
-        if (modeTextBtn) modeTextBtn.classList.toggle('is-active', !linkMode);
-        if (urlField) urlField.classList.toggle('is-deemphasized', !linkMode);
-        if (startTimeField) startTimeField.style.display = linkMode ? 'block' : 'none';
-
-
-        const urlLabel = document.getElementById('memoryUrlLabel');
-        const formIntro = document.getElementById('addMemoryFormIntro');
-        const confirmBtn = document.getElementById('confirmAddMemory');
-
-        if (urlInput) {
-            urlInput.placeholder = linkMode
-                ? 'https://www.youtube.com/watch?v=...'
-                : (i18n('editor_link_optional_placeholder') || '링크가 있다면 나중에 붙여도 괜찮아요');
-        }
-
-        if (urlLabel) {
-            urlLabel.textContent = linkMode
-                ? (i18n('editor_youtube_link') || 'YouTube 장면 링크')
-                : (i18n('editor_optional_link') || '참고 링크 (선택)');
-        }
-
-        if (formIntro) {
-            if (linkMode) {
-                formIntro.textContent = isFirstMoment
-                    ? (i18n('editor_add_first_memory_intro') || '링크와 짧은 메모를 남기면 이 장면에서 러브트리가 시작돼요.')
-                    : (i18n('editor_add_next_memory_intro') || '현재 마음에서 이어진 장면을 붙여 트리를 더 자라게 해보세요.');
-            } else {
-                formIntro.textContent = isFirstMoment
-                    ? (i18n('editor_add_first_memory_text_intro') || '링크 없이도 제목과 메모만으로 첫 순간을 심을 수 있어요.')
-                    : (i18n('editor_add_next_memory_text_intro') || '짧은 제목과 메모만으로도 이어진 순간을 남길 수 있어요.');
-            }
-        }
-
-        if (supportNoteText) {
-            supportNoteText.textContent = linkMode
-                ? (i18n('editor_link_mode_help') || '링크가 있으면 대표 장면과 썸네일이 잡혀요. 제목은 자동 제안 후 직접 다듬을 수 있어요.')
-                : (i18n('editor_text_mode_help') || '링크가 없어도 제목과 메모만으로 저장할 수 있어요. 카드에는 텍스트형 대표 순간이 표시돼요.');
-        }
-
-        if (confirmBtn) {
-            if (linkMode) {
-                confirmBtn.textContent = isFirstMoment
-                    ? (i18n('editor_confirm_add_first') || '첫 순간 심기')
-                    : (i18n('editor_confirm_add_next') || '이 순간 이어가기');
-            } else {
-                confirmBtn.textContent = isFirstMoment
-                    ? (i18n('editor_confirm_add_first_text') || '이 마음으로 시작하기')
-                    : (i18n('editor_confirm_add_next_text') || '이 메모 이어붙이기');
-            }
-        }
-
-        if (!linkMode) {
-            hideLinkPreview();
-        }
     }
 
     const focusTrap = (e) => {
         if (!isFormOpen) return;
+        const formInputs = getFormInputs();
         if (e.key !== 'Tab' || formInputs.length === 0) return;
 
         const focused = document.activeElement;
@@ -246,54 +157,86 @@ function createEditorMemoryForm(deps) {
         }
     };
 
-    const showAddMemoryForm = () => {
-        if (!addMemoryForm) return;
-        if (urlInput) urlInput.value = '';
-        if (startTimeInput) startTimeInput.value = '';
+    function resetFormValues() {
+        if (refs.urlInput) refs.urlInput.value = '';
+        if (refs.startTimeInput) refs.startTimeInput.value = '';
+        if (refs.endTimeInput) refs.endTimeInput.value = '';
+        if (refs.titleInput) refs.titleInput.value = '';
+        if (refs.memoInput) refs.memoInput.value = '';
         userHasEditedStartTime = false;
-
-        if (titleInput) titleInput.value = '';
-        if (memoInput) memoInput.value = '';
-
+        userHasEditedTitle = false;
         hideLinkPreview();
+    }
 
+    function applyOpenCopy(isFirstMoment) {
+        setText(refs.formEyebrow, isFirstMoment
+            ? (i18n('editor_add_first_memory') || '첫 순간 심기')
+            : (i18n('editor_add_next_memory') || '새 순간 이어가기'));
+        setText(refs.formTitle, isFirstMoment
+            ? (i18n('editor_add_first_memory_title') || '이 트리의 첫 순간을 심어볼까요?')
+            : (i18n('editor_add_next_memory_title') || '어떤 순간이 이어졌나요?'));
+        setText(refs.urlLabel, i18n('editor_youtube_link') || 'YouTube 장면 링크');
+        setText(refs.titleLabel, i18n('editor_memory_title') || '순간 제목');
+        setText(refs.memoLabel, i18n('editor_memory_memo_optional') || '감정 메모');
+    }
+
+    function bindPreviewEvents(isFirstMoment) {
+        if (refs.urlInput) {
+            if (previewInputHandler) refs.urlInput.removeEventListener('input', previewInputHandler);
+            previewInputHandler = () => {
+                const url = refs.urlInput.value.trim();
+                if (timeHelper && typeof timeHelper.autofillStartFromUrl === 'function') {
+                    timeHelper.autofillStartFromUrl({
+                        rawUrl: url,
+                        startTimeInput: refs.startTimeInput,
+                        userHasEditedStartTime
+                    });
+                }
+                updatePreview(isFirstMoment);
+            };
+            refs.urlInput.addEventListener('input', previewInputHandler);
+        }
+
+        if (refs.startTimeInput) {
+            if (startTimeInputHandler) refs.startTimeInput.removeEventListener('input', startTimeInputHandler);
+            startTimeInputHandler = () => {
+                userHasEditedStartTime = true;
+                updatePreview(isFirstMoment);
+            };
+            refs.startTimeInput.addEventListener('input', startTimeInputHandler);
+        }
+
+        if (refs.endTimeInput) {
+            if (endTimeInputHandler) refs.endTimeInput.removeEventListener('input', endTimeInputHandler);
+            endTimeInputHandler = () => updatePreview(isFirstMoment);
+            refs.endTimeInput.addEventListener('input', endTimeInputHandler);
+        }
+
+        if (refs.titleInput) {
+            refs.titleInput.addEventListener('input', function() {
+                userHasEditedTitle = true;
+            }, { once: true });
+        }
+    }
+
+    const showAddMemoryForm = () => {
+        const form = refs.addMemoryForm;
+        if (!form) return;
+        resetFormValues();
         applyFormOpenStyles();
         isFormOpen = true;
 
         const memories = getTreeMemories();
         const isFirstMoment = !memories || memories.length === 0;
 
-        const formEyebrow = document.getElementById('addMemoryFormEyebrow');
-        const formTitle = document.getElementById('addMemoryFormTitle');
-        const urlLabel = document.getElementById('memoryUrlLabel');
-        const titleLabel = document.getElementById('memoryTitleLabel');
-        const memoLabel = document.getElementById('memoryMemoLabel');
-
-        if (formEyebrow) {
-            formEyebrow.textContent = isFirstMoment
-                ? (i18n('editor_add_first_memory') || '첫 순간 심기')
-                : (i18n('editor_add_next_memory') || '새 순간 이어가기');
-        }
-        if (formTitle) {
-            formTitle.textContent = isFirstMoment
-                ? (i18n('editor_add_first_memory_title') || '이 트리의 첫 순간을 심어볼까요?')
-                : (i18n('editor_add_next_memory_title') || '어떤 순간이 이어졌나요?');
-        }
-        if (urlLabel) urlLabel.textContent = i18n('editor_youtube_link') || 'YouTube 장면 링크';
-        if (titleLabel) titleLabel.textContent = i18n('editor_memory_title') || '순간 제목';
-        if (memoLabel) memoLabel.textContent = i18n('editor_memory_memo_optional') || '감정 메모';
-
+        applyOpenCopy(isFirstMoment);
         setInputMode('link', isFirstMoment);
 
-        if (modeLinkBtn) {
-            modeLinkBtn.onclick = () => setInputMode('link', isFirstMoment);
-        }
-        if (modeTextBtn) {
-            modeTextBtn.onclick = () => setInputMode('text', isFirstMoment);
-        }
+        if (refs.modeLinkBtn) refs.modeLinkBtn.onclick = () => setInputMode('link', isFirstMoment);
+        if (refs.modeTextBtn) refs.modeTextBtn.onclick = () => setInputMode('text', isFirstMoment);
 
         document.addEventListener('keydown', focusTrap);
-        if (urlInput) urlInput.focus();
+        if (refs.urlInput) refs.urlInput.focus();
 
         escHandler = (e) => {
             if (e.key === 'Escape') {
@@ -305,116 +248,22 @@ function createEditorMemoryForm(deps) {
 
         outsideClickHandler = (e) => {
             const target = e.target;
-            if (addMemoryForm.contains(target)) return;
+            if (form.contains(target)) return;
             if (target.closest('#addMemoryBtn')) return;
             if (target.closest('.memory-add-affordance')) return;
             if (target.closest('#detailEmptyStartBtn')) return;
             hideAddMemoryForm();
         };
+        setTimeout(() => document.addEventListener('click', outsideClickHandler, true), 0);
 
-        setTimeout(() => {
-            document.addEventListener('click', outsideClickHandler, true);
-        }, 0);
-
-        let userHasEditedTitle = false;
-        if (titleInput) {
-            titleInput.addEventListener('input', function() {
-                userHasEditedTitle = true;
-            }, { once: true });
-        }
-
-        const updatePreview = function() {
-            if (currentInputMode !== 'link') {
-                hideLinkPreview();
-                return;
-            }
-
-            const previewInner = document.getElementById('memoryLinkPreview');
-            if (!previewInner) return;
-
-            const url = urlInput ? urlInput.value.trim() : '';
-            let videoId = '';
-
-            if (window.LoveBudMedia?.extractYouTubeId) {
-                videoId = window.LoveBudMedia.extractYouTubeId(url) || '';
-            }
-
-            if (videoId) {
-                previewInner.classList.remove('is-hidden');
-                applyPreviewStyles();
-
-                const thumb = document.getElementById('memoryPreviewThumb');
-                if (thumb) {
-                    thumb.src = window.LoveBudMedia?.getThumbnailUrl(url) || `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-                }
-
-                if (!userHasEditedTitle && titleInput) {
-                    const defaultTitle = isFirstMoment
-                        ? (i18n('editor_default_first_title') || '첫 순간')
-                        : (i18n('editor_default_next_title') || '이어진 순간');
-                    titleInput.value = defaultTitle;
-                }
-
-                // 시작 시간 힌트 업데이트
-                const hint = document.getElementById('memoryPreviewHint');
-
-                // Fix 3 Policy: userHasEditedStartTime === true 이면 수동 입력값만 우선
-                let startSeconds = null;
-                if (userHasEditedStartTime) {
-                    startSeconds = window.LoveBudMedia?.parseYouTubeTimeToSeconds(startTimeInput?.value);
-                } else {
-                    startSeconds = window.LoveBudMedia?.extractYouTubeStartSeconds(url);
-                }
-
-                const formatted = window.LoveBudMedia?.formatYouTubeStartTime(startSeconds);
-
-                if (hint && formatted) {
-                    hint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 트리에 심어 주세요.`;
-                } else if (hint) {
-                    hint.textContent = i18n('editor_preview_hint') || '이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.';
-                }
-
-                if (startTimeHint) {
-                    startTimeHint.textContent = formatted
-                        ? `${formatted}부터 재생돼요. 유튜브 공유에서 “시작 시간”을 체크한 링크도 자동으로 잡혀요.`
-                        : '유튜브 공유에서 “시작 시간”을 체크한 링크를 붙이면 자동으로 잡혀요.';
-                }
-            } else {
-                hideLinkPreview();
-            }
-        };
-
-        if (urlInput) {
-            if (previewInputHandler) urlInput.removeEventListener('input', previewInputHandler);
-            previewInputHandler = () => {
-                const url = urlInput.value.trim();
-                if (!userHasEditedStartTime && window.LoveBudMedia) {
-                    const fromUrl = window.LoveBudMedia.extractYouTubeStartSeconds(url);
-                    if (fromUrl) {
-                        startTimeInput.value = window.LoveBudMedia.formatYouTubeStartTime(fromUrl);
-                    } else {
-                        startTimeInput.value = '';
-                    }
-                }
-                updatePreview();
-            };
-            urlInput.addEventListener('input', previewInputHandler);
-        }
-
-        if (startTimeInput) {
-            if (startTimeInputHandler) startTimeInput.removeEventListener('input', startTimeInputHandler);
-            startTimeInputHandler = () => {
-                userHasEditedStartTime = true;
-                updatePreview();
-            };
-            startTimeInput.addEventListener('input', startTimeInputHandler);
-        }
+        bindPreviewEvents(isFirstMoment);
     };
 
     const hideAddMemoryForm = () => {
-        if (!addMemoryForm) return;
-        addMemoryForm.style.display = 'none';
-        addMemoryForm.classList.remove('is-open');
+        const form = refs.addMemoryForm;
+        if (!form) return;
+        form.style.display = 'none';
+        form.classList.remove('is-open');
         isFormOpen = false;
 
         document.removeEventListener('keydown', focusTrap);
@@ -426,99 +275,12 @@ function createEditorMemoryForm(deps) {
             document.removeEventListener('click', outsideClickHandler, true);
             outsideClickHandler = null;
         }
-        if (urlInput && previewInputHandler) {
-            urlInput.removeEventListener('input', previewInputHandler);
-        }
-        if (startTimeInput && startTimeInputHandler) {
-            startTimeInput.removeEventListener('input', startTimeInputHandler);
-        }
+        if (refs.urlInput && previewInputHandler) refs.urlInput.removeEventListener('input', previewInputHandler);
+        if (refs.startTimeInput && startTimeInputHandler) refs.startTimeInput.removeEventListener('input', startTimeInputHandler);
+        if (refs.endTimeInput && endTimeInputHandler) refs.endTimeInput.removeEventListener('input', endTimeInputHandler);
     };
 
-    const addMemoryFromForm = async () => {
-        const rawUrl = urlInput ? urlInput.value.trim() : '';
-        const titleValue = titleInput ? titleInput.value.trim() : '';
-        const memoValue = memoInput ? memoInput.value.trim() : '';
-        const usingLinkMode = currentInputMode === 'link';
-
-        if (usingLinkMode && !rawUrl) {
-            showToast(i18n('enter_youtube'), 'warn');
-            return;
-        }
-
-        if (!usingLinkMode && !titleValue && !memoValue) {
-            showToast(i18n('editor_enter_text_moment') || '제목이나 메모를 한 줄 이상 남겨 주세요.', 'warn');
-            return;
-        }
-
-        let embedUrl = '';
-        let thumbnailUrl = '';
-        let sourceType = 'other';
-        let sourceLabel = '';
-
-        if (rawUrl) {
-            let videoId;
-            if (window.LoveBudMedia?.extractYouTubeId) {
-                videoId = window.LoveBudMedia.extractYouTubeId(rawUrl);
-                if (!videoId) {
-                    showToast(getYouTubeInputErrorMessage(rawUrl), 'error');
-                    return;
-                }
-
-                // Fix 3 Policy
-                let startSeconds = null;
-                if (userHasEditedStartTime) {
-                    startSeconds = window.LoveBudMedia.parseYouTubeTimeToSeconds(startTimeInput?.value);
-                } else {
-                    startSeconds = window.LoveBudMedia.extractYouTubeStartSeconds(rawUrl);
-                }
-
-                embedUrl = window.LoveBudMedia.getEmbedUrl(rawUrl, 'youtube', { startSeconds });
-
-                thumbnailUrl = window.LoveBudMedia.getThumbnailUrl(rawUrl, 'youtube', 'mqdefault');
-            } else {
-                console.warn('[editor] LoveBudMedia not loaded, using fallback YouTube parsing');
-                const match = rawUrl.match(/(?:v=|\/|youtu\.be\/)([0-9A-Za-z_-]{11})/);
-                if (!match) {
-                    showToast(getYouTubeInputErrorMessage(rawUrl), 'error');
-                    return;
-                }
-                videoId = match[1];
-                embedUrl = `https://www.youtube.com/embed/${videoId}`;
-                thumbnailUrl = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-            }
-            sourceType = 'youtube';
-            sourceLabel = 'YouTube';
-        }
-
-        updateSaveStatus('saving', i18n('save_saving'));
-
-        const today = new Date();
-        const dateStr = `${today.getFullYear()}.${String(today.getMonth() + 1).padStart(2, '0')}.${String(today.getDate()).padStart(2, '0')}`;
-
-        const memories = getTreeMemories();
-        const isFirstMoment = !memories || memories.length === 0;
-        const defaultTitle = isFirstMoment
-            ? (i18n('editor_default_first_title') || '첫 순간')
-            : (i18n('editor_default_next_title') || '이어진 순간');
-        const title = titleValue || defaultTitle;
-
-        const newMemoryData = {
-            treeId,
-            title,
-            memo: memoValue || '',
-            timestamp: dateStr,
-            sourceUrl: embedUrl,
-            sourceType,
-            emotionTags: [],
-            parentId: resolveParentIdForCreate(getSelectedNodeId(), getCanonicalRootId()),
-            thumbnail: thumbnailUrl,
-            artist: '',
-            source: sourceLabel,
-            visibility: 'public'
-        };
-
-        hideAddMemoryForm();
-
+    async function createMemoryWithFallback(newMemoryData) {
         let createdMemory = null;
         let useApi = false;
         try {
@@ -532,7 +294,6 @@ function createEditorMemoryForm(deps) {
             }
         } catch (e) {
             console.warn('[editor] API createMemory failed, using local save:', e?.message || e);
-
             if (e?.message?.includes('401') || e?.message?.includes('403')) {
                 showToast(i18n('no_permission_local'), 'warn');
             } else if (e?.message?.includes('400')) {
@@ -549,11 +310,14 @@ function createEditorMemoryForm(deps) {
             createdMemory = {
                 id: nextMemoryId(),
                 ...newMemoryData,
-                createdAt: dateStr,
+                createdAt: newMemoryData.timestamp,
                 delay: '0.5s'
             };
         }
+        return { createdMemory, useApi };
+    }
 
+    function commitMemoryToTree(createdMemory, useApi) {
         const normalizedNew = normalizeMemory(createdMemory);
         const nextMemories = Array.isArray(getTreeMemories()) ? getTreeMemories().slice() : [];
         const exists = nextMemories.some((m) => m.id === normalizedNew?.id);
@@ -582,15 +346,9 @@ function createEditorMemoryForm(deps) {
             el.classList.add('new-node-highlight');
             setTimeout(() => el.classList.remove('new-node-highlight'), 2000);
         }
-        if (typeof focusNodeById === 'function') {
-            focusNodeById(normalizedMemory.id);
-        }
+        if (typeof focusNodeById === 'function') focusNodeById(normalizedMemory.id);
 
-        if (useApi) {
-            updateSaveStatus('saved', i18n('save_saved'));
-        } else {
-            updateSaveStatus('saved', i18n('save_saved_local') || '로컬 저장됨');
-        }
+        updateSaveStatus('saved', useApi ? i18n('save_saved') : (i18n('save_saved_local') || '로컬 저장됨'));
 
         if (typeof setCachedMemories === 'function' && treeId) {
             setCachedMemories(treeId, getTreeMemories());
@@ -600,6 +358,32 @@ function createEditorMemoryForm(deps) {
         updateSidebarStatus();
         updateFocusSelectedBtn();
         setDetailEmptyState(false);
+    }
+
+    const addMemoryFromForm = async () => {
+        const payloadResult = payloadHelper.buildMemoryPayload({
+            refs,
+            currentInputMode,
+            userHasEditedStartTime,
+            i18n,
+            treeId,
+            getYouTubeInputErrorMessage,
+            getTreeMemories,
+            resolveParentIdForCreate,
+            getSelectedNodeId,
+            getCanonicalRootId
+        });
+
+        if (!payloadResult.ok) {
+            showToast(payloadResult.message, payloadResult.level || 'warn');
+            return;
+        }
+
+        updateSaveStatus('saving', i18n('save_saving'));
+        hideAddMemoryForm();
+
+        const { createdMemory, useApi } = await createMemoryWithFallback(payloadResult.data);
+        commitMemoryToTree(createdMemory, useApi);
     };
 
     return {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -270,7 +270,11 @@
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
-    <script src="../js/editor/editor-memory-form.js?v=20260422-3"></script>
+    <script src="../js/editor/editor-memory-form-mode.js?v=20260510-1003"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1003"></script>
+    <script src="../js/editor/editor-memory-form-time.js?v=20260510-1003"></script>
+    <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1003"></script>
+    <script src="../js/editor/editor-memory-form.js?v=20260510-1003"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -270,11 +270,11 @@
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
-    <script src="../js/editor/editor-memory-form-mode.js?v=20260510-1003"></script>
-    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1003"></script>
-    <script src="../js/editor/editor-memory-form-time.js?v=20260510-1003"></script>
-    <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1003"></script>
-    <script src="../js/editor/editor-memory-form.js?v=20260510-1003"></script>
+    <script src="../js/editor/editor-memory-form-mode.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form-time.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form-payload.js?v=20260510-1004"></script>
+    <script src="../js/editor/editor-memory-form.js?v=20260510-1004"></script>
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>


### PR DESCRIPTION
## Summary

Refs #1003

Behavior-preserving refactor for the Editor first-moment / memory form.

This PR splits the large `editor-memory-form.js` responsibilities into focused browser-global helper files while preserving the current HTML script loading model. The helper copy/fallbacks are intended to preserve the current `main` behavior; #1001/#1002 UI polish and #1000 form UI changes remain out of scope.

## Changes

- Keep `window.createEditorMemoryForm` as the public entrypoint.
- Add focused helper modules for:
  - mode switching
  - YouTube preview state
  - start time helpers
  - payload/source preparation
- Add helper scripts before `editor-memory-form.js` in `pages/editor.html`.
- Reduce `editor-memory-form.js` toward thin orchestration.
- Add a guard for missing `LoveBudEditorMemoryFormPayload.buildMemoryPayload` so submit fails clearly instead of throwing a runtime TypeError.
- No ES module conversion.
- No backend/API/Auth/DB/schema changes.

## Notes

The time helper includes null-safe end-time parsing/validation support so PR #1000 can add the optional end-time field later without expanding the entrypoint again. Current `main` markup does not expose an end-time input, so this remains dormant future support in this refactor.

Inline style cleanup is intentionally left as a follow-up; this PR does not move modal/preview styling into CSS.

Browser verification was not performed. Browser verification remains CTO/user-owned after deployment to a fixed test slot.

PR #1000 remains draft/hold and should be reworked after this refactor if the refactor lands.

## Verification

- `git diff --check`: PASS
- `node --check` touched JS files: PASS
- `npm test`: PASS
- `npm run verify`: PASS

## Guardrails

- PR #7 untouched.
- prototype/reference/demo/variant paths untouched.
- No secret/private data exposure.
