### PR TITLE
fix(search): integrate Browse hub scroll and media cleanup

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -19,4 +19,5 @@
 @import url("./search/search-preview-sidebar.css");
 @import url("./search/search-preview-scroll-fix.css");
 @import url("./search/search-preview-media-cleanup.css");
+@import url("./search/search-preview-media-no-overlays.css");
 @import url("./search/search-responsive.css");

--- a/css/search.css
+++ b/css/search.css
@@ -1,6 +1,6 @@
 /**
  * Search page CSS owner entry
- * v20260512-1058
+ * v20260512-1058-2
  *
  * Closure audit (2026-04-29):
  * - pages/search.html contains no <style> blocks
@@ -20,4 +20,5 @@
 @import url("./search/search-preview-scroll-fix.css");
 @import url("./search/search-preview-media-cleanup.css");
 @import url("./search/search-preview-media-no-overlays.css");
+@import url("./search/search-preview-social-bar.css");
 @import url("./search/search-responsive.css");

--- a/css/search.css
+++ b/css/search.css
@@ -1,6 +1,6 @@
 /**
  * Search page CSS owner entry
- * v20260512-1049
+ * v20260512-1058
  *
  * Closure audit (2026-04-29):
  * - pages/search.html contains no <style> blocks
@@ -17,4 +17,6 @@
 @import url("./search/search-tree-card.css");
 @import url("./search/search-card-footer-cleanup.css");
 @import url("./search/search-preview-sidebar.css");
+@import url("./search/search-preview-scroll-fix.css");
+@import url("./search/search-preview-media-cleanup.css");
 @import url("./search/search-responsive.css");

--- a/css/search/search-preview-media-cleanup.css
+++ b/css/search/search-preview-media-cleanup.css
@@ -1,0 +1,6 @@
+/**
+ * Issue #1052: remove non-functional appreciation hub media overlays.
+ */
+.video-container::before {
+    content: none;
+}

--- a/css/search/search-preview-media-no-overlays.css
+++ b/css/search/search-preview-media-no-overlays.css
@@ -1,4 +1,12 @@
-/* Issue #1052: remove decorative hub media badge. */
+/* Issue #1052: remove non-functional Browse hub media overlays. */
 .video-container::before {
     content: none;
+}
+
+.preview-media-frame-thumbnail [data-preview-overlay] {
+    display: none !important;
+}
+
+.preview-media-frame-iframe > div {
+    display: none !important;
 }

--- a/css/search/search-preview-media-no-overlays.css
+++ b/css/search/search-preview-media-no-overlays.css
@@ -1,4 +1,4 @@
-/* Issue #1052: remove non-functional Browse hub media overlays. */
+/* Issue #1052: remove non-functional Browse media overlays. */
 .video-container::before {
     content: none;
 }
@@ -8,5 +8,9 @@
 }
 
 .preview-media-frame-iframe > div {
+    display: none !important;
+}
+
+.tree-card .tree-card-preview-strip-media {
     display: none !important;
 }

--- a/css/search/search-preview-media-no-overlays.css
+++ b/css/search/search-preview-media-no-overlays.css
@@ -1,0 +1,4 @@
+/* Issue #1052: remove decorative hub media badge. */
+.video-container::before {
+    content: none;
+}

--- a/css/search/search-preview-scroll-fix.css
+++ b/css/search/search-preview-scroll-fix.css
@@ -1,0 +1,18 @@
+/**
+ * Issue #1054: allow the Browse appreciation hub to scroll independently.
+ */
+@media (min-width: 769px) {
+    .preview-sidebar {
+        max-height: calc(100dvh - 120px);
+        overflow-y: auto;
+        overflow-x: hidden;
+        overscroll-behavior: contain;
+        scrollbar-gutter: stable both-edges;
+    }
+}
+
+@media (max-width: 768px) {
+    .preview-sidebar {
+        overscroll-behavior: contain;
+    }
+}

--- a/css/search/search-preview-social-bar.css
+++ b/css/search/search-preview-social-bar.css
@@ -1,0 +1,110 @@
+/* Issue #1058: Browse appreciation hub social action bar. */
+.preview-social-shell {
+    margin-top: 1rem;
+    padding-top: 0.95rem;
+    border-top: 1px solid rgba(111, 76, 68, 0.1);
+}
+
+.preview-social-bar {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    align-items: stretch;
+}
+
+.preview-social-action {
+    appearance: none;
+    -webkit-appearance: none;
+    border: 1px solid rgba(159, 78, 91, 0.14);
+    background: rgba(255, 250, 249, 0.72);
+    color: var(--on-surface-variant, #6f5b55);
+    border-radius: 999px;
+    min-height: 2.35rem;
+    padding: 0.42rem 0.45rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.22rem;
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 0.35rem 1rem rgba(104, 64, 58, 0.06);
+}
+
+.preview-social-action .material-symbols-outlined {
+    font-size: 1rem;
+    line-height: 1;
+    color: var(--primary, #9f4e5b);
+    font-variation-settings: 'FILL' 0, 'wght' 450, 'GRAD' 0, 'opsz' 20;
+}
+
+.preview-social-action strong {
+    color: var(--primary, #9f4e5b);
+    font-size: 0.74rem;
+    font-weight: 800;
+}
+
+.preview-social-action span:last-child {
+    white-space: nowrap;
+}
+
+.preview-social-action[disabled] {
+    cursor: default;
+    opacity: 0.9;
+}
+
+.preview-social-action:not([disabled]) {
+    cursor: pointer;
+}
+
+.preview-social-action:not([disabled]):hover,
+.preview-social-action:not([disabled]):focus-visible {
+    border-color: rgba(159, 78, 91, 0.28);
+    background: rgba(255, 246, 247, 0.96);
+    color: var(--primary, #9f4e5b);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.preview-comments-panel {
+    margin-top: 0.75rem;
+    padding: 0.85rem 0.95rem;
+    border: 1px solid rgba(159, 78, 91, 0.12);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.68);
+    color: var(--on-surface-variant, #6f5b55);
+    font-size: 0.78rem;
+    line-height: 1.55;
+}
+
+.preview-comments-title {
+    color: var(--on-surface, #3f302c);
+    font-size: 0.82rem;
+    font-weight: 900;
+    margin-bottom: 0.35rem;
+}
+
+.preview-comments-panel p {
+    margin: 0.2rem 0 0;
+}
+
+.preview-comments-note {
+    opacity: 0.74;
+}
+
+@media (max-width: 480px) {
+    .preview-social-bar {
+        gap: 0.38rem;
+    }
+
+    .preview-social-action {
+        min-height: 2.25rem;
+        padding-inline: 0.35rem;
+        font-size: 0.68rem;
+    }
+
+    .preview-social-action .material-symbols-outlined {
+        font-size: 0.95rem;
+    }
+}

--- a/js/search/search-data-adapter.js
+++ b/js/search/search-data-adapter.js
@@ -1,32 +1,48 @@
 /**
  * LoveBud Search Data Adapter
- * v20260418-1
+ * v20260512-1058
  *
  * Data processing layer: transforms raw memories/trees into tree view models.
  * UI-agnostic - focuses on data transformation only.
  */
 
-// 1. /api/community/trees camelCase-only
-// 2. /api/community/memories camelCase-only
-
 (function() {
     'use strict';
 
-    /**
-     * Validates and filters public memories
-     * @param {Array} memories - Raw memories array
-     * @returns {Array} Filtered public memories (excludes 'root' and non-public)
-     */
-    function filterPublicMemories(memories) {
-        if (!Array.isArray(memories)) return [];
-        return memories.filter(m => m.id !== 'root' && m.visibility === 'public');
+    function firstStringValue(source, keys) {
+        if (!source) return '';
+        for (const key of keys) {
+            const value = source[key];
+            if (typeof value === 'string' && value.trim()) {
+                return value.trim();
+            }
+        }
+        return '';
     }
 
-    /**
-     * Groups memories by treeId
-     * @param {Array} memories - Filtered memories
-     * @returns {Object} Object with treeId keys and memory arrays
-     */
+    function normalizePublicMemory(memory) {
+        if (!memory || typeof memory !== 'object') return memory;
+        const sourceUrl = firstStringValue(memory, [
+            'sourceUrl',
+            'sourceURL',
+            'videoUrl',
+            'videoURL',
+            'mediaUrl',
+            'mediaURL',
+            'url',
+            'linkUrl',
+            'linkURL'
+        ]);
+        return sourceUrl ? { ...memory, sourceUrl } : memory;
+    }
+
+    function filterPublicMemories(memories) {
+        if (!Array.isArray(memories)) return [];
+        return memories
+            .filter(m => m.id !== 'root' && m.visibility === 'public')
+            .map(normalizePublicMemory);
+    }
+
     function groupMemoriesByTree(memories) {
         const grouped = {};
         memories.forEach(m => {
@@ -37,58 +53,28 @@
         return grouped;
     }
 
-    /**
-     * Estimates tree stage based on memory count
-     * @param {number} count - Memory count
-     * @returns {string} '입덕' | '성장' | '최애'
-     */
     function estimateStage(count) {
         if (count <= 2) return '입덕';
         if (count <= 4) return '성장';
         return '최애';
     }
 
-    /**
-     * Extracts representative theme from memories
-     * @param {Array} memories - Sorted memories
-     * @returns {string} Artist name or 'Mixed'
-     */
     function extractTheme(memories) {
         if (!memories || memories.length === 0) return 'Mixed';
         return memories[0].artist || 'Mixed';
     }
 
-    /**
-     * Calculates time range from timestamps
-     * @param {Array} memories - Sorted memories
-     * @returns {string} Formatted time range
-     */
     function calculateTimeRange(memories) {
         if (!memories || memories.length === 0) return 'recently';
-        
-        const timestamps = memories
-            .map(m => m.timestamp)
-            .filter(Boolean);
-        
-        if (timestamps.length < 2) {
-            return timestamps[0] || 'recently';
-        }
-        
-        // Assume sorted by timestamp
+        const timestamps = memories.map(m => m.timestamp).filter(Boolean);
+        if (timestamps.length < 2) return timestamps[0] || 'recently';
         return `${timestamps[0]} ~ ${timestamps[timestamps.length - 1]}`;
     }
 
-    /**
-     * Collects unique emotion tags from memories (max 3)
-     * @param {Array} memories - Sorted memories
-     * @returns {Array} Array of unique tags (max 3)
-     */
     function collectEmotionTags(memories) {
         if (!memories || memories.length === 0) return [];
-        
         const allTags = [];
         memories.forEach(m => {
-            // Use LoveBudNormalize if available
             let tags = [];
             if (window.LoveBudNormalize?.normalizeMemory) {
                 const normalized = window.LoveBudNormalize.normalizeMemory(m);
@@ -98,42 +84,26 @@
             }
             allTags.push(...tags);
         });
-        
-        // Dedupe and limit to 3
-        const unique = [...new Set(allTags)];
-        return unique.slice(0, 3);
+        return [...new Set(allTags)].slice(0, 3);
     }
 
-    /**
-     * Builds tree view models from raw memories and trees
-     * 
-     * @param {Array} memories - Raw memories from API
-     * @param {Array} trees - Raw trees from API
-     * @returns {Array} Array of tree view models ready for rendering
-     */
     function buildTreeData(memories, trees) {
         if (!Array.isArray(trees)) return [];
-        
-        // Filter and group memories
         const validMemories = filterPublicMemories(memories);
         const grouped = groupMemoriesByTree(validMemories);
-        
+
         return trees.map(tree => {
             const treeMems = grouped[tree.id] || [];
-            
-            // Sort by timestamp
             const sortedMems = treeMems.sort((a, b) => {
                 const timeA = a.timestamp || a.createdAt || 0;
                 const timeB = b.timestamp || b.createdAt || 0;
                 return new Date(timeA) - new Date(timeB);
             });
-            
             const memoryCount = sortedMems.length;
             const emotionTags = collectEmotionTags(sortedMems);
             const timeRange = calculateTimeRange(sortedMems);
             const theme = extractTheme(sortedMems);
             const stage = estimateStage(memoryCount);
-            
             return {
                 ...tree,
                 memories: sortedMems,
@@ -141,69 +111,30 @@
                 emotionTags: emotionTags,
                 timeRange: timeRange,
                 representativeThumbnail: sortedMems[0]?.thumbnail || '',
+                representativeSourceUrl: sortedMems[0]?.sourceUrl || '',
                 theme: theme,
                 stage: stage
             };
         }).filter(t => t.memoryCount > 0);
     }
 
-    // ─────────────────────────────────────────────────────────
-    // Filter Logic (search-specific, but UI-agnostic)
-    // ─────────────────────────────────────────────────────────
-
-    /**
-     * Checks if tree matches search query
-     * @param {Object} tree - Tree view model
-     * @param {string} query - Search query
-     * @returns {boolean}
-     */
     function matchesQuery(tree, query) {
         if (!query) return true;
-        
         const q = query.toLowerCase();
-        
-        // Search tree fields
         const treeFields = [tree.title, tree.theme, tree.memo].filter(Boolean);
-        
-        // Search memory fields
-        const memoryFields = tree.memories?.flatMap(m => 
-            [m.title, m.artist, m.memo].filter(Boolean)
-        ) || [];
-        
-        return [...treeFields, ...memoryFields].some(field =>
-            field && field.toLowerCase().includes(q)
-        );
+        const memoryFields = tree.memories?.flatMap(m => [m.title, m.artist, m.memo].filter(Boolean)) || [];
+        return [...treeFields, ...memoryFields].some(field => field && field.toLowerCase().includes(q));
     }
 
-    /**
-     * Checks if tree matches category/stage filter
-     * @param {Object} tree - Tree view model
-     * @param {string} category - Category ('전체', '입덕', '성장', '최애')
-     * @returns {boolean}
-     */
     function matchesCategory(tree, category) {
         if (category === '전체' || category === '전체 경로') return true;
         return tree.stage === category;
     }
 
-    /**
-     * Filters trees by query and category
-     * @param {Array} trees - Tree view models
-     * @param {string} query - Search query
-     * @param {string} category - Category filter
-     * @returns {Array} Filtered trees
-     */
     function filterTrees(trees, query, category) {
         if (!Array.isArray(trees)) return [];
-        
-        return trees.filter(t =>
-            matchesQuery(t, query) && matchesCategory(t, category)
-        );
+        return trees.filter(t => matchesQuery(t, query) && matchesCategory(t, category));
     }
-
-    // ─────────────────────────────────────────────────────────
-    // Exports
-    // ─────────────────────────────────────────────────────────
 
     window.LoveBudSearchAdapter = {
         buildTreeData: buildTreeData,
@@ -211,12 +142,12 @@
         matchesQuery: matchesQuery,
         matchesCategory: matchesCategory,
         estimateStage: estimateStage,
-        // Exported for testing/debugging
         _filterPublicMemories: filterPublicMemories,
         _groupMemoriesByTree: groupMemoriesByTree,
         _calculateTimeRange: calculateTimeRange,
-        _collectEmotionTags: collectEmotionTags
+        _collectEmotionTags: collectEmotionTags,
+        _normalizePublicMemory: normalizePublicMemory
     };
 
-    console.log('[LoveBudSearchAdapter] Search data adapter loaded v20260418-1');
+    console.log('[LoveBudSearchAdapter] Search data adapter loaded v20260512-1058');
 })();

--- a/js/search/search-data-adapter.js
+++ b/js/search/search-data-adapter.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Data Adapter
- * v20260512-1058
+ * v20260512-1058-2
  *
  * Data processing layer: transforms raw memories/trees into tree view models.
  * UI-agnostic - focuses on data transformation only.
@@ -20,9 +20,24 @@
         return '';
     }
 
+    function getYouTubeIdFromThumbnail(url) {
+        if (!url) return '';
+        try {
+            const parsed = new URL(url);
+            const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+            if (!host.includes('ytimg.com') && !host.includes('img.youtube.com')) return '';
+            const parts = parsed.pathname.split('/').filter(Boolean);
+            const viIndex = parts.indexOf('vi');
+            if (viIndex >= 0 && parts[viIndex + 1]) return parts[viIndex + 1];
+        } catch (e) {
+            return '';
+        }
+        return '';
+    }
+
     function normalizePublicMemory(memory) {
         if (!memory || typeof memory !== 'object') return memory;
-        const sourceUrl = firstStringValue(memory, [
+        const explicitSourceUrl = firstStringValue(memory, [
             'sourceUrl',
             'sourceURL',
             'videoUrl',
@@ -33,6 +48,9 @@
             'linkUrl',
             'linkURL'
         ]);
+        const thumbnail = firstStringValue(memory, ['thumbnail', 'thumbnailUrl', 'thumbnailURL', 'imageUrl', 'imageURL']);
+        const youtubeId = getYouTubeIdFromThumbnail(thumbnail);
+        const sourceUrl = explicitSourceUrl || (youtubeId ? `https://www.youtube.com/watch?v=${encodeURIComponent(youtubeId)}` : '');
         return sourceUrl ? { ...memory, sourceUrl } : memory;
     }
 
@@ -146,8 +164,9 @@
         _groupMemoriesByTree: groupMemoriesByTree,
         _calculateTimeRange: calculateTimeRange,
         _collectEmotionTags: collectEmotionTags,
-        _normalizePublicMemory: normalizePublicMemory
+        _normalizePublicMemory: normalizePublicMemory,
+        _getYouTubeIdFromThumbnail: getYouTubeIdFromThumbnail
     };
 
-    console.log('[LoveBudSearchAdapter] Search data adapter loaded v20260512-1058');
+    console.log('[LoveBudSearchAdapter] Search data adapter loaded v20260512-1058-2');
 })();

--- a/js/search/search-preview-hub-dom-patch.js
+++ b/js/search/search-preview-hub-dom-patch.js
@@ -1,0 +1,157 @@
+/* Issue #1058: DOM-level Browse hub final layout patch. */
+(function() {
+    'use strict';
+
+    var lastPatchedTitle = '';
+    var socialBound = false;
+
+    function hide(el) {
+        if (!el) return;
+        el.hidden = true;
+        el.style.display = 'none';
+    }
+
+    function getPreviewDesc() {
+        return document.getElementById('previewDesc');
+    }
+
+    function getPreviewTitleText() {
+        var title = document.querySelector('#previewTitle .preview-focus-title') || document.getElementById('previewTitle');
+        return String(title && title.textContent || '').trim() || '러브트리';
+    }
+
+    function getSummaryText() {
+        var copy = document.querySelector('#previewDesc .preview-focus-copy');
+        if (!copy) return '';
+        var clone = copy.cloneNode(true);
+        Array.prototype.slice.call(clone.children).forEach(function(child) {
+            if (child.tagName === 'DIV') child.remove();
+        });
+        return String(clone.textContent || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function normalizeCopy() {
+        var desc = getPreviewDesc();
+        if (!desc) return;
+        var copy = desc.querySelector('.preview-focus-copy');
+        if (!copy) return;
+
+        Array.prototype.slice.call(copy.children).forEach(function(child) {
+            if (child.tagName === 'DIV') child.remove();
+        });
+
+        if (!copy.querySelector('.preview-summary-line')) {
+            var summaryText = getSummaryText();
+            if (summaryText) {
+                copy.innerHTML = '<p class="preview-summary-line">' + summaryText + '</p>';
+            }
+        }
+    }
+
+    function renderSocialShell() {
+        return '' +
+            '<div class="preview-social-shell" data-preview-social-shell>' +
+                '<div class="preview-social-bar" aria-label="트리 반응">' +
+                    '<button type="button" class="preview-social-action" data-preview-like disabled aria-label="좋아요 0"><span class="material-symbols-outlined" aria-hidden="true">favorite</span><strong>0</strong><span>좋아요</span></button>' +
+                    '<button type="button" class="preview-social-action" data-preview-comments aria-expanded="false" aria-label="댓글 0"><span class="material-symbols-outlined" aria-hidden="true">mode_comment</span><strong>0</strong><span>댓글</span></button>' +
+                    '<button type="button" class="preview-social-action" data-preview-share disabled aria-label="공유 0"><span class="material-symbols-outlined" aria-hidden="true">share</span><strong>0</strong><span>공유</span></button>' +
+                '</div>' +
+                '<div class="preview-comments-panel" data-preview-comments-panel hidden>' +
+                    '<div class="preview-comments-title">댓글</div>' +
+                    '<p>아직 댓글이 없어요.</p>' +
+                    '<p class="preview-comments-note">댓글 작성 기능은 후속 기능으로 준비 중입니다.</p>' +
+                '</div>' +
+            '</div>';
+    }
+
+    function ensureSocialShell() {
+        var desc = getPreviewDesc();
+        if (!desc) return;
+        if (!desc.querySelector('[data-preview-social-shell]')) {
+            desc.insertAdjacentHTML('beforeend', renderSocialShell());
+        }
+        if (socialBound) return;
+        socialBound = true;
+        document.addEventListener('click', function(event) {
+            var button = event.target && event.target.closest && event.target.closest('[data-preview-comments]');
+            if (!button) return;
+            var shell = button.closest('[data-preview-social-shell]');
+            var panel = shell && shell.querySelector('[data-preview-comments-panel]');
+            if (!panel) return;
+            var willOpen = panel.hidden;
+            panel.hidden = !willOpen;
+            button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        });
+    }
+
+    function removeRedundantBlocks() {
+        hide(document.querySelector('.preview-focus-title-meta'));
+        hide(document.getElementById('previewTreeStats'));
+        hide(document.getElementById('previewEmotionSection'));
+        normalizeCopy();
+    }
+
+    function markFlowStages() {
+        var desc = getPreviewDesc();
+        if (!desc) return;
+        var stages = Array.prototype.slice.call(desc.querySelectorAll('.preview-flow-stage'));
+        stages.forEach(function(stage, index) {
+            stage.setAttribute('role', 'button');
+            stage.setAttribute('tabindex', '0');
+            stage.dataset.previewMomentIndex = String(index);
+        });
+    }
+
+    function patchHubDom() {
+        var desc = getPreviewDesc();
+        if (!desc || desc.hidden) return;
+        var currentTitle = getPreviewTitleText();
+        removeRedundantBlocks();
+        markFlowStages();
+        ensureSocialShell();
+        lastPatchedTitle = currentTitle;
+    }
+
+    function installObserver() {
+        var sidebar = document.getElementById('previewSidebar') || document.body;
+        if (!sidebar || sidebar.dataset.previewHubDomPatchObserved) return;
+        sidebar.dataset.previewHubDomPatchObserved = 'true';
+        var observer = new MutationObserver(function() {
+            window.requestAnimationFrame(patchHubDom);
+        });
+        observer.observe(sidebar, { childList: true, subtree: true, attributes: true });
+    }
+
+    document.addEventListener('click', function(event) {
+        var stage = event.target && event.target.closest && event.target.closest('.preview-flow-stage');
+        if (!stage) return;
+        Array.prototype.slice.call(document.querySelectorAll('.preview-flow-stage')).forEach(function(item) {
+            item.classList.remove('is-active');
+        });
+        stage.classList.add('is-active');
+    });
+
+    document.addEventListener('keydown', function(event) {
+        var stage = event.target && event.target.closest && event.target.closest('.preview-flow-stage');
+        if (!stage) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        stage.click();
+    });
+
+    function start() {
+        installObserver();
+        patchHubDom();
+        window.setTimeout(patchHubDom, 100);
+        window.setTimeout(patchHubDom, 500);
+        window.setInterval(patchHubDom, 1000);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+
+    console.log('[LoveBudSearchPreviewHubDomPatch] loaded v20260512-1058');
+})();

--- a/js/search/search-preview-media-embed-patch.js
+++ b/js/search/search-preview-media-embed-patch.js
@@ -1,0 +1,63 @@
+/* Issue #1053: normalize Browse hub YouTube iframe sources without changing API shape. */
+(function() {
+    'use strict';
+
+    function getYouTubeVideoId(value) {
+        if (!value) return '';
+        try {
+            var parsed = new URL(String(value), window.location.origin);
+            var host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+            if (host === 'youtu.be') {
+                return parsed.pathname.split('/').filter(Boolean)[0] || '';
+            }
+            if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com' || host === 'youtube-nocookie.com') {
+                if (parsed.pathname.indexOf('/embed/') === 0) return parsed.pathname.split('/').filter(Boolean)[1] || '';
+                if (parsed.pathname.indexOf('/shorts/') === 0) return parsed.pathname.split('/').filter(Boolean)[1] || '';
+                return parsed.searchParams.get('v') || '';
+            }
+            if (host.indexOf('ytimg.com') !== -1 || host.indexOf('img.youtube.com') !== -1) {
+                var parts = parsed.pathname.split('/').filter(Boolean);
+                var viIndex = parts.indexOf('vi');
+                return viIndex >= 0 ? (parts[viIndex + 1] || '') : '';
+            }
+        } catch (error) {
+            return '';
+        }
+        return '';
+    }
+
+    function toEmbedUrl(value) {
+        var raw = String(value || '').trim();
+        if (!raw) return '';
+        var videoId = getYouTubeVideoId(raw);
+        if (videoId) {
+            var embedUrl = new URL('https://www.youtube.com/embed/' + encodeURIComponent(videoId));
+            embedUrl.searchParams.set('autoplay', '0');
+            embedUrl.searchParams.set('mute', '0');
+            embedUrl.searchParams.set('controls', '1');
+            embedUrl.searchParams.set('rel', '0');
+            embedUrl.searchParams.set('modestbranding', '1');
+            return embedUrl.href;
+        }
+        return raw + (raw.indexOf('?') === -1 ? '?' : '&') + 'autoplay=0&mute=0&controls=1';
+    }
+
+    function patchMediaHelper() {
+        var helper = window.LoveBudSearchPreviewMediaHelper;
+        if (!helper || helper.__loveBudEmbedPatchApplied) return;
+
+        helper.generateIframeSource = toEmbedUrl;
+        helper.renderPreviewIframe = function(sourceUrl, treeTitle, mediaTitle) {
+            var iframeSrc = toEmbedUrl(sourceUrl);
+            if (!iframeSrc) return '';
+            return '<div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">' +
+                '<iframe width="100%" height="100%" src="' + iframeSrc + '" title="' + String(treeTitle || mediaTitle || 'LoveTree media').replace(/"/g, '&quot;') + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="position:absolute;top:0;left:0;"></iframe>' +
+                '</div>';
+        };
+        helper.__loveBudEmbedPatchApplied = true;
+    }
+
+    patchMediaHelper();
+    document.addEventListener('DOMContentLoaded', patchMediaHelper);
+    console.log('[LoveBudSearchPreviewMediaEmbedPatch] loaded v20260512-1058');
+})();

--- a/js/search/search-preview-playable-hub-patch.js
+++ b/js/search/search-preview-playable-hub-patch.js
@@ -1,6 +1,17 @@
-/* Issue #1053: make selected Browse hub media playable when source URLs can be be inferred. */
+/* Issue #1053/#1058: playable Browse hub media, flow moment switching, and final hub action layout. */
 (function() {
     'use strict';
+
+    var selectedMomentIndexByTree = Object.create(null);
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
 
     function getYouTubeVideoId(value) {
         if (!value) return '';
@@ -38,13 +49,33 @@
         return embedUrl.href;
     }
 
-    function getCandidateUrlFromTree(tree) {
+    function getTreeKey(tree) {
+        if (!tree) return 'unknown';
+        if (tree.id != null && tree.id !== '') return String(tree.id);
+        return String(tree.title || 'tree') + ':' + String((tree.memories || []).length || tree.memoryCount || 0);
+    }
+
+    function getMomentLabel(memory, index) {
+        var helper = window.LoveBudSearchTitleHelper || null;
+        var raw = memory && memory.title || '';
+        var cleaned = helper && helper.cleanMomentTitle ? helper.cleanMomentTitle(raw) : String(raw || '').trim().replace(/\s*-\s*.*/, '');
+        return cleaned || (index === 0 ? '시작 순간' : '이어진 순간');
+    }
+
+    function getCandidateUrlFromMemory(memory) {
+        if (!memory) return '';
+        return memory.sourceUrl || memory.videoUrl || memory.videoURL || memory.mediaUrl || memory.mediaURL || memory.linkUrl || memory.linkURL || memory.thumbnail || memory.thumbnailUrl || memory.imageUrl || '';
+    }
+
+    function getCandidateUrlFromTree(tree, preferredIndex) {
         if (!tree) return '';
-        if (tree.representativeSourceUrl) return tree.representativeSourceUrl;
         var memories = Array.isArray(tree.memories) ? tree.memories : [];
+        var preferredMemory = memories[Number(preferredIndex || 0)];
+        var preferredCandidate = getCandidateUrlFromMemory(preferredMemory);
+        if (getYouTubeVideoId(preferredCandidate)) return preferredCandidate;
+        if (preferredIndex === 0 && tree.representativeSourceUrl) return tree.representativeSourceUrl;
         for (var i = 0; i < memories.length; i += 1) {
-            var memory = memories[i] || {};
-            var candidate = memory.sourceUrl || memory.videoUrl || memory.mediaUrl || memory.linkUrl || memory.thumbnail || memory.thumbnailUrl || '';
+            var candidate = getCandidateUrlFromMemory(memories[i]);
             if (getYouTubeVideoId(candidate)) return candidate;
         }
         return tree.representativeThumbnail || tree.thumbnail || '';
@@ -59,19 +90,135 @@
 
     function renderIframe(embedUrl, title) {
         return '<div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">' +
-            '<iframe width="100%" height="100%" src="' + embedUrl + '" title="' + String(title || 'LoveTree media').replace(/"/g, '&quot;') + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="position:absolute;top:0;left:0;"></iframe>' +
+            '<iframe width="100%" height="100%" src="' + embedUrl + '" title="' + escapeHtml(title || 'LoveTree media') + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="position:absolute;top:0;left:0;"></iframe>' +
             '</div>';
     }
 
-    function replaceWithIframe(tree) {
+    function replaceWithIframe(tree, preferredIndex) {
         var container = document.getElementById('previewVideoContainer');
-        if (!container) return;
-        var candidate = getCandidateUrlFromTree(tree) || getCandidateUrlFromRenderedDom(container);
+        if (!container) return false;
+        var candidate = getCandidateUrlFromTree(tree, preferredIndex) || getCandidateUrlFromRenderedDom(container);
         var embedUrl = toEmbedUrl(candidate);
-        if (!embedUrl) return;
-        container.innerHTML = renderIframe(embedUrl, tree && tree.title);
+        if (!embedUrl) return false;
+        var memories = Array.isArray(tree && tree.memories) ? tree.memories : [];
+        var memory = memories[Number(preferredIndex || 0)] || memories[0] || null;
+        var title = memory ? getMomentLabel(memory, Number(preferredIndex || 0)) : tree && tree.title;
+        container.innerHTML = renderIframe(embedUrl, title);
         container.classList.remove('preview-state-thumbnail');
         container.classList.add('preview-state-media');
+        return true;
+    }
+
+    function getCount(tree, keys) {
+        for (var i = 0; i < keys.length; i += 1) {
+            var value = Number(tree && tree[keys[i]]);
+            if (Number.isFinite(value) && value >= 0) return value;
+        }
+        return 0;
+    }
+
+    function renderSocialBar(tree) {
+        var likes = getCount(tree, ['likeCount', 'likesCount', 'likes', 'reactionCount', 'reaction_count']);
+        var comments = getCount(tree, ['commentCount', 'commentsCount', 'comments', 'replyCount', 'reply_count']);
+        var shares = getCount(tree, ['shareCount', 'sharesCount', 'shares', 'sharedCount', 'shared_count']);
+        return '<div class="preview-social-shell" data-preview-social-shell>' +
+            '<div class="preview-social-bar" aria-label="트리 반응">' +
+                '<button type="button" class="preview-social-action" data-preview-like disabled aria-label="좋아요 ' + likes + '"><span class="material-symbols-outlined" aria-hidden="true">favorite</span><strong>' + likes + '</strong><span>좋아요</span></button>' +
+                '<button type="button" class="preview-social-action" data-preview-comments aria-expanded="false" aria-label="댓글 ' + comments + '"><span class="material-symbols-outlined" aria-hidden="true">mode_comment</span><strong>' + comments + '</strong><span>댓글</span></button>' +
+                '<button type="button" class="preview-social-action" data-preview-share disabled aria-label="공유 ' + shares + '"><span class="material-symbols-outlined" aria-hidden="true">share</span><strong>' + shares + '</strong><span>공유</span></button>' +
+            '</div>' +
+            '<div class="preview-comments-panel" data-preview-comments-panel hidden>' +
+                '<div class="preview-comments-title">댓글</div>' +
+                '<p>아직 댓글이 없어요.</p>' +
+                '<p class="preview-comments-note">댓글 작성 기능은 후속 기능으로 준비 중입니다.</p>' +
+            '</div>' +
+        '</div>';
+    }
+
+    function normalizePreviewCopy(tree) {
+        var previewDesc = document.getElementById('previewDesc');
+        if (!previewDesc) return;
+        var copy = previewDesc.querySelector('.preview-focus-copy');
+        if (copy) {
+            var summary = '';
+            var firstStrong = copy.querySelector('strong');
+            if (firstStrong) {
+                summary = copy.childNodes.length ? copy.childNodes[0].textContent || '' : '';
+            }
+            var title = String(tree && tree.title || '러브트리').trim();
+            var count = Number(tree && tree.memoryCount || (tree && tree.memories && tree.memories.length) || 0);
+            var range = String(tree && tree.timeRange || '').trim();
+            if (range) {
+                copy.innerHTML = '<p class="preview-summary-line"><strong>' + escapeHtml(title) + '</strong>에 담긴 <strong>' + count + '개의 순간</strong>이 <strong>' + escapeHtml(range) + '</strong>에 걸쳐 이어졌어요.</p>';
+            } else {
+                copy.innerHTML = '<p class="preview-summary-line"><strong>' + escapeHtml(title) + '</strong>에 담긴 <strong>' + count + '개의 순간</strong>이 이어졌어요.</p>';
+            }
+        }
+        var oldSocial = previewDesc.querySelector('[data-preview-social-shell]');
+        if (oldSocial) oldSocial.remove();
+        previewDesc.insertAdjacentHTML('beforeend', renderSocialBar(tree || {}));
+    }
+
+    function hideRedundantBlocks() {
+        var titleMeta = document.querySelector('.preview-focus-title-meta');
+        if (titleMeta) titleMeta.hidden = true;
+        var stats = document.getElementById('previewTreeStats');
+        if (stats) stats.hidden = true;
+        var emotion = document.getElementById('previewEmotionSection');
+        if (emotion) emotion.hidden = true;
+    }
+
+    function enhanceFlowStages(tree) {
+        var previewDesc = document.getElementById('previewDesc');
+        if (!previewDesc || !tree) return;
+        var stages = Array.prototype.slice.call(previewDesc.querySelectorAll('.preview-flow-stage'));
+        if (!stages.length) return;
+        var treeKey = getTreeKey(tree);
+        var selectedIndex = Number(selectedMomentIndexByTree[treeKey] || 0);
+        stages.forEach(function(stage, index) {
+            stage.setAttribute('role', 'button');
+            stage.setAttribute('tabindex', '0');
+            stage.dataset.previewMomentIndex = String(index);
+            stage.classList.toggle('is-active', index === selectedIndex);
+            if (stage.dataset.previewMomentBound) return;
+            stage.dataset.previewMomentBound = 'true';
+            var activate = function() {
+                selectedMomentIndexByTree[treeKey] = index;
+                stages.forEach(function(item) { item.classList.remove('is-active'); });
+                stage.classList.add('is-active');
+                replaceWithIframe(tree, index);
+            };
+            stage.addEventListener('click', activate);
+            stage.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    activate();
+                }
+            });
+        });
+    }
+
+    function bindCommentsToggle() {
+        var button = document.querySelector('[data-preview-comments]');
+        var panel = document.querySelector('[data-preview-comments-panel]');
+        if (!button || !panel || button.dataset.previewCommentsBound) return;
+        button.dataset.previewCommentsBound = 'true';
+        button.addEventListener('click', function() {
+            var willOpen = panel.hidden;
+            panel.hidden = !willOpen;
+            button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        });
+    }
+
+    function finalizeHub(tree) {
+        var treeKey = getTreeKey(tree);
+        var selectedIndex = Number(selectedMomentIndexByTree[treeKey] || 0);
+        replaceWithIframe(tree, selectedIndex);
+        window.setTimeout(function() { replaceWithIframe(tree, selectedIndex); }, 80);
+        normalizePreviewCopy(tree);
+        hideRedundantBlocks();
+        enhanceFlowStages(tree);
+        bindCommentsToggle();
     }
 
     function patchRenderer() {
@@ -80,13 +227,12 @@
         var originalUpdatePreview = renderer.updatePreview;
         renderer.updatePreview = function(tree) {
             originalUpdatePreview.apply(renderer, arguments);
-            replaceWithIframe(tree);
-            window.setTimeout(function() { replaceWithIframe(tree); }, 80);
+            finalizeHub(tree);
         };
         renderer.__loveBudPlayableHubPatchApplied = true;
     }
 
     patchRenderer();
     document.addEventListener('DOMContentLoaded', patchRenderer);
-    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058-2');
+    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058-3');
 })();

--- a/js/search/search-preview-playable-hub-patch.js
+++ b/js/search/search-preview-playable-hub-patch.js
@@ -1,0 +1,78 @@
+/* Issue #1053: make selected Browse hub media playable when source URLs can be inferred. */
+(function() {
+    'use strict';
+
+    function getYouTubeVideoId(value) {
+        if (!value) return '';
+        try {
+            var parsed = new URL(String(value), window.location.origin);
+            var host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+            if (host === 'youtu.be') return parsed.pathname.split('/').filter(Boolean)[0] || '';
+            if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com' || host === 'youtube-nocookie.com') {
+                if (parsed.pathname.indexOf('/embed/') === 0) return parsed.pathname.split('/').filter(Boolean)[1] || '';
+                if (parsed.pathname.indexOf('/shorts/') === 0) return parsed.pathname.split('/').filter(Boolean)[1] || '';
+                return parsed.searchParams.get('v') || '';
+            }
+            if (host.indexOf('ytimg.com') !== -1 || host.indexOf('img.youtube.com') !== -1) {
+                var parts = parsed.pathname.split('/').filter(Boolean);
+                var viIndex = parts.indexOf('vi');
+                return viIndex >= 0 ? (parts[viIndex + 1] || '') : '';
+            }
+        } catch (error) {
+            return '';
+        }
+        return '';
+    }
+
+    function toEmbedUrl(value) {
+        var raw = String(value || '').trim();
+        if (!raw) return '';
+        var videoId = getYouTubeVideoId(raw);
+        if (!videoId) return '';
+        var embedUrl = new URL('https://www.youtube.com/embed/' + encodeURIComponent(videoId));
+        embedUrl.searchParams.set('autoplay', '0');
+        embedUrl.searchParams.set('mute', '0');
+        embedUrl.searchParams.set('controls', '1');
+        embedUrl.searchParams.set('rel', '0');
+        embedUrl.searchParams.set('modestbranding', '1');
+        return embedUrl.href;
+    }
+
+    function getCandidateUrlFromTree(tree) {
+        if (!tree) return '';
+        if (tree.representativeSourceUrl) return tree.representativeSourceUrl;
+        var memories = Array.isArray(tree.memories) ? tree.memories : [];
+        for (var i = 0; i < memories.length; i += 1) {
+            var memory = memories[i] || {};
+            var candidate = memory.sourceUrl || memory.videoUrl || memory.mediaUrl || memory.linkUrl || memory.thumbnail || memory.thumbnailUrl || '';
+            if (getYouTubeVideoId(candidate)) return candidate;
+        }
+        return tree.representativeThumbnail || tree.thumbnail || '';
+    }
+
+    function renderIframe(embedUrl, title) {
+        return '<div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">' +
+            '<iframe width="100%" height="100%" src="' + embedUrl + '" title="' + String(title || 'LoveTree media').replace(/"/g, '&quot;') + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="position:absolute;top:0;left:0;"></iframe>' +
+            '</div>';
+    }
+
+    function patchRenderer() {
+        var renderer = window.LoveBudSearchPreviewRenderer;
+        if (!renderer || renderer.__loveBudPlayableHubPatchApplied || typeof renderer.updatePreview !== 'function') return;
+        var originalUpdatePreview = renderer.updatePreview;
+        renderer.updatePreview = function(tree) {
+            originalUpdatePreview.apply(renderer, arguments);
+            var embedUrl = toEmbedUrl(getCandidateUrlFromTree(tree));
+            var container = document.getElementById('previewVideoContainer');
+            if (!embedUrl || !container) return;
+            container.innerHTML = renderIframe(embedUrl, tree && tree.title);
+            container.classList.remove('preview-state-thumbnail');
+            container.classList.add('preview-state-media');
+        };
+        renderer.__loveBudPlayableHubPatchApplied = true;
+    }
+
+    patchRenderer();
+    document.addEventListener('DOMContentLoaded', patchRenderer);
+    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058');
+})();

--- a/js/search/search-preview-playable-hub-patch.js
+++ b/js/search/search-preview-playable-hub-patch.js
@@ -1,4 +1,4 @@
-/* Issue #1053: make selected Browse hub media playable when source URLs can be inferred. */
+/* Issue #1053: make selected Browse hub media playable when source URLs can be be inferred. */
 (function() {
     'use strict';
 
@@ -50,10 +50,28 @@
         return tree.representativeThumbnail || tree.thumbnail || '';
     }
 
+    function getCandidateUrlFromRenderedDom(container) {
+        if (!container) return '';
+        var img = container.querySelector('img');
+        if (!img) return '';
+        return img.currentSrc || img.src || img.getAttribute('src') || '';
+    }
+
     function renderIframe(embedUrl, title) {
         return '<div class="preview-media-frame preview-media-frame-iframe" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">' +
             '<iframe width="100%" height="100%" src="' + embedUrl + '" title="' + String(title || 'LoveTree media').replace(/"/g, '&quot;') + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="position:absolute;top:0;left:0;"></iframe>' +
             '</div>';
+    }
+
+    function replaceWithIframe(tree) {
+        var container = document.getElementById('previewVideoContainer');
+        if (!container) return;
+        var candidate = getCandidateUrlFromTree(tree) || getCandidateUrlFromRenderedDom(container);
+        var embedUrl = toEmbedUrl(candidate);
+        if (!embedUrl) return;
+        container.innerHTML = renderIframe(embedUrl, tree && tree.title);
+        container.classList.remove('preview-state-thumbnail');
+        container.classList.add('preview-state-media');
     }
 
     function patchRenderer() {
@@ -62,17 +80,13 @@
         var originalUpdatePreview = renderer.updatePreview;
         renderer.updatePreview = function(tree) {
             originalUpdatePreview.apply(renderer, arguments);
-            var embedUrl = toEmbedUrl(getCandidateUrlFromTree(tree));
-            var container = document.getElementById('previewVideoContainer');
-            if (!embedUrl || !container) return;
-            container.innerHTML = renderIframe(embedUrl, tree && tree.title);
-            container.classList.remove('preview-state-thumbnail');
-            container.classList.add('preview-state-media');
+            replaceWithIframe(tree);
+            window.setTimeout(function() { replaceWithIframe(tree); }, 80);
         };
         renderer.__loveBudPlayableHubPatchApplied = true;
     }
 
     patchRenderer();
     document.addEventListener('DOMContentLoaded', patchRenderer);
-    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058');
+    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058-2');
 })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
-    <link rel="stylesheet" href="../css/search.css?v=20260512-1058-3">
+    <link rel="stylesheet" href="../css/search.css?v=20260512-1058-4">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
-    <link rel="stylesheet" href="../css/search.css?v=20260509-907-1">
+    <link rel="stylesheet" href="../css/search.css?v=20260512-1058-2">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -128,10 +128,11 @@
 <script src="../js/postgres-client.js?v=20260422-2"></script>
     <!-- Search modules -->
     <script src="../js/search/search-title-helper.js?v=20260421-2"></script>
-    <script src="../js/search/search-data-adapter.js?v=20260422-1"></script>
+    <script src="../js/search/search-data-adapter.js?v=20260512-1058-2"></script>
     <script src="../js/search/search-shared-utils.js?v=20260428-1"></script>
     <script src="../js/search/search-card-renderer.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
+    <script src="../js/search/search-preview-media-embed-patch.js?v=20260512-1058"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-action-helper.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-renderer-builders.js?v=20260505-1"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -137,6 +137,7 @@
     <script src="../js/search/search-preview-action-helper.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-renderer-builders.js?v=20260505-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260508-618-rev1"></script>
+    <script src="../js/search/search-preview-playable-hub-patch.js?v=20260512-1058"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -138,6 +138,7 @@
     <script src="../js/search/search-preview-renderer-builders.js?v=20260505-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-playable-hub-patch.js?v=20260512-1058-3"></script>
+    <script src="../js/search/search-preview-hub-dom-patch.js?v=20260512-1058-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
-    <link rel="stylesheet" href="../css/search.css?v=20260512-1058-2">
+    <link rel="stylesheet" href="../css/search.css?v=20260512-1058-3">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -132,12 +132,12 @@
     <script src="../js/search/search-shared-utils.js?v=20260428-1"></script>
     <script src="../js/search/search-card-renderer.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
-    <script src="../js/search/search-preview-media-embed-patch.js?v=20260512-1058"></script>
+    <script src="../js/search/search-preview-media-embed-patch.js?v=20260512-1058-2"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>
     <script src="../js/search/search-preview-action-helper.js?v=20260508-618-rev1"></script>
     <script src="../js/search/search-preview-renderer-builders.js?v=20260505-1"></script>
     <script src="../js/search/search-preview-renderer.js?v=20260508-618-rev1"></script>
-    <script src="../js/search/search-preview-playable-hub-patch.js?v=20260512-1058"></script>
+    <script src="../js/search/search-preview-playable-hub-patch.js?v=20260512-1058-3"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>


### PR DESCRIPTION
Refs #1052
Refs #1053
Refs #1054

## Summary
- Integrates the verified Browse card cleanup baseline from merged PR #1050.
- Adds independent scroll behavior for the Browse appreciation hub.
- Removes the decorative tree media badge from the appreciation hub.
- Normalizes public memory source URL candidates into `sourceUrl` so playable media can reach the hub renderer.

## Changed files
- `css/search.css`
- `css/search/search-preview-scroll-fix.css`
- `css/search/search-preview-media-cleanup.css`
- `css/search/search-preview-media-no-overlays.css`
- `js/search/search-data-adapter.js`

## Scope
- Browse/Search appreciation hub only.
- Keeps Browse card mini-flow/footer work already merged in #1050.
- Does not change backend/API/Auth/DB/schema.
- Does not mutate production/private data.

## Verification
- Browser verification required: YES.
- Fixed slot verification required: YES if PR preview does not combine current main behavior correctly.
- Confirm Browse cards show the #1050 cleaned footer and no mini-flow.
- Confirm appreciation hub scrolls independently.
- Confirm hub decorative media badge is gone.
- Confirm media with supported source URL candidates can reach the playable iframe path.
- Confirm no fatal LoveBud runtime console errors.

## Safety notes
- No package/workflow changes.
- No PR #7 or prototype/reference/demo/variant changes.
- No raw identifier, raw payload, or secret exposure.