### PR TITLE
fix(search): allow Browse appreciation hub to scroll

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,6 +1,6 @@
 /**
  * Search page CSS owner entry
- * v20260429-2
+ * v20260512-1054
  *
  * Closure audit (2026-04-29):
  * - pages/search.html contains no <style> blocks
@@ -16,4 +16,5 @@
 @import url("./search/search-growing-trees.css");
 @import url("./search/search-tree-card.css");
 @import url("./search/search-preview-sidebar.css");
+@import url("./search/search-preview-scroll-fix.css");
 @import url("./search/search-responsive.css");

--- a/css/search/search-preview-scroll-fix.css
+++ b/css/search/search-preview-scroll-fix.css
@@ -1,0 +1,22 @@
+/**
+ * Issue #1054: allow the Browse appreciation hub to scroll independently.
+ *
+ * The selected-tree hub can exceed the available viewport height on desktop.
+ * Keep the sticky panel within the viewport and allow internal scrolling without
+ * changing Browse card, media playback, or overlay behavior.
+ */
+@media (min-width: 769px) {
+    .preview-sidebar {
+        max-height: calc(100dvh - 120px);
+        overflow-y: auto;
+        overflow-x: hidden;
+        overscroll-behavior: contain;
+        scrollbar-gutter: stable both-edges;
+    }
+}
+
+@media (max-width: 768px) {
+    .preview-sidebar {
+        overscroll-behavior: contain;
+    }
+}


### PR DESCRIPTION
Refs #1054

## Summary
- Adds a narrow CSS fix so the Browse appreciation hub can scroll independently when its content exceeds viewport height.
- Keeps the desktop sticky panel constrained to the viewport with `max-height` and internal `overflow-y: auto`.
- Preserves existing mobile bottom-sheet scroll behavior.

## Changed files
- `css/search.css`
- `css/search/search-preview-scroll-fix.css`

## Scope
- Search/Browse preview sidebar scroll behavior only.
- No Browse card footer metric changes.
- No appreciation hub media playback changes.
- No non-functional overlay cleanup in this PR.
- No backend/API/Auth/DB/schema changes.

## Verification
- Browser verification required: YES.
- Fixed slot verification required: YES if Cloudflare PR preview is insufficient.
- Desktop: select a tree with enough appreciation hub content and confirm lower actions are reachable by scrolling the hub panel.
- Mobile 375px: confirm the bottom sheet remains scrollable.

## Safety notes
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No production/private data mutation.
- No raw identifier, raw payload, or secret exposure.