### PR TITLE
fix(ux): refine public viewer structured layout on mobile

### DIFF
--- a/css/visitor-viewer/visitor-viewer-shell.css
+++ b/css/visitor-viewer/visitor-viewer-shell.css
@@ -365,4 +365,20 @@
     .vv-panel {
         padding: 14px;
     }
+    /* Tighten hierarchy leaf labels on small screens */
+    .vv-leaf-label {
+        min-width: 80px;
+        padding: 4px 8px;
+    }
+    .vv-leaf-label-title {
+        font-size: 11px;
+        max-width: 72px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .vv-leaf-label-tag {
+        font-size: 9px;
+        padding: 1px 6px;
+    }
 }


### PR DESCRIPTION
Refs #1103

## Summary
Mobile verification and refinement for Public Viewer structured/hierarchy layout on 375px viewports.

## Changed files
- css/visitor-viewer/visitor-viewer-shell.css — Add mobile @media (max-width: 375px) hierarchy label safety

## Verification

### Mobile 375px (iPhone SE, Playwright device emulation)
- Organic mode: PASS — tree content visible, toggle reachable
- Hierarchy mode: PASS — SVG connector lines render, no overflow
- Toggle repeat (3x): PASS — no artifacts
- Trees tested: 아일릿 (6 moments), KiiiKiii (13+ elements), XLOV (6 moments)
- Horizontal overflow: 0 (scrollWidth === clientWidth === 375)
- Console fatal JS errors: 0
- Network blockers: 0

### Desktop regression
- PASS — organic/hierarchy toggle, tree render, panel, all unchanged

## Refinements
- Tighten .vv-leaf-label min-width 108px→80px on <=375px
- Reduce .vv-leaf-label-title font-size to 11px with max-width/ellipsis
- Reduce .vv-leaf-label-tag font-size/padding for dense-tree safety

All changes are inside @media (max-width: 375px) — desktop unaffected.

## Risk / rollback
- Low risk: CSS-only, inside mobile breakpoint
- Rollback: revert commit

## Protected areas untouched
- PR #7: NO
- prototype/reference/demo/variant: NO