### PR TITLE
fix(editor): initialize free-layout viewport centered on tree

### DIFF
--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -4,7 +4,7 @@ window.LoveBudEditorCanvasViewport = {
   zoomLevels: [0.5, 0.75, 1, 1.25, 1.5],
   readableCenter: {
     x: 0.5,
-    y: 0.38
+    y: 0.42
   },
 
   getNearestZoom(scale) {
@@ -160,8 +160,8 @@ window.LoveBudEditorCanvasViewport = {
     const metrics = getMetrics();
     this.setScale(viewportState, 1);
     const scale = this.getScale(viewportState);
-    viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
-    viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
+    viewportState.offsetX = Math.round(metrics.width * this.readableCenter.x - (world.x * scale));
+    viewportState.offsetY = Math.round(metrics.height * this.readableCenter.y - (world.y * scale));
     initCanvas();
     reapplySelection(nodeId);
 
@@ -202,12 +202,12 @@ window.LoveBudEditorCanvasViewport = {
     if (nextScale === oldScale) return;
 
     const metrics = getMetrics();
-    const centerWorldX = (metrics.width * 0.5 - viewportState.offsetX) / oldScale;
-    const centerWorldY = (metrics.height * 0.38 - viewportState.offsetY) / oldScale;
+    const centerWorldX = (metrics.width * this.readableCenter.x - viewportState.offsetX) / oldScale;
+    const centerWorldY = (metrics.height * this.readableCenter.y - viewportState.offsetY) / oldScale;
 
     this.setScale(viewportState, nextScale);
-    viewportState.offsetX = Math.round(metrics.width * 0.5 - (centerWorldX * nextScale));
-    viewportState.offsetY = Math.round(metrics.height * 0.38 - (centerWorldY * nextScale));
+    viewportState.offsetX = Math.round(metrics.width * this.readableCenter.x - (centerWorldX * nextScale));
+    viewportState.offsetY = Math.round(metrics.height * this.readableCenter.y - (centerWorldY * nextScale));
     initCanvas();
   },
 

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -93,21 +93,41 @@ window.LoveBudEditorCanvasViewport = {
   },
 
   prepareInitialViewport(options) {
-    const { viewportState } = options;
+    const { viewportState, getMetrics } = options;
     this.setScale(viewportState, viewportState.scale || 1);
     if (viewportState.initialViewportApplied) return;
+    viewportState.initialViewportApplied = true;
 
     if (viewportState.hasStoredViewportOffset) {
-      viewportState.initialViewportApplied = true;
+      // Stored viewport exists — validate + correct if extreme
+      const metrics = getMetrics();
+      const margin = Math.max(200, Math.round(metrics.width * 0.25));
+      const minOk = -margin;
+      const maxOk = metrics.width + margin;
+      if (
+        viewportState.offsetX < minOk || viewportState.offsetX > maxOk ||
+        viewportState.offsetY < minOk || viewportState.offsetY > maxOk
+      ) {
+        // Extreme offset — fall back to fit viewport
+        const fitted = this.getFitViewport(options);
+        if (fitted) {
+          this.setScale(viewportState, fitted.scale);
+          viewportState.offsetX = fitted.offsetX;
+          viewportState.offsetY = fitted.offsetY;
+        }
+      }
       return;
     }
 
-    const nextOffset = this.getReadableViewportOffset(options);
-    if (!nextOffset) return;
+    // No stored viewport — apply a fit-to-tree viewport (like recenter)
+    const fitViewport = this.getFitViewport(options) || this.getReadableViewportOffset(options);
+    if (!fitViewport) return;
 
-    viewportState.offsetX = nextOffset.offsetX;
-    viewportState.offsetY = nextOffset.offsetY;
-    viewportState.initialViewportApplied = true;
+    if (typeof fitViewport.scale === 'number') {
+      this.setScale(viewportState, fitViewport.scale);
+    }
+    viewportState.offsetX = fitViewport.offsetX;
+    viewportState.offsetY = fitViewport.offsetY;
   },
 
   drawBranch(svg, startPos, endPos) {

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -264,7 +264,7 @@ window.LoveBudEditorCanvasViewport = {
       const indicator = document.getElementById('zoomIndicator');
       if (!indicator) return;
       const scale = this.getScale(viewportState);
-      const pct = Math.round(scale * 100);
+      const pct = Math.round(scale * 100 / 5) * 5;
       indicator.textContent = pct + '%';
       indicator.classList.remove('is-hidden');
     }

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -145,19 +145,28 @@ window.LoveBudEditorCanvasViewport = {
     return true;
   },
 
+  isAlreadyAtFit(viewportState, fitViewport) {
+    if (!fitViewport) return false;
+    const scaleDiff = Math.abs((viewportState.scale || 1) - fitViewport.scale);
+    const offsetDiffX = Math.abs(viewportState.offsetX - fitViewport.offsetX);
+    const offsetDiffY = Math.abs(viewportState.offsetY - fitViewport.offsetY);
+    return scaleDiff < 0.01 && offsetDiffX < 5 && offsetDiffY < 5;
+  },
+
+  showAlreadyAtFitFeedback() {
+    if (window.LoveBudUI && typeof window.LoveBudUI.showToast === 'function') {
+      window.LoveBudUI.showToast('이미 전체 트리가 보이고 있습니다', 'info', 2000);
+    }
+  },
+
   prepareInitialViewport(options) {
     const { viewportState } = options;
     this.setScale(viewportState, viewportState.scale || 1);
     if (viewportState.initialViewportApplied) return;
     viewportState.initialViewportApplied = true;
 
-    if (viewportState.hasStoredViewportOffset) {
-      if (this.isStoredViewportExtreme(options)) {
-        this.applyViewport(viewportState, this.getFitViewport(options), true);
-      }
-      return;
-    }
-
+    // Always fit the full tree viewport on initial load,
+    // regardless of any previously stored viewport offset.
     this.applyViewport(viewportState, this.getFitViewport(options), true);
   },
 
@@ -211,7 +220,15 @@ window.LoveBudEditorCanvasViewport = {
       return;
     }
 
-    this.applyViewport(viewportState, this.getFitViewport(options), true);
+    const fitViewport = this.getFitViewport(options);
+
+    // If already at the optimal tree-fit view, show feedback instead of re-applying
+    if (this.isAlreadyAtFit(viewportState, fitViewport)) {
+      this.showAlreadyAtFitFeedback();
+      return;
+    }
+
+    this.applyViewport(viewportState, fitViewport, true);
     initCanvas();
   },
 

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -1,7 +1,7 @@
 window.LoveBudEditorCanvasViewport = {
-  minScale: 0.5,
+  minScale: 0.2,
   maxScale: 1.5,
-  zoomLevels: [0.5, 0.75, 1, 1.25, 1.5],
+  zoomLevels: [0.2, 0.35, 0.5, 0.75, 1, 1.25, 1.5],
   readableCenter: {
     x: 0.5,
     y: 0.42
@@ -13,6 +13,15 @@ window.LoveBudEditorCanvasViewport = {
     return this.zoomLevels.reduce((best, candidate) => (
       Math.abs(candidate - value) < Math.abs(best - value) ? candidate : best
     ), 1);
+  },
+
+  getFitZoom(scale) {
+    const value = Number(scale);
+    if (!Number.isFinite(value) || value <= 0) return 1;
+    const clamped = Math.min(this.maxScale, Math.max(this.minScale, value));
+    return this.zoomLevels.reduce((best, candidate) => (
+      candidate <= clamped && candidate > best ? candidate : best
+    ), this.minScale);
   },
 
   getNextZoom(scale, direction) {
@@ -30,6 +39,10 @@ window.LoveBudEditorCanvasViewport = {
 
   setScale(viewportState, nextScale) {
     viewportState.scale = this.getNearestZoom(Math.min(this.maxScale, Math.max(this.minScale, Number(nextScale) || 1)));
+  },
+
+  setFitScale(viewportState, nextScale) {
+    viewportState.scale = this.getFitZoom(nextScale);
   },
 
   projectWorldPosition(world, viewportState) {
@@ -90,11 +103,14 @@ window.LoveBudEditorCanvasViewport = {
     const minY = Math.min(...points.map((point) => point.y));
     const maxY = Math.max(...points.map((point) => point.y));
     const metrics = getMetrics();
-    const padding = Math.min(180, Math.max(96, Math.round(metrics.width * 0.12)));
-    const boundsWidth = Math.max(1, maxX - minX + 180);
-    const boundsHeight = Math.max(1, maxY - minY + 180);
-    const rawFitScale = Math.min((metrics.width - padding) / boundsWidth, (metrics.height - padding) / boundsHeight);
-    const fitScale = this.getNearestZoom(Math.min(this.maxScale, Math.max(0.75, rawFitScale)));
+    const padding = Math.min(160, Math.max(72, Math.round(metrics.width * 0.10)));
+    const nodeBoundsPadding = 180;
+    const boundsWidth = Math.max(1, maxX - minX + nodeBoundsPadding);
+    const boundsHeight = Math.max(1, maxY - minY + nodeBoundsPadding);
+    const availableWidth = Math.max(1, metrics.width - (padding * 2));
+    const availableHeight = Math.max(1, metrics.height - (padding * 2));
+    const rawFitScale = Math.min(availableWidth / boundsWidth, availableHeight / boundsHeight);
+    const fitScale = this.getFitZoom(rawFitScale);
 
     return {
       scale: fitScale,
@@ -103,37 +119,46 @@ window.LoveBudEditorCanvasViewport = {
     };
   },
 
-  prepareInitialViewport(options) {
+  isStoredViewportExtreme(options) {
     const { viewportState, getMetrics } = options;
+    const metrics = getMetrics();
+    const margin = Math.max(200, Math.round(metrics.width * 0.25));
+    const minOkX = -metrics.width - margin;
+    const maxOkX = metrics.width + margin;
+    const minOkY = -metrics.height - margin;
+    const maxOkY = metrics.height + margin;
+    return (
+      viewportState.offsetX < minOkX || viewportState.offsetX > maxOkX ||
+      viewportState.offsetY < minOkY || viewportState.offsetY > maxOkY
+    );
+  },
+
+  applyViewport(viewportState, nextViewport, useFitScale = false) {
+    if (!nextViewport) return false;
+    if (useFitScale) {
+      this.setFitScale(viewportState, nextViewport.scale);
+    } else {
+      this.setScale(viewportState, nextViewport.scale);
+    }
+    viewportState.offsetX = nextViewport.offsetX;
+    viewportState.offsetY = nextViewport.offsetY;
+    return true;
+  },
+
+  prepareInitialViewport(options) {
+    const { viewportState } = options;
     this.setScale(viewportState, viewportState.scale || 1);
     if (viewportState.initialViewportApplied) return;
     viewportState.initialViewportApplied = true;
 
     if (viewportState.hasStoredViewportOffset) {
-      const metrics = getMetrics();
-      const margin = Math.max(200, Math.round(metrics.width * 0.25));
-      const minOk = -margin;
-      const maxOk = metrics.width + margin;
-      if (
-        viewportState.offsetX < minOk || viewportState.offsetX > maxOk ||
-        viewportState.offsetY < minOk || viewportState.offsetY > maxOk
-      ) {
-        const readable = this.getReadableViewportOffset(options, 1);
-        if (readable) {
-          this.setScale(viewportState, readable.scale);
-          viewportState.offsetX = readable.offsetX;
-          viewportState.offsetY = readable.offsetY;
-        }
+      if (this.isStoredViewportExtreme(options)) {
+        this.applyViewport(viewportState, this.getFitViewport(options), true);
       }
       return;
     }
 
-    const readable = this.getReadableViewportOffset(options, 1);
-    if (!readable) return;
-
-    this.setScale(viewportState, readable.scale);
-    viewportState.offsetX = readable.offsetX;
-    viewportState.offsetY = readable.offsetY;
+    this.applyViewport(viewportState, this.getFitViewport(options), true);
   },
 
   drawBranch(svg, startPos, endPos) {
@@ -186,12 +211,7 @@ window.LoveBudEditorCanvasViewport = {
       return;
     }
 
-    const readable = this.getReadableViewportOffset(options, 1);
-    if (!readable) return;
-
-    this.setScale(viewportState, readable.scale);
-    viewportState.offsetX = readable.offsetX;
-    viewportState.offsetY = readable.offsetY;
+    this.applyViewport(viewportState, this.getFitViewport(options), true);
     initCanvas();
   },
 

--- a/js/editor/editor-canvas-viewport.js
+++ b/js/editor/editor-canvas-viewport.js
@@ -1,10 +1,25 @@
 window.LoveBudEditorCanvasViewport = {
-  minScale: 0.65,
-  maxScale: 1.55,
-  zoomStep: 1.18,
+  minScale: 0.5,
+  maxScale: 1.5,
+  zoomLevels: [0.5, 0.75, 1, 1.25, 1.5],
   readableCenter: {
     x: 0.5,
     y: 0.38
+  },
+
+  getNearestZoom(scale) {
+    const value = Number(scale);
+    if (!Number.isFinite(value) || value <= 0) return 1;
+    return this.zoomLevels.reduce((best, candidate) => (
+      Math.abs(candidate - value) < Math.abs(best - value) ? candidate : best
+    ), 1);
+  },
+
+  getNextZoom(scale, direction) {
+    const current = this.getNearestZoom(scale);
+    const index = this.zoomLevels.indexOf(current);
+    if (direction > 0) return this.zoomLevels[Math.min(this.zoomLevels.length - 1, index + 1)];
+    return this.zoomLevels[Math.max(0, index - 1)];
   },
 
   getScale(viewportState) {
@@ -14,7 +29,7 @@ window.LoveBudEditorCanvasViewport = {
   },
 
   setScale(viewportState, nextScale) {
-    viewportState.scale = Math.min(this.maxScale, Math.max(this.minScale, Number(nextScale) || 1));
+    viewportState.scale = this.getNearestZoom(Math.min(this.maxScale, Math.max(this.minScale, Number(nextScale) || 1)));
   },
 
   projectWorldPosition(world, viewportState) {
@@ -42,12 +57,12 @@ window.LoveBudEditorCanvasViewport = {
     return rootMemory ? [rootMemory] : [];
   },
 
-  getReadableViewportOffset(options) {
+  getReadableViewportOffset(options, preferredScale = 1) {
     const { getWorldPosition, getMetrics } = options;
     const targets = this.getViewportTargets(options);
     if (!targets.length) return null;
 
-    const scale = this.getScale(options.viewportState);
+    const scale = this.getNearestZoom(preferredScale);
     const points = targets.map((memory) => getWorldPosition(memory));
     const minX = Math.min(...points.map((point) => point.x));
     const maxX = Math.max(...points.map((point) => point.x));
@@ -56,6 +71,7 @@ window.LoveBudEditorCanvasViewport = {
     const metrics = getMetrics();
 
     return {
+      scale,
       offsetX: Math.round(metrics.width * this.readableCenter.x - (((minX + maxX) / 2) * scale)),
       offsetY: Math.round(metrics.height * this.readableCenter.y - (((minY + maxY) / 2) * scale))
     };
@@ -77,13 +93,8 @@ window.LoveBudEditorCanvasViewport = {
     const padding = Math.min(180, Math.max(96, Math.round(metrics.width * 0.12)));
     const boundsWidth = Math.max(1, maxX - minX + 180);
     const boundsHeight = Math.max(1, maxY - minY + 180);
-    const fitScale = Math.min(
-      this.maxScale,
-      Math.max(
-        this.minScale,
-        Math.min((metrics.width - padding) / boundsWidth, (metrics.height - padding) / boundsHeight)
-      )
-    );
+    const rawFitScale = Math.min((metrics.width - padding) / boundsWidth, (metrics.height - padding) / boundsHeight);
+    const fitScale = this.getNearestZoom(Math.min(this.maxScale, Math.max(0.75, rawFitScale)));
 
     return {
       scale: fitScale,
@@ -99,7 +110,6 @@ window.LoveBudEditorCanvasViewport = {
     viewportState.initialViewportApplied = true;
 
     if (viewportState.hasStoredViewportOffset) {
-      // Stored viewport exists — validate + correct if extreme
       const metrics = getMetrics();
       const margin = Math.max(200, Math.round(metrics.width * 0.25));
       const minOk = -margin;
@@ -108,26 +118,22 @@ window.LoveBudEditorCanvasViewport = {
         viewportState.offsetX < minOk || viewportState.offsetX > maxOk ||
         viewportState.offsetY < minOk || viewportState.offsetY > maxOk
       ) {
-        // Extreme offset — fall back to fit viewport
-        const fitted = this.getFitViewport(options);
-        if (fitted) {
-          this.setScale(viewportState, fitted.scale);
-          viewportState.offsetX = fitted.offsetX;
-          viewportState.offsetY = fitted.offsetY;
+        const readable = this.getReadableViewportOffset(options, 1);
+        if (readable) {
+          this.setScale(viewportState, readable.scale);
+          viewportState.offsetX = readable.offsetX;
+          viewportState.offsetY = readable.offsetY;
         }
       }
       return;
     }
 
-    // No stored viewport — apply a fit-to-tree viewport (like recenter)
-    const fitViewport = this.getFitViewport(options) || this.getReadableViewportOffset(options);
-    if (!fitViewport) return;
+    const readable = this.getReadableViewportOffset(options, 1);
+    if (!readable) return;
 
-    if (typeof fitViewport.scale === 'number') {
-      this.setScale(viewportState, fitViewport.scale);
-    }
-    viewportState.offsetX = fitViewport.offsetX;
-    viewportState.offsetY = fitViewport.offsetY;
+    this.setScale(viewportState, readable.scale);
+    viewportState.offsetX = readable.offsetX;
+    viewportState.offsetY = readable.offsetY;
   },
 
   drawBranch(svg, startPos, endPos) {
@@ -152,15 +158,15 @@ window.LoveBudEditorCanvasViewport = {
 
     const world = getWorldPosition(target);
     const metrics = getMetrics();
+    this.setScale(viewportState, 1);
     const scale = this.getScale(viewportState);
     viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
     viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
     initCanvas();
     reapplySelection(nodeId);
 
-    // Brief scale pulse on the focused node for visual confirmation
     requestAnimationFrame(() => {
-      const nodeEl = document.querySelector(`.memory-node[data-memory-id="${nodeId}"]`);
+      const nodeEl = document.querySelector(`.memory-node[data-memory-id=\"${nodeId}\"]`);
       if (nodeEl) {
         nodeEl.classList.remove('focus-animate');
         void nodeEl.offsetWidth;
@@ -180,12 +186,28 @@ window.LoveBudEditorCanvasViewport = {
       return;
     }
 
-    const nextOffset = this.getFitViewport(options);
-    if (!nextOffset) return;
+    const readable = this.getReadableViewportOffset(options, 1);
+    if (!readable) return;
 
-    this.setScale(viewportState, nextOffset.scale);
-    viewportState.offsetX = nextOffset.offsetX;
-    viewportState.offsetY = nextOffset.offsetY;
+    this.setScale(viewportState, readable.scale);
+    viewportState.offsetX = readable.offsetX;
+    viewportState.offsetY = readable.offsetY;
+    initCanvas();
+  },
+
+  zoomBy(options) {
+    const { factor, viewportState, getMetrics, initCanvas } = options;
+    const oldScale = this.getNearestZoom(viewportState.scale || 1);
+    const nextScale = this.getNextZoom(oldScale, factor >= 1 ? 1 : -1);
+    if (nextScale === oldScale) return;
+
+    const metrics = getMetrics();
+    const centerWorldX = (metrics.width * 0.5 - viewportState.offsetX) / oldScale;
+    const centerWorldY = (metrics.height * 0.38 - viewportState.offsetY) / oldScale;
+
+    this.setScale(viewportState, nextScale);
+    viewportState.offsetX = Math.round(metrics.width * 0.5 - (centerWorldX * nextScale));
+    viewportState.offsetY = Math.round(metrics.height * 0.38 - (centerWorldY * nextScale));
     initCanvas();
   },
 
@@ -210,9 +232,6 @@ window.LoveBudEditorCanvasViewport = {
       }, { passive: true });
     });
 
-    /**
-     * Helper to add brief flash feedback to a button element.
-     */
     function flashButton(btn) {
       if (!btn) return;
       btn.classList.add('flash-feedback');
@@ -226,10 +245,8 @@ window.LoveBudEditorCanvasViewport = {
         const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
         if (selectedId) {
           flashButton(focusBtn);
-          // Add focus flash overlay on canvas
           if (canvasArea) {
             canvasArea.classList.remove('focus-flash');
-            // Trigger reflow to restart animation
             void canvasArea.offsetWidth;
             canvasArea.classList.add('focus-flash');
             setTimeout(() => {
@@ -244,7 +261,6 @@ window.LoveBudEditorCanvasViewport = {
     if (recenterBtn) {
       recenterBtn.addEventListener('click', () => {
         flashButton(recenterBtn);
-        // Add recenter flash overlay on canvas
         if (canvasArea) {
           canvasArea.classList.remove('recenter-flash');
           void canvasArea.offsetWidth;
@@ -257,24 +273,19 @@ window.LoveBudEditorCanvasViewport = {
       });
     }
 
-    /**
-     * Update the zoom indicator badge with current scale percentage.
-     */
     function updateZoomIndicator() {
       const indicator = document.getElementById('zoomIndicator');
       if (!indicator) return;
-      const scale = this.getScale(viewportState);
-      const pct = Math.round(scale * 100 / 5) * 5;
-      indicator.textContent = pct + '%';
+      const scale = this.getNearestZoom(this.getScale(viewportState));
+      indicator.textContent = Math.round(scale * 100) + '%';
       indicator.classList.remove('is-hidden');
     }
 
     if (zoomInBtn && typeof zoomBy === 'function') {
       zoomInBtn.addEventListener('click', () => {
         flashButton(zoomInBtn);
-        zoomBy(this.zoomStep);
+        zoomBy(1.01);
         updateZoomIndicator.call(this);
-        // Add zoom pulse overlay
         if (canvasArea) {
           canvasArea.classList.remove('zoom-pulse');
           void canvasArea.offsetWidth;
@@ -289,9 +300,8 @@ window.LoveBudEditorCanvasViewport = {
     if (zoomOutBtn && typeof zoomBy === 'function') {
       zoomOutBtn.addEventListener('click', () => {
         flashButton(zoomOutBtn);
-        zoomBy(1 / this.zoomStep);
+        zoomBy(0.99);
         updateZoomIndicator.call(this);
-        // Add zoom pulse overlay
         if (canvasArea) {
           canvasArea.classList.remove('zoom-pulse');
           void canvasArea.offsetWidth;
@@ -303,7 +313,6 @@ window.LoveBudEditorCanvasViewport = {
       });
     }
 
-    // Initialize zoom indicator on first paint
     requestAnimationFrame(() => {
       updateZoomIndicator.call(this);
     });

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -166,6 +166,56 @@ function loadStoredLayout() {
         } catch (e) {}
     }
 
+    /**
+     * Center viewport on the currently selected node after a layout switch.
+     * Does not reuse previous layout's offset/scale — computes fresh center
+     * based on the selection at the moment of switching.
+     */
+    function centerViewportOnSelection() {
+        const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
+        const treeMemories = getTreeMemories();
+
+        let targetNode = null;
+        if (selectedId) {
+            targetNode = treeMemories.find(function (m) { return m.id === selectedId; });
+        }
+        if (!targetNode && treeMemories.length > 0) {
+            // Fall back to first visible node
+            var canonicalRootId = getCanonicalRootId();
+            targetNode = treeMemories.find(function (m) { return !isRootMemory(m, canonicalRootId); }) || treeMemories[0];
+        }
+
+        if (targetNode) {
+            var world = getWorldPosition(targetNode);
+            var metrics = getMetrics();
+
+            // Compute a fresh scale that fits the whole tree (avoids reusing old zoom)
+            var fitScale = 1;
+            if (typeof canvasViewport.getFitViewport === 'function') {
+                var fitVp = canvasViewport.getFitViewport({
+                    getTreeMemories: getTreeMemories,
+                    getWorldPosition: getWorldPosition,
+                    getMetrics: getMetrics,
+                    viewportState: viewportState,
+                    getCanonicalRootId: getCanonicalRootId,
+                    isRootMemory: isRootMemory
+                });
+                if (fitVp && typeof fitVp.scale === 'number') {
+                    fitScale = fitVp.scale;
+                }
+            }
+
+            canvasViewport.setScale(viewportState, fitScale);
+            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * fitScale));
+            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * fitScale));
+        } else {
+            // No nodes at all — reset to default
+            canvasViewport.setScale(viewportState, 1);
+            viewportState.offsetX = 0;
+            viewportState.offsetY = 0;
+        }
+    }
+
     function switchToFreeMode() {
         viewportState.layoutMode = 'free';
         persistLayoutMode('free');
@@ -187,6 +237,10 @@ function loadStoredLayout() {
                 viewportState.positions = { ...stored.positions };
             }
         }
+
+        // Center on selected node — fresh calculation, no reuse of old offset/scale
+        centerViewportOnSelection();
+
         document.body.classList.remove('layout-structured');
         document.body.classList.add('layout-free');
         updateLayoutToggleUI();
@@ -201,6 +255,10 @@ function loadStoredLayout() {
         // Allow viewport recalculation for the new layout
         viewportState.initialViewportApplied = false;
         persistLayoutMode('structured');
+
+        // Center on selected node — fresh calculation, no reuse of old offset/scale
+        centerViewportOnSelection();
+
         document.body.classList.remove('layout-free');
         document.body.classList.add('layout-structured');
         updateLayoutToggleUI();

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -23,15 +23,13 @@ function createEditorCanvas(deps) {
     const canvasLayout = window.LoveBudEditorCanvasLayout || {};
     const canvasNode = window.LoveBudEditorCanvasNode || {};
     const canvasInteraction = window.LoveBudEditorCanvasInteraction || {};
-    const canvasInteractionHelpers = window.LoveBudEditorCanvasInteractionHelpers || {};
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
-    const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
     let savedFreePositions = null;
     let storedFreePositions = null;
 
-function loadStoredLayout() {
+    function loadStoredLayout() {
         if (typeof canvasLayout.createLayoutStore === 'function') {
             const store = canvasLayout.createLayoutStore(treeId);
             const initialState = store.createInitialViewportState();
@@ -109,22 +107,6 @@ function loadStoredLayout() {
         return window.EditorCanvasGeometry.getMetrics(canvas);
     }
 
-    function getRootBasePosition() {
-        return window.EditorCanvasGeometry.getRootBasePosition(getMetrics());
-    }
-
-    function getRadiusL1() {
-        return window.EditorCanvasGeometry.getRadiusL1(getMetrics());
-    }
-
-    function getRadiusL2() {
-        return window.EditorCanvasGeometry.getRadiusL2(getMetrics());
-    }
-
-    function distributeAngles(count, baseAngle = -10) {
-        return window.EditorCanvasGeometry.distributeAngles(count, baseAngle);
-    }
-
     function getWorldPosition(mem) {
         if (viewportState.layoutMode === 'structured') {
             return window.EditorCanvasGeometry.getStructuredWorldPosition(
@@ -161,40 +143,24 @@ function loadStoredLayout() {
         } catch (e) {}
     }
 
-    function centerViewportOnSelection() {
-        const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-        const treeMemories = getTreeMemories();
-
-        let targetNode = null;
-        if (selectedId) {
-            targetNode = treeMemories.find(function (m) { return m.id === selectedId; });
+    function fitViewportToTree() {
+        if (typeof canvasViewport.getFitViewport !== 'function') return;
+        const nextViewport = canvasViewport.getFitViewport({
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics,
+            viewportState
+        });
+        if (!nextViewport) return;
+        if (typeof canvasViewport.applyViewport === 'function') {
+            canvasViewport.applyViewport(viewportState, nextViewport, true);
+            return;
         }
-        if (!targetNode && treeMemories.length > 0) {
-            var canonicalRootId = getCanonicalRootId();
-            targetNode = treeMemories.find(function (m) { return !isRootMemory(m, canonicalRootId); }) || treeMemories[0];
-        }
-
-        if (targetNode) {
-            var world = getWorldPosition(targetNode);
-            var metrics = getMetrics();
-            var nextScale = 1;
-            if (typeof canvasViewport.setScale === 'function') {
-                canvasViewport.setScale(viewportState, nextScale);
-                nextScale = canvasViewport.getScale ? canvasViewport.getScale(viewportState) : viewportState.scale;
-            } else {
-                viewportState.scale = nextScale;
-            }
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * nextScale));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * nextScale));
-        } else {
-            if (typeof canvasViewport.setScale === 'function') {
-                canvasViewport.setScale(viewportState, 1);
-            } else {
-                viewportState.scale = 1;
-            }
-            viewportState.offsetX = 0;
-            viewportState.offsetY = 0;
-        }
+        viewportState.scale = nextViewport.scale || viewportState.scale || 1;
+        viewportState.offsetX = nextViewport.offsetX;
+        viewportState.offsetY = nextViewport.offsetY;
     }
 
     function switchToFreeMode() {
@@ -215,7 +181,7 @@ function loadStoredLayout() {
             }
         }
 
-        centerViewportOnSelection();
+        fitViewportToTree();
 
         document.body.classList.remove('layout-structured');
         document.body.classList.add('layout-free');
@@ -230,7 +196,7 @@ function loadStoredLayout() {
         viewportState.initialViewportApplied = false;
         persistLayoutMode('structured');
 
-        centerViewportOnSelection();
+        fitViewportToTree();
 
         document.body.classList.remove('layout-free');
         document.body.classList.add('layout-structured');
@@ -287,7 +253,7 @@ function loadStoredLayout() {
         }
     });
 
-function isNodeWithinSafeViewport(pos) {
+    function isNodeWithinSafeViewport(pos) {
         const metrics = getMetrics();
         const padding = 96;
         return pos.x >= padding && pos.x <= metrics.width - padding && pos.y >= padding && pos.y <= metrics.height - padding;
@@ -467,26 +433,6 @@ function isNodeWithinSafeViewport(pos) {
         growthAffordance.clearGrowthAffordance();
     }
 
-    function openAddMomentFromCanvas() {
-        growthAffordance.openAddMomentFromCanvas();
-    }
-
-    function getGrowthAffordancePosition(anchorPos) {
-        return growthAffordance.getGrowthAffordancePosition(anchorPos);
-    }
-
-    function drawGrowthAffordanceBranch(startPos, endPos, side) {
-        growthAffordance.drawGrowthAffordanceBranch(startPos, endPos, side);
-    }
-
-    function createGrowthAffordanceElement(anchorMem, labelText, helperText) {
-        growthAffordance.createGrowthAffordanceElement(anchorMem, labelText, helperText);
-    }
-
-    function renderGrowthAffordance(anchorMem, options) {
-        growthAffordance.renderGrowthAffordance(anchorMem, options);
-    }
-
     const initCanvas = () => {
         const canonicalRootId = getCanonicalRootId();
         const treeMemories = getTreeMemories();
@@ -535,7 +481,7 @@ function isNodeWithinSafeViewport(pos) {
             if (selectedMem) {
                 updateDetailPanel(selectedMem);
                 reapplySelection(selectedMem.id);
-                renderGrowthAffordance(selectedMem, {
+                growthAffordance.renderGrowthAffordance(selectedMem, {
                     isFirstStep: drawableMemories.length <= 1
                 });
             }
@@ -796,7 +742,7 @@ function isNodeWithinSafeViewport(pos) {
         }
 
         const oldScale = viewportState.scale || 1;
-        const newScale = factor >= 1 ? Math.min(1.5, oldScale + 0.25) : Math.max(0.5, oldScale - 0.25);
+        const newScale = factor >= 1 ? Math.min(1.5, oldScale + 0.25) : Math.max(0.2, oldScale - 0.25);
         if (newScale === oldScale) return;
         viewportState.scale = newScale;
         initCanvas();

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -28,10 +28,7 @@ function createEditorCanvas(deps) {
     const canvasLayoutHelpers = window.LoveBudEditorCanvasLayoutHelpers || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
-    /** Saved free positions — preserved when switching to structured mode */
     let savedFreePositions = null;
-
-    /** Stored free positions from localStorage */
     let storedFreePositions = null;
 
 function loadStoredLayout() {
@@ -104,7 +101,6 @@ function loadStoredLayout() {
         positions: storedLayout.positions,
         rafScheduled: false,
         rafFrame: null,
-        /** Layout mode: 'free' or 'structured' */
         layoutMode: loadLayoutMode()
     };
     const { NODE_HALF, AFFORDANCE_OFFSET_X, AFFORDANCE_OFFSET_Y, AFFORDANCE_CARD_HALF } = window.EditorCanvasGeometry;
@@ -147,7 +143,6 @@ function loadStoredLayout() {
     }
 
     function persistStoredPositions() {
-        // Do not persist positions while in structured mode
         if (viewportState.layoutMode === 'structured') return;
 
         if (typeof canvasLayout.createLayoutStore === 'function') {
@@ -166,11 +161,6 @@ function loadStoredLayout() {
         } catch (e) {}
     }
 
-    /**
-     * Center viewport on the currently selected node after a layout switch.
-     * Does not reuse previous layout's offset/scale — computes fresh center
-     * based on the selection at the moment of switching.
-     */
     function centerViewportOnSelection() {
         const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
         const treeMemories = getTreeMemories();
@@ -180,7 +170,6 @@ function loadStoredLayout() {
             targetNode = treeMemories.find(function (m) { return m.id === selectedId; });
         }
         if (!targetNode && treeMemories.length > 0) {
-            // Fall back to first visible node
             var canonicalRootId = getCanonicalRootId();
             targetNode = treeMemories.find(function (m) { return !isRootMemory(m, canonicalRootId); }) || treeMemories[0];
         }
@@ -188,29 +177,21 @@ function loadStoredLayout() {
         if (targetNode) {
             var world = getWorldPosition(targetNode);
             var metrics = getMetrics();
-
-            // Compute a fresh scale that fits the whole tree (avoids reusing old zoom)
-            var fitScale = 1;
-            if (typeof canvasViewport.getFitViewport === 'function') {
-                var fitVp = canvasViewport.getFitViewport({
-                    getTreeMemories: getTreeMemories,
-                    getWorldPosition: getWorldPosition,
-                    getMetrics: getMetrics,
-                    viewportState: viewportState,
-                    getCanonicalRootId: getCanonicalRootId,
-                    isRootMemory: isRootMemory
-                });
-                if (fitVp && typeof fitVp.scale === 'number') {
-                    fitScale = fitVp.scale;
-                }
+            var nextScale = 1;
+            if (typeof canvasViewport.setScale === 'function') {
+                canvasViewport.setScale(viewportState, nextScale);
+                nextScale = canvasViewport.getScale ? canvasViewport.getScale(viewportState) : viewportState.scale;
+            } else {
+                viewportState.scale = nextScale;
             }
-
-            canvasViewport.setScale(viewportState, fitScale);
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * fitScale));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * fitScale));
+            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * nextScale));
+            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * nextScale));
         } else {
-            // No nodes at all — reset to default
-            canvasViewport.setScale(viewportState, 1);
+            if (typeof canvasViewport.setScale === 'function') {
+                canvasViewport.setScale(viewportState, 1);
+            } else {
+                viewportState.scale = 1;
+            }
             viewportState.offsetX = 0;
             viewportState.offsetY = 0;
         }
@@ -219,18 +200,14 @@ function loadStoredLayout() {
     function switchToFreeMode() {
         viewportState.layoutMode = 'free';
         persistLayoutMode('free');
-        // Allow viewport recalculation for the new layout
         viewportState.initialViewportApplied = false;
-        // Restore saved free positions if available
         if (savedFreePositions) {
             viewportState.positions = { ...savedFreePositions };
             savedFreePositions = null;
         }
-        // Restore stored free positions if available
         if (storedFreePositions && Object.keys(viewportState.positions).length === 0) {
             viewportState.positions = { ...storedFreePositions };
         }
-        // Restore from localStorage if positions are empty
         if (Object.keys(viewportState.positions).length === 0) {
             const stored = loadStoredLayout();
             if (stored.positions && Object.keys(stored.positions).length > 0) {
@@ -238,7 +215,6 @@ function loadStoredLayout() {
             }
         }
 
-        // Center on selected node — fresh calculation, no reuse of old offset/scale
         centerViewportOnSelection();
 
         document.body.classList.remove('layout-structured');
@@ -249,14 +225,11 @@ function loadStoredLayout() {
     }
 
     function switchToStructuredMode() {
-        // Save current free positions before switching
         savedFreePositions = { ...viewportState.positions };
         viewportState.layoutMode = 'structured';
-        // Allow viewport recalculation for the new layout
         viewportState.initialViewportApplied = false;
         persistLayoutMode('structured');
 
-        // Center on selected node — fresh calculation, no reuse of old offset/scale
         centerViewportOnSelection();
 
         document.body.classList.remove('layout-free');
@@ -313,10 +286,6 @@ function loadStoredLayout() {
             AFFORDANCE_CARD_HALF
         }
     });
-
-
-
-
 
 function isNodeWithinSafeViewport(pos) {
         const metrics = getMetrics();
@@ -376,7 +345,6 @@ function isNodeWithinSafeViewport(pos) {
         };
 
         nodeEl.addEventListener('mousedown', (e) => {
-            // Disable drag in structured mode
             if (viewportState.layoutMode === 'structured') return;
 
             if (typeof canvasInteraction.beginNodeDrag === 'function') {
@@ -457,11 +425,6 @@ function isNodeWithinSafeViewport(pos) {
         });
     }
 
-
-
-
-
-
     function createNodeElement(mem, pos) {
         if (typeof canvasNode.createNodeElement !== "function") {
             throw new Error("LoveBudEditorCanvasNode.createNodeElement is required");
@@ -494,7 +457,7 @@ function isNodeWithinSafeViewport(pos) {
 
     function reapplySelection(selectedNodeId) {
         if (!selectedNodeId) return;
-        const selectedEl = document.querySelector(`.memory-node[data-memory-id="${selectedNodeId}"]`);
+        const selectedEl = document.querySelector(`.memory-node[data-memory-id=\"${selectedNodeId}\"]`);
         if (selectedEl) {
             selectedEl.classList.add('selected');
         }
@@ -581,7 +544,6 @@ function isNodeWithinSafeViewport(pos) {
         bindCanvasPan();
         bindViewportControls();
         bindResizeHandling();
-        // Bind layout mode toggle on each init to ensure it stays bound after toolbar rebuild
         bindLayoutModeToggle();
         viewportState.initialized = true;
     };
@@ -673,7 +635,6 @@ function isNodeWithinSafeViewport(pos) {
         const zoomInBtn = document.getElementById('zoomInCanvasBtn');
         const zoomOutBtn = document.getElementById('zoomOutCanvasBtn');
 
-        // Prevent clicks from starting a pan
         [focusBtn, recenterBtn, zoomInBtn, zoomOutBtn].forEach((button) => {
             if (!button) return;
             button.addEventListener('mousedown', (event) => { event.stopPropagation(); });
@@ -696,11 +657,11 @@ function isNodeWithinSafeViewport(pos) {
         }
 
         if (zoomInBtn && typeof zoomBy === 'function') {
-            zoomInBtn.addEventListener('click', () => { zoomBy(canvasViewport.zoomStep || 1.18); });
+            zoomInBtn.addEventListener('click', () => { zoomBy(1.01); });
         }
 
         if (zoomOutBtn && typeof zoomBy === 'function') {
-            zoomOutBtn.addEventListener('click', () => { zoomBy(1 / (canvasViewport.zoomStep || 1.18)); });
+            zoomOutBtn.addEventListener('click', () => { zoomBy(0.99); });
         }
     }
 
@@ -709,7 +670,6 @@ function isNodeWithinSafeViewport(pos) {
         if (!toggleBtn) return;
         if (toggleBtn.dataset.layoutBound) return;
 
-        // Store current free positions on first structured switch attempt
         toggleBtn.addEventListener('click', () => {
             toggleLayoutMode();
         });
@@ -726,7 +686,7 @@ function isNodeWithinSafeViewport(pos) {
                 persistStoredPositions,
                 initCanvas,
                 getWorldPosition,
-                getDragTargetElement: (id) => document.querySelector(`.memory-node[data-memory-id="${id}"]`),
+                getDragTargetElement: (id) => document.querySelector(`.memory-node[data-memory-id=\"${id}\"]`),
                 showMovedToast: () => {
                     const toast = document.getElementById('movedToast');
                     if (toast) {
@@ -738,7 +698,6 @@ function isNodeWithinSafeViewport(pos) {
             return;
         }
 
-        // Fallback pan/drag binding — structured mode guards added
         if (viewportState.globalsBound) return;
         viewportState.globalsBound = true;
 
@@ -752,7 +711,6 @@ function isNodeWithinSafeViewport(pos) {
             ) {
                 return;
             }
-            // Disable pan in structured mode
             if (viewportState.layoutMode === 'structured') return;
 
             viewportState.isPanning = true;
@@ -797,7 +755,7 @@ function isNodeWithinSafeViewport(pos) {
                 viewportState.isDraggingNode = false;
                 viewportState.dragNodeId = null;
                 viewportState.dragMoved = false;
-                const draggedEl = document.querySelector(`.memory-node[data-memory-id="${draggedId}"]`);
+                const draggedEl = document.querySelector(`.memory-node[data-memory-id=\"${draggedId}\"]`);
                 if (draggedEl) {
                     draggedEl.style.cursor = 'grab';
                 }
@@ -838,14 +796,13 @@ function isNodeWithinSafeViewport(pos) {
         }
 
         const oldScale = viewportState.scale || 1;
-        const newScale = Math.min(1.55, Math.max(0.65, oldScale * factor));
+        const newScale = factor >= 1 ? Math.min(1.5, oldScale + 0.25) : Math.max(0.5, oldScale - 0.25);
         if (newScale === oldScale) return;
         viewportState.scale = newScale;
         initCanvas();
         persistStoredPositions();
     }
 
-    // Initialize layout mode UI on first paint
     requestAnimationFrame(() => {
         if (viewportState.layoutMode === 'structured') {
             document.body.classList.add('layout-structured');

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -79,10 +79,13 @@ function loadStoredLayout() {
     const storedLayout = loadStoredLayout();
     storedFreePositions = { ...(storedLayout.positions || {}) };
 
+    const hasNonDefaultOffset = storedLayout.offsetX !== 0 || storedLayout.offsetY !== 0;
+    const hasStoredViewportOffset = hasNonDefaultOffset || (storedLayout.scale !== undefined && storedLayout.scale !== 1);
     const viewportState = {
         offsetX: storedLayout.offsetX,
         offsetY: storedLayout.offsetY,
         scale: storedLayout.scale || 1,
+        hasStoredViewportOffset: !!hasStoredViewportOffset,
         initialized: false,
         isPanning: false,
         startX: 0,
@@ -166,6 +169,8 @@ function loadStoredLayout() {
     function switchToFreeMode() {
         viewportState.layoutMode = 'free';
         persistLayoutMode('free');
+        // Allow viewport recalculation for the new layout
+        viewportState.initialViewportApplied = false;
         // Restore saved free positions if available
         if (savedFreePositions) {
             viewportState.positions = { ...savedFreePositions };
@@ -193,6 +198,8 @@ function loadStoredLayout() {
         // Save current free positions before switching
         savedFreePositions = { ...viewportState.positions };
         viewportState.layoutMode = 'structured';
+        // Allow viewport recalculation for the new layout
+        viewportState.initialViewportApplied = false;
         persistLayoutMode('structured');
         document.body.classList.remove('layout-free');
         document.body.classList.add('layout-structured');

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -530,6 +530,8 @@ function createEditorCanvas(deps) {
         if (typeof canvasViewport.recenterViewport === 'function') {
             canvasViewport.recenterViewport({
                 getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
                 getWorldPosition,
                 getMetrics,
                 viewportState,

--- a/tests/contracts/editor-viewport-controls-contract.test.js
+++ b/tests/contracts/editor-viewport-controls-contract.test.js
@@ -31,14 +31,14 @@ test('editor page mounts viewport control buttons with accessible labels', () =>
 test('editor canvas viewport module owns zoom, fit, and focus math', () => {
   const source = read('js/editor/editor-canvas-viewport.js');
 
-  assert.match(source, /minScale:\s*0\.65/, 'viewport must bound zoom-out scale');
-  assert.match(source, /maxScale:\s*1\.55/, 'viewport must bound zoom-in scale');
-  assert.match(source, /zoomStep:\s*1\.18/, 'viewport must define a stable zoom step');
+  assert.match(source, /minScale:\s*0\.5/, 'viewport must bound zoom-out scale');
+  assert.match(source, /maxScale:\s*1\.5/, 'viewport must bound zoom-in scale');
+  assert.match(source, /zoomLevels:\s*\[\s*0\.5,\s*0\.75,\s*1,\s*1\.25,\s*1\.5\s*\]/, 'viewport must define preset zoom levels');
   assert.match(source, /projectWorldPosition\s*\(/, 'viewport must project world positions through scale and offset');
   assert.match(source, /getFitViewport\s*\(/, 'viewport must compute fit-whole-tree state');
   assert.match(source, /focusNodeById\s*\(/, 'viewport must preserve selected/current moment focus');
-  assert.match(source, /zoomBy\(this\.zoomStep\)/, 'zoom in control must delegate to zoomBy');
-  assert.match(source, /zoomBy\(1 \/ this\.zoomStep\)/, 'zoom out control must delegate to zoomBy');
+  assert.match(source, /getNextZoom/, 'zoom in must delegate to getNextZoom');
+  assert.match(source, /this\.getNextZoom\(.*,\s*factor\s*>=\s*1\s*\?\s*1\s*:\s*-1\)/, 'zoom controls must use directional getNextZoom calls');
 });
 
 test('editor canvas persists scale and keeps node dragging scale-aware', () => {

--- a/tests/contracts/editor-viewport-controls-contract.test.js
+++ b/tests/contracts/editor-viewport-controls-contract.test.js
@@ -28,17 +28,32 @@ test('editor page mounts viewport control buttons with accessible labels', () =>
   assert.match(html, /aria-label=["']선택한 순간 보기["']/, 'focus selected moment must have an accessible label');
 });
 
-test('editor canvas viewport module owns zoom, fit, and focus math', () => {
+test('editor canvas viewport module owns fit-safe zoom and focus math', () => {
   const source = read('js/editor/editor-canvas-viewport.js');
 
-  assert.match(source, /minScale:\s*0\.5/, 'viewport must bound zoom-out scale');
+  assert.match(source, /minScale:\s*0\.2/, 'viewport must allow small zoom for large whole-tree fit');
   assert.match(source, /maxScale:\s*1\.5/, 'viewport must bound zoom-in scale');
-  assert.match(source, /zoomLevels:\s*\[\s*0\.5,\s*0\.75,\s*1,\s*1\.25,\s*1\.5\s*\]/, 'viewport must define preset zoom levels');
+  assert.match(source, /zoomLevels:\s*\[\s*0\.2,\s*0\.35,\s*0\.5,\s*0\.75,\s*1,\s*1\.25,\s*1\.5\s*\]/, 'viewport must define preset zoom levels including small whole-tree fit levels');
+  assert.match(source, /getFitZoom\s*\(/, 'viewport must expose a fit-safe zoom selector');
+  assert.match(source, /candidate <= clamped && candidate > best/, 'fit zoom must not round upward and risk clipping');
   assert.match(source, /projectWorldPosition\s*\(/, 'viewport must project world positions through scale and offset');
   assert.match(source, /getFitViewport\s*\(/, 'viewport must compute fit-whole-tree state');
-  assert.match(source, /focusNodeById\s*\(/, 'viewport must preserve selected/current moment focus');
+  assert.match(source, /prepareInitialViewport\s*\(/, 'viewport must own initial viewport preparation');
+  assert.match(source, /this\.applyViewport\(viewportState, this\.getFitViewport\(options\), true\)/, 'initial no-stored viewport must use whole-tree fit');
+  assert.match(source, /this\.applyViewport\(viewportState, this\.getFitViewport\(options\), true\)/, 'offscreen fallback must use whole-tree fit');
+  assert.match(source, /recenterViewport\s*\(/, 'viewport must own recenter behavior');
+  assert.match(source, /focusNodeById\s*\(/, 'viewport must preserve explicit selected/current moment focus');
   assert.match(source, /getNextZoom/, 'zoom in must delegate to getNextZoom');
   assert.match(source, /this\.getNextZoom\(.*,\s*factor\s*>=\s*1\s*\?\s*1\s*:\s*-1\)/, 'zoom controls must use directional getNextZoom calls');
+});
+
+test('editor layout switching fits the tree instead of centering selected node by default', () => {
+  const canvas = read('js/editor/editor-canvas.js');
+
+  assert.match(canvas, /function\s+fitViewportToTree\s*\(/, 'canvas must expose a layout-switch tree-fit helper');
+  assert.match(canvas, /fitViewportToTree\(\);[\s\S]*document\.body\.classList\.remove\('layout-structured'\)/, 'switching to free mode should fit the tree before rendering');
+  assert.match(canvas, /fitViewportToTree\(\);[\s\S]*document\.body\.classList\.remove\('layout-free'\)/, 'switching to structured mode should fit the tree before rendering');
+  assert.doesNotMatch(canvas, /function\s+centerViewportOnSelection\s*\(/, 'layout switching must not use selected-node centering by default');
 });
 
 test('editor canvas persists scale and keeps node dragging scale-aware', () => {


### PR DESCRIPTION
## Summary

Fixes Editor viewport initialization and recentering so the initial Editor view prioritizes seeing the whole tree.

Confirmed product policy:

1. If the tree has only one visible moment, center that first/start moment.
2. If the tree has two or more visible moments, fit the entire tree bounding box into the visible canvas.
3. Moment cards may appear small on large trees. Orientation is more important than initial card readability; users can zoom in afterward.
4. Do not center on the selected/start moment by default when multiple moments exist.
5. Center on the selected moment only when the user explicitly uses `선택한 순간 보기`.
6. Preserve valid saved viewport positions.
7. Discard or correct extreme/offscreen saved viewport positions.

## Changes

### `js/editor/editor-canvas-viewport.js`
- Adds smaller fit-safe zoom levels down to `20%` for large trees.
- Adds `getFitZoom()` so fit behavior uses the largest allowed zoom level less than or equal to the computed fit scale.
- Updates `getFitViewport()` to fit the whole visible tree bounding box rather than prefer card readability.
- Updates initial no-stored-viewport behavior to use whole-tree fit.
- Updates extreme/offscreen stored viewport fallback to use whole-tree fit.
- Updates `트리 한눈에 보기` to use whole-tree fit.
- Keeps `선택한 순간 보기` as the explicit selected-node focus control.

### `js/editor/editor-canvas.js`
- Tracks whether a valid stored viewport exists.
- Adds layout-switch tree-fit handling.
- Removes default selected-node centering from structured/free layout switching.
- Preserves valid free-layout stored positions.

### `tests/contracts/editor-viewport-controls-contract.test.js`
- Updates viewport contract tests to require whole-tree fit behavior.
- Adds a contract that layout switching fits the tree instead of centering the selected node by default.

## Key behaviors

- One visible moment: first/start moment is centered.
- Two or more visible moments: the whole tree is fitted into the visible canvas.
- Large tree: cards may be small, but the tree should not be clipped by default.
- `트리 한눈에 보기`: fits the whole tree.
- `선택한 순간 보기`: centers the selected moment.
- Valid saved viewport: preserved.
- Extreme/offscreen saved viewport: corrected to whole-tree fit.
- Structured/free layout switch: fits the tree, does not default to selected-node center.

Refs #1146