### PR TITLE
ui(viewer): clarify root seed as tree overview anchor

### DIFF
--- a/css/visitor-viewer.css
+++ b/css/visitor-viewer.css
@@ -2,3 +2,8 @@
 @import url('./visitor-viewer/visitor-viewer-tree.css');
 @import url('./visitor-viewer/visitor-viewer-panel.css');
 @import url('./visitor-viewer/visitor-viewer-social.css');
+
+.vv-root-seed-overview-anchor {
+    cursor: default;
+    pointer-events: none;
+}

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -92,9 +92,9 @@
         var rootSeed = {
             id: 'moment-root',
             branchId: 'main',
-            title: (memories[0] && memories[0].title) || t('viewer.rootMoment', '시작된 순간', 'Starting moment'),
-            tag: t('viewer.start', '시작', 'Start'),
-            caption: (memories[0] && memories[0].emotionMemo) || '',
+            title: t('viewer.rootOverviewAnchor', '러브트리의 시작점', 'LoveTree starting point'),
+            tag: t('viewer.fullFlowAnchor', '전체 흐름', 'Full flow'),
+            caption: t('viewer.rootOverviewCaption', '전체 흐름의 기준점', 'The anchor for the full tree overview'),
             color: 'from-rose-200 via-rose-100 to-amber-50',
             emoji: '✦'
         };
@@ -179,7 +179,6 @@
 
             function getAllMoments() {
                 var results = [];
-                results.push({ id: viewerData.rootSeed.id, branchId: 'main', title: viewerData.rootSeed.title, tag: viewerData.rootSeed.tag, caption: viewerData.rootSeed.caption, emoji: viewerData.rootSeed.emoji });
                 viewerData.branches[0].moments.forEach(function(m) {
                     results.push({ id: m.id, branchId: 'main', title: m.title, tag: m.tag, caption: m.caption, emoji: m.emoji });
                 });
@@ -211,6 +210,10 @@
                     refresh();
                 },
                 onSelectMoment: function(momentId, branchId) {
+                    if (viewerData.rootSeed && momentId === viewerData.rootSeed.id) {
+                        handler.onSelectBranch(branchId || viewerData.rootSeed.branchId || 'main');
+                        return;
+                    }
                     state.selectedBranchId = branchId;
                     state.selectedMomentId = momentId;
                     state.activePanel = 'moment';

--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -65,14 +65,13 @@
 
         var rootEl = '';
         if (rootSeed) {
-            rootEl = '<button type="button" class="vv-root-seed ' + (selectedMomentId === rootSeed.id ? 'is-selected' : '') + '" data-moment-id="' + escapeHtml(rootSeed.id) + '" data-branch-id="' + escapeHtml(rootSeed.branchId) + '" aria-label="시작된 순간 열기">' +
+            rootEl = '<div class="vv-root-seed vv-root-seed-overview-anchor" data-overview-anchor="true" aria-label="러브트리의 시작점">' +
                 '<div class="vv-root-seed-shape" style="background:linear-gradient(135deg,' + (paletteObj.rose || {soft:'#fff1f3',stroke:'#e99aac'}).soft + ',' + (paletteObj.rose || {}).stroke + ' 40%,white)">' +
                 '<div class="vv-root-seed-inner"></div>' +
                 '<span class="vv-root-seed-emoji">' + escapeHtml(rootSeed.emoji) + '</span>' +
-                '<span class="vv-root-seed-play">▶</span>' +
                 '</div>' +
-                '<span class="vv-root-seed-label">시작된 순간</span>' +
-                '</button>';
+                '<span class="vv-root-seed-label">러브트리의 시작점</span>' +
+                '</div>';
         }
 
         container.innerHTML =


### PR DESCRIPTION
﻿Refs #976

## Summary

- Treat the public viewer root/seed as a tree overview anchor instead of a synthetic moment detail entry.
- Remove the root/seed button/open affordance and play badge from the rendered tree.
- Keep defensive handler behavior so any legacy synthetic root selection returns to the branch/tree overview state rather than opening moment detail.
- Add a minimal CSS override so the overview anchor does not present pointer/hover CTA behavior.

## Product decision

Applies **B_SEED_TREE_OVERVIEW** from #976.

Root/seed represents the visual starting anchor for the whole LoveTree overview. It is not a first public moment link, playback entry, or playlist/timeline starter.

## Changed files

- `js/visitor-viewer/visitor-viewer-render-tree.js`
- `js/viewer/tree-viewer.js`
- `css/visitor-viewer.css`

## Verification

- `node --check js/visitor-viewer/visitor-viewer-render-tree.js` — PASS
- `node --check js/viewer/tree-viewer.js` — PASS
- `git diff --check` — PASS
- `npm test` — PASS, 256 tests
- `npm run verify` — PASS, 158/158 checks
- Cloudflare PR Preview deploy — PASS
- Browser shell root/seed contract on PR Preview:
  - Desktop 1366px — PASS
  - Mobile 375px — PASS
  - Confirmed root/seed renders as one non-clickable overview anchor, not a button, not a moment `data-moment-id`, with no play badge and no horizontal overflow.
- Browser real `/pages/tree` route from Browse candidates:
  - Route reached on PR Preview.
  - Data-loaded tree proof is blocked by a preview fetch failure with no HTTP 4xx/5xx response observed.
  - This PR did not change API/runtime fetching.

## Safety notes

- No backend/API/Auth/DB/schema changes.
- No package file changes.
- No Editor/Builder owner mode changes.
- No Browse/My Trees/Auth/API/DB refactor.
- No PR #7 or prototype/reference/demo/variant changes.
- No raw identifiers, payloads, credentials, cookies, sessions, headers, private keys, or DB URLs included.

## Explicit out of scope

- No first-moment linking.
- No playback or playlist behavior.
- No backend persistence.
- No #1022 video clip playlist or timeline behavior.
