### PR TITLE
docs(editor): audit editor css selector ownership

### DIFF
--- a/docs/engineering/EDITOR_CSS_SELECTOR_OWNERSHIP_AUDIT_1076.md
+++ b/docs/engineering/EDITOR_CSS_SELECTOR_OWNERSHIP_AUDIT_1076.md
@@ -1,0 +1,74 @@
+# Editor CSS Selector Ownership Audit
+
+Issue: #1076
+
+This is an audit-only document for future `css/editor/overrides.css` relocation work. It does not authorize selector movement, selector removal, runtime behavior changes, or visual redesign.
+
+## Purpose
+
+`css/editor/overrides.css` is a large Editor override/cascade layer. Before moving rules into smaller files, selector ownership should be classified by responsibility so future PRs can remain narrow and verifiable.
+
+## Selector ownership buckets
+
+Use these buckets when reviewing or moving selectors.
+
+| Bucket | Meaning | Future PR shape |
+| --- | --- | --- |
+| shell/layout | outer Editor page shell, grid, panel placement, spacing | CSS-only relocation with full Editor visual smoke |
+| canvas | tree canvas, SVG branch layer, node placement, viewport controls | CSS-only relocation plus canvas empty/populated/selected checks |
+| detail panel | current moment panel, view mode, edit mode, metadata rows | CSS-only relocation plus selected-memory and inline-edit checks |
+| memory form | add/next memory form, inputs, buttons, validation hints | CSS-only relocation plus add-memory form checks |
+| responsive/mobile | mobile breakpoints and small-screen overrides | CSS-only relocation plus 375px smoke |
+| hidden/compatibility | selectors that preserve current hide/show or legacy compatibility behavior | do not remove without runtime evidence and owner approval |
+| temporary override | patch-style selector added to override another file | resolve only after cascade source and visual evidence are known |
+
+## Recommended inventory format
+
+Future implementation PRs should include a selector table like this:
+
+| Selector family | Bucket | Current file | Proposed target | Risk | Required visual state |
+| --- | --- | --- | --- | --- | --- |
+| `.editor-shell ...` | shell/layout | `css/editor/overrides.css` | `css/editor/layout.css` | medium | desktop + mobile |
+| `.memory-node ...` | canvas | `css/editor/overrides.css` | `css/editor/canvas.css` | high | populated + selected |
+
+## Future relocation sequence
+
+Recommended sequence:
+
+1. Refresh current selector inventory.
+2. Pick one bucket only.
+3. Move selectors without renaming them.
+4. Preserve import order and cascade behavior.
+5. Run static checks.
+6. Run Editor visual smoke on an approved preview/fixed slot if runtime UI files are affected.
+7. Report verified and unverified states separately.
+
+Do not combine selector relocation with JavaScript, API, Auth, Modal, or page-shell behavior changes.
+
+## Required visual states for implementation follow-up
+
+A relocation PR should verify:
+
+- Editor empty state;
+- populated tree state;
+- selected memory state;
+- inline edit state;
+- add memory form state;
+- mobile 375px state;
+- no new blocking console errors.
+
+## Forbidden scope
+
+Do not use this audit to perform:
+
+- broad Editor redesign;
+- selector renaming/removal;
+- JavaScript behavior changes;
+- `pages/editor.html` script-order changes;
+- Browse/Search/My Trees CSS changes;
+- global token rewrites;
+- prototype/reference/demo/variant cleanup.
+
+## Closure condition
+
+This audit can be considered complete when future Editor CSS relocation work has a clear selector-bucket checklist and no longer relies on line count alone as the extraction reason.


### PR DESCRIPTION
## Summary

Refs #1076

Adds an audit-only document for future `css/editor/overrides.css` selector ownership and relocation planning.

The document defines selector buckets for:
- shell/layout
- canvas
- detail panel
- memory form
- responsive/mobile
- hidden/compatibility
- temporary overrides

## Scope

Changed files:
- `docs/engineering/EDITOR_CSS_SELECTOR_OWNERSHIP_AUDIT_1076.md`

No CSS behavior changes.
No runtime behavior changes.
No selector relocation, rename, or removal.
No Editor JS/page/API/Auth/Modal changes.
No PR #7 / prototype / reference / demo / variant changes.

## Verification

Not run in this connector session.

Recommended:
- Docs review
- Link/index follow-up if this audit should be promoted in `docs/engineering/engineering_index.md`

Runtime/browser verification is not required because this PR is docs-only.