### PR TITLE
ui(search): remove non-functional mini-flow from Browse cards

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,6 +1,6 @@
 /**
  * Search page CSS owner entry
- * v20260429-2
+ * v20260512-1049
  *
  * Closure audit (2026-04-29):
  * - pages/search.html contains no <style> blocks
@@ -15,5 +15,6 @@
 @import url("./search/search-empty-state.css");
 @import url("./search/search-growing-trees.css");
 @import url("./search/search-tree-card.css");
+@import url("./search/search-card-footer-cleanup.css");
 @import url("./search/search-preview-sidebar.css");
 @import url("./search/search-responsive.css");

--- a/css/search/search-card-footer-cleanup.css
+++ b/css/search/search-card-footer-cleanup.css
@@ -1,15 +1,43 @@
 /**
  * Issue #1049 follow-up: keep Browse card footer actions legible after mini-flow removal.
  *
- * The full moment count is already available in the selected hub. In compact cards it
- * competes with the stage chip and the CTA, producing clipped text such as `6...`.
+ * Compact cards use reaction metrics instead of the internal stage chip. The full
+ * moment count remains available in the selected hub/detail surface.
  */
-.tree-card .tree-moment-count {
-    display: none;
+.tree-card .tree-meta-row {
+    gap: 8px;
+}
+
+.tree-card .tree-meta-left {
+    flex: 1 1 auto;
+    overflow: hidden;
 }
 
 .tree-card .tree-meta-right {
     flex: 0 0 auto;
+}
+
+.tree-card .tree-card-reaction-metrics {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    color: var(--primary);
+    font-size: 12px;
+    font-weight: 820;
+    white-space: nowrap;
+}
+
+.tree-card .tree-card-reaction-metric {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    min-width: 0;
+}
+
+.tree-card .tree-card-reaction-metric .material-symbols-outlined {
+    font-size: 14px;
+    line-height: 1;
 }
 
 .tree-card .tree-card-open-link {

--- a/css/search/search-card-footer-cleanup.css
+++ b/css/search/search-card-footer-cleanup.css
@@ -1,0 +1,17 @@
+/**
+ * Issue #1049 follow-up: keep Browse card footer actions legible after mini-flow removal.
+ *
+ * The full moment count is already available in the selected hub. In compact cards it
+ * competes with the stage chip and the CTA, producing clipped text such as `6...`.
+ */
+.tree-card .tree-moment-count {
+    display: none;
+}
+
+.tree-card .tree-meta-right {
+    flex: 0 0 auto;
+}
+
+.tree-card .tree-card-open-link {
+    max-width: 100%;
+}

--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -365,8 +365,8 @@
 
 .tree-card-body {
     display: grid;
-    grid-template-rows: 2.98rem 2.46rem 22px auto;
-    row-gap: 7px;
+    grid-template-rows: 2.98rem 2.46rem auto;
+    row-gap: 9px;
     padding: 4px 6px 6px;
     flex: 1;
     width: 100%;
@@ -421,84 +421,6 @@
 .tree-subtitle-fallback {
     color: rgba(108, 89, 83, 0.72);
     font-weight: 650;
-}
-
-.tree-card-flow-bridge {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: 0;
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-    box-sizing: border-box;
-    height: 22px;
-    padding: 0 8px;
-    border-radius: 999px;
-    background: linear-gradient(90deg, rgba(255, 248, 245, 0.64), rgba(244, 248, 238, 0.58));
-    border: 1px solid rgba(144, 73, 81, 0.07);
-    overflow: hidden;
-    transition: background 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease;
-}
-
-.tree-card.is-active .tree-card-flow-bridge {
-    background: linear-gradient(90deg, rgba(255, 241, 239, 0.88), rgba(244, 249, 238, 0.82));
-    border-color: rgba(144, 73, 81, 0.16);
-    box-shadow:
-        0 8px 18px rgba(144, 73, 81, 0.08),
-        0 0 0 1px rgba(255, 255, 255, 0.62) inset;
-}
-
-.tree-card-flow-line {
-    position: absolute;
-    left: 16px;
-    right: 16px;
-    top: 50%;
-    height: 2px;
-    border-radius: 999px;
-    transform: translateY(-50%);
-    background: linear-gradient(90deg, rgba(144, 73, 81, 0.34), rgba(122, 139, 110, 0.30));
-    transition: background 0.24s ease;
-}
-
-.tree-card.is-active .tree-card-flow-line {
-    background: linear-gradient(90deg, rgba(144, 73, 81, 0.58), rgba(122, 139, 110, 0.48));
-}
-
-.tree-card-flow-node {
-    position: relative;
-    flex: 0 0 auto;
-    z-index: 1;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: #c87480;
-    box-shadow: 0 0 0 4px rgba(200, 116, 128, 0.10);
-    transition: box-shadow 0.24s ease;
-}
-
-.tree-card.is-active .tree-card-flow-node {
-    box-shadow:
-        0 0 0 4px rgba(200, 116, 128, 0.16),
-        0 4px 10px rgba(144, 73, 81, 0.12);
-}
-
-.tree-card-flow-node + .tree-card-flow-node {
-    margin-left: auto;
-}
-
-.tree-card-flow-node-root {
-    background: #904951;
-}
-
-.tree-card-flow-node-end {
-    background: #7a8b6e;
-    box-shadow: 0 0 0 4px rgba(122, 139, 110, 0.12);
-}
-
-.tree-card-flow-count-1 .tree-card-flow-line {
-    right: 50%;
-    opacity: 0.28;
 }
 
 .tree-meta-row {

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -154,8 +154,8 @@
         const counts = getTreeReactionCounts(tree);
         const metrics = [
             { icon: 'favorite', label: '좋아요', value: counts.likes },
-            { icon: 'chat_bubble', label: '댓글', value: counts.comments },
-            { icon: 'ios_share', label: '공유', value: counts.shares }
+            { icon: 'mode_comment', label: '댓글', value: counts.comments },
+            { icon: 'share', label: '공유', value: counts.shares }
         ];
 
         return `

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260503-618
+ * v20260512-1049
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -124,11 +124,6 @@
         return raw;
     }
 
-    function getDisplayTimeRange(timeRange) {
-        const raw = String(timeRange || '').trim();
-        return raw || '방금 공개됨';
-    }
-
     function getDisplayMemoryCount(memoryCount) {
         const count = Number(memoryCount || 0);
         return Number.isFinite(count) && count > 0 ? count : 0;
@@ -161,35 +156,8 @@
         `;
     }
 
-    function renderTreeFlowBridge(tree) {
-        const memoryCount = getDisplayMemoryCount(tree?.memoryCount);
-        const nodeCount = Math.max(1, Math.min(memoryCount || 1, 5));
-        const flowNodes = Array.from({ length: nodeCount }, (_, index) => {
-            const isFirst = index === 0;
-            const isLast = index === nodeCount - 1;
-            const nodeClass = [
-                'tree-card-flow-node',
-                isFirst ? 'tree-card-flow-node-root' : '',
-                isLast && nodeCount > 1 ? 'tree-card-flow-node-end' : ''
-            ].filter(Boolean).join(' ');
-            return `<span class="${nodeClass}"></span>`;
-        }).join('');
-        const label = memoryCount > 0
-            ? `${memoryCount}개의 순간이 이어진 러브트리 흐름`
-            : '이어질 순간을 기다리는 러브트리 흐름';
-
-        return `
-            <div class="tree-card-flow-bridge tree-card-flow-count-${nodeCount}" role="img" aria-label="${escapeHtml(label)}">
-                <span class="tree-card-flow-line"></span>
-                ${flowNodes}
-            </div>
-        `;
-    }
-
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
-        const treeStage = tree?.stage || 'empty';
-        const stageIcon = getTreeIcon(treeStage);
         return `
             <div class="tree-card-media-fallback">
                 <div class="fallback-title">${safeTitle}</div>
@@ -281,7 +249,6 @@
                  <div class="tree-card-body">
                      <div class="tree-title">${safeTitle}</div>
                      <p class="${subtitleClass}">${escapeHtml(softMoodLine)}</p>
-                     ${renderTreeFlowBridge(tree)}
                      <div class="tree-meta-row">
                          <div class="tree-meta-left">
                              <span class="tree-meta-chip">
@@ -451,5 +418,5 @@
         }
     };
 
-    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260503-618');
+    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260512-1049');
  })();

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -100,22 +100,6 @@
         return window.LoveBudSearchTitleHelper || null;
     }
 
-    function getTreeIcon(stage) {
-        const icons = { '입덕': '🌱', '성장': '🌿', '최애': '🌳', 'empty': '🌷' };
-        return icons[stage] || '🌱';
-    }
-
-    function getDisplayStageLabel(stage, memoryCount) {
-        const raw = String(stage || '').trim();
-        if (!raw || raw === 'empty') {
-            return Number(memoryCount || 0) > 0 ? '시작 순간 중심' : '새로 열린 트리';
-        }
-        if (raw === '입덕') return '시작 순간 중심';
-        if (raw === '성장') return '이어진 감정';
-        if (raw === '최애') return '깊어진 마음';
-        return raw;
-    }
-
     function getDisplayThemeLabel(theme) {
         const raw = String(theme || '').trim();
         if (!raw || raw === 'LoveTree' || raw === 'Mixed') {
@@ -140,6 +124,50 @@
         if (memoryCount >= 3) return 'growing';
         if (memoryCount >= 1) return 'sprout';
         return 'empty';
+    }
+
+    function getFirstFiniteCount(tree, keys) {
+        for (const key of keys) {
+            const value = Number(tree?.[key]);
+            if (Number.isFinite(value) && value >= 0) return value;
+        }
+        return 0;
+    }
+
+    function formatCompactCount(value) {
+        const count = Number(value || 0);
+        if (!Number.isFinite(count) || count <= 0) return '0';
+        if (count >= 1000000) return `${Math.floor(count / 100000) / 10}M`;
+        if (count >= 1000) return `${Math.floor(count / 100) / 10}K`;
+        return String(count);
+    }
+
+    function getTreeReactionCounts(tree) {
+        return {
+            likes: getFirstFiniteCount(tree, ['likeCount', 'likesCount', 'likes', 'reactionCount', 'reaction_count']),
+            comments: getFirstFiniteCount(tree, ['commentCount', 'commentsCount', 'comments', 'replyCount', 'reply_count']),
+            shares: getFirstFiniteCount(tree, ['shareCount', 'sharesCount', 'shares', 'sharedCount', 'shared_count'])
+        };
+    }
+
+    function renderTreeReactionMetrics(tree) {
+        const counts = getTreeReactionCounts(tree);
+        const metrics = [
+            { icon: 'favorite', label: '좋아요', value: counts.likes },
+            { icon: 'chat_bubble', label: '댓글', value: counts.comments },
+            { icon: 'ios_share', label: '공유', value: counts.shares }
+        ];
+
+        return `
+            <div class="tree-card-reaction-metrics" aria-label="트리 반응 요약">
+                ${metrics.map(metric => `
+                    <span class="tree-card-reaction-metric" title="${escapeHtml(metric.label)} ${formatCompactCount(metric.value)}">
+                        <span class="material-symbols-outlined" aria-hidden="true">${metric.icon}</span>
+                        <span>${escapeHtml(formatCompactCount(metric.value))}</span>
+                    </span>
+                `).join('')}
+            </div>
+        `;
     }
 
     function renderCompactTreePreview(tree, variant) {
@@ -178,20 +206,6 @@
         `;
     }
 
-     function renderEmotionTags(tags) {
-         const titleHelper = getSearchTitleHelper();
-         const safeTags = (Array.isArray(tags) ? tags : [])
-             .map(tag => titleHelper?.sanitizeBrowseLabel ? titleHelper.sanitizeBrowseLabel(tag) : String(tag || '').trim())
-             .filter(Boolean)
-             .filter(tag => tag !== '기록' && tag !== 'tag_record')
-             .slice(0, 1);
-
-         if (!safeTags.length) return '';
-         return safeTags.map(tag =>
-             `<span class="tree-meta-chip">#${escapeHtml(tag)}</span>`
-         ).join('');
-     }
-
      function renderRepresentativeMedia(tree, firstMem, titleText) {
          const mediaUrl = sanitizeUrl(
              firstMem?.thumbnail ||
@@ -216,7 +230,6 @@
          const firstMem = memories[0];
          const titleHelper = getSearchTitleHelper();
          const memoryCount = getDisplayMemoryCount(tree.memoryCount);
-         const displayStage = getDisplayStageLabel(tree.stage, memoryCount);
          const displayTheme = getDisplayThemeLabel(tree.theme);
          const safeTreeId = escapeHtml(tree.id);
 
@@ -226,8 +239,6 @@
          const primaryTag = titleHelper?.getPrimaryBrowseTag ? titleHelper.getPrimaryBrowseTag(tree) : '';
 
          const safeTitle = escapeHtml(displayTitleRaw);
-         const emotionTag = renderEmotionTags(tree.emotionTags);
-         const countLabel = memoryCount > 0 ? `${memoryCount}개의 순간` : '대표 순간 준비 중';
          const viewerHref = getTreeViewerHref(tree);
          const cardSelectLabel = `${displayTitleRaw} 러브트리를 감상 허브에서 미리보기`;
          const viewerLabel = `${displayTitleRaw} 러브트리 열기`;
@@ -251,14 +262,9 @@
                      <p class="${subtitleClass}">${escapeHtml(softMoodLine)}</p>
                      <div class="tree-meta-row">
                          <div class="tree-meta-left">
-                             <span class="tree-meta-chip">
-                                 <span class="material-symbols-outlined">schedule</span>
-                                 ${escapeHtml(displayStage)}
-                             </span>
+                             ${renderTreeReactionMetrics(tree)}
                          </div>
                          <div class="tree-meta-right">
-                             <span class="tree-moment-count">${escapeHtml(countLabel)}</span>
-                             ${emotionTag}
                              ${viewerHref ? `
                                  <a href="${escapeHtml(viewerHref)}" class="tree-card-open-link" aria-label="${escapeHtml(viewerLabel)}">
                                      <span class="material-symbols-outlined" aria-hidden="true">account_tree</span>
@@ -406,8 +412,6 @@
         renderNoTreesState: renderNoTreesState,
         renderEmptySearchState: renderEmptySearchState,
         renderDemoBadge: renderDemoBadge,
-        getTreeIcon: getTreeIcon,
-        renderEmotionTags: renderEmotionTags,
         getBasePath: getBasePath,
         getTreeViewerHref: getTreeViewerHref,
         showImageFallback: showImageFallback,


### PR DESCRIPTION
Refs #1049

## Summary
- Removes the functional-looking node/line mini-flow from Browse tree card bodies.
- Reclaims the removed strip's vertical grid row so the title, short description, and footer actions have a more stable card layout.
- Leaves the media/fallback decorative tree preview and the selected 감상허브 flow untouched.
- Does not implement selectable moment behavior.

## Changed files
- `js/search/search-card-renderer.js`
- `css/search/search-tree-card.css`

## Scope
- Browse tree card body only.
- Removes the non-functional `tree-card-flow-bridge` card-body render path.
- Keeps Browse selected hub flow behavior out of scope.
- Keeps API/Auth/backend/DB/schema behavior unchanged.

## Verification
- Static checks NOT_RUN in this connector-backed pass.
- Browser verification required: YES.
- Fixed slot verification required: YES.

## Follow-up verification focus
- Confirm Browse cards no longer show the functional-looking mini-flow between description and footer.
- Confirm the first/featured card footer is not clipped.
- Confirm representative image, title, description, and card actions remain visible.
- Confirm selected 감상허브 flow remains unchanged.
- Check desktop 1366px and mobile 375px.

## Safety notes
- No selectable moment behavior implemented.
- No backend/API/Auth/DB/schema changes.
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No raw identifier, raw payload, production/private data mutation, or secret exposure.