### PR TITLE
fix(editor): increase canvas header spacing and reduce frame border collision (Refs #1044)

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -10,7 +10,7 @@
 /* Editor Canvas Topbar */
 .editor-canvas-topbar {
     position: absolute;
-    top: 22px;
+    top: 28px;
     left: 24px;
     right: 24px;
     z-index: 7;

--- a/css/editor/editor-overrides.css
+++ b/css/editor/editor-overrides.css
@@ -267,7 +267,7 @@ body .editor-canvas-title h2 {
 .canvas-area::before {
     content: '';
     position: absolute;
-    inset: 72px 28px 28px;
+    inset: 82px 28px 28px;
     border-radius: 30px;
     border: 1px solid rgba(255,255,255,0.42);
     background: radial-gradient(circle at 50% 28%,rgba(255,255,255,0.36),transparent 34%);


### PR DESCRIPTION
Refs #1044

## Summary
- Increases `.editor-canvas-topbar` top offset from 22px to 28px for more breathing room
- Increases canvas frame `::before` inset top from 72px to 82px to reduce visual collision between title text (`순간을 이어가는 중`) and the paper-like frame border
- Caption text was already hidden via #1002 (PR #1063) — this completes the canvas header cleanup

## Changed files (2 files, +2/-2)
- css/editor/editor-canvas-toolbar.css
- css/editor/editor-overrides.css

## Verification
- npm test: PASS (259/259)
- CSS-only change, no behavioral/JS modifications
- Requires browser verification on fixed test slot (Editor is Auth/API-dependent)

No toolbar changes, no tree content changes, no mobile layout regressions expected.