### PR TITLE
ui(my-trees): hide remaining visibility controls (Refs #1122)

### DIFF
--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -48,3 +48,4 @@
 [data-i18n="visibility_make_private"] {
   display: none !important;
 }
+#manageSelectedTreeMeta { display: none !important; }


### PR DESCRIPTION
Suppress leftover public-private visibility UI elements until subscription gating is defined.

Most visibility controls were already hidden by PR #1124 and #1137 (merged).
This PR adds one missing CSS rule for #manageSelectedTreeMeta in the management summary bar.

- css/my-trees/my-trees-visibility-gate.css: added #manageSelectedTreeMeta display:none