### PR TITLE
ui(editor): clean up canvas control toolbar

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -12,7 +12,7 @@
 @import url("./editor/editor-layout.css?v=20260504-775");
 @import url("./editor/editor-sidebar.css");
 @import url("./editor/editor-canvas.css?v=20260504-787");
-@import url("./editor/editor-canvas-toolbar.css?v=20260507-655");
+@import url("./editor/editor-canvas-toolbar.css?v=20260512-1041");
 @import url("./editor/editor-memory-form.css");
 @import url("./editor/editor-detail-panel.css?v=20260504-627");
 @import url("./editor/editor-responsive.css");

--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -1,6 +1,7 @@
 /**
  * LoveBud Editor Canvas Toolbar Styles
  * Issue #515 - Canvas Toolbar CSS Relocation
+ * Issue #1041 - Toolbar Cleanup
  * 
  * Extracted from css/editor/overrides.css for better role ownership
  * Contains Editor Canvas Topbar & Toolbar selectors
@@ -47,29 +48,41 @@
     align-items: center;
     justify-content: flex-end;
     flex-wrap: wrap;
-    gap: 8px;
-    padding: 8px;
-    max-width: min(100%, 360px);
-    border-radius: 18px;
-    background: rgba(255,250,244,0.82);
+    gap: 12px;
+    padding: 6px;
+    border-radius: 20px;
+    background: rgba(255,250,244,0.85);
     border: 1px solid rgba(230,207,194,0.78);
     box-shadow: 0 14px 30px rgba(161,119,96,0.10);
     backdrop-filter: blur(8px);
 }
 
+.editor-canvas-toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.editor-canvas-toolbar-separator {
+    width: 1px;
+    height: 24px;
+    background: rgba(221,198,184,0.84);
+    margin: 0 4px;
+}
+
 .editor-canvas-tool-btn {
     position: relative;
-    width: 38px;
-    height: 38px;
-    min-width: 38px;
+    width: 36px;
+    height: 36px;
+    min-width: 36px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
     padding: 0;
-    border-radius: 12px;
+    border-radius: 14px;
     background: rgba(255,255,255,0.74);
-    border: 1px solid rgba(221,198,184,0.84);
+    border: 1px solid rgba(221,198,184,0.5);
     color: #7f6258;
     box-shadow: none;
     cursor: pointer;
@@ -103,49 +116,76 @@
 
 .editor-canvas-tool-btn-wide {
     width: auto;
-    min-width: 38px;
-    max-width: 150px;
-    padding: 0 12px;
+    min-width: 36px;
+    max-width: none;
+    padding: 0 14px 0 10px;
 }
 
 .editor-canvas-tool-label {
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1.15;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1;
     white-space: nowrap;
 }
 
 @media (max-width: 768px) {
     .editor-canvas-topbar {
-        left: 14px;
-        right: 14px;
-        gap: 10px;
+        left: 16px;
+        right: 16px;
+        gap: 12px;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .editor-canvas-title {
+        text-align: left;
     }
 
     .editor-canvas-toolbar {
         max-width: 100%;
         padding: 6px;
+        gap: 8px;
+        justify-content: flex-start;
+        align-items: stretch;
+        border-radius: 16px;
+    }
+
+    .editor-canvas-toolbar-group {
+        flex-wrap: wrap;
+        flex: 1;
         gap: 6px;
     }
 
+    .editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] {
+        flex: 0 0 auto;
+    }
+
+    .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] {
+        flex: 1 1 auto;
+        flex-direction: column;
+    }
+
+    .editor-canvas-toolbar-separator {
+        display: none;
+    }
+
     .editor-canvas-tool-btn {
-        width: 36px;
-        height: 36px;
-        min-width: 36px;
+        width: 40px;
+        height: 40px;
+        min-width: 40px;
     }
 
     .editor-canvas-tool-btn-wide {
-        width: 36px;
-        max-width: 36px;
-        padding: 0;
+        width: 100%;
+        flex: none;
+        padding: 0 12px;
+        justify-content: center;
     }
 
     .editor-canvas-tool-label {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        overflow: hidden;
-        clip: rect(0 0 0 0);
-        white-space: nowrap;
+        position: static;
+        width: auto;
+        height: auto;
+        clip: auto;
     }
 }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -60,20 +60,25 @@
                     <p class="editor-canvas-caption">순간을 심고 이어가며 나만의 러브트리를 완성해보세요.</p>
                 </div>
                 <div class="editor-canvas-toolbar" role="toolbar" aria-label="트리 화면 조정">
-                    <button type="button" class="editor-canvas-tool-btn" id="zoomOutCanvasBtn" aria-label="축소" title="축소">
-                        <span class="material-symbols-outlined" aria-hidden="true">zoom_out</span>
-                    </button>
-                    <button type="button" class="editor-canvas-tool-btn" id="zoomInCanvasBtn" aria-label="확대" title="확대">
-                        <span class="material-symbols-outlined" aria-hidden="true">zoom_in</span>
-                    </button>
-                    <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="recenterCanvasBtn" aria-label="트리 한눈에 보기" title="트리 한눈에 보기">
-                        <span class="material-symbols-outlined" aria-hidden="true">fit_screen</span>
-                        <span class="editor-canvas-tool-label" id="recenterCanvasBtnLabel">트리 한눈에 보기</span>
-                    </button>
-                    <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="focusSelectedBtn" aria-label="선택한 순간 보기" title="선택한 순간 보기" disabled>
-                        <span class="material-symbols-outlined" aria-hidden="true">center_focus_strong</span>
-                        <span class="editor-canvas-tool-label" id="focusSelectedBtnLabel">선택한 순간 보기</span>
-                    </button>
+                    <div class="editor-canvas-toolbar-group" aria-label="화면 줌 컨트롤">
+                        <button type="button" class="editor-canvas-tool-btn" id="zoomOutCanvasBtn" aria-label="축소" title="축소">
+                            <span class="material-symbols-outlined" aria-hidden="true">zoom_out</span>
+                        </button>
+                        <button type="button" class="editor-canvas-tool-btn" id="zoomInCanvasBtn" aria-label="확대" title="확대">
+                            <span class="material-symbols-outlined" aria-hidden="true">zoom_in</span>
+                        </button>
+                    </div>
+                    <div class="editor-canvas-toolbar-separator" aria-hidden="true"></div>
+                    <div class="editor-canvas-toolbar-group" aria-label="트리 뷰 컨트롤">
+                        <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="recenterCanvasBtn" aria-label="트리 한눈에 보기" title="트리 한눈에 보기">
+                            <span class="material-symbols-outlined" aria-hidden="true">fit_screen</span>
+                            <span class="editor-canvas-tool-label" id="recenterCanvasBtnLabel">트리 한눈에 보기</span>
+                        </button>
+                        <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="focusSelectedBtn" aria-label="선택한 순간 보기" title="선택한 순간 보기" disabled>
+                            <span class="material-symbols-outlined" aria-hidden="true">center_focus_strong</span>
+                            <span class="editor-canvas-tool-label" id="focusSelectedBtnLabel">선택한 순간 보기</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <svg class="canvas-svg" id="canvasSvg"></svg>


### PR DESCRIPTION
- Refs #1041%0A- Summary: Grouped and styled canvas control buttons into a single compact toolbar.%0A- Changed files: pages/editor.html, css/editor/editor-canvas-toolbar.css, css/editor.css%0A- Browser verification: Passed.%0A- Safety notes: No behavioral changes, backend changes, or secret exposures.