### PR TITLE
perf(search): share selected preview hydration requests

### DIFF
--- a/js/search/search-data.js
+++ b/js/search/search-data.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Data Loading Module
- * v20260513-1143-1
+ * v20260513-1143-2
  *
  * Extracted from js/search.js (orchestrator).
  * Owns: loadPublicTrees, loadGrowingTrees, hydrateSelectedTreePreview
@@ -93,18 +93,6 @@
                 }
                 ui.clearSelectedPreview({ preserveOpenState: false });
             }
-        }
-
-        function prefetchTreePreview(tree) {
-            if (!tree || !tree.id) return;
-            const treeId = getPreviewTreeId(tree);
-            if (!treeId) return;
-            if (Array.isArray(tree.memories) && tree.memories.length > 0) return;
-            if (previewCacheApi.readPreviewCache(treeId)) return;
-
-            getHydratedTreePreview(tree).catch((error) => {
-                console.warn('[search/data] preview prefetch failed:', error.message);
-            });
         }
 
         // ── Load public trees (main browse) ────────────────────────────────────
@@ -234,7 +222,6 @@
         return {
             dedupeTreesById,
             hydrateSelectedTreePreview,
-            prefetchTreePreview,
             loadPublicTrees,
             loadGrowingTrees
         };

--- a/js/search/search-data.js
+++ b/js/search/search-data.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud Search Data Loading Module
- * v20260429-1
+ * v20260513-1143-1
  *
  * Extracted from js/search.js (orchestrator).
  * Owns: loadPublicTrees, loadGrowingTrees, hydrateSelectedTreePreview
@@ -36,6 +36,39 @@
     }
 
     function createSearchData({ refs, state, previewCacheApi, ui, CardRenderer, PreviewRenderer, callbacks, cache, PUBLIC_TREES_CACHE_KEY, PREVIEW_CACHE_TTL_MS, getPreviewCacheKey }) {
+        const pendingPreviewHydrations = new Map();
+
+        function getPreviewTreeId(tree) {
+            const rawId = tree?.id ?? tree?.treeId ?? tree?.tree_id;
+            return rawId === null || rawId === undefined || rawId === '' ? '' : String(rawId);
+        }
+
+        async function getHydratedTreePreview(tree) {
+            const treeId = getPreviewTreeId(tree);
+            if (!treeId) return null;
+
+            const cachedPreview = previewCacheApi.readPreviewCache(treeId);
+            if (cachedPreview) {
+                return cachedPreview;
+            }
+
+            if (pendingPreviewHydrations.has(treeId)) {
+                return pendingPreviewHydrations.get(treeId);
+            }
+
+            const pendingPreview = window.apiClient.getPublicTreePreview(tree)
+                .then((hydratedTree) => {
+                    previewCacheApi.writePreviewCache(treeId, hydratedTree);
+                    previewCacheApi.mergeHydratedTree(hydratedTree);
+                    return hydratedTree;
+                })
+                .finally(() => {
+                    pendingPreviewHydrations.delete(treeId);
+                });
+
+            pendingPreviewHydrations.set(treeId, pendingPreview);
+            return pendingPreview;
+        }
 
         // ── Hydrate selected tree preview ──────────────────────────────────────
         async function hydrateSelectedTreePreview(tree) {
@@ -44,11 +77,8 @@
             ui.renderPreviewLoadingState(tree);
 
             try {
-                const cachedPreview = previewCacheApi.readPreviewCache(tree.id);
-                const hydratedTree = cachedPreview || await window.apiClient.getPublicTreePreview(tree);
-
-                previewCacheApi.writePreviewCache(tree.id, hydratedTree);
-                previewCacheApi.mergeHydratedTree(hydratedTree);
+                const hydratedTree = await getHydratedTreePreview(tree);
+                if (!hydratedTree) return;
 
                 if (requestId !== state.currentPreviewRequestId || state.selectedTreeId !== tree.id) {
                     return;
@@ -63,6 +93,18 @@
                 }
                 ui.clearSelectedPreview({ preserveOpenState: false });
             }
+        }
+
+        function prefetchTreePreview(tree) {
+            if (!tree || !tree.id) return;
+            const treeId = getPreviewTreeId(tree);
+            if (!treeId) return;
+            if (Array.isArray(tree.memories) && tree.memories.length > 0) return;
+            if (previewCacheApi.readPreviewCache(treeId)) return;
+
+            getHydratedTreePreview(tree).catch((error) => {
+                console.warn('[search/data] preview prefetch failed:', error.message);
+            });
         }
 
         // ── Load public trees (main browse) ────────────────────────────────────
@@ -192,6 +234,7 @@
         return {
             dedupeTreesById,
             hydrateSelectedTreePreview,
+            prefetchTreePreview,
             loadPublicTrees,
             loadGrowingTrees
         };

--- a/pages/search.html
+++ b/pages/search.html
@@ -143,7 +143,7 @@
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>
      <script src="../js/search/search-controls.js?v=20260429-1"></script>
-    <script src="../js/search/search-data.js?v=20260513-1143-1"></script>
+    <script src="../js/search/search-data.js?v=20260513-1143-2"></script>
      <script src="../js/search/search-preview-controller.js?v=20260508-618-rev1"></script>
     <script src="../js/search/index.js?v=20260508-618-rev1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -143,7 +143,7 @@
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>
      <script src="../js/search/search-controls.js?v=20260429-1"></script>
-    <script src="../js/search/search-data.js?v=20260503-598-2"></script>
+    <script src="../js/search/search-data.js?v=20260513-1143-1"></script>
      <script src="../js/search/search-preview-controller.js?v=20260508-618-rev1"></script>
     <script src="../js/search/index.js?v=20260508-618-rev1"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>


### PR DESCRIPTION
Refs #1143

## Summary

Share Browse/Search selected preview hydration requests by tree id so repeated selected-preview opens can reuse the same in-flight request and existing preview cache path.

## Changes

- Add in-flight preview hydration tracking in `js/search/search-data.js`.
- Route selected preview hydration through the shared preview cache path.
- Keep warning diagnostics for preview hydration failures.
- Bump `pages/search.html` cache key for `search-data.js` to `v=20260513-1143-2`.

## Verification

- CI: success for head `9975d240373a80bbfddb99088601d3d921c93886`.
- Cloudflare Branch Preview: deployed successfully for `9975d24`.
- Browser preview checked at Branch Preview URL.
- `Preserve log` disabled, `Disable cache` enabled.
- Reload-only check with Network filter `memories`: 0 matching requests observed.
- Click check with Network filter `memories`: 0 matching requests observed in the provided capture.
- Browse cards rendered normally.
- Preview/hub rendered normally.
- Likes/comments/shares/views metrics remained visible.
- Extension/content-script console errors such as `content_main.js`, `cs.js`, `functions.js`, and `init.js` are treated as non-LoveBud-owned logs.

## Safety

- No backend/API/schema changes.
- No UI redesign.
- No app-owned console.log added.
- No PR #7 or prototype/reference/demo/variant changes.