### PR TITLE
fix(design): align hardcoded colors with LoveTree theme tokens (Refs #1051)

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -31,13 +31,13 @@
     font-size: 1.76rem;
     line-height: 1.12;
     letter-spacing: -0.05em;
-    color: #553f35;
+    color: var(--on-surface);
 }
 
 .editor-canvas-caption {
     margin: 7px 0 0;
     max-width: 360px;
-    color: #9a8175;
+    color: var(--on-surface-soft);
     font-size: 13px;
     line-height: 1.6;
 }
@@ -83,7 +83,7 @@
     border-radius: 14px;
     background: rgba(255,255,255,0.74);
     border: 1px solid rgba(221,198,184,0.5);
-    color: #7f6258;
+    color: var(--on-surface-soft);
     box-shadow: none;
     cursor: pointer;
     transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;

--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -61,7 +61,7 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.2em;
-    color: #904951;
+    color: var(--primary);
     opacity: 0.7;
 }
 
@@ -70,7 +70,7 @@
     font-size: clamp(1.72rem, 2.2vw, 2.82rem);
     font-weight: 700;
     letter-spacing: -0.02em;
-    color: #3f302b;
+    color: var(--on-background);
     line-height: 1.1;
 }
 
@@ -81,7 +81,7 @@
     gap: 6px;
     margin-top: 6px;
     font-size: 0.9rem;
-    color: #7e6b62;
+    color: var(--on-surface-variant);
 }
 
 .vv-dot {
@@ -209,7 +209,7 @@
     border: 1px solid rgba(255,255,255,0.8);
     border-radius: 999px;
     background: rgba(255,255,255,0.65);
-    color: #6b5850;
+    color: var(--on-surface-variant);
     font-size: 13px;
     font-weight: 600;
     cursor: pointer;
@@ -223,14 +223,14 @@
 }
 
 .vv-action-btn.is-active {
-    border-color: rgba(251,113,133,0.3);
-    background: rgba(255,241,243,0.8);
-    color: #881337;
+    border-color: rgba(var(--primary-rgb), 0.18);
+    background: rgba(var(--primary-rgb), 0.08);
+    color: var(--primary);
 }
 
 .vv-action-btn.is-liked {
-    background: rgba(255,241,243,0.7);
-    color: #be123c;
+    background: rgba(var(--primary-rgb), 0.07);
+    color: var(--primary-vibrant);
 }
 
 .vv-action-btn.is-liked .vv-icon-heart {
@@ -246,7 +246,7 @@
     border: 1px solid rgba(255,255,255,0.7);
     background: rgba(255,255,255,0.45);
     font-size: 12px;
-    color: #8a7a72;
+    color: var(--on-surface-note);
     display: none;
 }
 


### PR DESCRIPTION
## Summary

Replace hardcoded hex colors in Visitor Viewer and Editor Canvas toolbar with LoveTree CSS token variables from `css/global/tokens.css`.

## Changes

### Visitor Viewer (`css/visitor-viewer/visitor-viewer-shell.css`)
- Active/liked action button colors: out-of-palette rose-red (`#881337`, `#be123c`) → `--primary`, `--primary-vibrant` 
- Title and metadata colors: hardcoded browns → `--on-background`, `--on-surface-variant`, `--on-surface-note`
- Eyebrow: exact match `#904951` → `--primary`

### Editor Canvas Toolbar (`css/editor/editor-canvas-toolbar.css`)
- Title: `#553f35` → `--on-surface`
- Caption: `#9a8175` → `--on-surface-soft`
- Tool button: `#7f6258` → `--on-surface-soft`

## Verification
- ✅ CSS token references exist in tokens.css (imported via global.css → editor.css)
- ✅ No layout/structural changes

Refs #1051

No unauthorized main push, production mutation, raw identifier exposure, or secret exposure was performed.