### PR TITLE
fix(my-trees): resolve aria-hidden focus warning on create-tree modal close (Refs #998)

### DIFF
--- a/js/my-trees/my-trees-actions.js
+++ b/js/my-trees/my-trees-actions.js
@@ -142,19 +142,21 @@
       }
 
       createTreeModalState.backdrop.classList.remove('show');
-      createTreeModalState.backdrop.setAttribute('aria-hidden', 'true');
-      document.body.style.overflow = '';
       setSubmitting(false, i18n);
       setError('');
       if (createTreeModalState.escapeHandler) {
         document.removeEventListener('keydown', createTreeModalState.escapeHandler);
         createTreeModalState.escapeHandler = null;
       }
+      // Move focus before setting aria-hidden to avoid
+      // "Blocked aria-hidden on an element because its descendant retained focus"
       var restoreTarget = createTreeModalState.lastFocusedEl;
       createTreeModalState.lastFocusedEl = null;
       if (restoreTarget && typeof restoreTarget.focus === 'function') {
-        setTimeout(function() { restoreTarget.focus(); }, 0);
+        restoreTarget.focus();
       }
+      createTreeModalState.backdrop.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
       cleanupAndResolve(payload);
     }
 


### PR DESCRIPTION
## Summary

Fixes #998

The close-modal flow set `aria-hidden='true'` on the backdrop while the close button still had focus, causing browser warning:
`Blocked aria-hidden on an element because its descendant retained focus.`

**Fix:** Reorder `closeModal()` to move focus to the restore target \*before\* setting `aria-hidden='true'` on the backdrop.

## Changes

- `js/my-trees/my-trees-actions.js`: Move focus restoration ahead of `aria-hidden` assignment; removed unnecessary `setTimeout` wrapper (focus is now synchronous before aria state change)

## Verification

- `npm run lint`: PASS (no new warnings)
- Focus order: `restoreTarget.focus()` → `backdrop.setAttribute('aria-hidden', 'true')` ensures no focused descendant is hidden from assistive technology
- All close paths covered: close button, cancel button, Escape key, backdrop click

## Guardrails

- PR #7 and prototype/reference/demo/variant paths untouched
- No CSS, backend, API, or DB changes