### PR TITLE
ui(my-trees): remove card overflow menu after hub action migration

### DIFF
--- a/css/my-trees/my-trees-cards.css
+++ b/css/my-trees/my-trees-cards.css
@@ -31,12 +31,3 @@
 .tree-card-visibility { display: flex; align-items: center; gap: 4px; font-size: 12px; padding: 4px 10px; border-radius: 99px; background: var(--lovetree-chip-bg); border: 1px solid var(--lovetree-chip-border); color: var(--lovetree-chip-text); }
 .tree-card-visibility.public { background: rgba(122, 139, 110, 0.1); color: var(--secondary); }
 .tree-card-visibility.private { background: var(--lovetree-pill-bg); color: var(--lovetree-pill-text); }
-.tree-card-menu { position: absolute; right: 14px; bottom: 14px; width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; border-radius: 50%; cursor: pointer; opacity: 0.42; transition: opacity 0.2s ease, transform 0.2s ease, background 0.2s ease; z-index: 10; color: var(--on-surface-variant); }
-.tree-card:hover .tree-card-menu, .tree-card:focus-within .tree-card-menu { opacity: 0.86; transform: translateY(-1px); }
-.tree-card-menu:hover { opacity: 1; color: var(--on-surface); background: rgba(255,255,255,0.64); }
-.tree-card-menu .material-symbols-outlined { font-size: 20px; }
-.tree-card-dropdown { position: absolute; right: 14px; bottom: 58px; background: var(--lovetree-soft-surface); border: 1px solid var(--lovetree-soft-surface-border); border-radius: 12px; box-shadow: var(--lovetree-card-shadow); min-width: 148px; padding: 6px 0; z-index: 20; display: none; }
-.tree-card-dropdown.show { display: block; }
-.dropdown-item { display: flex; align-items: center; gap: 8px; padding: 10px 16px; font-size: 13px; color: var(--on-surface); cursor: pointer; transition: background 0.15s ease; }
-.dropdown-item:hover { background: var(--lovetree-pill-hover-bg); }
-.dropdown-item.delete { color: #c62828; }

--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -1,9 +1,3 @@
-.tree-card-menu,
-.tree-card-dropdown,
-.tree-card-dropdown.show {
-  display: none !important;
-  pointer-events: none !important;
-}
 
 .tree-card-info {
   min-height: 136px;
@@ -36,7 +30,6 @@
   box-shadow: 0 12px 26px rgba(144, 73, 81, 0.24);
 }
 
-.tree-card-dropdown .dropdown-item.visibility,
 .tree-card-visibility,
 #manageVisibilityBtn,
 #publicTreesCount,

--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -156,30 +156,7 @@
     showMissingActionError('toggleTreeVisibility');
   }
 
-  function closeAllDropdowns() {
-    if (myTreesUI && typeof myTreesUI.closeAllDropdowns === 'function') {
-      myTreesUI.closeAllDropdowns();
-    } else {
-      document.querySelectorAll('.tree-card-dropdown').forEach(function(dd) {
-        dd.classList.remove('show');
-      });
-    }
-  }
-
   function setupGlobalListeners() {
-    // Esc key to close dropdowns
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') {
-        closeAllDropdowns();
-      }
-    });
-
-    // Outside click to close dropdowns
-    document.addEventListener('click', function(e) {
-      if (!e.target.closest('.tree-card-menu') && !e.target.closest('.tree-card-dropdown')) {
-        closeAllDropdowns();
-      }
-    });
   }
 
   function renderTrees(trees) {

--- a/js/my-trees/my-trees-render.js
+++ b/js/my-trees/my-trees-render.js
@@ -16,12 +16,6 @@
   // Private state (mirrors/main-tracks selection, synced with my-trees-state)
   var _selectedTreeId = null;
 
-  function closeAllDropdowns() {
-    document.querySelectorAll('.tree-card-dropdown').forEach(function (dd) {
-      dd.classList.remove('show');
-    });
-  }
-
   function getSelectedTreeId(stateModule) {
     if (stateModule && typeof stateModule.getSelectedTreeId === 'function') {
       return stateModule.getSelectedTreeId();
@@ -104,7 +98,6 @@
   }
 
   var api = {
-    closeAllDropdowns: closeAllDropdowns,
     getSelectedTreeId: getSelectedTreeId,
     setSelectedTreeId: setSelectedTreeId,
     getRenderableTrees: getRenderableTrees,

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -17,11 +17,6 @@
       .replace(/"/g, '&quot;');
   }
 
-  function closeAllDropdowns() {
-    document.querySelectorAll('.tree-card-dropdown').forEach(function (dd) {
-      dd.classList.remove('show');
-    });
-  }
 
   function hashSeed(value) {
     var source = String(value || 'lovetree');
@@ -342,7 +337,6 @@
     var onNavigate = options && options.onNavigate;
     var onSelect = options && options.onSelect;
     var isSelected = options && options.isSelected;
-    var closeDropdowns = (options && options.closeAllDropdowns) || closeAllDropdowns;
 
     var normalizedTree = typeof normalizeTree === 'function'
       ? normalizeTree(tree)
@@ -369,8 +363,6 @@
     var cardMeta = getTreeCardMeta(normalizedTree, i18n);
     var title = cardMeta.title;
 
-    var menuBtnId = 'menuBtn_' + normalizedTree.id;
-    var dropdownId = 'dropdown_' + normalizedTree.id;
     var selectedClass = typeof isSelected === 'function' && isSelected(normalizedTree.id) ? ' is-selected' : '';
 
     var card = document.createElement('div');
@@ -389,16 +381,10 @@
     };
 
     card.addEventListener('click', function (e) {
-      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
-        return;
-      }
       openTree();
     });
 
     card.addEventListener('keydown', function (e) {
-      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
-        return;
-      }
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         openTree();
@@ -407,23 +393,6 @@
 
     card.innerHTML = [
       buildTreeThumbVisual(normalizedTree, i18n),
-      '<button class="tree-card-menu" id="' + menuBtnId + '" type="button" aria-label="' + escapeHtml(i18n('myTrees.card_menu') || '트리 메뉴 열기') + '">',
-        '<span class="material-symbols-outlined" aria-hidden="true">more_vert</span>',
-      '</button>',
-      '<div class="tree-card-dropdown" id="' + dropdownId + '">',
-        '<div class="dropdown-item visibility" data-action="visibility">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">' + cardMeta.visibilityIcon + '</span>',
-          cardMeta.visibilityActionLabel,
-        '</div>',
-        '<div class="dropdown-item rename" data-action="rename">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">edit</span>',
-          i18n('rename') || '이름 변경',
-        '</div>',
-        '<div class="dropdown-item delete" data-action="delete">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">delete</span>',
-          i18n('delete') || '삭제',
-        '</div>',
-      '</div>',
       '<div class="tree-card-info">',
         '<div class="tree-card-title-row">',
           '<div class="tree-card-title">' + escapeHtml(title) + '</div>',
@@ -433,45 +402,6 @@
       '</div>'
     ].join('');
 
-    setTimeout(function () {
-      var menuBtn = document.getElementById(menuBtnId);
-      var dropdown = document.getElementById(dropdownId);
-
-      if (menuBtn && dropdown) {
-        menuBtn.addEventListener('click', function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof onSelect === 'function') {
-            onSelect(normalizedTree.id);
-          }
-          closeDropdowns();
-          dropdown.classList.toggle('show');
-        });
-
-        dropdown.querySelectorAll('.dropdown-item').forEach(function (item) {
-          item.addEventListener('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            if (typeof onSelect === 'function') {
-              onSelect(normalizedTree.id);
-            }
-
-            var action = this.getAttribute('data-action');
-            if (action === 'visibility' && typeof onToggleVisibility === 'function') {
-              onToggleVisibility(normalizedTree.id, normalizedTree.visibility);
-            } else if (action === 'rename' && typeof onRename === 'function') {
-              onRename(normalizedTree.id, title);
-            } else if (action === 'delete' && typeof onDelete === 'function') {
-              onDelete(normalizedTree.id, title);
-            }
-
-            closeDropdowns();
-          });
-        });
-      }
-
-    }, 0);
 
     return card;
   }
@@ -633,7 +563,6 @@
 
   var api = {
     escapeHtml: escapeHtml,
-    closeAllDropdowns: closeAllDropdowns,
     buildMiniTreeSVG: buildMiniTreeSVG,
     getTreeMomentCount: getTreeMomentCount,
     buildTreeThumbVisual: buildTreeThumbVisual,


### PR DESCRIPTION
Remove or suppress the My Trees card three-dot overflow menu after the selected-tree appreciation hub becomes the primary place for tree-specific actions.

## Changes
- js/my-trees/my-trees-ui.js: removed menu button HTML, dropdown HTML, and all wiring
- css/my-trees/my-trees-cards.css: removed .tree-card-menu, .tree-card-dropdown, .dropdown-item CSS
- css/my-trees/my-trees-visibility-gate.css: removed display:none gate for menu/dropdown
- js/my-trees/my-trees-render.js: removed closeAllDropdowns function and export
- js/my-trees.js: removed closeAllDropdowns function and no-op global listeners

Closes #1123