### PR TITLE
fix(viewer): add [hidden] CSS fallback for production route (Refs #959)

### DIFF
--- a/css/viewer/public-tree-viewer.css
+++ b/css/viewer/public-tree-viewer.css
@@ -303,6 +303,10 @@
     min-height: 300px;
 }
 
+.viewer-tree-shell [hidden] {
+    display: none !important;
+}
+
 .viewer-state-content {
     text-align: center;
     color: var(--on-surface-variant);


### PR DESCRIPTION
## Summary

Refs #959

The JS fix for viewer state visibility (using `style.display` instead of `hidden` attribute) was already merged to main. This PR adds the complementary CSS fallback: `.viewer-tree-shell [hidden] { display: none !important; }` to ensure the `[hidden]` attribute works correctly on production route if any code path still uses it.

## Changes

- `css/viewer/public-tree-viewer.css`: Add `!important` display:none for `[hidden]` within viewer-tree-shell

## Related

- Original PR #959 had merge conflicts; this is the remaining CSS piece after the JS fix was already in main
- Closes #959