### PR TITLE
chore(search): remove noisy runtime console logs

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -420,5 +420,5 @@
         }
     };
 
-    console.log('[LoveBudSearchCardRenderer] Search card renderer loaded v20260513-1135-1');
+
  })();

--- a/js/search/search-data-adapter.js
+++ b/js/search/search-data-adapter.js
@@ -168,5 +168,4 @@
         _getYouTubeIdFromThumbnail: getYouTubeIdFromThumbnail
     };
 
-    console.log('[LoveBudSearchAdapter] Search data adapter loaded v20260512-1058-2');
 })();

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -158,5 +158,4 @@
         renderOpenTreeButton: renderOpenTreeButton
     };
 
-    console.log('[LoveBudSearchPreviewActionHelper] Search preview action helper loaded v20260501-1');
 })();

--- a/js/search/search-preview-copy-helper.js
+++ b/js/search/search-preview-copy-helper.js
@@ -76,5 +76,4 @@
         formatShortDate: formatShortDate
     };
 
-    console.log('[LoveBudSearchPreviewCopyHelper] Search preview copy helper loaded v20260501-1');
 })();

--- a/js/search/search-preview-hub-dom-patch.js
+++ b/js/search/search-preview-hub-dom-patch.js
@@ -153,5 +153,4 @@
         start();
     }
 
-    console.log('[LoveBudSearchPreviewHubDomPatch] loaded v20260512-1058');
 })();

--- a/js/search/search-preview-media-embed-patch.js
+++ b/js/search/search-preview-media-embed-patch.js
@@ -59,5 +59,4 @@
 
     patchMediaHelper();
     document.addEventListener('DOMContentLoaded', patchMediaHelper);
-    console.log('[LoveBudSearchPreviewMediaEmbedPatch] loaded v20260512-1058');
 })();

--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -214,5 +214,4 @@
         renderPreviewIframe: renderPreviewIframe
     };
 
-    console.log('[LoveBudSearchPreviewMediaHelper] Search preview media helper loaded v20260512-1053');
 })();

--- a/js/search/search-preview-playable-hub-patch.js
+++ b/js/search/search-preview-playable-hub-patch.js
@@ -234,5 +234,4 @@
 
     patchRenderer();
     document.addEventListener('DOMContentLoaded', patchRenderer);
-    console.log('[LoveBudSearchPreviewPlayableHubPatch] loaded v20260512-1058-3');
 })();

--- a/js/search/search-preview-renderer-builders.js
+++ b/js/search/search-preview-renderer-builders.js
@@ -288,5 +288,4 @@
         getPreviewSummaryCopy: getPreviewSummaryCopy
     };
 
-    console.log('[LoveBudSearchPreviewBuilders] Preview builder helpers loaded v20260506-1');
 })();

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -608,5 +608,4 @@
         }
     };
 
-    console.log('[LoveBudSearchPreviewRenderer] Search preview renderer loaded v20260506-1');
 })();

--- a/js/search/search-shared-utils.js
+++ b/js/search/search-shared-utils.js
@@ -60,5 +60,4 @@
         isSuspiciousYouTubeThumbnailImage: isSuspiciousYouTubeThumbnailImage
     };
 
-    console.log('[LoveBudSearchSharedUtils] Search shared renderer utilities loaded v20260428-1');
 })();


### PR DESCRIPTION
Refs #1136

## Summary
Remove module-loaded banner console.log and non-essential runtime info logs from Browse/Search files.

## Changed files
- js/search/search-data-adapter.js
- js/search/search-shared-utils.js
- js/search/search-card-renderer.js
- js/search/search-preview-media-helper.js
- js/search/search-preview-media-embed-patch.js
- js/search/search-preview-copy-helper.js
- js/search/search-preview-action-helper.js
- js/search/search-preview-renderer-builders.js
- js/search/search-preview-renderer.js
- js/search/search-preview-playable-hub-patch.js
- js/search/search-preview-hub-dom-patch.js

## Removed log classes
- Module-loaded banners (11 files)
- Runtime info logs

## Verification
- grep console.log on js/search: 0 matches
- console.warn/error preserved for diagnostics
- View metric (#1135) unchanged
- Cache key unchanged

## NOT_VERIFIED
Browser verification not performed.

## Safety
- No secrets/credentials exposed
- No raw identifiers in remaining logs
- No PR #7 or prototype changes
- No backend/Auth/DB changes