### PR TITLE
fix(ux): align create and edit moment form layouts (Refs #1036)

### DIFF
--- a/css/editor/editor-detail-panel.css
+++ b/css/editor/editor-detail-panel.css
@@ -184,15 +184,15 @@
     background: rgba(var(--primary-rgb), 0.08);
 }
 
-#detailEditMode .detail-info-group {
+#detailEditMode .editor-form-stack {
     margin: 0;
 }
 
-#detailEditMode .detail-info-group + .detail-info-group {
+#detailEditMode .editor-form-stack + .editor-form-stack {
     margin-top: 18px;
 }
 
-#detailEditMode .detail-info-group:nth-of-type(3) {
+#detailEditMode .editor-form-stack:nth-of-type(3) {
     margin-top: 20px;
 }
 
@@ -513,6 +513,26 @@
         min-height: 30px;
         padding: 0 10px;
         font-size: 10.5px;
+    }
+
+    #detailEditMode .editor-form-actions {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+        margin-top: 20px;
+    }
+
+    #detailEditMode .editor-form-action-btn {
+        width: 100%;
+        min-width: 0;
+    }
+
+    #detailEditMode .editor-form-action-btn:first-child {
+        order: 2;
+    }
+
+    #detailEditMode .editor-form-action-btn:last-child {
+        order: 1;
     }
 
     .editor-edit-actions-row {

--- a/js/editor/editor-memory-actions.js
+++ b/js/editor/editor-memory-actions.js
@@ -70,18 +70,19 @@ function createEditorMemoryActions(deps) {
 
     const ensureSourceUrlEditField = () => {
         const editMode = document.getElementById('detailEditMode');
-        const memoGroup = document.getElementById('editMemoInput')?.closest('.detail-info-group');
+        const memoGroup = document.getElementById('editMemoInput')?.closest('.editor-form-stack');
         if (!editMode || !memoGroup) return null;
 
         let field = document.getElementById('editSourceUrlGroup');
         if (!field) {
             field = document.createElement('div');
             field.id = 'editSourceUrlGroup';
-            field.className = 'detail-info-group editor-source-url-edit-group';
+            field.className = 'editor-form-stack editor-form-stack-compact editor-source-url-edit-group';
+            field.style.marginTop = '12px';
             field.innerHTML = `
-                <label id="editSourceUrlLabel" for="editSourceUrlInput">${formatI18nText('editor_source_url_label', '영상 또는 출처 링크')}</label>
-                <input type="text" id="editSourceUrlInput" class="editor-edit-input" placeholder="https://www.youtube.com/watch?v=...">
-                <p id="editSourceUrlHint" class="memory-edit-hint editor-source-url-edit-hint">${formatI18nText('editor_source_url_hint', 'YouTube 링크를 바꾸면 저장 후 대표 이미지도 함께 갱신됩니다.')}</p>
+                <label id="editSourceUrlLabel" for="editSourceUrlInput" class="editor-form-label">${formatI18nText('editor_source_url_label', '영상 또는 출처 링크')}</label>
+                <input type="text" id="editSourceUrlInput" class="editor-form-input" placeholder="https://www.youtube.com/watch?v=...">
+                <p id="editSourceUrlHint" class="editor-form-help editor-source-url-edit-hint">${formatI18nText('editor_source_url_hint', 'YouTube 링크를 바꾸면 저장 후 대표 이미지도 함께 갱신됩니다.')}</p>
             `;
             editMode.insertBefore(field, memoGroup);
         }

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -219,24 +219,24 @@
                 </div>
 
                 <div id="detailEditMode" class="editor-hidden-initial">
-                    <div class="detail-info-group">
-                        <label id="editTitleLabel">...</label>
-                        <input type="text" id="editTitleInput" class="editor-edit-input" placeholder="...">
+                    <div class="editor-form-stack editor-form-stack-compact">
+                        <label id="editTitleLabel" class="editor-form-label">...</label>
+                        <input type="text" id="editTitleInput" class="editor-form-input" placeholder="...">
                     </div>
 
-                    <div class="detail-info-group">
-                        <label id="editMemoLabel">...</label>
-                        <textarea id="editMemoInput" rows="4" class="editor-edit-textarea" placeholder="..."></textarea>
+                    <div class="editor-form-stack editor-form-stack-roomy" style="margin-top: 12px;">
+                        <label id="editMemoLabel" class="editor-form-label">...</label>
+                        <textarea id="editMemoInput" rows="4" class="editor-form-textarea" placeholder="..."></textarea>
                     </div>
 
-                    <div class="detail-info-group">
-                        <label id="editTagsLabel">...</label>
-                        <input type="text" id="editTagsInput" class="editor-edit-input" placeholder="...">
+                    <div class="editor-form-stack editor-form-stack-compact" style="margin-top: 12px;">
+                        <label id="editTagsLabel" class="editor-form-label">...</label>
+                        <input type="text" id="editTagsInput" class="editor-form-input" placeholder="...">
                     </div>
 
-                    <div class="detail-actions editor-edit-actions-row">
-                        <button id="cancelEditBtn" class="btn-round btn-outline editor-edit-action-btn">...</button>
-                        <button id="saveEditBtn" class="btn-round btn-primary editor-edit-action-btn">...</button>
+                    <div class="editor-form-actions" style="margin-top: 12px;">
+                        <button id="cancelEditBtn" class="btn-round btn-outline editor-form-action-btn">...</button>
+                        <button id="saveEditBtn" class="btn-round btn-primary editor-form-action-btn">...</button>
                     </div>
                     <div class="detail-actions editor-delete-row">
                         <button id="deleteMemoryBtn" class="editor-delete-link">...</button>


### PR DESCRIPTION
## Summary

Aligns the create-new-moment form and edit-existing-moment form to use consistent CSS classes and layout structure.

## Changes Made

### HTML (pages/editor.html)
- Changed edit mode input/textareas from `editor-edit-input`/  `editor-edit-textarea` to `editor-form-input`/  `editor-form-textarea` (matching create form)
- Added `editor-form-label` class to all edit form labels
- Changed field wrappers from `.detail-info-group` to `.editor-form-stack` with appropriate compact/roomy variants
- Changed action button container from `.editor-edit-actions-row` to `.editor-form-actions`
- Changed action buttons from `.editor-edit-action-btn` to `.editor-form-action-btn`

### JavaScript (js/editor/editor-memory-actions.js)
- Updated `ensureSourceUrlEditField()` to use aligned classes:
  - `detail-info-group` → `editor-form-stack editor-form-stack-compact`
  - `editor-edit-input` → `editor-form-input`
  - `memory-edit-hint` → `editor-form-help`
  - Added `editor-form-label` class to label

### CSS (css/editor/editor-detail-panel.css)
- Updated selectors from `#detailEditMode .detail-info-group` to `#detailEditMode .editor-form-stack`
- Added responsive (`@media max-width: 375px`) styles for `#detailEditMode .editor-form-actions` and `.editor-form-action-btn`
- Preserved old class selectors (`.editor-edit-input`, `.editor-edit-actions-row`, etc.) for backward compatibility

## Verification
- [ ] Create form (addMemoryForm) styling unchanged
- [ ] Edit form (detailEditMode) now uses same class system as create form
- [ ] Dynamic source URL field uses aligned classes
- [ ] Responsive layout works at all viewport sizes
- [ ] Old selectors preserved for backward compatibility

Closes #1036