### PR TITLE
test(api): add Cloudflare gateway route contract checks

### DIFF
--- a/tests/contracts/cloudflare-gateway-route-contract.test.js
+++ b/tests/contracts/cloudflare-gateway-route-contract.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+const gateway = () => readRepoFile('functions/api/[[path]].js');
+
+test('Cloudflare gateway preserves community read route mappings to Modal', () => {
+  const source = gateway();
+
+  assert.match(source, /path === '\/api\/community\/trees'/);
+  assert.match(source, /view'\) === 'summary'/);
+  assert.match(source, /target\.pathname = '\/modal\/browse\/latest'/);
+  assert.match(source, /path === '\/api\/community\/growing-trees'/);
+  assert.match(source, /target\.pathname = '\/modal\/browse\/growing'/);
+  assert.match(source, /path === '\/api\/community\/memories'/);
+  assert.match(source, /target\.pathname = '\/modal\/community\/memories'/);
+});
+
+test('Cloudflare gateway preserves private collection route mappings to Modal', () => {
+  const source = gateway();
+
+  assert.match(source, /path === '\/api\/trees'/);
+  assert.match(source, /target\.pathname = '\/modal\/private\/trees'/);
+  assert.match(source, /path === '\/api\/memories'/);
+  assert.match(source, /target\.pathname = '\/modal\/private\/memories'/);
+});
+
+test('Cloudflare gateway preserves detail route public-private split', () => {
+  const source = gateway();
+
+  assert.match(source, /const memoryMatch = path\.match/);
+  assert.match(source, /`\/modal\/private\/memories\/\$\{memoryId\}`/);
+  assert.match(source, /`\/modal\/memories\/\$\{memoryId\}`/);
+  assert.match(source, /const treeMatch = path\.match/);
+  assert.match(source, /`\/modal\/private\/trees\/\$\{encodeURIComponent\(decodeURIComponent\(treeMatch\[1\]\)\)\}`/);
+  assert.match(source, /`\/modal\/trees\/\$\{encodeURIComponent\(decodeURIComponent\(treeMatch\[1\]\)\)\}`/);
+});
+
+test('Cloudflare gateway preserves fork route and method ownership', () => {
+  const source = gateway();
+
+  assert.match(source, /treeForkMatch/);
+  assert.match(source, /method === 'POST'/);
+  assert.match(source, /`\/modal\/private\/trees\/\$\{treeId\}\/fork`/);
+  assert.match(source, /isModalOwnedWriteRoute/);
+  assert.match(source, /\['POST', 'PUT', 'DELETE'\]/);
+});
+
+test('Cloudflare gateway preserves request id and upstream response headers', () => {
+  const source = gateway();
+
+  assert.match(source, /generateRequestId/);
+  assert.match(source, /getOrCreateRequestId/);
+  assert.match(source, /x-lovebud-request-id/);
+  assert.match(source, /x-lovebud-upstream/);
+  assert.match(source, /x-lovebud-route-status/);
+  assert.match(source, /method-not-allowed/);
+  assert.match(source, /unhandled/);
+});


### PR DESCRIPTION
## Summary

Refs #1073

Adds a focused static contract test for the Cloudflare Pages Functions gateway route mapping in `functions/api/[[path]].js`.

The test checks preservation of:
- community read route mappings
- private collection route mappings
- public/private detail route split
- fork route method ownership
- request ID and upstream/route-status headers

## Scope

Changed files:
- `tests/contracts/cloudflare-gateway-route-contract.test.js`

No runtime behavior changes.
No gateway implementation changes.
No Modal/Auth/frontend changes.
No PR #7 / prototype / reference / demo / variant changes.

## Verification

Not run in this connector session.

Recommended:
- `node --test tests/contracts/cloudflare-gateway-route-contract.test.js`
- `npm test`
- `npm run lint`

Runtime/API smoke is not required because this PR is test-only.