### PR TITLE
ui(my-trees): add card footer CTA treatment

### DIFF
--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -1,19 +1,39 @@
-/*
- * LoveTree - My Trees visibility and card action gate
- *
- * Public/private visibility controls are a future subscription-gated product area.
- * Hide current MVP-facing visibility controls without changing underlying data.
- *
- * My Trees cards should read as appreciation/gallery surfaces during the MVP.
- * Suppress the per-card overflow menu entry point while follow-up hub/footer work
- * defines the approved management surface.
- */
-
 .tree-card-menu,
 .tree-card-dropdown,
 .tree-card-dropdown.show {
   display: none !important;
   pointer-events: none !important;
+}
+
+.tree-card-info {
+  min-height: 136px;
+}
+
+.tree-card-info::after {
+  content: "트리 열기";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+  min-width: 96px;
+  min-height: 34px;
+  margin-top: auto;
+  padding: 0 16px;
+  border-radius: 999px;
+  background: var(--primary, #904951);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  box-shadow: 0 10px 22px rgba(144, 73, 81, 0.18);
+  pointer-events: none;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.tree-card:hover .tree-card-info::after,
+.tree-card:focus-visible .tree-card-info::after {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(144, 73, 81, 0.24);
 }
 
 .tree-card-dropdown .dropdown-item.visibility,

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
-  <link rel="stylesheet" href="../css/my-trees.css?v=20260509-910-2">
+  <link rel="stylesheet" href="../css/my-trees.css?v=20260513-1138-1">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>


### PR DESCRIPTION
Refs #1134

## Summary

Add a lightweight My Trees card footer CTA treatment.

## Changed files

- `css/my-trees/my-trees-visibility-gate.css`

## Scope

- CSS-only My Trees card visual treatment.
- No JS runtime changes.
- No backend/API/schema changes.
- No Browse card changes.

## Verification

- Static diff scope: PASS
- One CSS file changed: PASS
- CSS-only change: PASS

## NOT_VERIFIED

- Logged-in browser verification not yet performed.
- Mobile/narrow viewport not yet browser-verified.