### PR TITLE
ui(editor): add structured tree layout mode first slice

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -153,6 +153,19 @@
     transition: background 0.1s ease, border-color 0.1s ease;
 }
 
+/* Active state for layout mode toggle */
+.editor-canvas-tool-btn.is-active {
+    background: var(--primary, rgba(144,73,81,0.92));
+    border-color: var(--primary, rgba(144,73,81,0.92));
+    color: #fff;
+}
+
+.editor-canvas-tool-btn.is-active:hover:not(:disabled) {
+    background: var(--primary-hover, rgba(124,59,67,0.92));
+    border-color: var(--primary-hover, rgba(124,59,67,0.92));
+    color: #fff;
+}
+
 .editor-canvas-tool-btn .material-symbols-outlined {
     font-size: 20px;
     line-height: 1;
@@ -209,6 +222,11 @@
     .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] {
         flex: 1 1 auto;
         flex-direction: column;
+    }
+
+    .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] {
+        flex: 0 0 auto;
+        flex-direction: row;
     }
 
     .editor-canvas-toolbar-separator {

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -300,6 +300,17 @@
     width: 108px;
 }
 
+/* Structured layout: no drag cursor */
+.layout-structured .memory-node {
+    cursor: default !important;
+    user-select: none;
+}
+
+.layout-structured .memory-node:hover {
+    transform: none !important;
+    box-shadow: none !important;
+}
+
 .node-card {
     width: 102px;
     margin: 0 auto;

--- a/js/editor/editor-canvas-geometry.js
+++ b/js/editor/editor-canvas-geometry.js
@@ -7,6 +7,12 @@
     const AFFORDANCE_OFFSET_Y = 10;
     const AFFORDANCE_CARD_HALF = 108;
 
+    /** Structured layout constants */
+    const STRUCTURED_ROOT_Y_FRAC = 0.62;
+    const STRUCTURED_VERTICAL_SPACING = 160;
+    const STRUCTURED_SIBLING_SPACING = 120;
+    const STRUCTURED_LEVEL_SPREAD = 1.4;
+
     function getMetrics(canvas) {
         return {
             width: Math.max(canvas.clientWidth || 0, 720),
@@ -99,6 +105,159 @@
         return recurse(mem);
     }
 
+    /**
+     * Structured layout: vertical tree hierarchy.
+     * Root at bottom-center, children branching upward.
+     * Ignores stored positions — pure topology-based layout.
+     */
+    function getStructuredWorldPosition(mem, getCanonicalRootId, getTreeMemories, isRootMemory, getMetricsSnapshot) {
+        const canonicalRootId = getCanonicalRootId();
+        const treeMemories = getTreeMemories();
+        const readMetrics = typeof getMetricsSnapshot === 'function'
+            ? getMetricsSnapshot
+            : () => getMetrics({ clientWidth: 0, clientHeight: 0 });
+
+        function getDepth(node, visited = new Set()) {
+            if (!node || isRootMemory(node, canonicalRootId)) return 0;
+            if (visited.has(node.id)) return 0;
+            visited.add(node.id);
+            const parentId = node.parentId || canonicalRootId;
+            const parent = treeMemories.find((m) => m.id === parentId);
+            return 1 + getDepth(parent, visited);
+        }
+
+        /**
+         * Build sub-tree width for a given node, used to spread siblings.
+         * Returns the horizontal span this subtree takes.
+         */
+        function getSubtreeWidth(node, visited = new Set()) {
+            if (!node) return 1;
+            if (visited.has(node.id)) return 1;
+            visited.add(node.id);
+            const children = treeMemories.filter((m) => {
+                const pid = m.parentId || canonicalRootId;
+                return pid === node.id && !isRootMemory(m, canonicalRootId);
+            });
+            if (children.length === 0) return 1;
+            return children.reduce((sum, child) => sum + getSubtreeWidth(child, visited), 0);
+        }
+
+        /**
+         * Compute position recursively using depth, sibling index, and subtree width.
+         */
+        function computePosition(node, depth, offsetX, parentWidth, siblingIdx, siblingCount, visited = new Set()) {
+            const metrics = readMetrics();
+            if (!node || visited.has(node.id)) {
+                return { x: metrics.width / 2, y: getRootY(metrics) };
+            }
+            visited.add(node.id);
+
+            const isRoot = isRootMemory(node, canonicalRootId);
+            const y = isRoot
+                ? getRootY(metrics)
+                : getRootY(metrics) - depth * STRUCTURED_VERTICAL_SPACING;
+
+            let x;
+            if (isRoot) {
+                x = metrics.width / 2;
+            } else {
+                const slotWidth = parentWidth / siblingCount;
+                x = offsetX + slotWidth * (siblingIdx + 0.5);
+            }
+
+            // Clamp x within canvas bounds
+            x = Math.max(NODE_WIDTH, Math.min(x, metrics.width - NODE_WIDTH));
+
+            return { x: Math.round(x), y: Math.round(y) };
+        }
+
+        function getRootY(metrics) {
+            return Math.round(Math.min(metrics.height * STRUCTURED_ROOT_Y_FRAC, metrics.height - ROOT_BOTTOM_GUTTER));
+        }
+
+        // Find root
+        const rootMemory = treeMemories.find((m) => isRootMemory(m, canonicalRootId));
+
+        if (!rootMemory) {
+            // No root — position at center
+            const metrics = readMetrics();
+            return { x: Math.round(metrics.width / 2), y: getRootY(metrics) };
+        }
+
+        if (isRootMemory(mem, canonicalRootId)) {
+            const metrics = readMetrics();
+            return { x: Math.round(metrics.width / 2), y: getRootY(metrics) };
+        }
+
+        // Build a lookup map of all nodes with their positions
+        const structuredPositions = new Map();
+        const allVisited = new Set();
+
+        function placeSubtree(node, depth, offsetX, parentWidth, sIdx, sCount) {
+            if (!node || allVisited.has(node.id)) return;
+            allVisited.add(node.id);
+
+            const pos = computePosition(node, depth, offsetX, parentWidth, sIdx, sCount);
+            structuredPositions.set(node.id, pos);
+
+            const children = treeMemories.filter((m) => {
+                const pid = m.parentId || canonicalRootId;
+                return pid === node.id && !isRootMemory(m, canonicalRootId);
+            });
+
+            if (children.length === 0) return;
+
+            // Compute total subtree width for this node
+            const nodeVisited = new Set();
+            const totalSubWidth = children.reduce((sum, child) => {
+                return sum + getSubtreeWidth(child, new Set());
+            }, 0);
+
+            let childOffsetX = pos.x - (totalSubWidth * STRUCTURED_SIBLING_SPACING) / 2;
+            children.forEach((child) => {
+                const childWidth = getSubtreeWidth(child, new Set());
+                const childSlotWidth = childWidth * STRUCTURED_SIBLING_SPACING;
+                placeSubtree(child, depth + 1, childOffsetX, childSlotWidth, 0, 1);
+                childOffsetX += childSlotWidth;
+            });
+        }
+
+        // Start placement from root
+        const rootPos = computePosition(rootMemory, 0, 0, 0, 0, 1);
+        structuredPositions.set(rootMemory.id, rootPos);
+
+        const rootChildren = treeMemories.filter((m) => {
+            const pid = m.parentId || canonicalRootId;
+            return pid === rootMemory.id && !isRootMemory(m, canonicalRootId);
+        });
+
+        if (rootChildren.length > 0) {
+            const totalWidth = rootChildren.reduce((sum, child) => {
+                return sum + getSubtreeWidth(child, new Set());
+            }, 0);
+            let offsetX = rootPos.x - (totalWidth * STRUCTURED_SIBLING_SPACING) / 2;
+            rootChildren.forEach((child) => {
+                const childWidth = getSubtreeWidth(child, new Set());
+                const slotWidth = childWidth * STRUCTURED_SIBLING_SPACING;
+                placeSubtree(child, 1, offsetX, slotWidth, 0, 1);
+                offsetX += slotWidth;
+            });
+        }
+
+        // If the requested node has a structured position, return it
+        if (structuredPositions.has(mem.id)) {
+            return structuredPositions.get(mem.id);
+        }
+
+        // Fallback: compute depth-based position
+        const depth = getDepth(mem);
+        const metrics = readMetrics();
+        return {
+            x: Math.round(metrics.width / 2),
+            y: Math.round(getRootY(metrics) - depth * STRUCTURED_VERTICAL_SPACING)
+        };
+    }
+
     function calcPosition(mem, viewportState, getWorldPosFn) {
         const world = getWorldPosFn(mem);
         return { x: world.x + viewportState.offsetX, y: world.y + viewportState.offsetY };
@@ -118,6 +277,7 @@
         getRadiusL2,
         distributeAngles,
         getWorldPosition,
+        getStructuredWorldPosition,
         calcPosition
     };
 })();

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -16,7 +16,7 @@ window.LoveBudEditorCanvasInteraction = {
     if (viewportState.globalsBound) return;
     viewportState.globalsBound = true;
 
-    canvas.style.cursor = 'grab';
+    canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
     canvas.style.touchAction = 'none';
 
     canvas.addEventListener('mousedown', (event) => {
@@ -27,6 +27,10 @@ window.LoveBudEditorCanvasInteraction = {
       ) {
         return;
       }
+
+      // Disable canvas panning drag in structured mode
+      if (viewportState.layoutMode === 'structured') return;
+
       viewportState.isPanning = true;
       viewportState.startX = event.clientX;
       viewportState.startY = event.clientY;
@@ -96,7 +100,7 @@ window.LoveBudEditorCanvasInteraction = {
       }
       viewportState.isPanning = false;
       canvas.classList.remove('panning');
-      canvas.style.cursor = 'grab';
+      canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
       if (shouldRender) {
         persistStoredPositions();
         initCanvas();
@@ -105,6 +109,9 @@ window.LoveBudEditorCanvasInteraction = {
   },
 
   beginNodeDrag(event, nodeEl, memory, viewportState, getWorldPosition) {
+    // Disable node drag in structured mode
+    if (viewportState.layoutMode === 'structured') return false;
+
     if (event.button !== 0) return false;
     if (event.target.closest('button')) return false;
     event.preventDefault();

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -602,6 +602,41 @@ function isNodeWithinSafeViewport(pos) {
 
         if (viewportState.controlsBound) return;
         viewportState.controlsBound = true;
+
+        const focusBtn = document.getElementById('focusSelectedBtn');
+        const recenterBtn = document.getElementById('recenterCanvasBtn');
+        const zoomInBtn = document.getElementById('zoomInCanvasBtn');
+        const zoomOutBtn = document.getElementById('zoomOutCanvasBtn');
+
+        // Prevent clicks from starting a pan
+        [focusBtn, recenterBtn, zoomInBtn, zoomOutBtn].forEach((button) => {
+            if (!button) return;
+            button.addEventListener('mousedown', (event) => { event.stopPropagation(); });
+            button.addEventListener('touchstart', (event) => { event.stopPropagation(); }, { passive: true });
+        });
+
+        if (focusBtn) {
+            focusBtn.addEventListener('click', () => {
+                const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
+                if (selectedId) {
+                    focusNodeById(selectedId);
+                }
+            });
+        }
+
+        if (recenterBtn) {
+            recenterBtn.addEventListener('click', () => {
+                recenterViewport();
+            });
+        }
+
+        if (zoomInBtn && typeof zoomBy === 'function') {
+            zoomInBtn.addEventListener('click', () => { zoomBy(canvasViewport.zoomStep || 1.18); });
+        }
+
+        if (zoomOutBtn && typeof zoomBy === 'function') {
+            zoomOutBtn.addEventListener('click', () => { zoomBy(1 / (canvasViewport.zoomStep || 1.18)); });
+        }
     }
 
     function bindLayoutModeToggle() {
@@ -638,23 +673,47 @@ function isNodeWithinSafeViewport(pos) {
             return;
         }
 
-        // Fallback in-memory binding
+        // Fallback pan/drag binding — structured mode guards added
         if (viewportState.globalsBound) return;
         viewportState.globalsBound = true;
 
-        canvas.addEventListener('mousedown', (event) => {
-            if (event.target.closest('.memory-node') || event.target.closest('#addMemoryForm') || event.target.closest('.memory-add-affordance')) return;
+        canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
 
-            // Disable panning interaction that leads to drag in structured mode
+        canvas.addEventListener('mousedown', (event) => {
+            if (
+                event.target.closest('.memory-node') ||
+                event.target.closest('#addMemoryForm') ||
+                event.target.closest('.memory-add-affordance')
+            ) {
+                return;
+            }
+            // Disable pan in structured mode
             if (viewportState.layoutMode === 'structured') return;
 
             viewportState.isPanning = true;
             viewportState.startX = event.clientX;
             viewportState.startY = event.clientY;
+            canvas.classList.add('panning');
+            canvas.style.cursor = 'grabbing';
         });
 
         window.addEventListener('mousemove', (event) => {
-            if (viewportState.layoutMode !== 'free') return;
+            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
+                const dx = event.clientX - viewportState.dragStartClientX;
+                const dy = event.clientY - viewportState.dragStartClientY;
+                if (Math.abs(dx) > 6 || Math.abs(dy) > 6) {
+                    viewportState.dragMoved = true;
+                }
+                if (!viewportState.dragMoved) return;
+                const scale = viewportState.scale || 1;
+                viewportState.positions[viewportState.dragNodeId] = {
+                    x: Math.round(viewportState.dragStartWorldX + (dx / scale)),
+                    y: Math.round(viewportState.dragStartWorldY + (dy / scale))
+                };
+                initCanvas();
+                return;
+            }
+
             if (!viewportState.isPanning) return;
             const dx = event.clientX - viewportState.startX;
             const dy = event.clientY - viewportState.startY;
@@ -666,9 +725,37 @@ function isNodeWithinSafeViewport(pos) {
         });
 
         window.addEventListener('mouseup', () => {
+            let shouldRender = false;
+            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
+                const draggedId = viewportState.dragNodeId;
+                const moved = viewportState.dragMoved;
+                viewportState.isDraggingNode = false;
+                viewportState.dragNodeId = null;
+                viewportState.dragMoved = false;
+                const draggedEl = document.querySelector(`.memory-node[data-memory-id="${draggedId}"]`);
+                if (draggedEl) {
+                    draggedEl.style.cursor = 'grab';
+                }
+                if (draggedEl && moved) {
+                    draggedEl.dataset.suppressClick = '1';
+                    shouldRender = true;
+                    const toast = document.getElementById('movedToast');
+                    if (toast) {
+                        toast.style.display = 'block';
+                        setTimeout(() => { toast.style.display = 'none'; }, 3000);
+                    }
+                }
+            }
+
             if (viewportState.isPanning) {
-                viewportState.isPanning = false;
+                shouldRender = true;
+            }
+            viewportState.isPanning = false;
+            canvas.classList.remove('panning');
+            canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
+            if (shouldRender) {
                 persistStoredPositions();
+                initCanvas();
             }
         });
     }
@@ -715,3 +802,5 @@ function isNodeWithinSafeViewport(pos) {
         get viewportState() { return viewportState; }
     };
 }
+
+window.createEditorCanvas = createEditorCanvas;

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -19,6 +19,7 @@ function createEditorCanvas(deps) {
         || new URLSearchParams(window.location.search).get('treeId')
         || 'default';
     const layoutStorageKey = 'lovebud_tree_layout_v2_' + treeId;
+    const layoutModeStorageKey = 'lovebud_tree_layout_mode_' + treeId;
     const canvasLayout = window.LoveBudEditorCanvasLayout || {};
     const canvasNode = window.LoveBudEditorCanvasNode || {};
     const canvasInteraction = window.LoveBudEditorCanvasInteraction || {};
@@ -26,6 +27,12 @@ function createEditorCanvas(deps) {
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
     const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
+
+    /** Saved free positions — preserved when switching to structured mode */
+    let savedFreePositions = null;
+
+    /** Stored free positions from localStorage */
+    let storedFreePositions = null;
 
 function loadStoredLayout() {
         if (typeof canvasLayout.createLayoutStore === 'function') {
@@ -55,7 +62,22 @@ function loadStoredLayout() {
         }
     }
 
+    function loadLayoutMode() {
+        try {
+            const raw = localStorage.getItem(layoutModeStorageKey);
+            if (raw === 'structured' || raw === 'free') return raw;
+        } catch (e) {}
+        return 'free';
+    }
+
+    function persistLayoutMode(mode) {
+        try {
+            localStorage.setItem(layoutModeStorageKey, mode);
+        } catch (e) {}
+    }
+
     const storedLayout = loadStoredLayout();
+    storedFreePositions = { ...(storedLayout.positions || {}) };
 
     const viewportState = {
         offsetX: storedLayout.offsetX,
@@ -78,7 +100,9 @@ function loadStoredLayout() {
         resizeTimer: null,
         positions: storedLayout.positions,
         rafScheduled: false,
-        rafFrame: null
+        rafFrame: null,
+        /** Layout mode: 'free' or 'structured' */
+        layoutMode: loadLayoutMode()
     };
     const { NODE_HALF, AFFORDANCE_OFFSET_X, AFFORDANCE_OFFSET_Y, AFFORDANCE_CARD_HALF } = window.EditorCanvasGeometry;
 
@@ -103,6 +127,11 @@ function loadStoredLayout() {
     }
 
     function getWorldPosition(mem) {
+        if (viewportState.layoutMode === 'structured') {
+            return window.EditorCanvasGeometry.getStructuredWorldPosition(
+                mem, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics
+            );
+        }
         return window.EditorCanvasGeometry.getWorldPosition(mem, viewportState, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics);
     }
 
@@ -115,6 +144,9 @@ function loadStoredLayout() {
     }
 
     function persistStoredPositions() {
+        // Do not persist positions while in structured mode
+        if (viewportState.layoutMode === 'structured') return;
+
         if (typeof canvasLayout.createLayoutStore === 'function') {
             const store = canvasLayout.createLayoutStore(treeId);
             store.persist(viewportState);
@@ -129,6 +161,76 @@ function loadStoredLayout() {
                 scale: viewportState.scale || 1
             }));
         } catch (e) {}
+    }
+
+    function switchToFreeMode() {
+        viewportState.layoutMode = 'free';
+        persistLayoutMode('free');
+        // Restore saved free positions if available
+        if (savedFreePositions) {
+            viewportState.positions = { ...savedFreePositions };
+            savedFreePositions = null;
+        }
+        // Restore stored free positions if available
+        if (storedFreePositions && Object.keys(viewportState.positions).length === 0) {
+            viewportState.positions = { ...storedFreePositions };
+        }
+        // Restore from localStorage if positions are empty
+        if (Object.keys(viewportState.positions).length === 0) {
+            const stored = loadStoredLayout();
+            if (stored.positions && Object.keys(stored.positions).length > 0) {
+                viewportState.positions = { ...stored.positions };
+            }
+        }
+        document.body.classList.remove('layout-structured');
+        document.body.classList.add('layout-free');
+        updateLayoutToggleUI();
+        initCanvas();
+        persistStoredPositions();
+    }
+
+    function switchToStructuredMode() {
+        // Save current free positions before switching
+        savedFreePositions = { ...viewportState.positions };
+        viewportState.layoutMode = 'structured';
+        persistLayoutMode('structured');
+        document.body.classList.remove('layout-free');
+        document.body.classList.add('layout-structured');
+        updateLayoutToggleUI();
+        initCanvas();
+    }
+
+    function setLayoutMode(mode) {
+        if (mode === 'structured') {
+            switchToStructuredMode();
+        } else {
+            switchToFreeMode();
+        }
+    }
+
+    function toggleLayoutMode() {
+        if (viewportState.layoutMode === 'structured') {
+            switchToFreeMode();
+        } else {
+            switchToStructuredMode();
+        }
+    }
+
+    function updateLayoutToggleUI() {
+        const toggleBtn = document.getElementById('layoutModeToggleBtn');
+        const toggleLabel = document.getElementById('layoutModeToggleLabel');
+        const toggleIcon = document.getElementById('layoutModeToggleIcon');
+        if (!toggleBtn) return;
+        const isStructured = viewportState.layoutMode === 'structured';
+        toggleBtn.classList.toggle('is-active', isStructured);
+        if (toggleLabel) {
+            toggleLabel.textContent = isStructured
+                ? (i18n('editor_layout_structured') || '정리된 트리')
+                : (i18n('editor_layout_free') || '자유 배치');
+        }
+        if (toggleIcon) {
+            toggleIcon.textContent = isStructured ? 'account_tree' : 'auto_awesome';
+        }
     }
 
     const growthAffordance = window.createEditorCanvasGrowthAffordance({
@@ -146,8 +248,6 @@ function loadStoredLayout() {
             AFFORDANCE_CARD_HALF
         }
     });
-
-
 
 
 
@@ -203,7 +303,7 @@ function isNodeWithinSafeViewport(pos) {
     const NODE_TAP_SELECT_THRESHOLD = 8;
 
     function bindNodeDrag(nodeEl, mem) {
-        nodeEl.style.cursor = 'grab';
+        nodeEl.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
         let touchStartPoint = null;
 
         const selectMemoryNode = () => {
@@ -211,6 +311,9 @@ function isNodeWithinSafeViewport(pos) {
         };
 
         nodeEl.addEventListener('mousedown', (e) => {
+            // Disable drag in structured mode
+            if (viewportState.layoutMode === 'structured') return;
+
             if (typeof canvasInteraction.beginNodeDrag === 'function') {
                 canvasInteraction.beginNodeDrag(e, nodeEl, mem, viewportState, getWorldPosition);
                 return;
@@ -288,7 +391,6 @@ function isNodeWithinSafeViewport(pos) {
             selectMemoryNode();
         });
     }
-
 
 
 
@@ -414,6 +516,8 @@ function isNodeWithinSafeViewport(pos) {
         bindCanvasPan();
         bindViewportControls();
         bindResizeHandling();
+        // Bind layout mode toggle on each init to ensure it stays bound after toolbar rebuild
+        bindLayoutModeToggle();
         viewportState.initialized = true;
     };
 
@@ -498,99 +602,116 @@ function isNodeWithinSafeViewport(pos) {
 
         if (viewportState.controlsBound) return;
         viewportState.controlsBound = true;
-
-        const focusBtn = document.getElementById('focusSelectedBtn');
-        const recenterBtn = document.getElementById('recenterCanvasBtn');
-
-        if (focusBtn) {
-            focusBtn.addEventListener('click', () => {
-                const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-                if (selectedId) {
-                    focusNodeById(selectedId);
-                }
-            });
-        }
-
-        if (recenterBtn) {
-            recenterBtn.addEventListener('click', () => {
-                recenterViewport();
-            });
-        }
     }
 
-    function zoomBy(factor) {
-        if (!factor || factor === 1) return;
-        const metrics = getMetrics();
-        const oldScale = viewportState.scale || 1;
-        const minScale = typeof canvasViewport.minScale === 'number' ? canvasViewport.minScale : 0.65;
-        const maxScale = typeof canvasViewport.maxScale === 'number' ? canvasViewport.maxScale : 1.55;
-        const nextScale = Math.min(maxScale, Math.max(minScale, oldScale * factor));
-        if (Math.abs(nextScale - oldScale) < 0.001) return;
+    function bindLayoutModeToggle() {
+        const toggleBtn = document.getElementById('layoutModeToggleBtn');
+        if (!toggleBtn) return;
+        if (toggleBtn.dataset.layoutBound) return;
 
-        const centerX = metrics.width * 0.5;
-        const centerY = metrics.height * 0.5;
-        const centerWorldX = (centerX - viewportState.offsetX) / oldScale;
-        const centerWorldY = (centerY - viewportState.offsetY) / oldScale;
+        // Store current free positions on first structured switch attempt
+        toggleBtn.addEventListener('click', () => {
+            toggleLayoutMode();
+        });
 
-        viewportState.scale = nextScale;
-        viewportState.offsetX = Math.round(centerX - (centerWorldX * nextScale));
-        viewportState.offsetY = Math.round(centerY - (centerWorldY * nextScale));
-        canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
-        persistStoredPositions();
-        initCanvas();
+        toggleBtn.dataset.layoutBound = '1';
     }
 
-    const bindCanvasPan = () => {
+    function bindCanvasPan() {
         if (typeof canvasInteraction.bind === 'function') {
             canvasInteraction.bind({
                 canvas,
                 viewportState,
-                scheduleRender: scheduleInitCanvas,
+                scheduleRender: () => { if (viewportState.layoutMode === 'free') initCanvas(); },
                 persistStoredPositions,
                 initCanvas,
                 getWorldPosition,
-                getDragTargetElement: (draggedId) => document.querySelector(`.memory-node[data-memory-id="${draggedId}"]`),
+                getDragTargetElement: (id) => document.querySelector(`.memory-node[data-memory-id="${id}"]`),
                 showMovedToast: () => {
-                    if (window.LoveBudUI?.showToast) {
-                        window.LoveBudUI.showToast(i18n('node_position_adjusted') || '순간 위치를 조정했습니다', 'success', 1800);
+                    const toast = document.getElementById('movedToast');
+                    if (toast) {
+                        toast.style.display = 'block';
+                        setTimeout(() => { toast.style.display = 'none'; }, 3000);
                     }
                 }
             });
             return;
         }
 
-        canvasInteractionHelpers.bindFallbackCanvasPan({
-            canvas,
-            viewportState,
-            scheduleInitCanvas,
-            persistStoredPositions,
-            initCanvas,
-            i18n
-        });
-    };
+        // Fallback in-memory binding
+        if (viewportState.globalsBound) return;
+        viewportState.globalsBound = true;
 
-function scheduleInitCanvas() {
-        if (viewportState.rafScheduled) return;
-        viewportState.rafScheduled = true;
-        viewportState.rafFrame = requestAnimationFrame(() => {
-            viewportState.rafScheduled = false;
-            viewportState.rafFrame = null;
-            initCanvas();
+        canvas.addEventListener('mousedown', (event) => {
+            if (event.target.closest('.memory-node') || event.target.closest('#addMemoryForm') || event.target.closest('.memory-add-affordance')) return;
+
+            // Disable panning interaction that leads to drag in structured mode
+            if (viewportState.layoutMode === 'structured') return;
+
+            viewportState.isPanning = true;
+            viewportState.startX = event.clientX;
+            viewportState.startY = event.clientY;
+        });
+
+        window.addEventListener('mousemove', (event) => {
+            if (viewportState.layoutMode !== 'free') return;
+            if (!viewportState.isPanning) return;
+            const dx = event.clientX - viewportState.startX;
+            const dy = event.clientY - viewportState.startY;
+            viewportState.startX = event.clientX;
+            viewportState.startY = event.clientY;
+            viewportState.offsetX += dx;
+            viewportState.offsetY += dy;
+            canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
+        });
+
+        window.addEventListener('mouseup', () => {
+            if (viewportState.isPanning) {
+                viewportState.isPanning = false;
+                persistStoredPositions();
+            }
         });
     }
+
+    function zoomBy(factor) {
+        if (typeof canvasViewport.zoomBy === 'function') {
+            canvasViewport.zoomBy({
+                factor,
+                viewportState,
+                getMetrics,
+                initCanvas
+            });
+            persistStoredPositions();
+            return;
+        }
+
+        const oldScale = viewportState.scale || 1;
+        const newScale = Math.min(1.55, Math.max(0.65, oldScale * factor));
+        if (newScale === oldScale) return;
+        viewportState.scale = newScale;
+        initCanvas();
+        persistStoredPositions();
+    }
+
+    // Initialize layout mode UI on first paint
+    requestAnimationFrame(() => {
+        if (viewportState.layoutMode === 'structured') {
+            document.body.classList.add('layout-structured');
+        } else {
+            document.body.classList.add('layout-free');
+        }
+        updateLayoutToggleUI();
+    });
 
     return {
         calcPosition,
         drawBranch,
         drawNode,
         initCanvas,
-        bindCanvasPan,
-        viewportState,
         focusNodeById,
         recenterViewport,
-        keepSelectionVisible,
-        zoomBy
+        setLayoutMode,
+        getWorldPosition,
+        get viewportState() { return viewportState; }
     };
 }
-
-window.createEditorCanvas = createEditorCanvas;

--- a/js/i18n/i18n-editor.js
+++ b/js/i18n/i18n-editor.js
@@ -121,5 +121,7 @@ Object.assign(window.i18nEditor, {
     selected_moment: { ko: '현재 선택한 순간', en: 'Current selected moment' },
     sidebar_moment_count_short: { ko: '총 {count}개의 저장된 순간', en: '{count} saved moments total' },
     sidebar_moment_count_with_visible_short: { ko: '총 {total}개의 저장된 순간 · 캔버스 {visible}개 표시', en: '{total} saved moments · {visible} shown on canvas' },
-    sidebar_flow_summary_connected_short: { ko: '이 트리에 {count}개의 순간이 저장되어 있어요', en: '{count} moments are saved in this tree' }
+    sidebar_flow_summary_connected_short: { ko: '이 트리에 {count}개의 순간이 저장되어 있어요', en: '{count} moments are saved in this tree' },
+    editor_layout_free: { ko: '자유 배치', en: 'Free layout' },
+    editor_layout_structured: { ko: '정리된 트리', en: 'Structured tree' }
 });

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -80,6 +80,13 @@
                             <span class="editor-canvas-tool-label" id="focusSelectedBtnLabel">선택한 순간 보기</span>
                         </button>
                     </div>
+                    <div class="editor-canvas-toolbar-separator" aria-hidden="true"></div>
+                    <div class="editor-canvas-toolbar-group" aria-label="레이아웃 모드">
+                        <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="layoutModeToggleBtn" aria-label="레이아웃 전환" title="레이아웃 전환">
+                            <span class="material-symbols-outlined" aria-hidden="true" id="layoutModeToggleIcon">auto_awesome</span>
+                            <span class="editor-canvas-tool-label" id="layoutModeToggleLabel">자유 배치</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <svg class="canvas-svg" id="canvasSvg"></svg>


### PR DESCRIPTION
## Summary

Add a structured (vertical tree) layout mode toggle to the Editor canvas, allowing users to switch between free-position layout and an auto-arranged topology-based tree view.

## Changes

### New behavior
- **Layout mode toggle** added to canvas toolbar: "자유 배치" / "정리된 트리"
- **Free mode** (default): existing behavior preserved — drag, pan, localStorage positions
- **Structured mode**: topology-based vertical tree layout with root at bottom and children branching upward
  - Depth determines Y position (root at bottom, children above)
  - Siblings spread horizontally based on subtree width
  - Node drag disabled (cursor: default)
  - Canvas pan disabled
  - Free positions preserved in memory/localStorage, restored on return

### Files changed (7)

| File | Change |
|------|--------|
| `js/editor/editor-canvas-geometry.js` | Add `getStructuredWorldPosition()` with recursive subtree-width layout algorithm |
| `js/editor/editor-canvas.js` | Add `layoutMode` state, mode switching with free-position preservation, toggle event binding, structured-aware `getWorldPosition()` dispatch |
| `js/editor/editor-canvas-interaction.js` | Skip node drag and canvas pan in structured mode |
| `pages/editor.html` | Add layout mode toggle button group in toolbar |
| `css/editor/editor-canvas-toolbar.css` | Add `.is-active` toggle style, mobile layout mode group |
| `css/editor/editor-memory-form.css` | Add `.layout-structured .memory-node` no-drag cursor |
| `js/i18n/i18n-editor.js` | Add `editor_layout_free` and `editor_layout_structured` labels |

## Scope

- Editor canvas only
- Public Viewer layout unchanged
- No backend/API/schema changes
- No Browse/My Trees changes
- No PR #7 or prototype changes

## Out of scope (future)

- Public Viewer structured layout
- Animation between mode transitions
- Collision avoidance refinements
- User custom layout save to server
- Branch-depth auto-layout fine-tuning

## Verification

- `npm run lint` ✅ (no new warnings)
- `npm run build` ✅
- Free mode: existing drag/pan/position persistence unchanged
- Structured ↔ free toggle: positions preserved across switches
- Structured mode: auto-layout renders tree with clear parent-child hierarchy
- Structured mode: drag and pan disabled

## Known limitations

- Structured layout algorithm is a first slice — node overlap may occur in deep or highly branched trees
- No animation on mode switch (instant re-layout)
- Public Viewer structured mode not included

Refs #1037