### PR TITLE
ux(search): remove non-functional Browse hub media overlays

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,6 +1,6 @@
 /**
  * Search page CSS owner entry
- * v20260429-2
+ * v20260512-1052
  *
  * Closure audit (2026-04-29):
  * - pages/search.html contains no <style> blocks
@@ -16,4 +16,5 @@
 @import url("./search/search-growing-trees.css");
 @import url("./search/search-tree-card.css");
 @import url("./search/search-preview-sidebar.css");
+@import url("./search/search-preview-media-cleanup.css");
 @import url("./search/search-responsive.css");

--- a/css/search/search-preview-media-cleanup.css
+++ b/css/search/search-preview-media-cleanup.css
@@ -1,0 +1,9 @@
+/**
+ * Issue #1052: remove non-functional appreciation hub media overlays.
+ *
+ * The hub media should not show decorative tree controls that look clickable when
+ * playback/continue behavior is not implemented in this scope.
+ */
+.video-container::before {
+    content: none;
+}

--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Preview Media Helper
- * v20260428-1
+ * v20260512-1052
  * 
  * Media helper boundary extracted from search-preview-renderer.js
  * Issue #424 PR B - Media helper extraction
@@ -105,14 +105,6 @@
             <div class="preview-media-frame preview-media-frame-thumbnail" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
                 <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
-                <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
-                <div data-preview-overlay style="position:absolute;left:18px;right:18px;bottom:18px;color:white;">
-                    <div style="display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:0 10px;border-radius:999px;background:rgba(255,255,255,0.18);backdrop-filter:blur(10px);font-size:12px;font-weight:800;margin-bottom:10px;">
-                        <span class="material-symbols-outlined" style="font-size:14px;">play_circle</span>
-                        ${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '대표 순간부터 감상하기', 'Start from the featured moment'))}
-                    </div>
-                    <div style="font-size:14px;font-weight:800;line-height:1.4;">${mediaTitle}</div>
-                </div>
             </div>
         `;
     }
@@ -176,10 +168,6 @@
                     title="${escapeHtml(treeTitle)}" frameborder="0"
                     allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen style="position:absolute;top:0;left:0;"></iframe>
-                <div style="position:absolute;bottom:0;left:0;right:0;background:linear-gradient(to top,rgba(0,0,0,0.8),transparent);padding:40px 20px 20px;color:white;text-align:center;">
-                    <div style="font-size:14px;font-weight:700;margin-bottom:8px;opacity:0.9;">${escapeHtml(getSearchCopy('search.previewStartFromFirstMoment', '대표 순간부터 감상하기', 'Start from the featured moment'))}</div>
-                    <div style="font-size:12px;opacity:0.7;">${escapeHtml(mediaTitle)}</div>
-                </div>
             </div>
         `;
     }
@@ -195,5 +183,5 @@
         renderPreviewIframe: renderPreviewIframe
     };
 
-    console.log('[LoveBudSearchPreviewMediaHelper] Search preview media helper loaded v20260428-1');
+    console.log('[LoveBudSearchPreviewMediaHelper] Search preview media helper loaded v20260512-1052');
 })();


### PR DESCRIPTION
Refs #1052

## Summary
- Removes the non-functional `대표 순간부터 감상하기` overlay from Browse appreciation hub thumbnail media.
- Removes the decorative tree-shaped media badge from the appreciation hub video container.
- Removes the iframe bottom overlay copy so playable/embed media is not covered by preview-only text.

## Changed files
- `js/search/search-preview-media-helper.js`
- `css/search.css`
- `css/search/search-preview-media-cleanup.css`

## Scope
- Browse appreciation hub media overlay cleanup only.
- No inline playback feature implementation.
- No Browse card footer metric changes.
- No selectable moment behavior.
- No backend/API/Auth/DB/schema changes.

## Verification
- Browser verification required: YES.
- Fixed slot verification required: YES if Cloudflare PR preview is insufficient.
- Browse page: select a tree and inspect the appreciation hub media area.
- Confirm thumbnail/video is not covered by non-functional CTA or decorative tree badge.
- Confirm no fatal LoveBud runtime console errors.

## Safety notes
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No production/private data mutation.
- No raw identifier, raw payload, or secret exposure.