### PR TITLE
route: use extensionless page links for deployed canonical routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,12 @@
                             반했던 장면과 오래 남은 마음을, 감정이 이어진 경로로 천천히 남겨 보세요.
                         </p>
                         <div class="home-v3-actions">
-                            <a href="pages/login.html?redirect=my-trees.html" class="btn-round btn-primary">내 러브트리 시작하기</a>
-                            <a href="pages/search.html" class="btn-round btn-outline">다른 트리 둘러보기</a>
+                            <a href="pages/login?redirect=my-trees" class="btn-round btn-primary">내 러브트리 시작하기</a>
+                            <a href="pages/search" class="btn-round btn-outline">다른 트리 둘러보기</a>
                         </div>
                         <div class="home-v3-note">처음에는 단 하나의 순간만 있어도 충분해요.</div>
                         <div class="home-intro-entry-wrapper">
-                            <a href="pages/intro.html" class="home-intro-entry" aria-label="러브트리 서비스 소개 페이지로 이동">러브트리가 처음이신가요?</a>
+                            <a href="pages/intro" class="home-intro-entry" aria-label="러브트리 서비스 소개 페이지로 이동">러브트리가 처음이신가요?</a>
                         </div>
                     </div>
                 </div>

--- a/js/browse-prefetch.js
+++ b/js/browse-prefetch.js
@@ -12,7 +12,7 @@
         var link = target && target.closest && target.closest('a[href]');
         if (!link) return false;
         var href = link.getAttribute('href') || '';
-        return href.indexOf('search.html') !== -1;
+        return /(?:^|\/)search(?:\.html)?(?:[?#]|$)/.test(href);
     }
 
     function prefetchBrowseTrees() {

--- a/js/editor.js
+++ b/js/editor.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/');
 
     const buildEditorRedirectTarget = shellHelpers.buildEditorRedirectTarget || (() =>
-        getEditorBasePath() + 'editor.html' + (window.location.search || ''));
+        getEditorBasePath() + 'editor' + (window.location.search || ''));
 
     const createInlineRedirectToEditorLoginFallback = entryFallbacks.createInlineRedirectToEditorLoginFallback;
 
@@ -126,7 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return selectedNodeId;
     });
 
-    const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees.html');
+    const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees');
     const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
 
     const escapeHtml = editorHelpers.escapeHtml || ((value) => String(value ?? '')

--- a/js/editor/editor-entry-fallbacks.js
+++ b/js/editor/editor-entry-fallbacks.js
@@ -14,11 +14,11 @@
     }
 
     function buildEditorRedirectTarget() {
-        return getEditorBasePath() + 'editor.html' + (window.location.search || '');
+        return getEditorBasePath() + 'editor' + (window.location.search || '');
     }
 
     function getMyTreesHref() {
-        return getEditorBasePath() + 'my-trees.html';
+        return getEditorBasePath() + 'my-trees';
     }
 
     function createInlineShowToastFallback() {
@@ -47,7 +47,7 @@
             var nextDelay = Number(delayMs || 0);
             var loginUrl =
                 basePathResolver() +
-                'login.html?redirect=' +
+                'login?redirect=' +
                 encodeURIComponent(redirectTargetResolver());
 
             if (nextDelay > 0) {

--- a/js/editor/editor-page-helpers.js
+++ b/js/editor/editor-page-helpers.js
@@ -14,14 +14,14 @@
   }
 
   function buildEditorRedirectTarget() {
-    return getEditorBasePath() + 'editor.html' + (window.location.search || '');
+    return getEditorBasePath() + 'editor' + (window.location.search || '');
   }
 
   function redirectToEditorLogin(delayMs) {
     var nextDelay = Number(delayMs || 0);
     var loginUrl =
       getEditorBasePath() +
-      'login.html?redirect=' +
+      'login?redirect=' +
       encodeURIComponent(buildEditorRedirectTarget());
 
     if (nextDelay > 0) {
@@ -35,7 +35,7 @@
   }
 
   function getMyTreesHref() {
-    return getEditorBasePath() + 'my-trees.html';
+    return getEditorBasePath() + 'my-trees';
   }
 
   function renderTreeLoadError(options) {

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -13,7 +13,7 @@ window.LoveBudEditorShellHelpers = {
     },
 
     buildEditorRedirectTarget: function() {
-        return this.getEditorBasePath() + 'editor.html' + (window.location.search || '');
+        return this.getEditorBasePath() + 'editor' + (window.location.search || '');
     },
 
     // Toast fallback

--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -5,7 +5,7 @@
  * Responsibilities:
  * - Auth guard: redirect to login if not authenticated
  * - Load tree list via window.apiClient.getTrees()
- * - Render tree cards (clickable → editor.html?treeId=xxx)
+ * - Render tree cards (clickable → editor?treeId=xxx)
  * - Empty state with "새 러브트리 만들기" CTA
  * - "새 러브트리 만들기" → createTree() → redirect to editor
  */
@@ -98,7 +98,7 @@
 
   function getLoginRedirectUrl() {
     var basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
-    return basePath + 'login.html?redirect=' + basePath + 'my-trees.html';
+    return basePath + 'login?redirect=' + basePath + 'my-trees';
   }
 
   function redirectToLogin() {

--- a/js/my-trees/my-trees-actions.js
+++ b/js/my-trees/my-trees-actions.js
@@ -379,9 +379,9 @@
 
       var treeId = newTree?.id;
       if (treeId) {
-        window.location.href = 'editor.html?treeId=' + encodeURIComponent(treeId);
+        window.location.href = 'editor?treeId=' + encodeURIComponent(treeId);
       } else {
-        window.location.href = 'editor.html';
+        window.location.href = 'editor';
       }
     } catch (e) {
       console.error('[my-trees-actions] createTree failed:', e);

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -384,7 +384,7 @@
       if (typeof onNavigate === 'function') {
         onNavigate(normalizedTree);
       } else {
-        window.location.href = 'editor.html?treeId=' + encodeURIComponent(normalizedTree.id);
+        window.location.href = 'editor?treeId=' + encodeURIComponent(normalizedTree.id);
       }
     };
 

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -136,7 +136,7 @@
 
     function getTreeViewerHref(tree) {
         if (!tree?.id) return '';
-        return `${getBasePath()}tree.html?treeId=${encodeURIComponent(tree.id)}`;
+        return `${getBasePath()}tree?treeId=${encodeURIComponent(tree.id)}`;
     }
 
     function getTreePreviewTone(tree) {

--- a/js/search/search-copy-ui.js
+++ b/js/search/search-copy-ui.js
@@ -2,7 +2,7 @@
  * LoveBud Search Copy UI
  *
  * Adds a lightweight "copy public tree to my LoveTrees" action to the Search Preview panel.
- * Loaded from i18n-search.js only on pages/search.html to avoid touching the large
+ * Loaded from i18n-search.js only on pages/search to avoid touching the large
  * Search renderer/orchestrator files while local git verification is unavailable.
  */
 (function () {
@@ -48,13 +48,13 @@
 
     function buildCopiedTreeHref(treeId) {
         const basePath = getBasePath();
-        return `${basePath}editor.html?treeId=${encodeURIComponent(treeId)}`;
+        return `${basePath}editor?treeId=${encodeURIComponent(treeId)}`;
     }
 
     function buildLoginHref(treeId) {
         const basePath = getBasePath();
-        const redirect = `search.html?tree=${encodeURIComponent(treeId)}`;
-        return `${basePath}login.html?redirect=${encodeURIComponent(redirect)}`;
+        const redirect = `search?tree=${encodeURIComponent(treeId)}`;
+        return `${basePath}login?redirect=${encodeURIComponent(redirect)}`;
     }
 
     function hasAuthSession() {

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -135,7 +135,7 @@
      */
     function renderOpenTreeButton(tree) {
         if (!tree?.id) return '';
-        const href = `${getBasePath()}tree.html?treeId=${encodeURIComponent(tree.id)}`;
+        const href = `${getBasePath()}tree?treeId=${encodeURIComponent(tree.id)}`;
         const label = getSearchCopy(
             'search.previewOpenTreeCta',
             '트리 열기',

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -546,7 +546,7 @@
                 const failedText = getSearchCopy('search.previewShareLinkFailed', '복사하지 못했어요', 'Copy failed');
 
                 try {
-                    const url = new URL('/pages/search.html', window.location.origin);
+                    const url = new URL('/pages/search', window.location.origin);
                     url.searchParams.set('tree', treeId);
                     await navigator.clipboard.writeText(url.toString());
                     labelSpan.textContent = copiedText;

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -75,20 +75,20 @@
         // root (index.html)
         'root': {
             home: { textKey: 'nav.home', href: 'index.html', active: true },
-            intro: { textKey: 'nav.intro', href: 'pages/intro.html' },
-            search: { textKey: 'nav.search', href: 'pages/search.html' },
-            myTrees: { textKey: 'nav.myTrees', href: 'pages/my-trees.html', highlight: true },
-            settings: { textKey: 'nav.settings', href: 'pages/settings.html' },
+            intro: { textKey: 'nav.intro', href: 'pages/intro' },
+            search: { textKey: 'nav.search', href: 'pages/search' },
+            myTrees: { textKey: 'nav.myTrees', href: 'pages/my-trees', highlight: true },
+            settings: { textKey: 'nav.settings', href: 'pages/settings' },
             editor: null // root에서는 에디터 숨김
         },
         // pages 폴더 내 페이지
         'pages': {
             home: { textKey: 'nav.home', href: '../index.html' },
-            intro: { textKey: 'nav.intro', href: 'intro.html' },
-            search: { textKey: 'nav.search', href: 'search.html' },
-            myTrees: { textKey: 'nav.myTrees', href: 'my-trees.html', highlight: true },
-            settings: { textKey: 'nav.settings', href: 'settings.html' },
-            editor: { textKey: 'nav.editor', href: 'editor.html' }
+            intro: { textKey: 'nav.intro', href: 'intro' },
+            search: { textKey: 'nav.search', href: 'search' },
+            myTrees: { textKey: 'nav.myTrees', href: 'my-trees', highlight: true },
+            settings: { textKey: 'nav.settings', href: 'settings' },
+            editor: { textKey: 'nav.editor', href: 'editor' }
         }
     };
 
@@ -101,7 +101,14 @@
         'my-trees.html': 'myTrees',
         'editor.html': 'editor',
         'login.html': null, // login은 메뉴 active 없음
-        'settings.html': 'settings'
+        'settings.html': 'settings',
+        'intro': 'intro',
+        'search': 'search',
+        'detail': 'search',
+        'my-trees': 'myTrees',
+        'editor': 'editor',
+        'login': null,
+        'settings': 'settings'
     };
 
     // 현재 페이지 감지
@@ -132,7 +139,8 @@
     }
 
     function isEditorPage() {
-        return getCurrentPage() === 'editor.html';
+        var currentPage = getCurrentPage();
+        return currentPage === 'editor.html' || currentPage === 'editor';
     }
 
     // Confirmed session helper - 헤더 즉시 렌더링용
@@ -189,12 +197,12 @@
 
         // 현재 페이지가 설정 페이지면 내 트리로 링크, 아니면 설정으로 링크
         var currentPage = getCurrentPage();
-        var myTreesHref = getContextType() === 'root' ? 'pages/my-trees.html' : './my-trees.html';
-        var settingsHref = appendSettingsReturnTo(getContextType() === 'root' ? 'pages/settings.html' : './settings.html');
-        var avatarHref = currentPage === 'settings.html'
+        var myTreesHref = getContextType() === 'root' ? 'pages/my-trees' : './my-trees';
+        var settingsHref = appendSettingsReturnTo(getContextType() === 'root' ? 'pages/settings' : './settings');
+        var avatarHref = currentPage === 'settings.html' || currentPage === 'settings'
             ? myTreesHref
             : settingsHref;
-        var avatarLabel = currentPage === 'settings.html' ? '내 러브트리로 돌아가기' : '설정 열기';
+        var avatarLabel = currentPage === 'settings.html' || currentPage === 'settings' ? '내 러브트리로 돌아가기' : '설정 열기';
 
         return [
             '<a href="' + avatarHref + '" title="' + avatarLabel + '" class="cached-avatar-link">',
@@ -208,11 +216,12 @@
 
     // 로그인 페이지인지 확인
     function isLoginPage() {
-        return getCurrentPage() === 'login.html';
+        var currentPage = getCurrentPage();
+        return currentPage === 'login.html' || currentPage === 'login';
     }
 
     function getLoginRedirectHref(targetHref) {
-        var loginHref = getContextType() === 'root' ? 'pages/login.html' : 'login.html';
+        var loginHref = getContextType() === 'root' ? 'pages/login' : 'login';
         return loginHref + '?redirect=' + encodeURIComponent(targetHref);
     }
 

--- a/js/utils/path.js
+++ b/js/utils/path.js
@@ -26,7 +26,7 @@
 
     /**
      * 페이지 URL 생성
-     * @param {string} pageName - 예: 'detail.html', 'search.html'
+     * @param {string} pageName - 예: 'detail', 'search'
      * @returns {string} 완성된 경로
      */
     function resolvePageUrl(pageName) {

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -17,7 +17,7 @@
 
     <div class="detail-page-shell page-transition-enter">
         <div class="detail-topbar">
-            <a id="backButton" class="detail-back-link" href="search.html">
+            <a id="backButton" class="detail-back-link" href="search">
                 <span class="material-symbols-outlined">arrow_back</span>
                 <span>둘러보기로 돌아가기</span>
             </a>

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -18,7 +18,7 @@
     <div class="editor-layout page-transition-enter">
         <aside class="sidebar reveal-fade">
             <div class="editor-sidebar-back-wrap">
-                <a id="backToMyTreesLink" href="my-trees.html" class="editor-sidebar-back-link">
+                <a id="backToMyTreesLink" href="my-trees" class="editor-sidebar-back-link">
                     <span aria-hidden="true" class="editor-sidebar-back-icon">←</span>
                     <span id="backToMyTreesLabel">내 러브트리로 돌아가기</span>
                 </a>

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -28,8 +28,8 @@
             사랑에 빠진 첫 순간부터 차곡차곡 쌓인 마음까지,<br class="pc-only">당신만의 감정 경로를 하나의 러브트리로 피워내세요.
           </p>
           <div class="intro-hero-actions">
-            <a href="my-trees.html" class="intro-cta-link"><span class="btn-round btn-primary intro-cta-primary" data-i18n="intro.heroPrimaryCta">내 러브트리 시작하기</span></a>
-            <a href="search.html" class="intro-cta-link"><span class="btn-round btn-outline intro-cta-secondary" data-i18n="intro.ctaSecondary">다른 트리 둘러보기</span></a>
+            <a href="my-trees" class="intro-cta-link"><span class="btn-round btn-primary intro-cta-primary" data-i18n="intro.heroPrimaryCta">내 러브트리 시작하기</span></a>
+            <a href="search" class="intro-cta-link"><span class="btn-round btn-outline intro-cta-secondary" data-i18n="intro.ctaSecondary">다른 트리 둘러보기</span></a>
           </div>
         </div>
         <div class="intro-hero-visual reveal-scale" aria-hidden="true">
@@ -246,8 +246,8 @@
         <h2 data-i18n="intro.ctaTitle">첫 순간을 남길 준비가 되셨나요?</h2>
         <p data-i18n="intro.ctaDesc">시작된 장면부터 당신의 러브트리를 남겨보세요.</p>
         <div class="cta-buttons">
-          <a href="my-trees.html" class="intro-cta-link"><span class="btn-round btn-primary intro-cta-primary" data-i18n="intro.ctaPrimary">첫 순간 남기러 가기</span></a>
-          <a href="search.html" class="intro-cta-link"><span class="btn-round btn-outline intro-cta-secondary" data-i18n="intro.ctaSecondary">다른 트리 둘러보기</span></a>
+          <a href="my-trees" class="intro-cta-link"><span class="btn-round btn-primary intro-cta-primary" data-i18n="intro.ctaPrimary">첫 순간 남기러 가기</span></a>
+          <a href="search" class="intro-cta-link"><span class="btn-round btn-outline intro-cta-secondary" data-i18n="intro.ctaSecondary">다른 트리 둘러보기</span></a>
         </div>
       </section>
     </main>

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -61,7 +61,7 @@
                 <span class="badge" data-i18n="badge_safe">안전한 보관</span>
             </div>
 
-            <p class="login-first-time-note"><span data-i18n="already_have_account_question">이미 계정이 있나요?</span> <a href="login.html" class="login-signup-link" data-i18n="login_link_label">로그인하기</a></p>
+            <p class="login-first-time-note"><span data-i18n="already_have_account_question">이미 계정이 있나요?</span> <a href="login" class="login-signup-link" data-i18n="login_link_label">로그인하기</a></p>
 
             <a href="../index.html" class="login-later-link" data-i18n="later">
                 나중에 시작하기

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -16,7 +16,7 @@
     <div id="shared-header"></div>
     <div class="viewer-page-shell page-transition-enter">
         <div class="viewer-topbar">
-            <a id="backButton" class="viewer-back-link" href="../pages/search.html">
+            <a id="backButton" class="viewer-back-link" href="../pages/search">
                 <span class="material-symbols-outlined">arrow_back</span>
                 <span data-i18n="viewer.backToBrowse">둘러보기로 돌아가기</span>
             </a>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -105,7 +105,7 @@ test('browse cards expose a truthful public tree viewer bridge', () => {
   const cardRenderer = read('js/search/search-card-renderer.js');
 
   assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
-  assert.match(cardRenderer, /tree\.html\?treeId=/);
+  assert.match(cardRenderer, /tree\?treeId=/);
   assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
   assert.match(cardRenderer, /tree-card-open-link/);
   assert.match(cardRenderer, /트리 열기/);
@@ -142,7 +142,7 @@ test('browse selected hub primary tree CTA and secondary viewing CTA keep truthf
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
-  assert.match(actionHelper, /tree\.html\?treeId=/);
+  assert.match(actionHelper, /tree\?treeId=/);
   assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
@@ -178,6 +178,6 @@ test('browse selected hub exposes focus-stage shell without changing route helpe
   assert.match(previewCss, /Issue #907: focus-stage selected hub shell/);
   assert.match(previewCss, /preview-sidebar\.preview-state-media \.video-container|preview-sidebar\.preview-state-media[\s\S]*?\.video-container/);
   assert.match(previewCss, /preview-sidebar \.preview-primary-action/);
-  assert.match(actionHelper, /tree\.html\?treeId=/);
+  assert.match(actionHelper, /tree\?treeId=/);
   assert.match(actionHelper, /data-share-tree-link/);
 });

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -3,10 +3,10 @@
  * Issue #923 — First slice of read-only LoveTree viewer route
  *
  * Verifies:
- * - Viewer route (pages/tree.html) exists
+ * - Viewer page file (pages/tree.html) exists
  * - Viewer JS does not expose Editor/Builder controls
  * - Viewer does not load Editor entry script
- * - Browse "트리 열기" targets tree.html (not editor or detail)
+ * - Browse "트리 열기" targets extensionless tree route (not editor or detail)
  */
 
 const test = require('node:test');
@@ -41,12 +41,27 @@ test('tree viewer route does not reference Editor/Builder page', () => {
     assert.ok(noEditorPage, 'tree.html must not load any Editor module');
 });
 
-test('Browse tree-open CTA targets tree.html with treeId param', () => {
+test('Browse tree-open CTA targets extensionless tree route with treeId param', () => {
     const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
-    const hasTreeUrl = helper.includes('tree.html?treeId=');
-    assert.ok(hasTreeUrl, 'search-preview-action-helper.js must use tree.html?treeId= for tree-open CTA');
+    const hasTreeUrl = helper.includes('tree?treeId=');
+    assert.ok(hasTreeUrl, 'search-preview-action-helper.js must use tree?treeId= for tree-open CTA');
+    assert.ok(!helper.includes('tree.html?treeId='), 'search-preview-action-helper.js must not use .html tree route for tree-open CTA');
     const noDetailUrl = !helper.includes('detail.html?tree=');
     assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
+});
+
+test('Browse card renderer targets extensionless tree route with treeId param', () => {
+    const renderer = fs.readFileSync('js/search/search-card-renderer.js', 'utf8');
+    assert.ok(renderer.includes('tree?treeId='), 'search-card-renderer.js must use tree?treeId= for card tree-open link');
+    assert.ok(!renderer.includes('tree.html?treeId='), 'search-card-renderer.js must not use .html tree route for card tree-open link');
+});
+
+test('My Trees owner routes target extensionless editor route with treeId param', () => {
+    const ui = fs.readFileSync('js/my-trees/my-trees-ui.js', 'utf8');
+    const actions = fs.readFileSync('js/my-trees/my-trees-actions.js', 'utf8');
+    const source = ui + '\n' + actions;
+    assert.ok(source.includes("'editor?treeId='"), 'My Trees must use editor?treeId= for owner editor navigation');
+    assert.ok(!source.includes("'editor.html?treeId='"), 'My Trees must not use .html editor route for owner editor navigation');
 });
 
 test('tree viewer loads Canvas v4 modules', () => {

--- a/tests/routes/viewer-share-contract.test.js
+++ b/tests/routes/viewer-share-contract.test.js
@@ -32,7 +32,7 @@ function loadShareActions(options = {}) {
         URL,
         Promise,
         window: {
-            location: { href: options.href || 'https://lovebud.pages.dev/pages/tree.html?treeId=public-route-ref#selected' },
+            location: { href: options.href || 'https://lovebud.pages.dev/pages/tree?treeId=public-route-ref#selected' },
             LoveBudVisitorViewerData: options.viewerData || {
                 tree: { title: '공개 러브트리' }
             },
@@ -157,7 +157,7 @@ test('platform intent builder uses public viewer route shape', () => {
 
     assert.equal(target.origin + target.pathname, 'https://twitter.com/intent/tweet');
     assert.equal(shared.origin, 'https://lovebud.pages.dev');
-    assert.equal(shared.pathname, '/pages/tree.html');
+    assert.equal(shared.pathname, '/pages/tree');
     assert.equal(shared.hash, '');
     assert.ok(shared.searchParams.has('treeId'), 'shared URL keeps current public viewer route parameter');
 });
@@ -168,9 +168,9 @@ test('platform intents are limited to route URL and title text', () => {
     const email = Share.getPlatformIntent('email').url;
 
     assert.equal(facebook.origin + facebook.pathname, 'https://www.facebook.com/sharer/sharer.php');
-    assert.equal(new URL(facebook.searchParams.get('u')).pathname, '/pages/tree.html');
+    assert.equal(new URL(facebook.searchParams.get('u')).pathname, '/pages/tree');
     assert.match(email, /^mailto:\?subject=/);
-    assert.ok(email.includes(encodeURIComponent('/pages/tree.html')), 'email body should include public viewer route');
+    assert.ok(email.includes(encodeURIComponent('/pages/tree')), 'email body should include public viewer route');
 });
 
 test('unsupported platform falls back to canonical link copy', async () => {
@@ -178,7 +178,7 @@ test('unsupported platform falls back to canonical link copy', async () => {
     const result = await Share.shareToPlatform(null, 'unsupported');
 
     assert.equal(result.success, true);
-    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree.html?treeId=public-route-ref');
+    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree?treeId=public-route-ref');
 });
 
 test('existing link copy is preserved', async () => {
@@ -186,7 +186,7 @@ test('existing link copy is preserved', async () => {
     const result = await Share.copyLink();
 
     assert.equal(result.success, true);
-    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree.html?treeId=public-route-ref');
+    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree?treeId=public-route-ref');
 });
 
 test('native share behavior is preserved when available', async () => {
@@ -200,7 +200,7 @@ test('native share behavior is preserved when available', async () => {
 
     assert.equal(result.success, true);
     assert.equal(nativePayload.title, '공개 러브트리');
-    assert.equal(nativePayload.url, 'https://lovebud.pages.dev/pages/tree.html?treeId=public-route-ref');
+    assert.equal(nativePayload.url, 'https://lovebud.pages.dev/pages/tree?treeId=public-route-ref');
 });
 
 test('tree image card payload uses public-safe viewer content only', () => {
@@ -239,7 +239,7 @@ test('tree image card export falls back to canonical link copy when canvas is un
 
     assert.equal(result.success, true);
     assert.equal(result.message, '링크를 복사했어요');
-    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree.html?treeId=public-route-ref');
+    assert.equal(state.copied, 'https://lovebud.pages.dev/pages/tree?treeId=public-route-ref');
 });
 
 test('tree image card export can save a client-side png without copying a link', async () => {


### PR DESCRIPTION
Refs #1018

Summary:
- Updates generated internal page links to match extensionless deployed routes.
- Changes public viewer opens from tree.html?treeId=... to tree?treeId=...
- Changes owner editor opens from editor.html?treeId=... to editor?treeId=...
- Leaves actual pages/*.html files unchanged.

Verification:
- git diff --check: PASS
- node --check touched JS: PASS
- npm test: PASS
- npm run verify: PASS

Notes:
- Browser/fixed-slot verification required before ready/merge.
- PR #7 untouched.
- prototype/reference/demo/variant paths untouched.
- No backend/API/Auth/DB/schema changes.