### PR TITLE
fix(browse): remove non-functional mini-flow from tree cards (Refs #1049)

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -170,26 +170,11 @@
         `;
     }
 
-    function renderCompactTreePreview(tree, variant) {
-        const tone = getTreePreviewTone(tree);
-        return `
-            <div class="tree-card-preview-strip tree-card-preview-strip-${variant} tree-card-preview-${tone}" aria-hidden="true">
-                <span class="tree-card-preview-line tree-card-preview-line-main"></span>
-                <span class="tree-card-preview-line tree-card-preview-line-branch"></span>
-                <span class="tree-card-preview-node tree-card-preview-node-root"></span>
-                <span class="tree-card-preview-node tree-card-preview-node-branch"></span>
-                <span class="tree-card-preview-node tree-card-preview-node-leaf"></span>
-                <span class="tree-card-preview-node tree-card-preview-node-end"></span>
-            </div>
-        `;
-    }
-
     function renderMediaFallback(tree, titleText) {
         const safeTitle = escapeHtml(titleText || '러브트리');
         return `
             <div class="tree-card-media-fallback">
                 <div class="fallback-title">${safeTitle}</div>
-                ${renderCompactTreePreview(tree, 'fallback')}
             </div>
         `;
     }
@@ -215,12 +200,9 @@
          );
          const firstMoment = escapeHtml(firstMem?.title || '대표 순간 준비 중');
 
-         const mediaPreview = mediaUrl ? renderCompactTreePreview(tree, 'media') : '';
-
          return `
              <div class="tree-card-media" aria-label="${firstMoment}" style="position:relative;overflow:hidden;">
                  ${renderRepresentativeImage(mediaUrl, firstMoment, tree, titleText)}
-                 ${mediaPreview}
              </div>
          `;
      }


### PR DESCRIPTION
Refs #1049

## Summary
- Removes the node/line mini-flow overlay from Browse tree cards
- The mini-flow visually appeared like an interactive tree-flow control but served no functional purpose
- Media fallback (when no image is available) now shows title only instead of title + mini-flow decoration
- Card content has more stable vertical spacing after removing the flow strip

## Changed files (1 file, -18 lines)
- js/search/search-card-renderer.js

## Verification
- npm test: PASS (259/259)
- npm run verify: PASS (159/161, expected missing firebase-admin/pg in local env)
- Browser verification required for desktop 1366px and mobile 375px

No backend/API/Auth/DB/schema changes.
No PR #7 or prototype/reference/demo/variant changes.