### PR TITLE
fix(my-trees): keep sort source in sync

### DIFF
--- a/js/my-trees/my-trees-state.js
+++ b/js/my-trees/my-trees-state.js
@@ -37,9 +37,15 @@
   }
 
   function sortTrees(trees, sortBy) {
-    if (!sortBy || !trees) return trees;
+    var source = Array.isArray(trees) ? trees : [];
 
-    var sorted = Array.isArray(trees) ? trees.slice() : [];
+    if (source.length === 0 && Array.isArray(lastTreesData) && lastTreesData.length > 0) {
+      source = lastTreesData;
+    }
+
+    var sorted = source.slice();
+
+    if (!sortBy) return sorted;
 
     switch (sortBy) {
       case 'recent':


### PR DESCRIPTION
Refs #1126

## Summary

Fix My Trees sort changes so they reorder the current tree list instead of rendering an incorrect empty state when a local caller passes stale or empty sort input.

## Changed files

- `js/my-trees/my-trees-state.js`
  - Uses the state module's latest `lastTreesData` as a fallback source when sorting receives an empty local array while the stored tree list is non-empty.
  - Returns a cloned array consistently, preserving zero-tree empty state behavior when no stored trees exist.

## Scope

- My Trees sort state handling only.
- No public/private visibility UI work.
- No card cover redesign.
- No overflow menu removal.
- No backend/Auth/API/DB/schema changes.
- No PR #7 / prototype / reference / demo / variant changes.

## Verification

- Static diff scope: PASS
- Changed files limited to `js/my-trees/my-trees-state.js`: PASS
- Empty input with stored tree data falls back to stored list: PASS by code inspection
- Empty input with no stored tree data still returns empty list: PASS by code inspection

## NOT_VERIFIED

- Cloudflare/test-slot browser verification with login not yet performed.
- Progressive scroll/batch behavior not browser-verified in this pass.
- Mobile/narrow viewport not browser-verified in this pass.

## Safety

No private payload, raw DB rows, credentials, tokens, cookies, sessions, private keys, API keys, or raw identifiers are included.