### PR TITLE
ui(my-trees): hide visibility controls from MVP UI

### DIFF
--- a/css/my-trees.css
+++ b/css/my-trees.css
@@ -3,4 +3,5 @@
 @import url('./my-trees/my-trees-cards.css');
 @import url('./my-trees/my-trees-states.css');
 @import url('./my-trees/my-trees-create-modal.css');
+@import url('./my-trees/my-trees-visibility-gate.css');
 @import url('./my-trees/my-trees-responsive.css');

--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -1,0 +1,19 @@
+/*
+ * LoveTree - My Trees visibility gate
+ *
+ * Public/private visibility controls are a future subscription-gated product area.
+ * Hide current MVP-facing visibility controls without changing underlying data.
+ */
+
+.tree-card-dropdown .dropdown-item.visibility,
+.tree-card-visibility,
+#manageVisibilityBtn,
+#publicTreesCount,
+#privateTreesCount,
+[data-i18n="myTrees.manage_visibility"],
+[data-i18n="myTrees.summary_public"],
+[data-i18n="myTrees.summary_private"],
+[data-i18n="visibility_make_public"],
+[data-i18n="visibility_make_private"] {
+  display: none !important;
+}


### PR DESCRIPTION
Refs #1122

## Summary

Hide public/private visibility controls from the current My Trees MVP UI while preserving the underlying data and existing tree loading behavior.

## Changed files

- `css/my-trees.css`
  - Imports the new My Trees visibility gate stylesheet.
- `css/my-trees/my-trees-visibility-gate.css`
  - Hides current user-facing public/private visibility actions, badges, counters, and related i18n-bound controls.

## Product rationale

Public/private switching is intended to be handled later as a subscription-gated product area. The current MVP should not expose visibility switching as a normal free user control.

## Verification

- Static scope check: PASS
- Changed files limited to My Trees CSS: PASS
- Underlying data/API behavior unchanged: PASS
- No `pages/*`, JS runtime, backend, Auth, API, DB, schema, workflow, package, or deployment config changes: PASS
- PR #7 / prototype / reference / demo / variant paths untouched: PASS
- Cloudflare fixed test slot `test1`: PASS
- Login redirect for My Trees: PASS
- Logged-in My Trees initial render: PASS
- Public/private badge exposure: PASS - not visible
- Public/private menu action exposure: PASS - not visible
- Tree card rendering after visibility UI hiding: PASS
- Existing card menu still shows rename/delete only: EXPECTED, tracked separately in #1123
- Sort option `생성순` causes incorrect empty state: FAIL, tracked separately in #1126
- Editor smoke after navigation: PASS for initial render; unrelated follow-ups tracked in #1127, #1128, #1129

## NOT_VERIFIED

- Mobile 375px screenshot intentionally deferred for this pass
- Network blockers not separately captured

## Safety

No restricted private values are included.