### PR TITLE
ui(search): add public tree view metric

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Card Renderer
- * v20260512-1049
+ * v20260513-1135-1
  * 
  * Rendering layer: tree cards, empty states.
  * DOM-agnostic - returns HTML strings.
@@ -146,7 +146,22 @@
         return {
             likes: getFirstFiniteCount(tree, ['likeCount', 'likesCount', 'likes', 'reactionCount', 'reaction_count']),
             comments: getFirstFiniteCount(tree, ['commentCount', 'commentsCount', 'comments', 'replyCount', 'reply_count']),
-            shares: getFirstFiniteCount(tree, ['shareCount', 'sharesCount', 'shares', 'sharedCount', 'shared_count'])
+            shares: getFirstFiniteCount(tree, ['shareCount', 'sharesCount', 'shares', 'sharedCount', 'shared_count']),
+            views: getFirstFiniteCount(tree, [
+                'viewCount',
+                'viewsCount',
+                'views',
+                'view_count',
+                'views_count',
+                'visitorCount',
+                'visitorsCount',
+                'visitCount',
+                'visitsCount',
+                'visits',
+                'openCount',
+                'opensCount',
+                'open_count'
+            ])
         };
     }
 
@@ -155,7 +170,8 @@
         const metrics = [
             { icon: 'favorite', label: '좋아요', value: counts.likes },
             { icon: 'mode_comment', label: '댓글', value: counts.comments },
-            { icon: 'share', label: '공유', value: counts.shares }
+            { icon: 'share', label: '공유', value: counts.shares },
+            { icon: 'visibility', label: '조회수', value: counts.views }
         ];
 
         return `
@@ -404,5 +420,5 @@
         }
     };
 
-    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260512-1049');
+    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260513-1135-1');
  })();

--- a/pages/search.html
+++ b/pages/search.html
@@ -130,7 +130,7 @@
     <script src="../js/search/search-title-helper.js?v=20260421-2"></script>
     <script src="../js/search/search-data-adapter.js?v=20260512-1058-2"></script>
     <script src="../js/search/search-shared-utils.js?v=20260428-1"></script>
-    <script src="../js/search/search-card-renderer.js?v=20260508-618-rev1"></script>
+    <script src="../js/search/search-card-renderer.js?v=20260513-1135-1"></script>
     <script src="../js/search/search-preview-media-helper.js?v=20260503-594"></script>
     <script src="../js/search/search-preview-media-embed-patch.js?v=20260512-1058-2"></script>
     <script src="../js/search/search-preview-copy-helper.js?v=20260501-1"></script>


### PR DESCRIPTION
Refs #1135

## Summary

Add a public tree view metric to the Browse/Search card reaction row when a view-like count field is available on the tree view model.

## Changed files

- `js/search/search-card-renderer.js`
- `pages/search.html`

## Scope

- Browse/Search card metric rendering only.
- No analytics tracking.
- No backend/API/schema changes.
- No My Trees card changes.

## Verification

- Static diff scope: PASS
- Renderer cache key bumped: PASS
- Existing reaction metrics preserved: PASS

## NOT_VERIFIED

- Runtime data-field availability not yet confirmed.
- Browser visual verification not yet performed.
- Mobile/narrow viewport not yet verified.