### PR TITLE
feat(viewer): add structured (hierarchy) layout toggle to Public Viewer

### DIFF
--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -91,6 +91,70 @@
     background: #cbb8b0;
 }
 
+/* Layout toggle button */
+.vv-header-actions {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.vv-layout-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: 1px solid rgba(144, 73, 81, 0.14);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--primary);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all .18s ease;
+    white-space: nowrap;
+}
+
+.vv-layout-toggle:hover {
+    background: #fff;
+    border-color: rgba(144, 73, 81, 0.22);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(111, 70, 44, 0.08);
+}
+
+.vv-layout-toggle:active {
+    transform: translateY(0);
+}
+
+.vv-layout-toggle-label {
+    pointer-events: none;
+}
+
+/* Hierarchy layout adjustments */
+.vv-tree-canvas[data-layout="hierarchy"] .vv-media-leaf {
+    pointer-events: auto;
+}
+
+.vv-tree-canvas[data-layout="hierarchy"] .vv-media-leaf .vv-leaf-shape {
+    width: clamp(48px, 4vw, 64px) !important;
+    height: clamp(62px, 5vw, 80px) !important;
+}
+
+.vv-tree-canvas[data-layout="hierarchy"] .vv-media-leaf .vv-leaf-emoji {
+    font-size: clamp(18px, 1.6vw, 24px);
+}
+
+@media (max-width: 900px) {
+    .vv-header-actions {
+        width: 100%;
+        justify-content: flex-end;
+    }
+    .vv-layout-toggle {
+        font-size: 11px;
+        padding: 5px 10px;
+    }
+}
+
 .vv-viewer-layout {
     display: grid;
     grid-template-columns: minmax(760px, 1fr) clamp(248px, 17vw, 300px);

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -258,7 +258,7 @@
             var Panels = window.LoveBudVisitorViewerPanels;
 
             // Render state
-            var state = { selectedBranchId: 'main', selectedMomentId: null, activePanel: 'empty', likedTree: false };
+            var state = { selectedBranchId: 'main', selectedMomentId: null, activePanel: 'empty', likedTree: false, layoutMode: 'organic' };
 
             show(SEL.treeContainer);
             hide(SEL.loading, SEL.empty, SEL.error);
@@ -274,6 +274,11 @@
                 '  <div><p class="vv-eyebrow">Public LoveTree Viewer</p>' +
                 '  <h1 class="vv-title">' + escapeHtml(treeTitle) + '</h1>' +
                 '  <div class="vv-meta-row"><span>' + escapeHtml(viewerData.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(treeMetaText) + '</span></div></div>' +
+                '  <div class="vv-header-actions">' +
+                '    <button type="button" class="vv-layout-toggle" data-action="toggle-layout" aria-label="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;" title="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;">' +
+                '      <span class="vv-layout-toggle-label" id="vvLayoutToggleLabel">&#xAD6C;&#xC870; &#xBCF4;&#xAE30;</span>' +
+                '    </button>' +
+                '  </div>' +
                 '</header>' +
                 '<div class="vv-action-dock">' +
                 '  <div class="vv-action-group">' +
@@ -350,6 +355,14 @@
                     refresh();
                 },
                 toggleLike: function() { state.likedTree = !state.likedTree; },
+                onToggleLayout: function() {
+                    state.layoutMode = state.layoutMode === 'organic' ? 'hierarchy' : 'organic';
+                    var toggleLabel = document.getElementById('vvLayoutToggleLabel');
+                    if (toggleLabel) {
+                        toggleLabel.textContent = state.layoutMode === 'hierarchy' ? '유기적 보기' : '구조 보기';
+                    }
+                    refresh();
+                },
                 copyLink: function() {
                     var Share = window.LoveBudShareActions;
                     if (!Share) return;
@@ -405,6 +418,7 @@
                     else if (a === 'native-share') handler.nativeShare();
                     else if (a === 'platform-share') handler.platformShare(action.dataset.platform);
                     else if (a === 'export-tree-card') handler.exportTreeImageCard();
+                    else if (a === 'toggle-layout') handler.onToggleLayout();
                     return;
                 }
                 var momentBtn = e.target.closest('[data-moment-id]');

--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -23,8 +23,240 @@
         });
     }
 
-    function renderTree(container, state, handlers) {
-        if (!container) return;
+    // ── Structured (hierarchy) layout ─────────────────────────────────────
+
+    function buildHierarchyLayout(branches, rootSeed) {
+        if (!branches || branches.length === 0) return null;
+
+        // Collect all nodes with parent-child relationships
+        var nodes = [];
+        var edges = [];
+        var nodeMap = {};
+        var colorMap = {};
+        var startX = 50;
+        var startY = 8;
+        var levelSpacing = 22;
+        var minHorizontalGap = 12;
+
+        // Build nodes from branches + moments
+        branches.forEach(function(branch) {
+            var branchNodeId = 'branch-' + branch.id;
+            // Branch label as a node
+            nodes.push({
+                id: branchNodeId,
+                label: branch.name,
+                type: 'branch',
+                color: branch.color,
+                isBranch: true,
+                children: []
+            });
+            colorMap[branchNodeId] = branch.color;
+
+            // Connect branch to trunk root (center)
+            edges.push({
+                from: 'trunk-root',
+                to: branchNodeId
+            });
+
+            // Moments on this branch
+            (branch.moments || []).forEach(function(moment) {
+                var momentNodeId = moment.id;
+                nodes.push({
+                    id: momentNodeId,
+                    label: moment.title,
+                    type: 'moment',
+                    emoji: moment.emoji || '✦',
+                    tag: moment.tag || '',
+                    branchId: branchNodeId,
+                    color: branch.color,
+                    children: []
+                });
+                colorMap[momentNodeId] = branch.color;
+                edges.push({
+                    from: branchNodeId,
+                    to: momentNodeId
+                });
+            });
+        });
+
+        // If we only have one branch, simplify: build straight hierarchy of moments
+        if (branches.length === 1) {
+            var singleBranch = branches[0];
+            var moments = singleBranch.moments || [];
+            if (moments.length <= 1) {
+                // Too few nodes, not worth hierarchy view
+                return null;
+            }
+
+            // Simple: root → moment1 → moment2 → moment3 (chain)
+            nodes = [];
+            edges = [];
+
+            // Root seed as top
+            if (rootSeed) {
+                nodes.push({
+                    id: 'seed-root',
+                    label: rootSeed.title,
+                    type: 'root',
+                    emoji: rootSeed.emoji || '✦',
+                    tag: '',
+                    children: []
+                });
+            }
+
+            moments.forEach(function(moment, i) {
+                nodes.push({
+                    id: moment.id,
+                    label: moment.title,
+                    type: 'moment',
+                    emoji: moment.emoji || '✦',
+                    tag: moment.tag || '',
+                    children: []
+                });
+                if (i === 0) {
+                    edges.push({ from: 'seed-root', to: moment.id });
+                } else {
+                    edges.push({ from: moments[i-1].id, to: moment.id });
+                }
+            });
+
+            // Compute positions: top-down chain
+            var maxWidth = 100;
+            var totalNodes = nodes.length;
+            var availableHeight = 100 - startY - 5;
+            var ySpacing = totalNodes > 1 ? availableHeight / (totalNodes - 1) : 0;
+
+            nodes.forEach(function(node, i) {
+                node.x = startX;
+                node.y = startY + (totalNodes > 1 ? i * ySpacing : 0);
+            });
+
+            return { nodes: nodes, edges: edges };
+        }
+
+        // Multiple branches: build hierarchy with trunk root branching out
+        // Compute positions: root at top center, branches radially outward
+        var allNodes = nodes;
+        var level = {};
+        var maxLevel = 0;
+
+        // Assign levels using simple BFS
+        allNodes.forEach(function(n) { level[n.id] = 0; });
+        edges.forEach(function(e) {
+            var childLevel = (level[e.from] || 0) + 1;
+            if (childLevel > (level[e.to] || 0)) {
+                level[e.to] = childLevel;
+            }
+            if (childLevel > maxLevel) maxLevel = childLevel;
+        });
+
+        // Group nodes by level
+        var nodesByLevel = {};
+        allNodes.forEach(function(n) {
+            var lvl = level[n.id] || 0;
+            if (!nodesByLevel[lvl]) nodesByLevel[lvl] = [];
+            nodesByLevel[lvl].push(n);
+        });
+
+        // Compute positions
+        Object.keys(nodesByLevel).forEach(function(lvlStr) {
+            var lvl = parseInt(lvlStr, 10);
+            var lvlNodes = nodesByLevel[lvl];
+            var count = lvlNodes.length;
+            // Position: evenly spaced across (100 - margins)
+            var leftMargin = 10;
+            var rightMargin = 10;
+            var availableWidth = 100 - leftMargin - rightMargin;
+            var spacing = count > 1 ? availableWidth / (count - 1) : 0;
+
+            lvlNodes.forEach(function(node, i) {
+                node.x = count > 1 ? leftMargin + i * spacing : startX;
+                node.y = startY + lvl * levelSpacing;
+            });
+        });
+
+        // Adjust deep chains: if a node has a single child, keep them aligned
+        // (already handled by level-based positioning)
+
+        return { nodes: allNodes, edges: edges };
+    }
+
+    function renderHierarchyTree(container, state, handlers) {
+        var branches = getData('branches') || [];
+        var rootSeed = getData('rootSeed');
+        var paletteObj = getData('palette') || {};
+        var treeData = getData('tree') || {};
+
+        var layout = buildHierarchyLayout(branches, rootSeed);
+        if (!layout) {
+            // Fall back to organic mode if hierarchy can't be built
+            renderOrganicTree(container, state, handlers);
+            return;
+        }
+
+        var selectedMomentId = state.selectedMomentId;
+        var hasSelection = Boolean(selectedMomentId);
+        var isSingleChain = branches.length === 1 && layout.nodes.length > 1;
+
+        // Build SVG lines for edges
+        var svgLines = '';
+        layout.edges.forEach(function(edge) {
+            var fromNode = layout.nodes.find(function(n) { return n.id === edge.from; });
+            var toNode = layout.nodes.find(function(n) { return n.id === edge.to; });
+            if (!fromNode || !toNode) return;
+
+            var pColor = paletteColor({ color: toNode.color || 'rose' });
+            var muted = hasSelection && selectedMomentId !== toNode.id && selectedMomentId !== fromNode.id;
+
+            // Draw a vertical-then-horizontal connector line
+            var x1 = fromNode.x, y1 = fromNode.y;
+            var x2 = toNode.x, y2 = toNode.y;
+            var midY = y1 + (y2 - y1) * 0.5;
+
+            // L-shaped connector: vertical down from parent, horizontal to child, vertical to child
+            var pathData = 'M' + x1 + ' ' + y1 + ' L' + x1 + ' ' + midY + ' L' + x2 + ' ' + midY + ' L' + x2 + ' ' + y2;
+
+            svgLines += '<path d="' + pathData + '" stroke="' + (pColor.stroke || '#d4a0a0') + '" stroke-width="' + (muted ? '0.7' : '1.2') + '" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="' + (muted ? '0.25' : '0.55') + '" />';
+        });
+
+        // Build node elements
+        var nodeEls = '';
+        layout.nodes.forEach(function(node) {
+            var isSelected = selectedMomentId === node.id;
+            var pColor = paletteColor({ color: node.color || 'rose' });
+            var leafShape = 'width:clamp(52px, 4.5vw, 72px);height:clamp(68px, 5.5vw, 92px);border-radius:54% 46% 52% 48% / 43% 58% 42% 57%;background:' + leafGrad({ color: node.color }) + ';box-shadow:' + (isSelected ? '0 0 0 6px rgba(255,241,243,0.9),0 20px 38px rgba(80,45,39,0.18)' : '0 8px 20px rgba(97,61,38,0.10)');
+
+            var dataAttrs = 'data-moment-id="' + escapeHtml(node.id) + '" data-branch-id="' + escapeHtml(node.branchId || '') + '"';
+
+            nodeEls += '<div class="vv-media-leaf' + (isSelected ? ' is-selected' : '') + '" ' + dataAttrs + ' style="left:' + node.x + '%;top:' + node.y + '%">' +
+                '<button type="button" class="vv-leaf-shape' + (isSelected ? ' is-active' : '') + '" style="' + leafShape + '" aria-label="' + escapeHtml(node.label) + '">' +
+                '  <span class="vv-leaf-inner"></span>' +
+                '  <span class="vv-leaf-emoji">' + (node.emoji ? escapeHtml(node.emoji) : '✦') + '</span>' +
+                '  <span class="vv-leaf-play">▶</span></button>' +
+                (isSingleChain || node.type !== 'moment' ? '' :
+                '<div class="vv-leaf-label vv-leaf-label--right"><span class="vv-leaf-label-title">' + escapeHtml(node.label) + '</span>' +
+                (node.tag ? '<span class="vv-leaf-label-tag" style="background:' + pColor.soft + ';color:' + pColor.text + '">' + escapeHtml(node.tag) + '</span>' : '') +
+                '</div>') +
+                '</div>';
+        });
+
+        container.innerHTML =
+            '<div class="vv-tree-canvas" data-has-selection="' + hasSelection + '" data-layout="hierarchy">' +
+            '  <div class="vv-tree-bg-pattern"></div>' +
+            '  <div class="vv-tree-glow-top"></div>' +
+            '  <div class="vv-tree-glow-bottom"></div>' +
+            '  <svg class="vv-tree-svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">' +
+            '    <defs><filter id="hierarchyShadow"><feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="#7c4a3f" floodOpacity="0.12" /></filter></defs>' +
+            svgLines +
+            '  </svg>' +
+            '  <div class="vv-tree-organs">' + nodeEls + '</div>' +
+            '  <div class="vv-tree-badge">완성된 공개 러브트리</div>' +
+            '</div>';
+    }
+
+    // ── Organic (default) layout ───────────────────────────────────────────
+
+    function renderOrganicTree(container, state, handlers) {
         var branches = getData('branches') || [];
         var rootSeed = getData('rootSeed');
         var paletteObj = getData('palette') || {};
@@ -75,7 +307,7 @@
         }
 
         container.innerHTML =
-            '<div class="vv-tree-canvas" data-has-selection="' + hasSelection + '">' +
+            '<div class="vv-tree-canvas" data-has-selection="' + hasSelection + '" data-layout="organic">' +
             '  <div class="vv-tree-bg-pattern"></div>' +
             '  <div class="vv-tree-glow-top"></div>' +
             '  <div class="vv-tree-glow-bottom"></div>' +
@@ -121,6 +353,18 @@
             '  <span class="vv-leaf-play">▶</span></button>' +
             (showLabel ? '<div class="vv-leaf-label ' + labelSide + '"><span class="vv-leaf-label-title">' + escapeHtml(moment.title) + '</span><span class="vv-leaf-label-tag" style="background:' + p.soft + ';color:' + p.text + '">' + escapeHtml(moment.tag) + '</span></div>' : '') +
             '</div>';
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────
+
+    function renderTree(container, state, handlers) {
+        if (!container) return;
+        var layoutMode = (state && state.layoutMode) || 'organic';
+        if (layoutMode === 'hierarchy') {
+            renderHierarchyTree(container, state, handlers);
+        } else {
+            renderOrganicTree(container, state, handlers);
+        }
     }
 
     window.LoveBudVisitorViewerRenderTree = { renderTree: renderTree };


### PR DESCRIPTION
## Summary

Add a structured (hierarchy) layout toggle to the Public Viewer, allowing visitors to switch between the default organic branch/leaf visualization and a clean top-down tree hierarchy view.

## Changed files

| File | Change |
|------|--------|
| js/visitor-viewer/visitor-viewer-render-tree.js | Add `buildHierarchyLayout()`, `renderHierarchyTree()`; split organic/hierarchy dispatch in `renderTree()` |
| js/viewer/tree-viewer.js | Add `layoutMode` state, toggle button in header, `onToggleLayout` handler, toggle label wiring |
| css/visitor-viewer/visitor-viewer-shell.css | Add `.vv-header-actions`, `.vv-layout-toggle`, hierarchy layout adjustments with responsive styles |

## Scope

- Layout mode toggle button in viewer header (right side)
- Organic mode (default): existing branch/leaf SVG rendering preserved unchanged
- Hierarchy mode: new layout computed client-side from branch/moment data:
  - Nodes arranged top-down by tree depth
  - SVG connector lines between related nodes
  - Leaf shapes with emoji, title, tag preserved
  - Selection/interaction state preserved across mode switches
- Responsive: toggle button wraps on narrow screens (900px)

## Out of scope

- Mobile-specific hierarchy layout optimization (responsive grid still needs work)
- Collision avoidance for dense trees
- Branch-depth-based auto-layout algorithm improvements
- Public Viewer layout preference persistence
- Editor structured layout changes (already done in PR #1100)

## Verification

- npm run lint -- passed
- npm run build -- passed (static build check)
- Requires Cloudflare PR preview browser verification: editor login not needed, public tree URL works directly

## Known limitations

- Hierarchy layout uses simple level-based spacing; very dense trees may overlap at deeper levels
- Single-branch trees render as vertical chain (root -> moment1 -> moment2 ...)
- Mobile responsive layout may need further refinement for very small viewports

Refs: #1037
