### PR TITLE
ux(editor): anchor growth affordance to selected moment

### DIFF
--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -101,6 +101,16 @@ function createEditorCanvasGrowthAffordance(deps) {
         svg.appendChild(path);
     }
 
+    function drawGrowthAffordanceAnchorDot(startPos) {
+        const anchorDot = documentRef.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        anchorDot.setAttribute('cx', startPos.x);
+        anchorDot.setAttribute('cy', startPos.y);
+        anchorDot.setAttribute('r', '3');
+        anchorDot.setAttribute('fill', 'rgba(144, 73, 81, 0.5)');
+        anchorDot.setAttribute('class', 'branch-line-affordance');
+        svg.appendChild(anchorDot);
+    }
+
     function createGrowthAffordanceElement(anchorMem, labelText, helperText) {
         const anchorPos = calcPosition(anchorMem);
         const affPos = getGrowthAffordancePosition(anchorPos);
@@ -207,6 +217,7 @@ function createEditorCanvasGrowthAffordance(deps) {
             branchEnd,
             affPos.side
         );
+        drawGrowthAffordanceAnchorDot(branchStart);
         canvas.appendChild(wrap);
     }
 


### PR DESCRIPTION
Refs #1113

Closed without merge after browser verification.

Reason:
- Product verification did not pass.
- The continue bubble did not reliably appear immediately on moment selection.
- The bubble can obscure nearby moments.
- Free-layout initial viewport positioning needs to be fixed first.

Next:
- Fix free-layout initial viewport centering.
- Redesign the continue affordance as a compact + tip with tooltip behavior.