### PR TITLE
fix(theme): replace hardcoded colors with CSS tokens in editor/search CSS (Refs #1051)

### DIFF
--- a/css/editor/editor-canvas.css
+++ b/css/editor/editor-canvas.css
@@ -1,7 +1,7 @@
 .canvas-area {
     flex: 1;
     position: relative;
-    background-color: #faf8f6;
+    background-color: var(--surface-container-low);
     background-image: radial-gradient(rgba(144, 73, 81, 0.035) 1px, transparent 1px);
     background-size: 34px 34px;
     overflow: hidden;

--- a/css/editor/editor-detail-panel.css
+++ b/css/editor/editor-detail-panel.css
@@ -1,6 +1,6 @@
 .detail-panel {
     width: var(--detail-panel-width);
-    background: #fdfcfb; /* Warm paper tone */
+    background: var(--surface);
     border-left: 1px solid rgba(144, 73, 81, 0.08);
     display: flex;
     flex-direction: column;
@@ -72,7 +72,7 @@
 
 .editor-current-moment-card {
     gap: 9px;
-    background: #ffffff;
+    background: var(--surface-container-lowest);
     border: 1px solid rgba(144, 73, 81, 0.12);
     box-shadow: 0 6px 16px rgba(75, 64, 57, 0.05);
 }
@@ -151,7 +151,7 @@
     border-radius: 999px;
     border-color: rgba(197,146,128,0.30);
     background: rgba(255,255,255,0.78);
-    color: #9b5f58;
+    color: var(--on-surface-soft);
     font-size: 11px;
     font-weight: 800;
     line-height: 1;
@@ -174,14 +174,14 @@
 
 .editor-edit-actions-row .editor-edit-danger-action {
     margin-right: auto;
-    color: #a05a63;
-    border-color: rgba(158,81,88,0.18);
+    color: var(--primary);
+    border-color: rgba(var(--primary-rgb), 0.18);
     background: rgba(255,253,249,0.72);
     box-shadow: none;
 }
 
 .editor-edit-actions-row .editor-edit-danger-action:hover {
-    background: rgba(158,81,88,0.08);
+    background: rgba(var(--primary-rgb), 0.08);
 }
 
 #detailEditMode .detail-info-group {
@@ -228,18 +228,18 @@
     padding: 4px 8px;
     border: none;
     background: none;
-    color: #b08b8b;
+    color: var(--on-surface-note);
     font-size: 12px;
     cursor: pointer;
     border-radius: 6px;
     transition: color 0.15s, background 0.15s;
 }
 .editor-delete-link:hover {
-    color: #b33636;
-    background: rgba(179,54,54,0.06);
+    color: var(--primary-vibrant);
+    background: rgba(var(--primary-rgb), 0.06);
 }
 .editor-delete-link:focus-visible {
-    outline: 2px solid #b33636;
+    outline: 2px solid var(--primary-vibrant);
     outline-offset: 2px;
 }
 
@@ -264,7 +264,7 @@
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 2px;
-    color: #aaa;
+    color: var(--on-surface-note);
     margin-bottom: 7px;
     display: block;
 }

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -131,7 +131,7 @@
     border-radius: 999px;
     background: rgba(144, 73, 81, 0.08);
     border: 1px solid rgba(144, 73, 81, 0.12);
-    color: var(--primary, #904951);
+    color: var(--primary);
     font-size: 11px;
     font-weight: 800;
     line-height: 1;
@@ -370,7 +370,7 @@
 .node-skeleton {
     position: absolute;
     inset: 0;
-    background: linear-gradient(135deg, #f5f5f7 0%, #eef0f3 50%, #f5f5f7 100%);
+    background: linear-gradient(135deg, var(--surface-container-low) 0%, var(--surface-container) 50%, var(--surface-container-low) 100%);
     background-size: 200% 200%;
     animation: skeleton-shimmer 2s infinite linear;
     z-index: 1;

--- a/css/editor/editor-overrides.css
+++ b/css/editor/editor-overrides.css
@@ -39,7 +39,7 @@
 }
 
 .sidebar-btn-primary:hover {
-    background: #7d3f46;
+    background: var(--primary);
     box-shadow: 0 4px 16px rgba(144, 73, 81, 0.16);
     opacity: 1;
 }
@@ -103,8 +103,8 @@
 
 /* 1. Base Layout & Backgrounds */
 body .editor-layout {
-    background: #fdfcfb;
-    background-image: linear-gradient(180deg, #fffcf9 0%, #f9f5f0 100%);
+    background: var(--surface);
+    background-image: linear-gradient(180deg, var(--surface) 0%, var(--surface-container-low) 100%);
 }
 
 body .sidebar,
@@ -115,7 +115,7 @@ body .detail-panel {
 }
 
 body .canvas-area {
-    background-color: #faf8f6;
+    background-color: var(--surface-container-low);
     background-image: radial-gradient(rgba(144, 73, 81, 0.03) 1px, transparent 1px);
     border: 1px solid rgba(144, 73, 81, 0.08);
     box-shadow: inset 0 0 60px rgba(0, 0, 0, 0.015);
@@ -127,24 +127,24 @@ body .canvas-area::before {
 
 /* 2. Left Status Card (Scrapbook Cover/Paper) */
 body .editor-status-card {
-    background: #ffffff;
-    background-image: linear-gradient(165deg, #ffffff 0%, #fdfbf9 100%);
+    background: var(--surface-container-lowest);
+    background-image: linear-gradient(165deg, var(--surface-container-lowest) 0%, var(--surface) 100%);
     border: 1px solid rgba(144, 73, 81, 0.16);
     box-shadow: 0 8px 24px rgba(75, 64, 57, 0.06), 0 2px 4px rgba(0, 0, 0, 0.02);
 }
 
 body .editor-status-card strong {
-    color: #4a372e;
+    color: var(--on-background);
 }
 
 body .editor-tree-quiet-note {
-    color: #8f776c;
+    color: var(--on-surface-note);
     border-top: 1px dashed rgba(190, 147, 127, 0.24);
 }
 
 /* 3. Node Card (Paper Scrap) */
 body .node-card {
-    background: #ffffff;
+    background: var(--surface-container-lowest);
     border: 1px solid rgba(144, 73, 81, 0.08);
     box-shadow: 1px 2px 6px rgba(75, 64, 57, 0.05);
     border-radius: 6px;
@@ -158,7 +158,7 @@ body .memory-node.selected .node-card {
 }
 
 body .node-img-wrapper {
-    background: #f8f6f4;
+    background: var(--surface-container-low);
     border-radius: 4px;
 }
 
@@ -178,31 +178,31 @@ body .editor-moment-info-card {
 body .diary-note {
     background: rgba(253, 252, 251, 0.8);
     border-left: 4px solid rgba(144, 73, 81, 0.15);
-    color: #55443d;
+    color: var(--on-surface);
 }
 
 /* 5. Button/Chip/Pill Tone */
 body .editor-tree-visibility-pill.is-private {
     background: rgba(144, 73, 81, 0.06);
-    color: #904951;
+    color: var(--primary);
     border: 1px solid rgba(144, 73, 81, 0.12);
 }
 
 body .editor-mini-setting-btn {
     background: rgba(255, 255, 255, 0.86);
     border-color: rgba(144, 73, 81, 0.14);
-    color: #6d544b;
+    color: var(--on-surface-variant);
 }
 
 body .editor-memory-mode-chip {
-    background: #ffffff;
+    background: var(--surface-container-lowest);
     border-color: rgba(144, 73, 81, 0.12);
 }
 
 body .editor-memory-mode-chip.is-active {
     background: rgba(144, 73, 81, 0.08);
     border-color: rgba(144, 73, 81, 0.24);
-    color: #904951;
+    color: var(--primary);
 }
 
 /* 6. Mobile Polish (375px) */
@@ -235,7 +235,7 @@ body .editor-canvas-title h2 {
 
 
 .editor-layout {
-    background: linear-gradient(180deg,#fff8f0 0%,#f8ede2 52%,#f5e6dc 100%);
+    background: linear-gradient(180deg, var(--surface) 0%, var(--surface-container-low) 52%, var(--surface-container) 100%);
     gap: 18px;
     padding: 18px;
     box-sizing: border-box;
@@ -293,7 +293,7 @@ body .editor-canvas-title h2 {
     border-radius: 999px;
     background: rgba(255,248,242,0.90);
     border: 1px solid rgba(233,213,199,0.86);
-    color: #a36b62;
+    color: var(--on-surface-soft);
     font-size: 12px;
     font-weight: 800;
     letter-spacing: 0.01em;
@@ -314,7 +314,7 @@ body .editor-canvas-title h2 {
 
 .editor-status-card strong {
     font-size: 1.62rem;
-    color: #583f35;
+    color: var(--on-surface);
 }
 
 .editor-rename-btn {
@@ -330,7 +330,7 @@ body .editor-canvas-title h2 {
     border-radius: 999px;
     background: rgba(255,255,255,0.78);
     border-color: rgba(197,146,128,0.30);
-    color: #9b5f58;
+    color: var(--on-surface-soft);
     font-size: 11px;
     font-weight: 900;
     line-height: 1;
@@ -364,7 +364,7 @@ body .editor-canvas-title h2 {
     border-radius: 999px;
     background: rgba(255,255,255,0.70);
     border-color: rgba(221,198,184,0.84);
-    color: #7f6258;
+    color: var(--on-surface-soft);
     font-weight: 800;
     box-shadow: 0 8px 16px rgba(165,124,101,0.06);
 }
@@ -377,7 +377,7 @@ body .editor-canvas-title h2 {
     margin: 20px 0 0;
     padding-top: 18px;
     border-top: 1px dashed rgba(190,147,127,0.36);
-    color: #8f776c;
+    color: var(--on-surface-note);
     font-size: 13px;
     line-height: 1.7;
     text-align: center;

--- a/css/editor/editor-sidebar.css
+++ b/css/editor/editor-sidebar.css
@@ -1,7 +1,7 @@
 .sidebar {
     width: var(--sidebar-width);
     min-width: var(--sidebar-width);
-    background: #fdfcfb; /* Warm paper tone */
+    background: var(--surface);
     border-right: 1px solid rgba(144, 73, 81, 0.08);
     display: flex;
     flex-direction: column;
@@ -61,7 +61,7 @@
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.3px;
-    color: #aaa;
+    color: var(--on-surface-note);
     line-height: 1.4;
     max-width: 100%;
     text-align: center;

--- a/css/editor/editor-status-settings.css
+++ b/css/editor/editor-status-settings.css
@@ -92,13 +92,13 @@
 
 .editor-tree-visibility-pill.is-public {
     background: rgba(76,175,80,0.06);
-    color: #6ab06a;
+    color: var(--secondary);
     border: 1px solid rgba(76,175,80,0.12);
 }
 
 .editor-tree-visibility-pill.is-private {
     background: rgba(144,73,81,0.04);
-    color: #a36b62;
+    color: var(--on-surface-soft);
     border: 1px solid rgba(144,73,81,0.08);
 }
 

--- a/css/search/search-preview-sidebar.css
+++ b/css/search/search-preview-sidebar.css
@@ -508,7 +508,7 @@
 }
 
 .preview-media-frame-iframe iframe {
-    background: #201917;
+    background: var(--on-background);
 }
 
 .preview-media-fallback {
@@ -573,8 +573,8 @@
 
 .preview-sidebar.preview-state-empty .preview-badge,
 .preview-sidebar.preview-state-loading .preview-badge {
-    background: rgba(122, 139, 110, 0.10);
-    color: #6f7c61;
+    background: rgba(var(--primary-rgb), 0.10);
+    color: var(--secondary);
 }
 
 .preview-sidebar.preview-state-empty .tree-meta,

--- a/css/search/search-preview-social-bar.css
+++ b/css/search/search-preview-social-bar.css
@@ -2,7 +2,7 @@
 .preview-social-shell {
     margin-top: 1rem;
     padding-top: 0.95rem;
-    border-top: 1px solid rgba(111, 76, 68, 0.1);
+    border-top: 1px solid var(--outline-variant);
 }
 
 .preview-social-bar {
@@ -15,9 +15,9 @@
 .preview-social-action {
     appearance: none;
     -webkit-appearance: none;
-    border: 1px solid rgba(159, 78, 91, 0.14);
+    border: 1px solid var(--outline-variant);
     background: rgba(255, 250, 249, 0.72);
-    color: var(--on-surface-variant, #6f5b55);
+    color: var(--on-surface-variant);
     border-radius: 999px;
     min-height: 2.35rem;
     padding: 0.42rem 0.45rem;
@@ -35,12 +35,12 @@
 .preview-social-action .material-symbols-outlined {
     font-size: 1rem;
     line-height: 1;
-    color: var(--primary, #9f4e5b);
+    color: var(--primary);
     font-variation-settings: 'FILL' 0, 'wght' 450, 'GRAD' 0, 'opsz' 20;
 }
 
 .preview-social-action strong {
-    color: var(--primary, #9f4e5b);
+    color: var(--primary);
     font-size: 0.74rem;
     font-weight: 800;
 }
@@ -60,9 +60,9 @@
 
 .preview-social-action:not([disabled]):hover,
 .preview-social-action:not([disabled]):focus-visible {
-    border-color: rgba(159, 78, 91, 0.28);
+    border-color: rgba(var(--primary-rgb), 0.28);
     background: rgba(255, 246, 247, 0.96);
-    color: var(--primary, #9f4e5b);
+    color: var(--primary);
     outline: none;
     transform: translateY(-1px);
 }
@@ -70,16 +70,16 @@
 .preview-comments-panel {
     margin-top: 0.75rem;
     padding: 0.85rem 0.95rem;
-    border: 1px solid rgba(159, 78, 91, 0.12);
+    border: 1px solid var(--outline-variant);
     border-radius: 1rem;
     background: rgba(255, 255, 255, 0.68);
-    color: var(--on-surface-variant, #6f5b55);
+    color: var(--on-surface-variant);
     font-size: 0.78rem;
     line-height: 1.55;
 }
 
 .preview-comments-title {
-    color: var(--on-surface, #3f302c);
+    color: var(--on-surface);
     font-size: 0.82rem;
     font-weight: 900;
     margin-bottom: 0.35rem;

--- a/css/search/search-tree-card.css
+++ b/css/search/search-tree-card.css
@@ -93,7 +93,7 @@
 .tree-card.is-active .tree-card-open-link {
     background: rgba(144, 73, 81, 0.92);
     border-color: rgba(144, 73, 81, 0.22);
-    color: #fffaf8;
+    color: var(--surface-container-lowest);
 }
 
 .tree-card:hover::before,
@@ -508,7 +508,7 @@
 .tree-card-open-link:focus-visible {
     background: rgba(144, 73, 81, 0.92);
     border-color: rgba(144, 73, 81, 0.24);
-    color: #fffaf8;
+    color: var(--surface-container-lowest);
     transform: translateY(-1px);
 }
 


### PR DESCRIPTION
## Summary

## What

Replaces hardcoded hex colors with theme CSS tokens across all remaining Editor and Search CSS files.

## Why

Issue #1051 — complete the unified theme color system. PR #1090 already fixed Visitor Viewer CSS. This PR covers Editor and Search surfaces.

## Changed files (9 files)

- `css/editor/editor-overrides.css` — ~20 hardcoded colors → tokens
- `css/editor/editor-detail-panel.css` — delete link reds, card bg
- `css/editor/editor-status-settings.css` — visibility pill colors
- `css/editor/editor-sidebar.css` — label/section bg
- `css/editor/editor-canvas.css` — canvas bg
- `css/editor/editor-memory-form.css` — skeleton shimmer
- `css/search/search-preview-social-bar.css` — fallback values
- `css/search/search-tree-card.css` — link hover bg
- `css/search/search-preview-sidebar.css` — iframe bg, badge

## Verification
- ✅ CSS token values verified against `css/global/tokens.css`
- ✅ No runtime JS changes
- ✅ No backend changes

## Safety notes
- No secret/private exposure
- No raw identifiers
- No production data mutation

Refs #1051