### PR TITLE
UX: align My Trees initial batch loading to two-row grid

### DIFF
--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -477,7 +477,7 @@
   }
 
   // Issue #616: first-batch rendering constants
-  var FIRST_BATCH_SIZE = 6;
+  var FIRST_BATCH_SIZE = 4;
   var BATCH_SIZE = 6;
   var currentVisibleCount = 0;
   var totalTreesCount = 0;
@@ -532,7 +532,8 @@
   // Issue #616: Render next batch of trees
   function renderNextBatch(grid, buildTreeCardFn, setState, stateEnum) {
     var startIndex = currentVisibleCount;
-    var endIndex = Math.min(startIndex + BATCH_SIZE, totalTreesCount);
+    var batchSize = currentVisibleCount === 0 ? FIRST_BATCH_SIZE : BATCH_SIZE;
+    var endIndex = Math.min(startIndex + batchSize, totalTreesCount);
     
     for (var i = startIndex; i < endIndex; i++) {
       var tree = allTreesData[i];


### PR DESCRIPTION
## Purpose

Adjust My Trees incremental list rendering so the initial visible batch matches the two-column card grid.

Refs #1120

## Changes

1. **`FIRST_BATCH_SIZE` changed from 6 → 4** — initial render now shows 4 cards (2 rows × 2 columns)
2. **`BATCH_SIZE` stays at 6** — scroll-continuation batches remain 6 for smooth loading
3. **`renderNextBatch` now uses `FIRST_BATCH_SIZE` for the first batch** — previously it used `BATCH_SIZE` for everything, ignoring `FIRST_BATCH_SIZE`. Now:\n   - When `currentVisibleCount === 0` → uses `FIRST_BATCH_SIZE` (4)\n   - When `currentVisibleCount > 0` → uses `BATCH_SIZE` (6)

## Verification

- [x] npm test — all 274 tests pass
- [x] Incremental batch loading preserved via IntersectionObserver
- [x] Sorting/re-rendering resets visible batch safely (resets `currentVisibleCount = 0`)
- [x] Empty/error/auth states unaffected
- [x] Card click/navigation behavior unchanged

## Files changed

- `js/my-trees/my-trees-ui.js`