### PR TITLE
ui(editor): align first moment segment fields by row

### DIFF
--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -188,31 +188,41 @@
 .editor-video-segment-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+        "startLabel endLabel"
+        "startInput endInput"
+        "help help";
     column-gap: 10px;
     row-gap: 7px;
     align-items: start;
-    padding: 9px;
+    padding: 10px;
     border: 1px solid rgba(144,73,81,0.08);
     border-radius: 16px;
     background: rgba(255, 250, 247, 0.52);
 }
 
 .editor-video-segment-field {
-    display: grid !important;
-    grid-template-rows: 26px 42px;
-    row-gap: 6px;
-    min-width: 0;
-    height: 94px;
-    min-height: 94px;
-    padding: 10px;
-    border: 1px solid rgba(144,73,81,0.07);
-    border-radius: 14px;
-    background: rgba(255,255,255,0.50);
-    box-sizing: border-box;
+    display: contents !important;
+}
+
+.editor-video-segment-field-start .editor-form-label {
+    grid-area: startLabel;
+}
+
+.editor-video-segment-field-start .editor-form-input {
+    grid-area: startInput;
+}
+
+.editor-video-segment-field-end .editor-form-label {
+    grid-area: endLabel;
+}
+
+.editor-video-segment-field-end .editor-form-input {
+    grid-area: endInput;
 }
 
 .editor-video-segment-field .editor-form-label {
-    align-self: start;
+    align-self: end;
     justify-self: start;
     margin: 0;
 }
@@ -227,7 +237,7 @@
 }
 
 .editor-video-segment-help {
-    grid-column: 1 / -1;
+    grid-area: help;
     margin: 0;
     padding: 6px 8px;
     border-radius: 12px;
@@ -270,12 +280,12 @@
 
     .editor-video-segment-grid {
         grid-template-columns: 1fr;
-        padding: 9px;
-    }
-
-    .editor-video-segment-field {
-        height: 92px;
-        min-height: 92px;
+        grid-template-areas:
+            "startLabel"
+            "startInput"
+            "endLabel"
+            "endInput"
+            "help";
         padding: 9px;
     }
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -6,7 +6,7 @@
     <title>러브트리 편집 | LoveTree</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
-    <link rel="stylesheet" href="../css/editor.css?v=20260510-1005">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1006">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -109,11 +109,11 @@
                         <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
                     </div>
                     <div class="editor-video-segment-grid" id="memoryVideoSegmentGrid">
-                        <div class="editor-form-field editor-video-segment-field" id="memoryStartTimeField">
+                        <div class="editor-form-field editor-video-segment-field editor-video-segment-field-start" id="memoryStartTimeField">
                             <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">시작</label>
                             <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23" class="editor-form-input">
                         </div>
-                        <div class="editor-form-field editor-video-segment-field" id="memoryEndTimeField">
+                        <div class="editor-form-field editor-video-segment-field editor-video-segment-field-end" id="memoryEndTimeField">
                             <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
                             <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
                         </div>


### PR DESCRIPTION
## Summary

Refs #1016

- Reworks the first-moment start/end segment block into a row-based grid.
- Aligns start/end labels on one row and start/end inputs on one row.
- Keeps the helper as a full-width segment-level note.
- Preserves modal footer, body scroll, preview, text mode, and validation behavior.

## Verification

- `git diff --check`: PASS
- `node --check touched JS`: NOT_NEEDED
- `npm test`: PASS
- `npm run verify`: PASS

## Notes

- Browser verification required before ready/merge.
- PR #7 untouched.
- prototype/reference/demo/variant paths untouched.
- No backend/API/Auth/DB/schema changes.