### PR TITLE
chore(ops): remove editor console identifiers

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const bTime = b.createdAt || b.timestamp || '9999';
                 return new Date(aTime) - new Date(bTime);
             })[0];
-            console.log('[editor] Multiple parentId=null nodes found, using oldest as root:', oldest.id);
+            /* console.log('[editor] Multiple parentId=null nodes found, using oldest as root:', oldest.id); — removed: raw id */
             return oldest;
         }
 
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ...tree,
             visibility: tree.visibility || 'public'
         };
-        console.log('[editor] currentTreeData set:', window.currentTreeData.visibility);
+        /* console.log('[editor] currentTreeData set:', window.currentTreeData.visibility); — removed: operational log */
     });
 
     const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate || ((selectedNodeId, canonicalRootId) => {
@@ -700,7 +700,7 @@ document.addEventListener('DOMContentLoaded', () => {
             editorBindings.bindDetailActionButtons({ editMemoryBtn, deleteMemoryBtn, cancelEditBtn, saveEditBtn, enterEditMode, deleteMemory, exitEditMode, saveMemoryEdit });
         }
 
-        console.log('[editor] Ready for tree:', treeId, 'memories:', treeMemories().length);
+        /* console.log('[editor] Ready for tree:', treeId, 'memories:', treeMemories().length); — removed: raw treeId */
         updateSidebarStatus();
         markEditorReady();
     };

--- a/js/editor.js
+++ b/js/editor.js
@@ -29,7 +29,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 const bTime = b.createdAt || b.timestamp || '9999';
                 return new Date(aTime) - new Date(bTime);
             })[0];
-            /* console.log('[editor] Multiple parentId=null nodes found, using oldest as root:', oldest.id); — removed: raw id */
             return oldest;
         }
 
@@ -116,7 +115,6 @@ document.addEventListener('DOMContentLoaded', () => {
             ...tree,
             visibility: tree.visibility || 'public'
         };
-        /* console.log('[editor] currentTreeData set:', window.currentTreeData.visibility); — removed: operational log */
     });
 
     const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate || ((selectedNodeId, canonicalRootId) => {
@@ -700,7 +698,6 @@ document.addEventListener('DOMContentLoaded', () => {
             editorBindings.bindDetailActionButtons({ editMemoryBtn, deleteMemoryBtn, cancelEditBtn, saveEditBtn, enterEditMode, deleteMemory, exitEditMode, saveMemoryEdit });
         }
 
-        /* console.log('[editor] Ready for tree:', treeId, 'memories:', treeMemories().length); — removed: raw treeId */
         updateSidebarStatus();
         markEditorReady();
     };

--- a/js/editor/editor-data-loader.js
+++ b/js/editor/editor-data-loader.js
@@ -59,7 +59,7 @@
                     tree = await apiClient.getTree(urlTreeId);
                     if (tree) {
                         treeLoadStatus = 'loaded';
-                        console.log('[editor] Tree from URL loaded:', tree.id);
+                        /* console.log('[editor] Tree from URL loaded:', tree.id); — removed: raw id */
                     }
                 } else {
                     treeLoadStatus = 'api_unavailable';
@@ -93,9 +93,9 @@
                     if (apiTree) {
                         tree = apiTree;
                         treeLoadStatus = 'loaded';
-                        console.log('[editor] API tree loaded (getFirstTree)');
+                        /* console.log('[editor] API tree loaded (getFirstTree)'); — removed: operational log */
                     } else if (apiClient.createTree) {
-                        console.log('[editor] No tree found, creating default tree...');
+                        /* console.log('[editor] No tree found, creating default tree...'); — removed: operational log */
                         const newTree = await apiClient.createTree({
                             title: createDefaultTreeTitle(),
                             visibility: 'public'
@@ -103,7 +103,7 @@
                         tree = newTree;
                         isNewTree = true;
                         treeLoadStatus = 'created';
-                        console.log('[editor] Default tree created:', newTree);
+                        /* console.log('[editor] Default tree created:', newTree); — removed: raw object */
                     }
                 }
             } catch (e) {
@@ -147,7 +147,7 @@
         const cachedMemories = cache ? cache.get(cacheKey) : null;
 
         if (cachedMemories && Array.isArray(cachedMemories)) {
-            console.log('[editor] Using cached memories:', cachedMemories.length);
+            /* console.log('[editor] Using cached memories:', cachedMemories.length); — removed: operational log */
             memories = cachedMemories;
             window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
         }
@@ -157,7 +157,7 @@
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
                     memories = apiMemories;
-                    console.log('[editor] API memories loaded:', apiMemories.length);
+                    /* console.log('[editor] API memories loaded:', apiMemories.length); — removed: operational log */
 
                     if (cache) {
                         cache.set(cacheKey, memories, cacheTtlMs);
@@ -196,7 +196,7 @@
                     const apiMemories = await apiClient.getMemoriesByTree(treeId);
                     if (Array.isArray(apiMemories)) {
                         window.currentTreeMemories = apiMemories.map(normalizeMemory).filter(Boolean);
-                        console.log('[editor] Memories refreshed:', window.currentTreeMemories.length);
+                        /* console.log('[editor] Memories refreshed:', window.currentTreeMemories.length); — removed: operational log */
                         onMemoriesUpdated(window.currentTreeMemories);
                     }
                 }

--- a/js/editor/editor-data-loader.js
+++ b/js/editor/editor-data-loader.js
@@ -59,7 +59,6 @@
                     tree = await apiClient.getTree(urlTreeId);
                     if (tree) {
                         treeLoadStatus = 'loaded';
-                        /* console.log('[editor] Tree from URL loaded:', tree.id); — removed: raw id */
                     }
                 } else {
                     treeLoadStatus = 'api_unavailable';
@@ -93,9 +92,7 @@
                     if (apiTree) {
                         tree = apiTree;
                         treeLoadStatus = 'loaded';
-                        /* console.log('[editor] API tree loaded (getFirstTree)'); — removed: operational log */
                     } else if (apiClient.createTree) {
-                        /* console.log('[editor] No tree found, creating default tree...'); — removed: operational log */
                         const newTree = await apiClient.createTree({
                             title: createDefaultTreeTitle(),
                             visibility: 'public'
@@ -103,7 +100,6 @@
                         tree = newTree;
                         isNewTree = true;
                         treeLoadStatus = 'created';
-                        /* console.log('[editor] Default tree created:', newTree); — removed: raw object */
                     }
                 }
             } catch (e) {
@@ -147,7 +143,6 @@
         const cachedMemories = cache ? cache.get(cacheKey) : null;
 
         if (cachedMemories && Array.isArray(cachedMemories)) {
-            /* console.log('[editor] Using cached memories:', cachedMemories.length); — removed: operational log */
             memories = cachedMemories;
             window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
         }
@@ -157,8 +152,6 @@
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
                     memories = apiMemories;
-                    /* console.log('[editor] API memories loaded:', apiMemories.length); — removed: operational log */
-
                     if (cache) {
                         cache.set(cacheKey, memories, cacheTtlMs);
                     }
@@ -196,7 +189,6 @@
                     const apiMemories = await apiClient.getMemoriesByTree(treeId);
                     if (Array.isArray(apiMemories)) {
                         window.currentTreeMemories = apiMemories.map(normalizeMemory).filter(Boolean);
-                        /* console.log('[editor] Memories refreshed:', window.currentTreeMemories.length); — removed: operational log */
                         onMemoriesUpdated(window.currentTreeMemories);
                     }
                 }

--- a/js/editor/editor-root-helpers.js
+++ b/js/editor/editor-root-helpers.js
@@ -43,7 +43,6 @@
                 const bTime = b.createdAt || b.timestamp || '9999';
                 return new Date(aTime) - new Date(bTime);
             })[0];
-            /* console.log('[editor-root-helpers] Multiple parentId=null nodes found, using oldest as root:', oldest.id); — removed: raw id */
             return oldest;
         }
         
@@ -112,5 +111,4 @@
         module.exports = LoveBudEditorUtils;
     }
 
-    /* console.log('[editor-root-helpers] Root memory utilities loaded v1.0.0'); — removed: version banner */
 })();

--- a/js/editor/editor-root-helpers.js
+++ b/js/editor/editor-root-helpers.js
@@ -43,7 +43,7 @@
                 const bTime = b.createdAt || b.timestamp || '9999';
                 return new Date(aTime) - new Date(bTime);
             })[0];
-            console.log('[editor-root-helpers] Multiple parentId=null nodes found, using oldest as root:', oldest.id);
+            /* console.log('[editor-root-helpers] Multiple parentId=null nodes found, using oldest as root:', oldest.id); — removed: raw id */
             return oldest;
         }
         
@@ -112,5 +112,5 @@
         module.exports = LoveBudEditorUtils;
     }
 
-    console.log('[editor-root-helpers] Root memory utilities loaded v1.0.0');
+    /* console.log('[editor-root-helpers] Root memory utilities loaded v1.0.0'); — removed: version banner */
 })();

--- a/js/i18n/i18n-index.js
+++ b/js/i18n/i18n-index.js
@@ -39,5 +39,5 @@
     window._i18nSetDictionary(mergedDictionary);
   }
 
-  console.log('[i18n-index] Dictionary merged:', Object.keys(mergedDictionary).length, 'keys');
+  /* console.log('[i18n-index] Dictionary merged:', Object.keys(mergedDictionary).length, 'keys'); — removed: operational log */
 })();

--- a/js/i18n/i18n-index.js
+++ b/js/i18n/i18n-index.js
@@ -39,5 +39,4 @@
     window._i18nSetDictionary(mergedDictionary);
   }
 
-  /* console.log('[i18n-index] Dictionary merged:', Object.keys(mergedDictionary).length, 'keys'); — removed: operational log */
 })();

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -262,7 +262,7 @@
         } else if (cachedUser) {
             // Confirmed session 있으면 즉시 사용자 아바타 표시 (로딩 없음)
             authHTML = '<div id="auth-nav" style="min-width:100px;height:36px;display:flex;align-items:center;justify-content:flex-end;">' + buildCachedUserAvatar(cachedUser) + '</div>';
-            console.log('[shared-header] Rendering cached user immediately:', cachedUser.displayName || cachedUser.email);
+            /* console.log('[shared-header] Rendering cached user immediately:', cachedUser.displayName || cachedUser.email); — removed: user info exposure */
         } else {
             // Session 없으면 로딩 스피너 표시 (auth.js가 나중에 교체)
             authHTML = '<div id="auth-nav" style="min-width:100px;height:36px;display:flex;align-items:center;justify-content:flex-end;"><span class="material-symbols-outlined" style="color:var(--on-surface-variant);animation:spin 1s linear infinite;font-size:20px;">progress_activity</span></div>';
@@ -418,7 +418,7 @@
                 console.error('[shared-header] initAuth after render failed:', e);
             }
         }
-        console.log('[shared-header] Rendered for:', getCurrentPage(), '| context:', getContextType());
+        /* console.log('[shared-header] Rendered for:', getCurrentPage(), '| context:', getContextType()); — removed: operational log */
     };
 
     function bindSettingsReturnLinkCapture() {

--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -262,7 +262,6 @@
         } else if (cachedUser) {
             // Confirmed session 있으면 즉시 사용자 아바타 표시 (로딩 없음)
             authHTML = '<div id="auth-nav" style="min-width:100px;height:36px;display:flex;align-items:center;justify-content:flex-end;">' + buildCachedUserAvatar(cachedUser) + '</div>';
-            /* console.log('[shared-header] Rendering cached user immediately:', cachedUser.displayName || cachedUser.email); — removed: user info exposure */
         } else {
             // Session 없으면 로딩 스피너 표시 (auth.js가 나중에 교체)
             authHTML = '<div id="auth-nav" style="min-width:100px;height:36px;display:flex;align-items:center;justify-content:flex-end;"><span class="material-symbols-outlined" style="color:var(--on-surface-variant);animation:spin 1s linear infinite;font-size:20px;">progress_activity</span></div>';
@@ -418,7 +417,6 @@
                 console.error('[shared-header] initAuth after render failed:', e);
             }
         }
-        /* console.log('[shared-header] Rendered for:', getCurrentPage(), '| context:', getContextType()); — removed: operational log */
     };
 
     function bindSettingsReturnLinkCapture() {


### PR DESCRIPTION
Refs #1130

## Summary
Remove non-essential console.log statements from editor-related files. Keep console.warn/error for diagnostics.

## Changed files
- js/shared-header.js
- js/editor/editor-data-loader.js
- js/editor/editor-root-helpers.js
- js/editor.js
- js/i18n/i18n-index.js

## Removed log classes
- User info logs (cachedUser.displayName/email)
- Raw identifier logs (tree.id, oldest.id, treeId)
- Operational info logs (tree loaded, memories loaded/refreshed)
- Version banner logs

## Verification
- grep console.log on target files confirmed all non-essential logs removed
- console.warn/error preserved for diagnostics
- PR #1132 scope not touched

## NOT_VERIFIED
Browser verification not performed.

## Safety
- ✅ No secrets/credentials exposed
- ✅ No raw identifiers in remaining logs
- ✅ No PR #7 or prototype changes
- ✅ No backend/Auth/DB changes