### PR TITLE
fix(my-trees): clear grid before re-render on sort or data change (Refs #997)

### DIFF
--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -513,9 +513,10 @@
       grid = document.createElement('div');
       grid.className = 'trees-grid';
       grid.id = 'trees-grid';
-      container.innerHTML = '';
       container.appendChild(grid);
     }
+    // Sort change or re-render: clear old cards before appending new ones
+    grid.innerHTML = '';
 
     // Issue #616: Render first batch only
     renderNextBatch(grid, buildTreeCardFn, setState, stateEnum);


### PR DESCRIPTION
## Summary

Fixes #997

The My Trees sort mechanism had a rendering issue: on sort change, the existing tree grid was NOT cleared before appending newly sorted cards, causing duplicate cards and potential empty-state rendering bugs.

**Root cause:** `renderTrees()` in `my-trees-ui.js` only cleared `container.innerHTML` when creating a new grid element. On subsequent calls (sort change, data refresh), the existing grid was reused without clearing, so old cards remained and new sorted cards were appended as duplicates.

**Fix:** Always clear `grid.innerHTML = ''` before `renderNextBatch()`, regardless of whether the grid was newly created or reused.

## Changes

- `js/my-trees/my-trees-ui.js`: Extract grid creation from container initialization; always clear grid before appending batch

## Verification

- `npm run lint`: PASS
- Sort change no longer duplicates cards
- Empty state only shows when truly no trees exist