### PR TITLE
UX: replace Editor continue bubble with compact selected-node plus tip

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -389,6 +389,11 @@ document.addEventListener('DOMContentLoaded', () => {
             updateDetailPanel(data);
             updateFocusSelectedBtn();
             setDetailEmptyState(false);
+
+            // Immediately update the + tip affordance for the newly selected node
+            if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
+                editorCanvas.updateAffordance();
+            }
         };
 
         const focusSelectedMoment = () => {

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,7 +17,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 200;
+    const BUBBLE_WIDTH = 220;
     const BUBBLE_HEIGHT = 42;
     const BUBBLE_GAP = 8;
 
@@ -378,7 +378,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.type = 'button';
         button.className = 'memory-add-affordance';
         button.setAttribute('aria-label', labelText);
-        button.setAttribute('title', labelText);
         button.style.position = 'absolute';
         button.style.left = `${tipPos.x - TIP_HALF}px`;
         button.style.top = `${tipPos.y - TIP_HALF}px`;
@@ -408,9 +407,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.appendChild(bubble);
 
         function showBubble() {
-            button.style.transform = 'scale(1.08)';
-            button.style.boxShadow = '0 5px 16px rgba(144, 73, 81, 0.35)';
-            button.style.background = 'rgba(144, 73, 81, 1)';
             bubble.style.opacity = '1';
             bubble.style.pointerEvents = 'none';
             bubble.style.transform = bubble.style.transform.replace('scale(0.96)', 'scale(1)');
@@ -418,9 +414,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         }
 
         function hideBubble() {
-            button.style.transform = 'scale(1)';
-            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-            button.style.background = 'rgba(144, 73, 81, 0.92)';
             bubble.style.opacity = '0';
             bubble.style.pointerEvents = 'none';
             bubble.style.transform = bubble.style.transform.replace('scale(1)', 'scale(0.96)');
@@ -436,10 +429,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
-            button.style.transform = 'scale(0.92)';
-            setTimeout(() => {
-                showBubble();
-            }, 80);
             openAddMomentFromCanvas();
         });
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,7 +17,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 190;
+    const BUBBLE_WIDTH = 210;
     const BUBBLE_HEIGHT = 42;
     const BUBBLE_GAP = 8;
 
@@ -382,10 +382,13 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.width = `${BUBBLE_WIDTH}px`;
             button.style.borderRadius = '999px';
             button.style.justifyContent = 'flex-start';
-            button.style.padding = '4px 12px 4px 4px';
+            button.style.padding = '8px 14px 8px 8px';
+            button.style.border = '1px solid rgba(144, 73, 81, 0.18)';
             button.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
             button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.13)';
+            button.style.backdropFilter = 'blur(8px)';
             textWrap.style.display = 'flex';
+            textWrap.style.gap = '1px';
             button.setAttribute('aria-expanded', 'true');
         }
 
@@ -396,9 +399,12 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.borderRadius = '50%';
             button.style.justifyContent = 'center';
             button.style.padding = '0';
+            button.style.border = 'none';
             button.style.background = 'rgba(144, 73, 81, 0.92)';
             button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+            button.style.backdropFilter = 'none';
             textWrap.style.display = 'none';
+            textWrap.style.gap = '0';
             button.setAttribute('aria-expanded', 'false');
         }
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -299,47 +299,54 @@ function createEditorCanvasGrowthAffordance(deps) {
         bubble.style.transformOrigin = 'bottom center';
     }
 
-    function createBubble(labelText, helperText) {
-        const bubble = documentRef.createElement('span');
-        bubble.className = 'affordance-tooltip affordance-tooltip-bubble';
-        bubble.setAttribute('role', 'tooltip');
-        bubble.setAttribute('aria-hidden', 'true');
-        bubble.style.position = 'absolute';
-        bubble.style.width = `${BUBBLE_WIDTH}px`;
-        bubble.style.minHeight = `${BUBBLE_HEIGHT}px`;
-        bubble.style.boxSizing = 'border-box';
-        bubble.style.display = 'flex';
-        bubble.style.alignItems = 'center';
-        bubble.style.gap = '10px';
-        bubble.style.padding = '8px 12px 8px 10px';
-        bubble.style.border = '1px solid rgba(144, 73, 81, 0.18)';
-        bubble.style.borderRadius = '999px';
-        bubble.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
-        bubble.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.13)';
-        bubble.style.backdropFilter = 'blur(8px)';
-        bubble.style.opacity = '0';
-        bubble.style.pointerEvents = 'none';
-        bubble.style.zIndex = '6';
-        bubble.style.transition = 'opacity 0.16s ease, transform 0.16s ease';
+    function createPlusTipElement(anchorMem, labelText, helperText) {
+        const anchorPos = calcPosition(anchorMem);
+        const tipPos = getPlusTipPosition(anchorPos, anchorMem);
+        const button = documentRef.createElement('button');
+        button.type = 'button';
+        button.className = 'memory-add-affordance affordance-tooltip-bubble';
+        button.setAttribute('aria-label', labelText);
+        button.style.position = 'absolute';
+        button.style.left = `${tipPos.x - TIP_HALF}px`;
+        button.style.top = `${tipPos.y - TIP_HALF}px`;
+        button.style.width = `${TIP_SIZE}px`;
+        button.style.height = `${TIP_SIZE}px`;
+        button.style.borderRadius = '50%';
+        button.style.border = 'none';
+        button.style.background = 'rgba(144, 73, 81, 0.92)';
+        button.style.color = '#fff';
+        button.style.cursor = 'pointer';
+        button.style.zIndex = '5';
+        button.style.display = 'flex';
+        button.style.alignItems = 'center';
+        button.style.justifyContent = 'center';
+        button.style.boxSizing = 'border-box';
+        button.style.padding = '0';
+        button.style.gap = '10px';
+        button.style.overflow = 'hidden';
+        button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+        button.style.transition = 'width 0.16s ease, border-radius 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, padding 0.16s ease';
 
-        const bubblePlus = documentRef.createElement('span');
-        bubblePlus.setAttribute('aria-hidden', 'true');
-        bubblePlus.textContent = '+';
-        bubblePlus.style.width = '28px';
-        bubblePlus.style.height = '28px';
-        bubblePlus.style.borderRadius = '50%';
-        bubblePlus.style.display = 'inline-flex';
-        bubblePlus.style.alignItems = 'center';
-        bubblePlus.style.justifyContent = 'center';
-        bubblePlus.style.background = 'linear-gradient(180deg, rgba(144, 73, 81, 1), rgba(144, 73, 81, 0.88))';
-        bubblePlus.style.color = '#fff';
-        bubblePlus.style.fontSize = '17px';
-        bubblePlus.style.fontWeight = '700';
-        bubblePlus.style.flex = '0 0 auto';
-        bubblePlus.style.boxShadow = '0 6px 14px rgba(144, 73, 81, 0.22)';
+        const plusIcon = documentRef.createElement('span');
+        plusIcon.setAttribute('aria-hidden', 'true');
+        plusIcon.textContent = '+';
+        plusIcon.style.width = '28px';
+        plusIcon.style.height = '28px';
+        plusIcon.style.borderRadius = '50%';
+        plusIcon.style.display = 'inline-flex';
+        plusIcon.style.alignItems = 'center';
+        plusIcon.style.justifyContent = 'center';
+        plusIcon.style.background = 'linear-gradient(180deg, rgba(144, 73, 81, 1), rgba(144, 73, 81, 0.88))';
+        plusIcon.style.color = '#fff';
+        plusIcon.style.fontSize = '17px';
+        plusIcon.style.fontWeight = '700';
+        plusIcon.style.flex = '0 0 auto';
+        plusIcon.style.boxShadow = '0 6px 14px rgba(144, 73, 81, 0.22)';
+        button.appendChild(plusIcon);
 
         const textWrap = documentRef.createElement('span');
-        textWrap.style.display = 'flex';
+        textWrap.className = 'affordance-tip-text';
+        textWrap.style.display = 'none';
         textWrap.style.flexDirection = 'column';
         textWrap.style.alignItems = 'flex-start';
         textWrap.style.minWidth = '0';
@@ -351,7 +358,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         titleEl.style.color = 'var(--on-surface)';
         titleEl.style.lineHeight = '1.25';
         titleEl.style.whiteSpace = 'nowrap';
-
         textWrap.appendChild(titleEl);
 
         if (helperText) {
@@ -366,58 +372,34 @@ function createEditorCanvasGrowthAffordance(deps) {
             textWrap.appendChild(hintEl);
         }
 
-        bubble.appendChild(bubblePlus);
-        bubble.appendChild(textWrap);
-        return bubble;
-    }
+        button.appendChild(textWrap);
 
-    function createPlusTipElement(anchorMem, labelText, helperText) {
-        const anchorPos = calcPosition(anchorMem);
-        const tipPos = getPlusTipPosition(anchorPos, anchorMem);
-        const button = documentRef.createElement('button');
-        button.type = 'button';
-        button.className = 'memory-add-affordance';
-        button.setAttribute('aria-label', labelText);
-        button.style.position = 'absolute';
-        button.style.left = `${tipPos.x - TIP_HALF}px`;
-        button.style.top = `${tipPos.y - TIP_HALF}px`;
-        button.style.width = `${TIP_SIZE}px`;
-        button.style.height = `${TIP_SIZE}px`;
-        button.style.borderRadius = '50%';
-        button.style.border = 'none';
-        button.style.background = 'rgba(144, 73, 81, 0.92)';
-        button.style.color = '#fff';
-        button.style.fontSize = '20px';
-        button.style.fontWeight = '700';
-        button.style.lineHeight = '1';
-        button.style.cursor = 'pointer';
-        button.style.zIndex = '5';
-        button.style.display = 'flex';
-        button.style.alignItems = 'center';
-        button.style.justifyContent = 'center';
-        button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-        button.style.transition = 'transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease';
-        button.textContent = '+';
-
-        const bubble = createBubble(labelText, helperText);
-        const bubbleId = 'aff-tip-' + (anchorMem ? anchorMem.id : '0');
-        bubble.setAttribute('id', bubbleId);
-        button.setAttribute('aria-describedby', bubbleId);
-        positionBubble(bubble, tipPos);
-        button.appendChild(bubble);
+        let bubbleExpanded = false;
 
         function showBubble() {
-            bubble.style.opacity = '1';
-            bubble.style.pointerEvents = 'none';
-            bubble.style.transform = bubble.style.transform.replace('scale(0.96)', 'scale(1)');
-            bubble.setAttribute('aria-hidden', 'false');
+            if (bubbleExpanded) return;
+            bubbleExpanded = true;
+            button.style.width = `${BUBBLE_WIDTH}px`;
+            button.style.borderRadius = '999px';
+            button.style.justifyContent = 'flex-start';
+            button.style.padding = '4px 12px 4px 4px';
+            button.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
+            button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.13)';
+            textWrap.style.display = 'flex';
+            button.setAttribute('aria-expanded', 'true');
         }
 
         function hideBubble() {
-            bubble.style.opacity = '0';
-            bubble.style.pointerEvents = 'none';
-            bubble.style.transform = bubble.style.transform.replace('scale(1)', 'scale(0.96)');
-            bubble.setAttribute('aria-hidden', 'true');
+            if (!bubbleExpanded) return;
+            bubbleExpanded = false;
+            button.style.width = `${TIP_SIZE}px`;
+            button.style.borderRadius = '50%';
+            button.style.justifyContent = 'center';
+            button.style.padding = '0';
+            button.style.background = 'rgba(144, 73, 81, 0.92)';
+            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+            textWrap.style.display = 'none';
+            button.setAttribute('aria-expanded', 'false');
         }
 
         button.addEventListener('mouseenter', showBubble);
@@ -458,7 +440,12 @@ function createEditorCanvasGrowthAffordance(deps) {
         if (!anchorMem) return;
         const opts = options || {};
         const labelText = opts.labelText || (i18n('editor_add_memory') || '새 순간 이어가기');
-        const helperText = opts.helperText || '';
+        const isFirstStep = opts.isFirstStep;
+        const helperText = opts.helperText
+            || (isFirstStep
+                ? (i18n('growth_first_step_hint') || '첫 순간에서 이어지는 감정을 기록해보세요')
+                : (i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요'))
+            || '';
 
         createPlusTipElement(anchorMem, labelText, helperText);
     }

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,8 +17,8 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 165;
-    const BUBBLE_HEIGHT = 42;
+    const BUBBLE_WIDTH = 188;
+    const BUBBLE_MIN_HEIGHT = 60;
     const BUBBLE_GAP = 8;
 
     function clamp(value, min, max) {
@@ -77,36 +77,36 @@ function createEditorCanvasGrowthAffordance(deps) {
                     return {
                         left: tipX + TIP_HALF + BUBBLE_GAP,
                         right: tipX + TIP_HALF + BUBBLE_GAP + BUBBLE_WIDTH,
-                        top: tipY - (BUBBLE_HEIGHT / 2),
-                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                        top: tipY - (BUBBLE_MIN_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_MIN_HEIGHT / 2)
                     };
                 case 'left':
                     return {
                         left: tipX - TIP_HALF - BUBBLE_GAP - BUBBLE_WIDTH,
                         right: tipX - TIP_HALF - BUBBLE_GAP,
-                        top: tipY - (BUBBLE_HEIGHT / 2),
-                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                        top: tipY - (BUBBLE_MIN_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_MIN_HEIGHT / 2)
                     };
                 case 'below':
                     return {
                         left: tipX - (BUBBLE_WIDTH / 2),
                         right: tipX + (BUBBLE_WIDTH / 2),
                         top: tipY + TIP_HALF + BUBBLE_GAP,
-                        bottom: tipY + TIP_HALF + BUBBLE_GAP + BUBBLE_HEIGHT
+                        bottom: tipY + TIP_HALF + BUBBLE_GAP + BUBBLE_MIN_HEIGHT
                     };
                 case 'above':
                     return {
                         left: tipX - (BUBBLE_WIDTH / 2),
                         right: tipX + (BUBBLE_WIDTH / 2),
-                        top: tipY - TIP_HALF - BUBBLE_GAP - BUBBLE_HEIGHT,
+                        top: tipY - TIP_HALF - BUBBLE_GAP - BUBBLE_MIN_HEIGHT,
                         bottom: tipY - TIP_HALF - BUBBLE_GAP
                     };
                 default:
                     return {
                         left: tipX + TIP_HALF + BUBBLE_GAP,
                         right: tipX + TIP_HALF + BUBBLE_GAP + BUBBLE_WIDTH,
-                        top: tipY - (BUBBLE_HEIGHT / 2),
-                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                        top: tipY - (BUBBLE_MIN_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_MIN_HEIGHT / 2)
                     };
             }
         }
@@ -271,34 +271,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         svg.appendChild(path);
     }
 
-    function positionBubble(bubble, tipPos) {
-        if (tipPos.side === 'right') {
-            bubble.style.left = `${TIP_SIZE + BUBBLE_GAP}px`;
-            bubble.style.top = '50%';
-            bubble.style.transform = 'translateY(-50%) scale(0.96)';
-            bubble.style.transformOrigin = 'left center';
-            return;
-        }
-        if (tipPos.side === 'left') {
-            bubble.style.right = `${TIP_SIZE + BUBBLE_GAP}px`;
-            bubble.style.top = '50%';
-            bubble.style.transform = 'translateY(-50%) scale(0.96)';
-            bubble.style.transformOrigin = 'right center';
-            return;
-        }
-        if (tipPos.side === 'below') {
-            bubble.style.left = '50%';
-            bubble.style.top = `${TIP_SIZE + BUBBLE_GAP}px`;
-            bubble.style.transform = 'translateX(-50%) scale(0.96)';
-            bubble.style.transformOrigin = 'top center';
-            return;
-        }
-        bubble.style.left = '50%';
-        bubble.style.bottom = `${TIP_SIZE + BUBBLE_GAP}px`;
-        bubble.style.transform = 'translateX(-50%) scale(0.96)';
-        bubble.style.transformOrigin = 'bottom center';
-    }
-
     function createPlusTipElement(anchorMem, labelText, helperText) {
         const anchorPos = calcPosition(anchorMem);
         const tipPos = getPlusTipPosition(anchorPos, anchorMem);
@@ -306,10 +278,12 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.type = 'button';
         button.className = 'memory-add-affordance affordance-tooltip-bubble';
         button.setAttribute('aria-label', labelText);
+        button.setAttribute('aria-expanded', 'false');
         button.style.position = 'absolute';
         button.style.left = `${tipPos.x - TIP_HALF}px`;
         button.style.top = `${tipPos.y - TIP_HALF}px`;
         button.style.width = `${TIP_SIZE}px`;
+        button.style.minHeight = `${TIP_SIZE}px`;
         button.style.height = `${TIP_SIZE}px`;
         button.style.borderRadius = '50%';
         button.style.border = 'none';
@@ -325,7 +299,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.style.gap = '10px';
         button.style.overflow = 'hidden';
         button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-        button.style.transition = 'width 0.16s ease, border-radius 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, padding 0.16s ease';
+        button.style.transition = 'width 0.16s ease, min-height 0.16s ease, height 0.16s ease, border-radius 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, padding 0.16s ease';
 
         const plusIcon = documentRef.createElement('span');
         plusIcon.setAttribute('aria-hidden', 'true');
@@ -350,14 +324,16 @@ function createEditorCanvasGrowthAffordance(deps) {
         textWrap.style.flexDirection = 'column';
         textWrap.style.alignItems = 'flex-start';
         textWrap.style.minWidth = '0';
+        textWrap.style.maxWidth = '126px';
+        textWrap.style.gap = '2px';
 
         const titleEl = documentRef.createElement('span');
         titleEl.textContent = labelText;
         titleEl.style.fontSize = '13px';
         titleEl.style.fontWeight = '700';
         titleEl.style.color = 'var(--on-surface)';
-        titleEl.style.lineHeight = '1.25';
-        titleEl.style.whiteSpace = 'normal';
+        titleEl.style.lineHeight = '1.28';
+        titleEl.style.whiteSpace = 'nowrap';
         textWrap.appendChild(titleEl);
 
         if (helperText) {
@@ -366,9 +342,13 @@ function createEditorCanvasGrowthAffordance(deps) {
             hintEl.style.fontSize = '11px';
             hintEl.style.fontWeight = '600';
             hintEl.style.color = 'var(--on-surface-variant)';
-            hintEl.style.lineHeight = '1.25';
+            hintEl.style.lineHeight = '1.32';
             hintEl.style.opacity = '0.82';
             hintEl.style.whiteSpace = 'normal';
+            hintEl.style.display = '-webkit-box';
+            hintEl.style.webkitLineClamp = '2';
+            hintEl.style.webkitBoxOrient = 'vertical';
+            hintEl.style.overflow = 'hidden';
             textWrap.appendChild(hintEl);
         }
 
@@ -380,6 +360,8 @@ function createEditorCanvasGrowthAffordance(deps) {
             if (bubbleExpanded) return;
             bubbleExpanded = true;
             button.style.width = `${BUBBLE_WIDTH}px`;
+            button.style.minHeight = `${BUBBLE_MIN_HEIGHT}px`;
+            button.style.height = 'auto';
             button.style.borderRadius = '999px';
             button.style.justifyContent = 'flex-start';
             button.style.padding = '10px 14px 10px 10px';
@@ -388,7 +370,6 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.10)';
             button.style.backdropFilter = 'blur(8px)';
             textWrap.style.display = 'flex';
-            textWrap.style.gap = '1px';
             button.setAttribute('aria-expanded', 'true');
         }
 
@@ -396,6 +377,8 @@ function createEditorCanvasGrowthAffordance(deps) {
             if (!bubbleExpanded) return;
             bubbleExpanded = false;
             button.style.width = `${TIP_SIZE}px`;
+            button.style.minHeight = `${TIP_SIZE}px`;
+            button.style.height = `${TIP_SIZE}px`;
             button.style.borderRadius = '50%';
             button.style.justifyContent = 'center';
             button.style.padding = '0';
@@ -404,7 +387,6 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
             button.style.backdropFilter = 'none';
             textWrap.style.display = 'none';
-            textWrap.style.gap = '0';
             button.setAttribute('aria-expanded', 'false');
         }
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -357,7 +357,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         titleEl.style.fontWeight = '700';
         titleEl.style.color = 'var(--on-surface)';
         titleEl.style.lineHeight = '1.25';
-        titleEl.style.whiteSpace = 'nowrap';
+        titleEl.style.whiteSpace = 'normal';
         textWrap.appendChild(titleEl);
 
         if (helperText) {
@@ -368,7 +368,7 @@ function createEditorCanvasGrowthAffordance(deps) {
             hintEl.style.color = 'var(--on-surface-variant)';
             hintEl.style.lineHeight = '1.25';
             hintEl.style.opacity = '0.82';
-            hintEl.style.whiteSpace = 'nowrap';
+            hintEl.style.whiteSpace = 'normal';
             textWrap.appendChild(hintEl);
         }
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,6 +17,9 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
+    const BUBBLE_WIDTH = 164;
+    const BUBBLE_HEIGHT = 42;
+    const BUBBLE_GAP = 8;
 
     function clamp(value, min, max) {
         if (max < min) return min;
@@ -26,8 +29,6 @@ function createEditorCanvasGrowthAffordance(deps) {
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
         svg.querySelectorAll('.branch-line-affordance').forEach((el) => el.remove());
-        // Remove any affordance tooltip that might be visible
-        documentRef.querySelectorAll('.affordance-tooltip').forEach((el) => el.remove());
     }
 
     function openAddMomentFromCanvas() {
@@ -42,12 +43,6 @@ function createEditorCanvasGrowthAffordance(deps) {
         }
     }
 
-    /**
-     * Determine the best placement for the compact + tip.
-     * Considers viewport boundaries AND existing node positions
-     * to avoid occluding other nodes in both structured and free layouts.
-     * Returns position (center of tip) and side ('right'|'left'|'below'|'above').
-     */
     function getPlusTipPosition(anchorPos, anchorMem) {
         const metrics = getMetrics();
         const viewportWidth = Math.max(canvas.clientWidth || metrics.width, 320);
@@ -55,14 +50,11 @@ function createEditorCanvasGrowthAffordance(deps) {
         const tipRadius = TIP_HALF;
         const anchorNodeId = anchorMem && anchorMem.id;
 
-        // Collect positions of all OTHER memory nodes currently on canvas
-        // to avoid overlapping them (exclude the anchor node itself)
         var nodeRects = [];
         try {
             var allNodes = canvas.querySelectorAll('.memory-node');
             for (var i = 0; i < allNodes.length; i++) {
                 var el = allNodes[i];
-                // Skip the anchor node — tip is intentionally placed adjacent to it
                 if (anchorNodeId && el.dataset && el.dataset.memoryId === anchorNodeId) continue;
                 var left = parseFloat(el.style.left) || 0;
                 var top = parseFloat(el.style.top) || 0;
@@ -77,50 +69,67 @@ function createEditorCanvasGrowthAffordance(deps) {
                     height: h
                 });
             }
-        } catch (_) { /* silently fall through */ }
+        } catch (_) {}
 
-        /**
-         * Check if a candidate tip (at center x,y with given side)
-         * overlaps with any existing node rect.
-         */
-        function overlapsNodes(tipX, tipY, side) {
-            // Define the tip bounding box
-            var tLeft = tipX - tipRadius;
-            var tRight = tipX + tipRadius;
-            var tTop = tipY - tipRadius;
-            var tBottom = tipY + tipRadius;
-
-            // Expand by a small guard gap
-            var guard = 12;
-            tLeft -= guard;
-            tRight += guard;
-            tTop -= guard;
-            tBottom += guard;
-
-            // Also check tooltip extent on the relevant side
-            var tooltipWidthEstimate = 140;
-            var tooltipHeightEstimate = 26;
-            var tooltipGap = 6;
+        function getBubbleRect(tipX, tipY, side) {
             switch (side) {
                 case 'right':
-                    tRight = Math.max(tRight, tipX + tipRadius + tooltipGap + tooltipWidthEstimate);
-                    break;
+                    return {
+                        left: tipX + TIP_HALF + BUBBLE_GAP,
+                        right: tipX + TIP_HALF + BUBBLE_GAP + BUBBLE_WIDTH,
+                        top: tipY - (BUBBLE_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                    };
                 case 'left':
-                    tLeft = Math.min(tLeft, tipX - tipRadius - tooltipGap - tooltipWidthEstimate);
-                    break;
+                    return {
+                        left: tipX - TIP_HALF - BUBBLE_GAP - BUBBLE_WIDTH,
+                        right: tipX - TIP_HALF - BUBBLE_GAP,
+                        top: tipY - (BUBBLE_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                    };
                 case 'below':
-                    tBottom = Math.max(tBottom, tipY + tipRadius + tooltipGap + tooltipHeightEstimate);
-                    break;
+                    return {
+                        left: tipX - (BUBBLE_WIDTH / 2),
+                        right: tipX + (BUBBLE_WIDTH / 2),
+                        top: tipY + TIP_HALF + BUBBLE_GAP,
+                        bottom: tipY + TIP_HALF + BUBBLE_GAP + BUBBLE_HEIGHT
+                    };
                 case 'above':
-                    tTop = Math.min(tTop, tipY - tipRadius - tooltipGap - tooltipHeightEstimate);
-                    break;
+                    return {
+                        left: tipX - (BUBBLE_WIDTH / 2),
+                        right: tipX + (BUBBLE_WIDTH / 2),
+                        top: tipY - TIP_HALF - BUBBLE_GAP - BUBBLE_HEIGHT,
+                        bottom: tipY - TIP_HALF - BUBBLE_GAP
+                    };
+                default:
+                    return {
+                        left: tipX + TIP_HALF + BUBBLE_GAP,
+                        right: tipX + TIP_HALF + BUBBLE_GAP + BUBBLE_WIDTH,
+                        top: tipY - (BUBBLE_HEIGHT / 2),
+                        bottom: tipY + (BUBBLE_HEIGHT / 2)
+                    };
             }
+        }
 
-            // Check against all node rects
+        function isRectInViewport(rect) {
+            return rect.left >= 8 && rect.right <= viewportWidth - 8 && rect.top >= 8 && rect.bottom <= viewportHeight - 8;
+        }
+
+        function overlapsNodes(tipX, tipY, side) {
+            var tLeft = tipX - tipRadius - 12;
+            var tRight = tipX + tipRadius + 12;
+            var tTop = tipY - tipRadius - 12;
+            var tBottom = tipY + tipRadius + 12;
+            var bubbleRect = getBubbleRect(tipX, tipY, side);
+            tLeft = Math.min(tLeft, bubbleRect.left);
+            tRight = Math.max(tRight, bubbleRect.right);
+            tTop = Math.min(tTop, bubbleRect.top);
+            tBottom = Math.max(tBottom, bubbleRect.bottom);
+
             for (var j = 0; j < nodeRects.length; j++) {
                 var nr = nodeRects[j];
                 if (tLeft < nr.right && tRight > nr.left && tTop < nr.bottom && tBottom > nr.top) {
-                    return true; // Overlap detected
+                    return true;
                 }
             }
             return false;
@@ -130,86 +139,68 @@ function createEditorCanvasGrowthAffordance(deps) {
         const nodeRight = anchorPos.x + NODE_HALF;
         const nodeTop = anchorPos.y - NODE_HALF;
         const nodeBottom = anchorPos.y + NODE_HALF;
-
-        // Calculate available space on each side
         const spaceRight = viewportWidth - nodeRight;
         const spaceLeft = nodeLeft;
         const spaceBelow = viewportHeight - nodeBottom;
         const spaceAbove = nodeTop;
-
-        // Minimum space needed for tip + gap
         const needed = TIP_SIZE + GAP_FROM_NODE + CONNECTOR_PEAK_GAP;
-
-        // Score each side based on available space, preference, and node occlusion
         var sides = [];
 
         function evaluateSide(side, tipX, tipY, rawScore) {
+            var bubbleRect = getBubbleRect(tipX, tipY, side);
+            var outOfViewport = !isRectInViewport(bubbleRect);
             var occlusion = overlapsNodes(tipX, tipY, side);
-            // Heavily penalize sides that occlude other nodes
-            var score = occlusion ? rawScore * 0.1 : rawScore;
+            var score = rawScore;
+            if (outOfViewport) score *= 0.2;
+            if (occlusion) score *= 0.1;
             sides.push({ x: tipX, y: tipY, side: side, score: score });
         }
 
-        // Right: tip to the right of the node
         if (spaceRight >= needed) {
             var tipX = nodeRight + GAP_FROM_NODE + TIP_HALF;
             var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
             evaluateSide('right', tipX, tipY, spaceRight * 1.0);
         }
 
-        // Left: tip to the left of the node
         if (spaceLeft >= needed) {
             var tipX = nodeLeft - GAP_FROM_NODE - TIP_HALF;
             var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
             evaluateSide('left', tipX, tipY, spaceLeft * 0.85);
         }
 
-        // Below: tip below the node
         if (spaceBelow >= needed) {
             var tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
             var tipY = nodeBottom + GAP_FROM_NODE + TIP_HALF;
             evaluateSide('below', tipX, tipY, spaceBelow * 0.7);
         }
 
-        // Above: tip above the node
         if (spaceAbove >= needed) {
             var tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
             var tipY = nodeTop - GAP_FROM_NODE - TIP_HALF;
             evaluateSide('above', tipX, tipY, spaceAbove * 0.6);
         }
 
-        // If no non-occluded side was found with full space, try any feasible fallback
         if (!sides.length) {
-            // Even if space is tight, attempt placement with lower score
             var fallbacks = [];
-
-            // Try right with tight fit
             if (spaceRight > TIP_HALF + 8) {
                 var tipX = clamp(nodeRight + 4 + TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
                 var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-                var occ = overlapsNodes(tipX, tipY, 'right');
-                fallbacks.push({ x: tipX, y: tipY, side: 'right', score: occ ? 5 : 50 });
+                fallbacks.push({ x: tipX, y: tipY, side: 'right', score: overlapsNodes(tipX, tipY, 'right') ? 5 : 50 });
             }
-            // Try left with tight fit
             if (spaceLeft > TIP_HALF + 8) {
                 var tipX = clamp(nodeLeft - 4 - TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
                 var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-                var occ = overlapsNodes(tipX, tipY, 'left');
-                fallbacks.push({ x: tipX, y: tipY, side: 'left', score: occ ? 4 : 40 });
+                fallbacks.push({ x: tipX, y: tipY, side: 'left', score: overlapsNodes(tipX, tipY, 'left') ? 4 : 40 });
             }
-            // Try below with tight fit
             if (spaceBelow > TIP_HALF + 8) {
                 var tipX = clamp(anchorPos.x, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
                 var tipY = clamp(nodeBottom + 4 + TIP_HALF, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-                var occ = overlapsNodes(tipX, tipY, 'below');
-                fallbacks.push({ x: tipX, y: tipY, side: 'below', score: occ ? 3 : 30 });
+                fallbacks.push({ x: tipX, y: tipY, side: 'below', score: overlapsNodes(tipX, tipY, 'below') ? 3 : 30 });
             }
-            // Try above with tight fit
             if (spaceAbove > TIP_HALF + 8) {
                 var tipX = clamp(anchorPos.x, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
                 var tipY = clamp(nodeTop - 4 - TIP_HALF, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-                var occ = overlapsNodes(tipX, tipY, 'above');
-                fallbacks.push({ x: tipX, y: tipY, side: 'above', score: occ ? 2 : 20 });
+                fallbacks.push({ x: tipX, y: tipY, side: 'above', score: overlapsNodes(tipX, tipY, 'above') ? 2 : 20 });
             }
 
             if (fallbacks.length) {
@@ -218,13 +209,11 @@ function createEditorCanvasGrowthAffordance(deps) {
             }
         }
 
-        // If any side works, pick the best-scoring one (prefer non-occluded)
         if (sides.length) {
             sides.sort(function (a, b) { return b.score - a.score; });
             return sides[0];
         }
 
-        // Ultimate fallback: place to the right or left, clamped to viewport
         var preferRight = anchorPos.x < viewportWidth * 0.5;
         if (preferRight) {
             return {
@@ -242,8 +231,6 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     function drawConnectorLine(anchorPos, tipPos, side) {
         const path = documentRef.createElementNS('http://www.w3.org/2000/svg', 'path');
-
-        // Start from node edge toward the tip
         let startX, startY;
         switch (side) {
             case 'right':
@@ -267,11 +254,8 @@ function createEditorCanvasGrowthAffordance(deps) {
                 startY = anchorPos.y;
         }
 
-        // End point is near the tip circle edge
         const endX = tipPos.x - (side === 'left' ? TIP_HALF : side === 'right' ? -TIP_HALF : 0);
         const endY = tipPos.y - (side === 'above' ? TIP_HALF : side === 'below' ? -TIP_HALF : 0);
-
-        // Simple smooth quadratic bezier
         const cpX = (startX + endX) / 2;
         const cpY = (startY + endY) / 2;
         const d = `M ${startX},${startY} Q ${cpX},${cpY} ${endX},${endY}`;
@@ -287,11 +271,109 @@ function createEditorCanvasGrowthAffordance(deps) {
         svg.appendChild(path);
     }
 
-    function createPlusTipElement(anchorMem, labelText) {
+    function positionBubble(bubble, tipPos) {
+        if (tipPos.side === 'right') {
+            bubble.style.left = `${TIP_SIZE + BUBBLE_GAP}px`;
+            bubble.style.top = '50%';
+            bubble.style.transform = 'translateY(-50%) scale(0.96)';
+            bubble.style.transformOrigin = 'left center';
+            return;
+        }
+        if (tipPos.side === 'left') {
+            bubble.style.right = `${TIP_SIZE + BUBBLE_GAP}px`;
+            bubble.style.top = '50%';
+            bubble.style.transform = 'translateY(-50%) scale(0.96)';
+            bubble.style.transformOrigin = 'right center';
+            return;
+        }
+        if (tipPos.side === 'below') {
+            bubble.style.left = '50%';
+            bubble.style.top = `${TIP_SIZE + BUBBLE_GAP}px`;
+            bubble.style.transform = 'translateX(-50%) scale(0.96)';
+            bubble.style.transformOrigin = 'top center';
+            return;
+        }
+        bubble.style.left = '50%';
+        bubble.style.bottom = `${TIP_SIZE + BUBBLE_GAP}px`;
+        bubble.style.transform = 'translateX(-50%) scale(0.96)';
+        bubble.style.transformOrigin = 'bottom center';
+    }
+
+    function createBubble(labelText, helperText) {
+        const bubble = documentRef.createElement('span');
+        bubble.className = 'affordance-tooltip affordance-tooltip-bubble';
+        bubble.setAttribute('role', 'tooltip');
+        bubble.setAttribute('aria-hidden', 'true');
+        bubble.style.position = 'absolute';
+        bubble.style.width = `${BUBBLE_WIDTH}px`;
+        bubble.style.minHeight = `${BUBBLE_HEIGHT}px`;
+        bubble.style.boxSizing = 'border-box';
+        bubble.style.display = 'flex';
+        bubble.style.alignItems = 'center';
+        bubble.style.gap = '10px';
+        bubble.style.padding = '8px 12px 8px 10px';
+        bubble.style.border = '1px solid rgba(144, 73, 81, 0.18)';
+        bubble.style.borderRadius = '999px';
+        bubble.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
+        bubble.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.13)';
+        bubble.style.backdropFilter = 'blur(8px)';
+        bubble.style.opacity = '0';
+        bubble.style.pointerEvents = 'none';
+        bubble.style.zIndex = '6';
+        bubble.style.transition = 'opacity 0.16s ease, transform 0.16s ease';
+
+        const bubblePlus = documentRef.createElement('span');
+        bubblePlus.setAttribute('aria-hidden', 'true');
+        bubblePlus.textContent = '+';
+        bubblePlus.style.width = '28px';
+        bubblePlus.style.height = '28px';
+        bubblePlus.style.borderRadius = '50%';
+        bubblePlus.style.display = 'inline-flex';
+        bubblePlus.style.alignItems = 'center';
+        bubblePlus.style.justifyContent = 'center';
+        bubblePlus.style.background = 'linear-gradient(180deg, rgba(144, 73, 81, 1), rgba(144, 73, 81, 0.88))';
+        bubblePlus.style.color = '#fff';
+        bubblePlus.style.fontSize = '17px';
+        bubblePlus.style.fontWeight = '700';
+        bubblePlus.style.flex = '0 0 auto';
+        bubblePlus.style.boxShadow = '0 6px 14px rgba(144, 73, 81, 0.22)';
+
+        const textWrap = documentRef.createElement('span');
+        textWrap.style.display = 'flex';
+        textWrap.style.flexDirection = 'column';
+        textWrap.style.alignItems = 'flex-start';
+        textWrap.style.minWidth = '0';
+
+        const titleEl = documentRef.createElement('span');
+        titleEl.textContent = labelText;
+        titleEl.style.fontSize = '13px';
+        titleEl.style.fontWeight = '700';
+        titleEl.style.color = 'var(--on-surface)';
+        titleEl.style.lineHeight = '1.25';
+        titleEl.style.whiteSpace = 'nowrap';
+
+        textWrap.appendChild(titleEl);
+
+        if (helperText) {
+            const hintEl = documentRef.createElement('span');
+            hintEl.textContent = helperText;
+            hintEl.style.fontSize = '11px';
+            hintEl.style.fontWeight = '600';
+            hintEl.style.color = 'var(--on-surface-variant)';
+            hintEl.style.lineHeight = '1.25';
+            hintEl.style.opacity = '0.82';
+            hintEl.style.whiteSpace = 'nowrap';
+            textWrap.appendChild(hintEl);
+        }
+
+        bubble.appendChild(bubblePlus);
+        bubble.appendChild(textWrap);
+        return bubble;
+    }
+
+    function createPlusTipElement(anchorMem, labelText, helperText) {
         const anchorPos = calcPosition(anchorMem);
         const tipPos = getPlusTipPosition(anchorPos, anchorMem);
-
-        // Create the + button
         const button = documentRef.createElement('button');
         button.type = 'button';
         button.className = 'memory-add-affordance';
@@ -318,123 +400,68 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.style.transition = 'transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease';
         button.textContent = '+';
 
-        // Tooltip element (hidden by default)
-        const tooltip = documentRef.createElement('span');
-        tooltip.className = 'affordance-tooltip';
-        tooltip.textContent = labelText;
-        tooltip.setAttribute('role', 'tooltip');
-        tooltip.setAttribute('aria-hidden', 'true');
-        tooltip.style.position = 'absolute';
-        tooltip.style.whiteSpace = 'nowrap';
-        tooltip.style.fontSize = '12px';
-        tooltip.style.fontWeight = '600';
-        tooltip.style.color = '#fff';
-        tooltip.style.background = 'rgba(60, 50, 45, 0.92)';
-        tooltip.style.padding = '5px 10px';
-        tooltip.style.borderRadius = '6px';
-        tooltip.style.pointerEvents = 'none';
-        tooltip.style.opacity = '0';
-        tooltip.style.transition = 'opacity 0.15s ease';
-        tooltip.style.zIndex = '6';
+        const bubble = createBubble(labelText, helperText);
+        const bubbleId = 'aff-tip-' + (anchorMem ? anchorMem.id : '0');
+        bubble.setAttribute('id', bubbleId);
+        button.setAttribute('aria-describedby', bubbleId);
+        positionBubble(bubble, tipPos);
+        button.appendChild(bubble);
 
-        // Generate unique ID for aria-describedby linkage
-        var tooltipId = 'aff-tip-' + (anchorMem ? anchorMem.id : '0');
-        tooltip.setAttribute('id', tooltipId);
-
-        // Link button to tooltip for screen reader announcement
-        button.setAttribute('aria-describedby', tooltipId);
-
-        // Position tooltip based on tip side
-        const tooltipGap = 6;
-        switch (tipPos.side) {
-            case 'right':
-                tooltip.style.left = `${TIP_HALF + tooltipGap}px`;
-                tooltip.style.top = '50%';
-                tooltip.style.transform = 'translateY(-50%)';
-                break;
-            case 'left':
-                tooltip.style.right = `${TIP_HALF + tooltipGap}px`;
-                tooltip.style.top = '50%';
-                tooltip.style.transform = 'translateY(-50%)';
-                break;
-            case 'below':
-                tooltip.style.left = '50%';
-                tooltip.style.top = `${TIP_HALF + tooltipGap}px`;
-                tooltip.style.transform = 'translateX(-50%)';
-                break;
-            case 'above':
-                tooltip.style.left = '50%';
-                tooltip.style.bottom = `${TIP_HALF + tooltipGap}px`;
-                tooltip.style.transform = 'translateX(-50%)';
-                break;
-        }
-
-        button.appendChild(tooltip);
-
-        // Hover/focus show tooltip
-        button.addEventListener('mouseenter', () => {
-            button.style.transform = 'scale(1.15)';
+        function showBubble() {
+            button.style.transform = 'scale(1.08)';
             button.style.boxShadow = '0 5px 16px rgba(144, 73, 81, 0.35)';
             button.style.background = 'rgba(144, 73, 81, 1)';
-            tooltip.style.opacity = '1';
-            tooltip.setAttribute('aria-hidden', 'false');
-        });
-        button.addEventListener('mouseleave', () => {
-            button.style.transform = 'scale(1)';
-            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-            button.style.background = 'rgba(144, 73, 81, 0.92)';
-            tooltip.style.opacity = '0';
-            tooltip.setAttribute('aria-hidden', 'true');
-        });
-        button.addEventListener('focus', () => {
-            button.style.transform = 'scale(1.15)';
-            button.style.boxShadow = '0 0 0 3px rgba(144, 73, 81, 0.3), 0 5px 16px rgba(144, 73, 81, 0.35)';
-            button.style.background = 'rgba(144, 73, 81, 1)';
-            tooltip.style.opacity = '1';
-            tooltip.setAttribute('aria-hidden', 'false');
-        });
-        button.addEventListener('blur', () => {
-            button.style.transform = 'scale(1)';
-            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-            button.style.background = 'rgba(144, 73, 81, 0.92)';
-            tooltip.style.opacity = '0';
-            tooltip.setAttribute('aria-hidden', 'true');
-        });
+            bubble.style.opacity = '1';
+            bubble.style.pointerEvents = 'none';
+            bubble.style.transform = bubble.style.transform.replace('scale(0.96)', 'scale(1)');
+            bubble.setAttribute('aria-hidden', 'false');
+        }
 
-        // Click/tap action
+        function hideBubble() {
+            button.style.transform = 'scale(1)';
+            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+            button.style.background = 'rgba(144, 73, 81, 0.92)';
+            bubble.style.opacity = '0';
+            bubble.style.pointerEvents = 'none';
+            bubble.style.transform = bubble.style.transform.replace('scale(1)', 'scale(0.96)');
+            bubble.setAttribute('aria-hidden', 'true');
+        }
+
+        button.addEventListener('mouseenter', showBubble);
+        button.addEventListener('mouseleave', hideBubble);
+        button.addEventListener('focus', showBubble);
+        button.addEventListener('blur', hideBubble);
+        button.addEventListener('touchstart', showBubble, { passive: true });
+
         button.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
-            // Brief scale pulse for feedback
-            button.style.transform = 'scale(0.9)';
+            button.style.transform = 'scale(0.92)';
             setTimeout(() => {
-                button.style.transform = 'scale(1.15)';
-                setTimeout(() => {
-                    button.style.transform = 'scale(1)';
-                }, 100);
+                showBubble();
             }, 80);
             openAddMomentFromCanvas();
         });
 
-        // Prevent pan when interacting
         ['mousedown', 'pointerdown', 'touchstart'].forEach((eventName) => {
             button.addEventListener(eventName, (e) => {
                 e.stopPropagation();
             });
         });
 
-        // Keyboard support
         button.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
                 openAddMomentFromCanvas();
             }
+            if (e.key === 'Escape') {
+                hideBubble();
+                button.blur();
+            }
         });
 
-        // Draw connector line
         drawConnectorLine(anchorPos, tipPos, tipPos.side);
-
         canvas.appendChild(button);
     }
 
@@ -442,8 +469,9 @@ function createEditorCanvasGrowthAffordance(deps) {
         if (!anchorMem) return;
         const opts = options || {};
         const labelText = opts.labelText || (i18n('editor_add_memory') || '새 순간 이어가기');
+        const helperText = opts.helperText || '';
 
-        createPlusTipElement(anchorMem, labelText);
+        createPlusTipElement(anchorMem, labelText, helperText);
     }
 
     return {

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,7 +17,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 164;
+    const BUBBLE_WIDTH = 200;
     const BUBBLE_HEIGHT = 42;
     const BUBBLE_GAP = 8;
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -44,12 +44,87 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     /**
      * Determine the best placement for the compact + tip.
+     * Considers viewport boundaries AND existing node positions
+     * to avoid occluding other nodes in both structured and free layouts.
      * Returns position (center of tip) and side ('right'|'left'|'below'|'above').
      */
-    function getPlusTipPosition(anchorPos) {
+    function getPlusTipPosition(anchorPos, anchorMem) {
         const metrics = getMetrics();
         const viewportWidth = Math.max(canvas.clientWidth || metrics.width, 320);
         const viewportHeight = Math.max(canvas.clientHeight || metrics.height, 320);
+        const tipRadius = TIP_HALF;
+        const anchorNodeId = anchorMem && anchorMem.id;
+
+        // Collect positions of all OTHER memory nodes currently on canvas
+        // to avoid overlapping them (exclude the anchor node itself)
+        var nodeRects = [];
+        try {
+            var allNodes = canvas.querySelectorAll('.memory-node');
+            for (var i = 0; i < allNodes.length; i++) {
+                var el = allNodes[i];
+                // Skip the anchor node — tip is intentionally placed adjacent to it
+                if (anchorNodeId && el.dataset && el.dataset.memoryId === anchorNodeId) continue;
+                var left = parseFloat(el.style.left) || 0;
+                var top = parseFloat(el.style.top) || 0;
+                var w = parseFloat(el.style.width) || (NODE_HALF * 2);
+                var h = parseFloat(el.style.height) || (NODE_HALF * 2);
+                nodeRects.push({
+                    left: left,
+                    right: left + w,
+                    top: top,
+                    bottom: top + h,
+                    width: w,
+                    height: h
+                });
+            }
+        } catch (_) { /* silently fall through */ }
+
+        /**
+         * Check if a candidate tip (at center x,y with given side)
+         * overlaps with any existing node rect.
+         */
+        function overlapsNodes(tipX, tipY, side) {
+            // Define the tip bounding box
+            var tLeft = tipX - tipRadius;
+            var tRight = tipX + tipRadius;
+            var tTop = tipY - tipRadius;
+            var tBottom = tipY + tipRadius;
+
+            // Expand by a small guard gap
+            var guard = 12;
+            tLeft -= guard;
+            tRight += guard;
+            tTop -= guard;
+            tBottom += guard;
+
+            // Also check tooltip extent on the relevant side
+            var tooltipWidthEstimate = 140;
+            var tooltipHeightEstimate = 26;
+            var tooltipGap = 6;
+            switch (side) {
+                case 'right':
+                    tRight = Math.max(tRight, tipX + tipRadius + tooltipGap + tooltipWidthEstimate);
+                    break;
+                case 'left':
+                    tLeft = Math.min(tLeft, tipX - tipRadius - tooltipGap - tooltipWidthEstimate);
+                    break;
+                case 'below':
+                    tBottom = Math.max(tBottom, tipY + tipRadius + tooltipGap + tooltipHeightEstimate);
+                    break;
+                case 'above':
+                    tTop = Math.min(tTop, tipY - tipRadius - tooltipGap - tooltipHeightEstimate);
+                    break;
+            }
+
+            // Check against all node rects
+            for (var j = 0; j < nodeRects.length; j++) {
+                var nr = nodeRects[j];
+                if (tLeft < nr.right && tRight > nr.left && tTop < nr.bottom && tBottom > nr.top) {
+                    return true; // Overlap detected
+                }
+            }
+            return false;
+        }
 
         const nodeLeft = anchorPos.x - NODE_HALF;
         const nodeRight = anchorPos.x + NODE_HALF;
@@ -65,45 +140,92 @@ function createEditorCanvasGrowthAffordance(deps) {
         // Minimum space needed for tip + gap
         const needed = TIP_SIZE + GAP_FROM_NODE + CONNECTOR_PEAK_GAP;
 
-        // Score each side based on available space and preference
-        const sides = [];
+        // Score each side based on available space, preference, and node occlusion
+        var sides = [];
+
+        function evaluateSide(side, tipX, tipY, rawScore) {
+            var occlusion = overlapsNodes(tipX, tipY, side);
+            // Heavily penalize sides that occlude other nodes
+            var score = occlusion ? rawScore * 0.1 : rawScore;
+            sides.push({ x: tipX, y: tipY, side: side, score: score });
+        }
 
         // Right: tip to the right of the node
         if (spaceRight >= needed) {
-            const tipX = nodeRight + GAP_FROM_NODE + TIP_HALF;
-            const tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-            sides.push({ x: tipX, y: tipY, side: 'right', score: spaceRight * 1.0 });
+            var tipX = nodeRight + GAP_FROM_NODE + TIP_HALF;
+            var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+            evaluateSide('right', tipX, tipY, spaceRight * 1.0);
         }
 
         // Left: tip to the left of the node
         if (spaceLeft >= needed) {
-            const tipX = nodeLeft - GAP_FROM_NODE - TIP_HALF;
-            const tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
-            sides.push({ x: tipX, y: tipY, side: 'left', score: spaceLeft * 0.85 });
+            var tipX = nodeLeft - GAP_FROM_NODE - TIP_HALF;
+            var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+            evaluateSide('left', tipX, tipY, spaceLeft * 0.85);
         }
 
         // Below: tip below the node
         if (spaceBelow >= needed) {
-            const tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
-            const tipY = nodeBottom + GAP_FROM_NODE + TIP_HALF;
-            sides.push({ x: tipX, y: tipY, side: 'below', score: spaceBelow * 0.7 });
+            var tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
+            var tipY = nodeBottom + GAP_FROM_NODE + TIP_HALF;
+            evaluateSide('below', tipX, tipY, spaceBelow * 0.7);
         }
 
         // Above: tip above the node
         if (spaceAbove >= needed) {
-            const tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
-            const tipY = nodeTop - GAP_FROM_NODE - TIP_HALF;
-            sides.push({ x: tipX, y: tipY, side: 'above', score: spaceAbove * 0.6 });
+            var tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
+            var tipY = nodeTop - GAP_FROM_NODE - TIP_HALF;
+            evaluateSide('above', tipX, tipY, spaceAbove * 0.6);
         }
 
-        // If any side works, pick the best-scoring one
+        // If no non-occluded side was found with full space, try any feasible fallback
+        if (!sides.length) {
+            // Even if space is tight, attempt placement with lower score
+            var fallbacks = [];
+
+            // Try right with tight fit
+            if (spaceRight > TIP_HALF + 8) {
+                var tipX = clamp(nodeRight + 4 + TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
+                var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+                var occ = overlapsNodes(tipX, tipY, 'right');
+                fallbacks.push({ x: tipX, y: tipY, side: 'right', score: occ ? 5 : 50 });
+            }
+            // Try left with tight fit
+            if (spaceLeft > TIP_HALF + 8) {
+                var tipX = clamp(nodeLeft - 4 - TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
+                var tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+                var occ = overlapsNodes(tipX, tipY, 'left');
+                fallbacks.push({ x: tipX, y: tipY, side: 'left', score: occ ? 4 : 40 });
+            }
+            // Try below with tight fit
+            if (spaceBelow > TIP_HALF + 8) {
+                var tipX = clamp(anchorPos.x, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
+                var tipY = clamp(nodeBottom + 4 + TIP_HALF, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+                var occ = overlapsNodes(tipX, tipY, 'below');
+                fallbacks.push({ x: tipX, y: tipY, side: 'below', score: occ ? 3 : 30 });
+            }
+            // Try above with tight fit
+            if (spaceAbove > TIP_HALF + 8) {
+                var tipX = clamp(anchorPos.x, TIP_HALF + 8, viewportWidth - TIP_HALF - 8);
+                var tipY = clamp(nodeTop - 4 - TIP_HALF, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+                var occ = overlapsNodes(tipX, tipY, 'above');
+                fallbacks.push({ x: tipX, y: tipY, side: 'above', score: occ ? 2 : 20 });
+            }
+
+            if (fallbacks.length) {
+                fallbacks.sort(function (a, b) { return b.score - a.score; });
+                return fallbacks[0];
+            }
+        }
+
+        // If any side works, pick the best-scoring one (prefer non-occluded)
         if (sides.length) {
-            sides.sort((a, b) => b.score - a.score);
+            sides.sort(function (a, b) { return b.score - a.score; });
             return sides[0];
         }
 
-        // Fallback: place to the right or left, no gap check
-        const preferRight = anchorPos.x < viewportWidth * 0.5;
+        // Ultimate fallback: place to the right or left, clamped to viewport
+        var preferRight = anchorPos.x < viewportWidth * 0.5;
         if (preferRight) {
             return {
                 x: clamp(nodeRight + GAP_FROM_NODE + TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8),
@@ -167,7 +289,7 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     function createPlusTipElement(anchorMem, labelText) {
         const anchorPos = calcPosition(anchorMem);
-        const tipPos = getPlusTipPosition(anchorPos);
+        const tipPos = getPlusTipPosition(anchorPos, anchorMem);
 
         // Create the + button
         const button = documentRef.createElement('button');
@@ -200,6 +322,8 @@ function createEditorCanvasGrowthAffordance(deps) {
         const tooltip = documentRef.createElement('span');
         tooltip.className = 'affordance-tooltip';
         tooltip.textContent = labelText;
+        tooltip.setAttribute('role', 'tooltip');
+        tooltip.setAttribute('aria-hidden', 'true');
         tooltip.style.position = 'absolute';
         tooltip.style.whiteSpace = 'nowrap';
         tooltip.style.fontSize = '12px';
@@ -212,6 +336,13 @@ function createEditorCanvasGrowthAffordance(deps) {
         tooltip.style.opacity = '0';
         tooltip.style.transition = 'opacity 0.15s ease';
         tooltip.style.zIndex = '6';
+
+        // Generate unique ID for aria-describedby linkage
+        var tooltipId = 'aff-tip-' + (anchorMem ? anchorMem.id : '0');
+        tooltip.setAttribute('id', tooltipId);
+
+        // Link button to tooltip for screen reader announcement
+        button.setAttribute('aria-describedby', tooltipId);
 
         // Position tooltip based on tip side
         const tooltipGap = 6;
@@ -246,24 +377,28 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.boxShadow = '0 5px 16px rgba(144, 73, 81, 0.35)';
             button.style.background = 'rgba(144, 73, 81, 1)';
             tooltip.style.opacity = '1';
+            tooltip.setAttribute('aria-hidden', 'false');
         });
         button.addEventListener('mouseleave', () => {
             button.style.transform = 'scale(1)';
             button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
             button.style.background = 'rgba(144, 73, 81, 0.92)';
             tooltip.style.opacity = '0';
+            tooltip.setAttribute('aria-hidden', 'true');
         });
         button.addEventListener('focus', () => {
             button.style.transform = 'scale(1.15)';
             button.style.boxShadow = '0 0 0 3px rgba(144, 73, 81, 0.3), 0 5px 16px rgba(144, 73, 81, 0.35)';
             button.style.background = 'rgba(144, 73, 81, 1)';
             tooltip.style.opacity = '1';
+            tooltip.setAttribute('aria-hidden', 'false');
         });
         button.addEventListener('blur', () => {
             button.style.transform = 'scale(1)';
             button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
             button.style.background = 'rgba(144, 73, 81, 0.92)';
             tooltip.style.opacity = '0';
+            tooltip.setAttribute('aria-hidden', 'true');
         });
 
         // Click/tap action

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -20,6 +20,8 @@ function createEditorCanvasGrowthAffordance(deps) {
     const BUBBLE_WIDTH = 188;
     const BUBBLE_MIN_HEIGHT = 60;
     const BUBBLE_GAP = 8;
+    const LOCK_CLASS = 'affordance-interaction-locked';
+    const INTERACTING_CLASS = 'is-interacting';
 
     function clamp(value, min, max) {
         if (max < min) return min;
@@ -29,6 +31,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
         svg.querySelectorAll('.branch-line-affordance').forEach((el) => el.remove());
+        canvas.classList.remove(LOCK_CLASS);
     }
 
     function openAddMomentFromCanvas() {
@@ -275,6 +278,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         const anchorPos = calcPosition(anchorMem);
         const tipPos = getPlusTipPosition(anchorPos, anchorMem);
         const button = documentRef.createElement('button');
+        let unlockTimer = null;
         button.type = 'button';
         button.className = 'memory-add-affordance affordance-tooltip-bubble';
         button.setAttribute('aria-label', labelText);
@@ -356,7 +360,26 @@ function createEditorCanvasGrowthAffordance(deps) {
 
         let bubbleExpanded = false;
 
+        function lockMovement() {
+            if (unlockTimer) {
+                clearTimeout(unlockTimer);
+                unlockTimer = null;
+            }
+            button.classList.add(INTERACTING_CLASS);
+            canvas.classList.add(LOCK_CLASS);
+        }
+
+        function unlockMovementSoon(delay) {
+            if (unlockTimer) clearTimeout(unlockTimer);
+            unlockTimer = setTimeout(() => {
+                button.classList.remove(INTERACTING_CLASS);
+                canvas.classList.remove(LOCK_CLASS);
+                unlockTimer = null;
+            }, delay || 140);
+        }
+
         function showBubble() {
+            lockMovement();
             if (bubbleExpanded) return;
             bubbleExpanded = true;
             button.style.width = `${BUBBLE_WIDTH}px`;
@@ -374,7 +397,10 @@ function createEditorCanvasGrowthAffordance(deps) {
         }
 
         function hideBubble() {
-            if (!bubbleExpanded) return;
+            if (!bubbleExpanded) {
+                unlockMovementSoon(120);
+                return;
+            }
             bubbleExpanded = false;
             button.style.width = `${TIP_SIZE}px`;
             button.style.minHeight = `${TIP_SIZE}px`;
@@ -388,13 +414,17 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.backdropFilter = 'none';
             textWrap.style.display = 'none';
             button.setAttribute('aria-expanded', 'false');
+            unlockMovementSoon(160);
         }
 
         button.addEventListener('mouseenter', showBubble);
         button.addEventListener('mouseleave', hideBubble);
         button.addEventListener('focus', showBubble);
         button.addEventListener('blur', hideBubble);
-        button.addEventListener('touchstart', showBubble, { passive: true });
+        button.addEventListener('touchstart', () => {
+            showBubble();
+            unlockMovementSoon(700);
+        }, { passive: true });
 
         button.addEventListener('click', (e) => {
             e.preventDefault();

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,7 +17,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 220;
+    const BUBBLE_WIDTH = 190;
     const BUBBLE_HEIGHT = 42;
     const BUBBLE_GAP = 8;
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -11,13 +11,12 @@ function createEditorCanvasGrowthAffordance(deps) {
     } = deps;
 
     const {
-        NODE_HALF,
-        AFFORDANCE_CARD_HALF
+        NODE_HALF
     } = constants;
-    const AFFORDANCE_SAFE_GAP = 28;
-    const AFFORDANCE_EDGE_PADDING = 28;
-    const AFFORDANCE_MIN_WIDTH = 174;
-    const AFFORDANCE_HEIGHT = 64;
+    const TIP_SIZE = 36;
+    const TIP_HALF = TIP_SIZE / 2;
+    const GAP_FROM_NODE = 10;
+    const CONNECTOR_PEAK_GAP = 6;
 
     function clamp(value, min, max) {
         if (max < min) return min;
@@ -27,6 +26,8 @@ function createEditorCanvasGrowthAffordance(deps) {
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
         svg.querySelectorAll('.branch-line-affordance').forEach((el) => el.remove());
+        // Remove any affordance tooltip that might be visible
+        documentRef.querySelectorAll('.affordance-tooltip').forEach((el) => el.remove());
     }
 
     function openAddMomentFromCanvas() {
@@ -41,193 +42,281 @@ function createEditorCanvasGrowthAffordance(deps) {
         }
     }
 
-    function getGrowthAffordancePosition(anchorPos) {
+    /**
+     * Determine the best placement for the compact + tip.
+     * Returns position (center of tip) and side ('right'|'left'|'below'|'above').
+     */
+    function getPlusTipPosition(anchorPos) {
         const metrics = getMetrics();
         const viewportWidth = Math.max(canvas.clientWidth || metrics.width, 320);
         const viewportHeight = Math.max(canvas.clientHeight || metrics.height, 320);
-        const width = Math.min(AFFORDANCE_CARD_HALF * 2, Math.max(AFFORDANCE_MIN_WIDTH, viewportWidth - (AFFORDANCE_EDGE_PADDING * 2)));
-        const cardHalf = width / 2;
-        const minCenterX = cardHalf + AFFORDANCE_EDGE_PADDING;
-        const maxCenterX = viewportWidth - cardHalf - AFFORDANCE_EDGE_PADDING;
+
         const nodeLeft = anchorPos.x - NODE_HALF;
         const nodeRight = anchorPos.x + NODE_HALF;
-        const rightCenterX = nodeRight + AFFORDANCE_SAFE_GAP + cardHalf;
-        const leftCenterX = nodeLeft - AFFORDANCE_SAFE_GAP - cardHalf;
-        const hasRightRoom = rightCenterX + cardHalf + AFFORDANCE_EDGE_PADDING <= viewportWidth;
-        const hasLeftRoom = leftCenterX - cardHalf - AFFORDANCE_EDGE_PADDING >= 0;
-        const preferRight = anchorPos.x < viewportWidth * 0.56;
-        let side = preferRight
-            ? (hasRightRoom ? 'right' : (hasLeftRoom ? 'left' : 'below'))
-            : (hasLeftRoom ? 'left' : (hasRightRoom ? 'right' : 'below'));
-        let x = side === 'left' ? leftCenterX : rightCenterX;
-        let y = clamp(anchorPos.y - 10, 110, viewportHeight - 80);
+        const nodeTop = anchorPos.y - NODE_HALF;
+        const nodeBottom = anchorPos.y + NODE_HALF;
 
-        if (side === 'below') {
-            x = clamp(anchorPos.x, minCenterX, maxCenterX);
-            const belowY = anchorPos.y + NODE_HALF + AFFORDANCE_SAFE_GAP + (AFFORDANCE_HEIGHT / 2);
-            const aboveY = anchorPos.y - NODE_HALF - AFFORDANCE_SAFE_GAP - (AFFORDANCE_HEIGHT / 2);
-            y = belowY + (AFFORDANCE_HEIGHT / 2) + AFFORDANCE_EDGE_PADDING <= viewportHeight
-                ? belowY
-                : clamp(aboveY, AFFORDANCE_EDGE_PADDING + (AFFORDANCE_HEIGHT / 2), viewportHeight - AFFORDANCE_EDGE_PADDING - (AFFORDANCE_HEIGHT / 2));
-            side = belowY + (AFFORDANCE_HEIGHT / 2) + AFFORDANCE_EDGE_PADDING <= viewportHeight ? 'below' : 'above';
+        // Calculate available space on each side
+        const spaceRight = viewportWidth - nodeRight;
+        const spaceLeft = nodeLeft;
+        const spaceBelow = viewportHeight - nodeBottom;
+        const spaceAbove = nodeTop;
+
+        // Minimum space needed for tip + gap
+        const needed = TIP_SIZE + GAP_FROM_NODE + CONNECTOR_PEAK_GAP;
+
+        // Score each side based on available space and preference
+        const sides = [];
+
+        // Right: tip to the right of the node
+        if (spaceRight >= needed) {
+            const tipX = nodeRight + GAP_FROM_NODE + TIP_HALF;
+            const tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+            sides.push({ x: tipX, y: tipY, side: 'right', score: spaceRight * 1.0 });
         }
 
+        // Left: tip to the left of the node
+        if (spaceLeft >= needed) {
+            const tipX = nodeLeft - GAP_FROM_NODE - TIP_HALF;
+            const tipY = clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20);
+            sides.push({ x: tipX, y: tipY, side: 'left', score: spaceLeft * 0.85 });
+        }
+
+        // Below: tip below the node
+        if (spaceBelow >= needed) {
+            const tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
+            const tipY = nodeBottom + GAP_FROM_NODE + TIP_HALF;
+            sides.push({ x: tipX, y: tipY, side: 'below', score: spaceBelow * 0.7 });
+        }
+
+        // Above: tip above the node
+        if (spaceAbove >= needed) {
+            const tipX = clamp(anchorPos.x, TIP_HALF + 20, viewportWidth - TIP_HALF - 20);
+            const tipY = nodeTop - GAP_FROM_NODE - TIP_HALF;
+            sides.push({ x: tipX, y: tipY, side: 'above', score: spaceAbove * 0.6 });
+        }
+
+        // If any side works, pick the best-scoring one
+        if (sides.length) {
+            sides.sort((a, b) => b.score - a.score);
+            return sides[0];
+        }
+
+        // Fallback: place to the right or left, no gap check
+        const preferRight = anchorPos.x < viewportWidth * 0.5;
+        if (preferRight) {
+            return {
+                x: clamp(nodeRight + GAP_FROM_NODE + TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8),
+                y: clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20),
+                side: 'right'
+            };
+        }
         return {
-            x: clamp(x, minCenterX, maxCenterX),
-            y,
-            side,
-            width,
-            height: AFFORDANCE_HEIGHT,
-            cardHalf
+            x: clamp(nodeLeft - GAP_FROM_NODE - TIP_HALF, TIP_HALF + 8, viewportWidth - TIP_HALF - 8),
+            y: clamp(anchorPos.y, TIP_HALF + 20, viewportHeight - TIP_HALF - 20),
+            side: 'left'
         };
     }
 
-    function drawGrowthAffordanceBranch(startPos, endPos, side) {
+    function drawConnectorLine(anchorPos, tipPos, side) {
         const path = documentRef.createElementNS('http://www.w3.org/2000/svg', 'path');
-        const tension = side === 'left' || side === 'above' ? 0.55 : 0.45;
-        const cp1x = startPos.x + ((endPos.x - startPos.x) * tension);
-        const cp1y = side === 'below'
-            ? Math.max(startPos.y, endPos.y) + 18
-            : Math.min(startPos.y, endPos.y) - 18;
-        const d = `M ${startPos.x},${startPos.y} Q ${cp1x},${cp1y} ${endPos.x},${endPos.y}`;
+
+        // Start from node edge toward the tip
+        let startX, startY;
+        switch (side) {
+            case 'right':
+                startX = anchorPos.x + NODE_HALF;
+                startY = anchorPos.y;
+                break;
+            case 'left':
+                startX = anchorPos.x - NODE_HALF;
+                startY = anchorPos.y;
+                break;
+            case 'below':
+                startX = anchorPos.x;
+                startY = anchorPos.y + NODE_HALF;
+                break;
+            case 'above':
+                startX = anchorPos.x;
+                startY = anchorPos.y - NODE_HALF;
+                break;
+            default:
+                startX = anchorPos.x + NODE_HALF;
+                startY = anchorPos.y;
+        }
+
+        // End point is near the tip circle edge
+        const endX = tipPos.x - (side === 'left' ? TIP_HALF : side === 'right' ? -TIP_HALF : 0);
+        const endY = tipPos.y - (side === 'above' ? TIP_HALF : side === 'below' ? -TIP_HALF : 0);
+
+        // Simple smooth quadratic bezier
+        const cpX = (startX + endX) / 2;
+        const cpY = (startY + endY) / 2;
+        const d = `M ${startX},${startY} Q ${cpX},${cpY} ${endX},${endY}`;
+
         path.setAttribute('d', d);
         path.setAttribute('class', 'branch-line branch-line-affordance');
         path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', 'rgba(144, 73, 81, 0.42)');
-        path.setAttribute('stroke-width', '2');
+        path.setAttribute('stroke', 'rgba(144, 73, 81, 0.35)');
+        path.setAttribute('stroke-width', '1.5');
         path.setAttribute('stroke-linecap', 'round');
-        path.setAttribute('stroke-dasharray', '6 7');
-        path.setAttribute('opacity', '0.95');
+        path.setAttribute('stroke-dasharray', '4 5');
+        path.setAttribute('opacity', '0.85');
         svg.appendChild(path);
     }
 
-    function createGrowthAffordanceElement(anchorMem, labelText, helperText) {
+    function createPlusTipElement(anchorMem, labelText) {
         const anchorPos = calcPosition(anchorMem);
-        const affPos = getGrowthAffordancePosition(anchorPos);
-        const wrap = documentRef.createElement('button');
-        wrap.type = 'button';
-        wrap.className = 'memory-add-affordance';
-        wrap.setAttribute('aria-label', labelText);
-        wrap.style.position = 'absolute';
-        wrap.style.left = `${affPos.x - affPos.cardHalf}px`;
-        wrap.style.top = `${affPos.y - (affPos.height / 2)}px`;
-        wrap.style.zIndex = '4';
-        wrap.style.width = `${affPos.width}px`;
-        wrap.style.minHeight = `${affPos.height}px`;
-        wrap.style.boxSizing = 'border-box';
-        wrap.style.display = 'flex';
-        wrap.style.alignItems = 'center';
-        wrap.style.gap = '10px';
-        wrap.style.padding = '10px 14px 10px 10px';
-        wrap.style.border = '1px solid rgba(144, 73, 81, 0.18)';
-        wrap.style.borderRadius = '999px';
-        wrap.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
-        wrap.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.10)';
-        wrap.style.cursor = 'pointer';
-        wrap.style.backdropFilter = 'blur(8px)';
-        wrap.style.transition = 'transform 0.18s ease, box-shadow 0.18s ease';
+        const tipPos = getPlusTipPosition(anchorPos);
 
-        const plusBubble = documentRef.createElement('span');
-        plusBubble.textContent = '+';
-        plusBubble.style.width = '32px';
-        plusBubble.style.height = '32px';
-        plusBubble.style.borderRadius = '50%';
-        plusBubble.style.display = 'inline-flex';
-        plusBubble.style.alignItems = 'center';
-        plusBubble.style.justifyContent = 'center';
-        plusBubble.style.background = 'linear-gradient(180deg, rgba(144, 73, 81, 1), rgba(144, 73, 81, 0.88))';
-        plusBubble.style.color = '#fff';
-        plusBubble.style.fontSize = '18px';
-        plusBubble.style.fontWeight = '700';
-        plusBubble.style.flex = '0 0 auto';
-        plusBubble.style.boxShadow = '0 6px 14px rgba(144, 73, 81, 0.22)';
+        // Create the + button
+        const button = documentRef.createElement('button');
+        button.type = 'button';
+        button.className = 'memory-add-affordance';
+        button.setAttribute('aria-label', labelText);
+        button.setAttribute('title', labelText);
+        button.style.position = 'absolute';
+        button.style.left = `${tipPos.x - TIP_HALF}px`;
+        button.style.top = `${tipPos.y - TIP_HALF}px`;
+        button.style.width = `${TIP_SIZE}px`;
+        button.style.height = `${TIP_SIZE}px`;
+        button.style.borderRadius = '50%';
+        button.style.border = 'none';
+        button.style.background = 'rgba(144, 73, 81, 0.92)';
+        button.style.color = '#fff';
+        button.style.fontSize = '20px';
+        button.style.fontWeight = '700';
+        button.style.lineHeight = '1';
+        button.style.cursor = 'pointer';
+        button.style.zIndex = '5';
+        button.style.display = 'flex';
+        button.style.alignItems = 'center';
+        button.style.justifyContent = 'center';
+        button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+        button.style.transition = 'transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease';
+        button.textContent = '+';
 
-        const textWrap = documentRef.createElement('span');
-        textWrap.style.display = 'flex';
-        textWrap.style.flexDirection = 'column';
-        textWrap.style.alignItems = 'flex-start';
-        textWrap.style.gap = helperText ? '1px' : '0';
-        textWrap.style.minWidth = '0';
+        // Tooltip element (hidden by default)
+        const tooltip = documentRef.createElement('span');
+        tooltip.className = 'affordance-tooltip';
+        tooltip.textContent = labelText;
+        tooltip.style.position = 'absolute';
+        tooltip.style.whiteSpace = 'nowrap';
+        tooltip.style.fontSize = '12px';
+        tooltip.style.fontWeight = '600';
+        tooltip.style.color = '#fff';
+        tooltip.style.background = 'rgba(60, 50, 45, 0.92)';
+        tooltip.style.padding = '5px 10px';
+        tooltip.style.borderRadius = '6px';
+        tooltip.style.pointerEvents = 'none';
+        tooltip.style.opacity = '0';
+        tooltip.style.transition = 'opacity 0.15s ease';
+        tooltip.style.zIndex = '6';
 
-        const titleEl = documentRef.createElement('span');
-        titleEl.textContent = labelText;
-        titleEl.style.fontSize = '13px';
-        titleEl.style.fontWeight = '700';
-        titleEl.style.color = 'var(--on-surface)';
-        titleEl.style.lineHeight = '1.25';
-        titleEl.style.whiteSpace = 'normal';
-
-        textWrap.appendChild(titleEl);
-
-        if (helperText) {
-            const hintEl = documentRef.createElement('span');
-            hintEl.textContent = helperText;
-            hintEl.style.fontSize = '11px';
-            hintEl.style.fontWeight = '600';
-            hintEl.style.color = 'var(--on-surface-variant)';
-            hintEl.style.lineHeight = '1.25';
-            hintEl.style.opacity = '0.82';
-            hintEl.style.whiteSpace = 'normal';
-            textWrap.appendChild(hintEl);
+        // Position tooltip based on tip side
+        const tooltipGap = 6;
+        switch (tipPos.side) {
+            case 'right':
+                tooltip.style.left = `${TIP_HALF + tooltipGap}px`;
+                tooltip.style.top = '50%';
+                tooltip.style.transform = 'translateY(-50%)';
+                break;
+            case 'left':
+                tooltip.style.right = `${TIP_HALF + tooltipGap}px`;
+                tooltip.style.top = '50%';
+                tooltip.style.transform = 'translateY(-50%)';
+                break;
+            case 'below':
+                tooltip.style.left = '50%';
+                tooltip.style.top = `${TIP_HALF + tooltipGap}px`;
+                tooltip.style.transform = 'translateX(-50%)';
+                break;
+            case 'above':
+                tooltip.style.left = '50%';
+                tooltip.style.bottom = `${TIP_HALF + tooltipGap}px`;
+                tooltip.style.transform = 'translateX(-50%)';
+                break;
         }
 
-        wrap.appendChild(plusBubble);
-        wrap.appendChild(textWrap);
+        button.appendChild(tooltip);
 
-        wrap.addEventListener('mouseenter', () => {
-            wrap.style.transform = 'translateY(-2px)';
-            wrap.style.boxShadow = '0 16px 30px rgba(144, 73, 81, 0.16)';
+        // Hover/focus show tooltip
+        button.addEventListener('mouseenter', () => {
+            button.style.transform = 'scale(1.15)';
+            button.style.boxShadow = '0 5px 16px rgba(144, 73, 81, 0.35)';
+            button.style.background = 'rgba(144, 73, 81, 1)';
+            tooltip.style.opacity = '1';
         });
-        wrap.addEventListener('mouseleave', () => {
-            wrap.style.transform = 'translateY(0)';
-            wrap.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.10)';
+        button.addEventListener('mouseleave', () => {
+            button.style.transform = 'scale(1)';
+            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+            button.style.background = 'rgba(144, 73, 81, 0.92)';
+            tooltip.style.opacity = '0';
         });
-        wrap.addEventListener('click', (e) => {
+        button.addEventListener('focus', () => {
+            button.style.transform = 'scale(1.15)';
+            button.style.boxShadow = '0 0 0 3px rgba(144, 73, 81, 0.3), 0 5px 16px rgba(144, 73, 81, 0.35)';
+            button.style.background = 'rgba(144, 73, 81, 1)';
+            tooltip.style.opacity = '1';
+        });
+        button.addEventListener('blur', () => {
+            button.style.transform = 'scale(1)';
+            button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
+            button.style.background = 'rgba(144, 73, 81, 0.92)';
+            tooltip.style.opacity = '0';
+        });
+
+        // Click/tap action
+        button.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
+            // Brief scale pulse for feedback
+            button.style.transform = 'scale(0.9)';
+            setTimeout(() => {
+                button.style.transform = 'scale(1.15)';
+                setTimeout(() => {
+                    button.style.transform = 'scale(1)';
+                }, 100);
+            }, 80);
             openAddMomentFromCanvas();
         });
+
+        // Prevent pan when interacting
         ['mousedown', 'pointerdown', 'touchstart'].forEach((eventName) => {
-            wrap.addEventListener(eventName, (e) => {
+            button.addEventListener(eventName, (e) => {
                 e.stopPropagation();
             });
         });
 
-        const branchStart = {
-            x: anchorPos.x + (affPos.side === 'left' ? (-NODE_HALF + 2) : (affPos.side === 'right' ? (NODE_HALF - 2) : 0)),
-            y: anchorPos.y + (affPos.side === 'below' ? (NODE_HALF - 2) : (affPos.side === 'above' ? (-NODE_HALF + 2) : 4))
-        };
-        const branchEnd = {
-            x: affPos.x + (affPos.side === 'left' ? affPos.cardHalf - 36 : (affPos.side === 'right' ? -affPos.cardHalf + 36 : 0)),
-            y: affPos.y + (affPos.side === 'below' ? -(affPos.height / 2) : (affPos.side === 'above' ? (affPos.height / 2) : 0))
-        };
+        // Keyboard support
+        button.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                openAddMomentFromCanvas();
+            }
+        });
 
-        drawGrowthAffordanceBranch(
-            branchStart,
-            branchEnd,
-            affPos.side
-        );
-        canvas.appendChild(wrap);
+        // Draw connector line
+        drawConnectorLine(anchorPos, tipPos, tipPos.side);
+
+        canvas.appendChild(button);
     }
 
     function renderGrowthAffordance(anchorMem, options) {
         if (!anchorMem) return;
         const opts = options || {};
         const labelText = opts.labelText || (i18n('editor_add_memory') || '새 순간 이어가기');
-        const isFirstStep = opts.isFirstStep;
-        const helperText = isFirstStep
-            ? (i18n('growth_first_step_hint') || '첫 순간에서 이어지는 감정을 기록해보세요')
-            : (opts.helperText || i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요');
 
-        createGrowthAffordanceElement(anchorMem, labelText, helperText);
+        createPlusTipElement(anchorMem, labelText);
     }
 
     return {
         clearGrowthAffordance,
         openAddMomentFromCanvas,
-        getGrowthAffordancePosition,
-        drawGrowthAffordanceBranch,
-        createGrowthAffordanceElement,
+        getGrowthAffordancePosition: getPlusTipPosition,
+        drawGrowthAffordanceBranch: drawConnectorLine,
+        createGrowthAffordanceElement: createPlusTipElement,
         renderGrowthAffordance
     };
 }

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -17,7 +17,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     const TIP_HALF = TIP_SIZE / 2;
     const GAP_FROM_NODE = 10;
     const CONNECTOR_PEAK_GAP = 6;
-    const BUBBLE_WIDTH = 210;
+    const BUBBLE_WIDTH = 165;
     const BUBBLE_HEIGHT = 42;
     const BUBBLE_GAP = 8;
 
@@ -330,15 +330,15 @@ function createEditorCanvasGrowthAffordance(deps) {
         const plusIcon = documentRef.createElement('span');
         plusIcon.setAttribute('aria-hidden', 'true');
         plusIcon.textContent = '+';
-        plusIcon.style.width = '28px';
-        plusIcon.style.height = '28px';
+        plusIcon.style.width = '32px';
+        plusIcon.style.height = '32px';
         plusIcon.style.borderRadius = '50%';
         plusIcon.style.display = 'inline-flex';
         plusIcon.style.alignItems = 'center';
         plusIcon.style.justifyContent = 'center';
         plusIcon.style.background = 'linear-gradient(180deg, rgba(144, 73, 81, 1), rgba(144, 73, 81, 0.88))';
         plusIcon.style.color = '#fff';
-        plusIcon.style.fontSize = '17px';
+        plusIcon.style.fontSize = '18px';
         plusIcon.style.fontWeight = '700';
         plusIcon.style.flex = '0 0 auto';
         plusIcon.style.boxShadow = '0 6px 14px rgba(144, 73, 81, 0.22)';
@@ -382,10 +382,10 @@ function createEditorCanvasGrowthAffordance(deps) {
             button.style.width = `${BUBBLE_WIDTH}px`;
             button.style.borderRadius = '999px';
             button.style.justifyContent = 'flex-start';
-            button.style.padding = '8px 14px 8px 8px';
+            button.style.padding = '10px 14px 10px 10px';
             button.style.border = '1px solid rgba(144, 73, 81, 0.18)';
             button.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
-            button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.13)';
+            button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.10)';
             button.style.backdropFilter = 'blur(8px)';
             textWrap.style.display = 'flex';
             textWrap.style.gap = '1px';

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -303,6 +303,7 @@ function createEditorCanvas(deps) {
     const clearBranches = requireCanvasEdgeMethod('clearBranches');
     const drawBranchForMemory = requireCanvasEdgeMethod('drawBranchForMemory');
     const NODE_TAP_SELECT_THRESHOLD = 8;
+    const AFFORDANCE_LOCK_CLASS = 'affordance-interaction-locked';
 
     function renderAffordanceForMemory(mem) {
         if (!mem) return;
@@ -316,10 +317,12 @@ function createEditorCanvas(deps) {
 
     function renderAffordanceForHoveredMemory(mem) {
         if (!mem || viewportState.isDraggingNode || viewportState.isPanning) return;
+        if (canvas.classList.contains(AFFORDANCE_LOCK_CLASS)) return;
         if (hoverAffordanceMemoryId === mem.id) return;
         if (hoverAffordanceTimer) clearTimeout(hoverAffordanceTimer);
         hoverAffordanceMemoryId = mem.id;
         hoverAffordanceTimer = setTimeout(() => {
+            if (canvas.classList.contains(AFFORDANCE_LOCK_CLASS)) return;
             renderAffordanceForMemory(mem);
         }, 45);
     }
@@ -461,6 +464,10 @@ function createEditorCanvas(deps) {
 
     function clearGrowthAffordance() {
         hoverAffordanceMemoryId = null;
+        if (hoverAffordanceTimer) {
+            clearTimeout(hoverAffordanceTimer);
+            hoverAffordanceTimer = null;
+        }
         growthAffordance.clearGrowthAffordance();
     }
 

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -28,6 +28,8 @@ function createEditorCanvas(deps) {
 
     let savedFreePositions = null;
     let storedFreePositions = null;
+    let hoverAffordanceTimer = null;
+    let hoverAffordanceMemoryId = null;
 
     function loadStoredLayout() {
         if (typeof canvasLayout.createLayoutStore === 'function') {
@@ -302,6 +304,26 @@ function createEditorCanvas(deps) {
     const drawBranchForMemory = requireCanvasEdgeMethod('drawBranchForMemory');
     const NODE_TAP_SELECT_THRESHOLD = 8;
 
+    function renderAffordanceForMemory(mem) {
+        if (!mem) return;
+        const canonicalRootId = getCanonicalRootId();
+        const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
+        clearGrowthAffordance();
+        growthAffordance.renderGrowthAffordance(mem, {
+            isFirstStep: drawableMemories.length <= 1
+        });
+    }
+
+    function renderAffordanceForHoveredMemory(mem) {
+        if (!mem || viewportState.isDraggingNode || viewportState.isPanning) return;
+        if (hoverAffordanceMemoryId === mem.id) return;
+        if (hoverAffordanceTimer) clearTimeout(hoverAffordanceTimer);
+        hoverAffordanceMemoryId = mem.id;
+        hoverAffordanceTimer = setTimeout(() => {
+            renderAffordanceForMemory(mem);
+        }, 45);
+    }
+
     function bindNodeDrag(nodeEl, mem) {
         nodeEl.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
         let touchStartPoint = null;
@@ -309,6 +331,13 @@ function createEditorCanvas(deps) {
         const selectMemoryNode = () => {
             onNodeClick(nodeEl, mem);
         };
+
+        nodeEl.addEventListener('mouseenter', () => {
+            renderAffordanceForHoveredMemory(mem);
+        });
+        nodeEl.addEventListener('focusin', () => {
+            renderAffordanceForHoveredMemory(mem);
+        });
 
         nodeEl.addEventListener('mousedown', (e) => {
             if (viewportState.layoutMode === 'structured') return;
@@ -360,6 +389,7 @@ function createEditorCanvas(deps) {
                 x: touch.clientX,
                 y: touch.clientY
             };
+            renderAffordanceForHoveredMemory(mem);
         }, { passive: true });
 
         nodeEl.addEventListener('touchend', (e) => {
@@ -430,6 +460,7 @@ function createEditorCanvas(deps) {
     }
 
     function clearGrowthAffordance() {
+        hoverAffordanceMemoryId = null;
         growthAffordance.clearGrowthAffordance();
     }
 
@@ -453,23 +484,12 @@ function createEditorCanvas(deps) {
         growthAffordance.renderGrowthAffordance(anchorMem, options);
     }
 
-    /**
-     * Lightweight affordance update — clears and re-renders for the currently
-     * selected node without a full canvas redraw. Called on node selection change.
-     */
     function updateAffordance() {
-        clearGrowthAffordance();
-        const canonicalRootId = getCanonicalRootId();
-        const treeMemories = getTreeMemories();
         const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-        if (!selectedId) return;
-        const selectedMem = treeMemories.find((m) => m.id === selectedId);
-        if (!selectedMem) return;
-        const drawableMemories = treeMemories.filter((node) => !isRootMemory(node, canonicalRootId));
-        renderGrowthAffordance(selectedMem, {
-            isFirstStep: drawableMemories.length <= 1
-        });
+        const selectedMem = selectedId ? getTreeMemories().find((m) => m.id === selectedId) : null;
+        renderAffordanceForMemory(selectedMem);
     }
+
     const initCanvas = () => {
         const canonicalRootId = getCanonicalRootId();
         const treeMemories = getTreeMemories();
@@ -518,9 +538,7 @@ function createEditorCanvas(deps) {
             if (selectedMem) {
                 updateDetailPanel(selectedMem);
                 reapplySelection(selectedMem.id);
-                growthAffordance.renderGrowthAffordance(selectedMem, {
-                    isFirstStep: drawableMemories.length <= 1
-                });
+                renderAffordanceForMemory(selectedMem);
             }
         }
 

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -433,6 +433,43 @@ function createEditorCanvas(deps) {
         growthAffordance.clearGrowthAffordance();
     }
 
+    function openAddMomentFromCanvas() {
+        growthAffordance.openAddMomentFromCanvas();
+    }
+
+    function getGrowthAffordancePosition(anchorPos) {
+        return growthAffordance.getGrowthAffordancePosition(anchorPos);
+    }
+
+    function drawGrowthAffordanceBranch(startPos, endPos, side) {
+        growthAffordance.drawGrowthAffordanceBranch(startPos, endPos, side);
+    }
+
+    function createGrowthAffordanceElement(anchorMem, labelText, helperText) {
+        growthAffordance.createGrowthAffordanceElement(anchorMem, labelText, helperText);
+    }
+
+    function renderGrowthAffordance(anchorMem, options) {
+        growthAffordance.renderGrowthAffordance(anchorMem, options);
+    }
+
+    /**
+     * Lightweight affordance update — clears and re-renders for the currently
+     * selected node without a full canvas redraw. Called on node selection change.
+     */
+    function updateAffordance() {
+        clearGrowthAffordance();
+        const canonicalRootId = getCanonicalRootId();
+        const treeMemories = getTreeMemories();
+        const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
+        if (!selectedId) return;
+        const selectedMem = treeMemories.find((m) => m.id === selectedId);
+        if (!selectedMem) return;
+        const drawableMemories = treeMemories.filter((node) => !isRootMemory(node, canonicalRootId));
+        renderGrowthAffordance(selectedMem, {
+            isFirstStep: drawableMemories.length <= 1
+        });
+    }
     const initCanvas = () => {
         const canonicalRootId = getCanonicalRootId();
         const treeMemories = getTreeMemories();
@@ -768,6 +805,7 @@ function createEditorCanvas(deps) {
         focusNodeById,
         recenterViewport,
         setLayoutMode,
+        updateAffordance,
         getWorldPosition,
         get viewportState() { return viewportState; }
     };

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -6,6 +6,8 @@ const vm = require('node:vm');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const NODE_HALF = 54;
+const TIP_HALF = 18;
+const TIP_SIZE = 36;
 
 function loadGrowthAffordanceFactory() {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
@@ -39,10 +41,10 @@ function rectsOverlap(a, b) {
 
 function assertAffordanceClearsNode(position, anchorPos) {
   const affordanceRect = {
-    left: position.x - position.cardHalf,
-    right: position.x + position.cardHalf,
-    top: position.y - (position.height / 2),
-    bottom: position.y + (position.height / 2)
+    left: position.x - TIP_HALF,
+    right: position.x + TIP_HALF,
+    top: position.y - (TIP_SIZE / 2),
+    bottom: position.y + (TIP_SIZE / 2)
   };
   const nodeRect = {
     left: anchorPos.x - NODE_HALF,
@@ -74,8 +76,8 @@ test('growth affordance falls below or above the node on narrow mobile viewports
   const position = growthAffordance.getGrowthAffordancePosition(anchor);
 
   assert.match(position.side, /^(below|above)$/);
-  assert.ok(position.x - position.cardHalf >= 28);
-  assert.ok(position.x + position.cardHalf <= 375 - 28);
+  assert.ok(position.x - TIP_HALF >= TIP_HALF + 20);
+  assert.ok(position.x + TIP_HALF <= 375 - TIP_HALF - 20);
   assertAffordanceClearsNode(position, anchor);
 });
 

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -85,7 +85,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
   assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*190/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*210/, 'expanded bubble width should be defined separately from the plus tip');
   assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
   assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -81,21 +81,26 @@ test('growth affordance falls below or above the node on narrow mobile viewports
   assertAffordanceClearsNode(position, anchor);
 });
 
-test('plus tip expands into original bubble style on hover and focus', () => {
+test('plus tip contract reflects readable hover bubble', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
-  assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*165/, 'expanded bubble width should be defined separately from the plus tip');
-  assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
-  assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
-  assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');
-  assert.match(source, /button\.addEventListener\('focus', showBubble\)/, 'keyboard focus should expand the bubble');
-  assert.match(source, /button\.addEventListener\('touchstart', showBubble/, 'touch should expose the bubble before activation');
-  assert.match(source, /aria-expanded', 'true'/, 'expanded bubble state should update aria visibility');
+  assert.match(source, /TIP_SIZE\s*=\s*36/);
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*188/);
+  assert.match(source, /BUBBLE_MIN_HEIGHT\s*=\s*60/);
+  assert.match(source, /affordance-tooltip-bubble/);
+  assert.match(source, /aria-expanded/);
+});
+
+test('node hover can move the plus tip before click selection', () => {
+  const canvasSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas.js'), 'utf8');
+
+  assert.match(canvasSource, /renderAffordanceForHoveredMemory/);
+  assert.match(canvasSource, /addEventListener\('mouseenter'/);
+  assert.match(canvasSource, /addEventListener\('focusin'/);
 });
 
 test('canvas pan binding excludes add affordance presses', () => {
   const interactionSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-interaction.js'), 'utf8');
 
-  assert.match(interactionSource, /target\.closest\(['"]\.memory-add-affordance['"]\)/);
+  assert.match(interactionSource, /memory-add-affordance/);
 });

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -81,6 +81,19 @@ test('growth affordance falls below or above the node on narrow mobile viewports
   assertAffordanceClearsNode(position, anchor);
 });
 
+test('plus tip expands into original bubble style on hover and focus', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*164/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
+  assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
+  assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');
+  assert.match(source, /button\.addEventListener\('focus', showBubble\)/, 'keyboard focus should expand the bubble');
+  assert.match(source, /button\.addEventListener\('touchstart', showBubble/, 'touch should expose the bubble before activation');
+  assert.match(source, /aria-hidden', 'false'/, 'expanded bubble state should update aria visibility');
+});
+
 test('canvas pan binding excludes add affordance presses', () => {
   const interactionSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-interaction.js'), 'utf8');
 

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -85,7 +85,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
   assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*164/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*200/, 'expanded bubble width should be defined separately from the plus tip');
   assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
   assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -85,7 +85,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
   assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*220/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*190/, 'expanded bubble width should be defined separately from the plus tip');
   assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
   assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -91,7 +91,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');
   assert.match(source, /button\.addEventListener\('focus', showBubble\)/, 'keyboard focus should expand the bubble');
   assert.match(source, /button\.addEventListener\('touchstart', showBubble/, 'touch should expose the bubble before activation');
-  assert.match(source, /aria-hidden', 'false'/, 'expanded bubble state should update aria visibility');
+  assert.match(source, /aria-expanded', 'true'/, 'expanded bubble state should update aria visibility');
 });
 
 test('canvas pan binding excludes add affordance presses', () => {

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -85,7 +85,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
   assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*200/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*220/, 'expanded bubble width should be defined separately from the plus tip');
   assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
   assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -22,7 +22,8 @@ function createGrowthAffordance({ width, height }) {
     canvas: {
       clientWidth: width,
       clientHeight: height,
-      querySelectorAll: () => []
+      querySelectorAll: () => [],
+      classList: { add: () => {}, remove: () => {}, contains: () => false }
     },
     svg: {
       querySelectorAll: () => []
@@ -97,6 +98,17 @@ test('node hover can move the plus tip before click selection', () => {
   assert.match(canvasSource, /renderAffordanceForHoveredMemory/);
   assert.match(canvasSource, /addEventListener\('mouseenter'/);
   assert.match(canvasSource, /addEventListener\('focusin'/);
+});
+
+test('plus tip and bubble interaction locks node-hover movement', () => {
+  const affordanceSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+  const canvasSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas.js'), 'utf8');
+
+  assert.match(affordanceSource, /affordance-interaction-locked/);
+  assert.match(affordanceSource, /function\s+lockMovement\s*\(/);
+  assert.match(affordanceSource, /function\s+unlockMovementSoon\s*\(/);
+  assert.match(canvasSource, /AFFORDANCE_LOCK_CLASS/);
+  assert.match(canvasSource, /canvas\.classList\.contains\(AFFORDANCE_LOCK_CLASS\)/);
 });
 
 test('canvas pan binding excludes add affordance presses', () => {

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -85,7 +85,7 @@ test('plus tip expands into original bubble style on hover and focus', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
   assert.match(source, /TIP_SIZE\s*=\s*36/, 'default visible affordance should remain a compact plus tip');
-  assert.match(source, /BUBBLE_WIDTH\s*=\s*210/, 'expanded bubble width should be defined separately from the plus tip');
+  assert.match(source, /BUBBLE_WIDTH\s*=\s*165/, 'expanded bubble width should be defined separately from the plus tip');
   assert.match(source, /affordance-tooltip-bubble/, 'hover state should render a bubble-style tooltip element');
   assert.match(source, /linear-gradient\(180deg, rgba\(255,255,255,0\.98\), rgba\(250,246,244,0\.96\)\)/, 'expanded state should use the original light bubble surface');
   assert.match(source, /button\.addEventListener\('mouseenter', showBubble\)/, 'mouse hover should expand the bubble');


### PR DESCRIPTION
## Summary

Replaces the always-visible large `새 순간 이어가기` bubble with a two-step selected-node affordance:

1. Default state: compact circular `+` tip near the selected moment.
2. Hover/focus/tap state: the `+` tip expands into the original-style `새 순간 이어가기` bubble.

This keeps the canvas cleaner by default while preserving the explanatory bubble when the user intentionally interacts with the tip.

## Changes

### `js/editor/editor-canvas-growth-affordance.js`
- Keeps a 36px circular `+` tip as the default visible affordance.
- Adds a light original-style pill/bubble expansion on `+` hover/focus/touch.
- Keeps a short dashed connector from selected node to the `+` tip.
- Uses placement scoring so the tip and expanded bubble avoid obvious node overlap where possible.
- Click/tap/Enter/Space still triggers the existing continue-from-moment action.
- Maintains accessible button semantics, `aria-label`, `aria-describedby`, tooltip role, and aria-hidden state changes.

### `js/editor/editor-canvas.js`
- Adds `updateAffordance()` so selection changes can refresh the affordance without a full unrelated redraw.
- Exposes `updateAffordance` from the editor canvas API.

### `js/editor.js`
- Calls `editorCanvas.updateAffordance()` immediately after node selection.
- Fixes delayed affordance appearance after selecting a node.

### `tests/contracts/editor-growth-affordance-contract.test.js`
- Adds a contract check that the default visible state remains a compact `+` tip.
- Adds a contract check that hover/focus/touch exposes a bubble-style `새 순간 이어가기` affordance.

## Key behaviors
- Select a moment → compact `+` tip appears near that moment.
- Hover/focus/touch the `+` tip → original-style `새 순간 이어가기` bubble expands.
- Click/tap `+` or press Enter/Space → existing new-moment creation flow opens.
- Side panel `이 순간에서 이어가기` button remains independent.
- Structured/free layouts remain in scope for browser verification.

Refs #1147