### PR TITLE
docs(ops): add legacy runtime guardrails

### DIFF
--- a/docs/ops/LEGACY_RUNTIME_GUARDRAILS.md
+++ b/docs/ops/LEGACY_RUNTIME_GUARDRAILS.md
@@ -1,0 +1,83 @@
+# Legacy Runtime Guardrails
+
+Issue: #1078
+
+This document prevents future backend, API, and security policy work from being implemented in legacy runtime artifacts by mistake.
+
+## Current active runtime
+
+The active runtime path is:
+
+```text
+browser
+→ same-origin /api/*
+→ Cloudflare Pages Functions under functions/api/*
+→ Modal under modal_compute/*
+```
+
+New backend/API/security policy work should target the active Cloudflare Pages Functions + Modal runtime unless the CTO explicitly reactivates another runtime.
+
+## Legacy and transitional artifacts
+
+| Path | Current treatment | Guardrail |
+| --- | --- | --- |
+| `netlify/functions/**` | legacy artifact / removal-audit candidate | Do not implement new active backend policy here unless Netlify runtime is explicitly reactivated. |
+| `netlify.toml` | legacy artifact / removal-audit candidate | Do not delete or repurpose without a separate removal/audit issue. |
+| `vercel.json` | transitional / secondary-entry artifact | Do not classify as automatically removable from filename alone. |
+| `_redirects` | shared static-host routing artifact candidate | Do not classify as Netlify-only without checking Cloudflare Pages behavior. |
+
+## Required PR posture
+
+A PR that changes legacy runtime paths should state:
+
+```text
+Legacy runtime path changed: YES
+Reason: audit/docs/explicit reactivation/removal-approved
+Active runtime behavior changed: YES/NO
+Cloudflare/Modal behavior changed: YES/NO
+Owning issue: <issue or PR reference>
+```
+
+If a PR introduces new auth, visibility, owner guard, entitlement, private storage, public read, write route, API response shape, or security policy, the default target is:
+
+```text
+functions/api/*
+modal_compute/*
+docs/engineering/API_CONTRACT.md
+```
+
+Do not add that policy only under `netlify/functions/*` or a Vercel-only path.
+
+## Allowed changes without runtime reactivation
+
+Allowed examples:
+
+- documentation that marks a path as legacy;
+- audit inventory;
+- tests or guardrails that prevent wrong-target implementation;
+- removal planning documents;
+- explicit compatibility comments that do not change active behavior.
+
+## Forbidden without explicit approval
+
+Forbidden examples:
+
+- implementing a new active API route only in `netlify/functions/*`;
+- changing owner/private/public visibility policy only in legacy runtime files;
+- deleting `netlify.toml`, `vercel.json`, `_redirects`, or `netlify/functions/**` as incidental cleanup;
+- treating `_redirects` as Netlify-only without Cloudflare Pages verification;
+- using legacy runtime files as evidence that production behavior has changed.
+
+## Verification
+
+Docs/check-only PRs:
+
+- docs review;
+- static guardrail check if a script/check changes;
+- no runtime verification required.
+
+Runtime PRs that touch active files:
+
+- relevant contract tests;
+- Cloudflare Preview or fixed-slot smoke where API/Auth/data-loaded behavior is affected;
+- report verified and unverified items separately.


### PR DESCRIPTION
## Summary

Refs #1078

Adds a docs-only guardrail for legacy/transitional runtime artifacts.

The new document clarifies:
- active runtime is same-origin `/api/*` → Cloudflare Pages Functions → Modal
- `netlify/functions/**` is not the default target for new backend policy
- `netlify.toml`, `vercel.json`, and `_redirects` must not be deleted or reclassified from filename alone
- legacy runtime path changes should state reason, active-runtime impact, and owning issue

## Scope

Changed files:
- `docs/ops/LEGACY_RUNTIME_GUARDRAILS.md`

No runtime behavior changes.
No legacy file deletion.
No Cloudflare/Modal route changes.
No PR #7 / prototype / reference / demo / variant changes.
No secret/token/cookie/session/credential/private payload output.

## Verification

Not run in this connector session.

Recommended:
- Docs review
- Link/index follow-up if this document should be promoted in `docs/ops/ops_index.md`

Runtime verification is not required because this PR is docs-only.