### PR TITLE
fix(modal): import owner tree lookup for memory writes

### DIFF
--- a/modal_compute/owner_writes.py
+++ b/modal_compute/owner_writes.py
@@ -11,6 +11,9 @@ from modal_compute.db import (
     get_db_connection,
     run_db_with_retry,
 )
+from modal_compute.owner_reads import (
+    fetch_owner_tree,
+)
 from modal_compute.validation import (
     _to_isoformat,
     estimate_stage,


### PR DESCRIPTION
Refs #1025

## Summary

- Imports `fetch_owner_tree` into `modal_compute/owner_writes.py`.
- Preserves the runtime fix for authenticated memory create/update writes.
- Keeps PR #1024 frontend source URL state/cache work separate.

## Root cause

Modal logs identified `NameError: fetch_owner_tree is not defined` when `create_owner_memory()` attempted to verify the owned tree before inserting a memory.

## Verification

- Modal runtime redeploy after equivalent fix: POST `/api/memories` returned 2xx per sanitized report.
- Repository CI: NOT_RUN on this branch yet.
- Browser PR #1024 source URL persistence verification: NOT_RUN after this repository fix.

## Safety

- No secret values included.
- No raw treeId/memoryId/ownerId/source URL/request payload/response body/DB row included.
- No PR #7 or prototype/reference/demo/variant changes intended.