### PR TITLE
fix(editor): pass i18n to resolveTreeTitleText in sidebar

### DIFF
--- a/js/editor/editor-detail-sidebar-status-boundary.js
+++ b/js/editor/editor-detail-sidebar-status-boundary.js
@@ -39,7 +39,7 @@
             const isPublic = visibility === 'public';
 
             if (treeTitleEl) {
-                treeTitleEl.textContent = resolveTreeTitleText(currentTreeData?.title);
+                treeTitleEl.textContent = resolveTreeTitleText(i18n, currentTreeData?.title);
             }
             if (visibilityEl) {
                 visibilityEl.textContent = isPublic


### PR DESCRIPTION
Refs #1043

## Summary
- Fix: sidebar now passes `i18n` as first argument to `resolveTreeTitleText()`
- Before: only `currentTreeData?.title` was passed → fallback \러브트리\ always shown
- After: `resolveTreeTitleText(i18n, currentTreeData?.title)` → actual tree title displayed

## Changed files
- `js/editor/editor-detail-sidebar-status-boundary.js` (+1/-1)

## Verification
- npm test: PASS
- npm run verify: PASS (159/161, backend deps only)

## Safety
- No CSS/HTML/backend changes
- No editor/owner control exposure
- No secrets/raw IDs