### PR TITLE
ui(my-trees): suppress card overflow menu

### DIFF
--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -1,9 +1,20 @@
 /*
- * LoveTree - My Trees visibility gate
+ * LoveTree - My Trees visibility and card action gate
  *
  * Public/private visibility controls are a future subscription-gated product area.
  * Hide current MVP-facing visibility controls without changing underlying data.
+ *
+ * My Trees cards should read as appreciation/gallery surfaces during the MVP.
+ * Suppress the per-card overflow menu entry point while follow-up hub/footer work
+ * defines the approved management surface.
  */
+
+.tree-card-menu,
+.tree-card-dropdown,
+.tree-card-dropdown.show {
+  display: none !important;
+  pointer-events: none !important;
+}
 
 .tree-card-dropdown .dropdown-item.visibility,
 .tree-card-visibility,


### PR DESCRIPTION
Refs #1123

## Summary

Suppress the visible My Trees card three-dot overflow menu so cards read more like an appreciation/gallery surface.

## Changed files

- `css/my-trees/my-trees-visibility-gate.css`

## Scope

- CSS-only My Trees card menu suppression.
- No JS runtime changes.
- No backend/API/schema changes.
- No My Trees footer redesign; tracked in #1134.
- No Browse/Search view-count work; tracked in #1135.
- No Browse/Search console hygiene work; tracked in #1136.
- No PR #7 / prototype / reference / demo / variant changes.

## Verification

- Static diff scope: PASS
- Changed files limited to one My Trees CSS gate file: PASS
- CSS-only change: PASS

## NOT_VERIFIED

- Fixed-slot logged-in My Trees browser verification not yet performed.
- Mobile/narrow viewport not yet browser-verified.