### PR TITLE
chore(ops): remove noisy utility console logs

### DIFF
--- a/js/cache-utils.js
+++ b/js/cache-utils.js
@@ -181,6 +181,4 @@
     clearAll: clearAllCache,
     status: getCacheStatus
   };
-
-  console.log('[cache-utils] Cache system initialized');
 })();

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -188,6 +188,4 @@
         validateSourceUrl,
         detectSourceType
     };
-
-    console.log('[LoveBudMedia] Media utilities loaded v20260424-3 (pure)');
 })();

--- a/js/utils/path.js
+++ b/js/utils/path.js
@@ -56,6 +56,4 @@
         resolvePageUrl,
         buildUrl
     };
-
-    console.log('[LoveBudPath] Path utilities loaded v20260418-1');
 })();

--- a/js/utils/ui.js
+++ b/js/utils/ui.js
@@ -156,7 +156,6 @@
      * 로딩 표시 (향후 확장용)
      */
     function showLoading() {
-        console.log('[LoveBudUI] showLoading called (placeholder)');
         // TODO: 향후 구현
     }
 
@@ -164,7 +163,6 @@
      * 로딩 숨김 (향후 확장용)
      */
     function hideLoading() {
-        console.log('[LoveBudUI] hideLoading called (placeholder)');
         // TODO: 향후 구현
     }
 
@@ -183,6 +181,4 @@
         hideLoading,
         showConfirm
     };
-
-    console.log('[LoveBudUI] UI utilities loaded v20260418-1');
 })();


### PR DESCRIPTION
Refs #1130

## Summary

Remove non-actionable production/test boot and placeholder console logs from shared utility modules that are loaded during normal LoveTree user flows.

## Changed files

- `js/cache-utils.js`
  - Removes normal boot log for cache initialization.
- `js/utils/path.js`
  - Removes normal boot log for path utility load.
- `js/utils/ui.js`
  - Removes normal boot log for UI utility load.
  - Removes placeholder `showLoading` / `hideLoading` console logs.
- `js/utils/media.js`
  - Removes normal boot log for media utility load.

## Scope

- Runtime logging hygiene only.
- No UI redesign.
- No backend/Auth/API/DB/schema changes.
- No package/workflow/deployment config changes.
- No PR #7 / prototype / reference / demo / variant changes.

## NOT_APPLIED

The following issue-requested files still need a follow-up pass because the current tool write path blocked full-file updates during this turn:

- `js/shared-header.js`
- `js/editor/editor-data-loader.js`
- `js/editor/editor-root-helpers.js`
- `js/editor.js`
- `js/i18n/i18n-index.js`

Known remaining examples include cached-user detail logs, raw tree/root identifier logs, and i18n merge count logs. They are not included in this PR to avoid unsafe partial rewrites.

## Verification

- Static diff scope: PASS
- Changed files limited to shared utility JS files: PASS
- Removed logs are non-actionable boot/placeholder `console.log` calls only: PASS by code inspection

## NOT_VERIFIED

- Cloudflare/test-slot browser console verification not performed in this pass.
- Editor login/runtime verification not performed in this pass.

## Safety

No private payload, raw DB rows, credentials, tokens, cookies, sessions, private keys, API keys, or raw identifiers are included.