### PR TITLE
ui(viewer): expose tree social dock controls

### DIFF
--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -233,6 +233,10 @@
     color: #be123c;
 }
 
+.vv-action-btn.is-liked .vv-icon-heart {
+    fill: currentColor;
+}
+
 .vv-action-icon { display: inline-flex; }
 
 .vv-mobile-note {

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -161,7 +161,13 @@
                 '</header>' +
                 '<div class="vv-action-dock">' +
                 '  <div class="vv-action-group">' +
-                '    <button type="button" class="vv-action-btn" data-action="open-share"><span class="vv-action-icon">' +
+                '    <button type="button" class="vv-action-btn" data-action="toggle-like" aria-label="트리 좋아요"><span class="vv-action-icon">' +
+                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon vv-icon-heart"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
+                '    좋아요</button>' +
+                '    <button type="button" class="vv-action-btn" data-action="open-tree-comments" aria-label="트리 댓글 보기"><span class="vv-action-icon">' +
+                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
+                '    댓글</button>' +
+                '    <button type="button" class="vv-action-btn" data-action="open-share" aria-label="트리 공유하기"><span class="vv-action-icon">' +
                 '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M8.1 12.7 15.9 17M15.9 7 8.1 11.3M6.4 14.6a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm10.9-5a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm0 10a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg></span>' +
                 '    공유</button>' +
                 '  </div>' +
@@ -271,7 +277,7 @@
                     var a = action.dataset.action;
                     if (a === 'close-moment') handler.closeMoment();
                     else if (a === 'close-panel') handler.closePanel();
-                    else if (a === 'toggle-like') handler.toggleLike();
+                    else if (a === 'toggle-like') { handler.toggleLike(); action.classList.toggle('is-liked'); }
                     else if (a === 'open-tree-comments') handler.openPanel('tree-comments');
                     else if (a === 'open-share') handler.openPanel('share');
                     else if (a === 'copy-link') handler.copyLink();


### PR DESCRIPTION
## Summary

Expose the existing `toggle-like` and `open-tree-comments` handler actions as UI buttons in the public viewer's tree-level action dock.

### Before
- Tree-level action dock had only **Share** button
- Like and Comments handler existed but had no UI entry point

### After
- Tree-level action dock shows: **Like → Comments → Share**
- Like button toggles `is-liked` class for visual feedback (heart fill + pink tint)
- Comments button opens tree comments panel via existing `openPanel('tree-comments')` path
- Share button unchanged, with added `aria-label`

### Changed files
- `js/viewer/tree-viewer.js` — Add like/comment buttons to vv-action-dock template
- `css/visitor-viewer/visitor-viewer-shell.css` — Heart icon fill on liked state

### Verification
- `node --check js/viewer/tree-viewer.js`: PASS
- `npm test`: 256/256 pass
- `npm run verify`: 156/158 pass (backend deps only)
- Desktop browser: Like/Comment/Share all visible
- Mobile (375px): CSS responsive breakpoints in place (flex-wrap, compact padding)

### Safety
- No backend/API/Auth/DB/schema changes
- No package files touched
- No PR #7 / prototype / reference / demo / variant changes
- No production mutation
- Read-only public viewer boundary preserved
- Owner/editor controls not exposed

Refs #975