### PR TITLE
ui(my-trees): align card footer with Browse engagement pattern (#1134)

### DIFF
--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -6,34 +6,91 @@
 }
 
 .tree-card-info {
-  min-height: 136px;
+  min-height: 96px;
 }
 
-.tree-card-info::after {
-  content: "트리 열기";
+/* Compact footer row matching Browse engagement pattern */
+.tree-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 18px 14px;
+  border-top: 1px solid rgba(144,73,81,0.08);
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  min-width: 0;
+}
+
+.tree-card-footer-left,
+.tree-card-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tree-card-footer-right {
+  justify-content: flex-end;
+  overflow: hidden;
+  flex: 1 1 auto;
+  gap: 6px;
+}
+
+.tree-card-footer-metrics {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 820;
+  white-space: nowrap;
+}
+
+.tree-card-footer-metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+}
+
+.tree-card-footer-metric .material-symbols-outlined {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.tree-card-open-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  align-self: flex-end;
-  min-width: 96px;
-  min-height: 34px;
-  margin-top: auto;
-  padding: 0 16px;
+  gap: 4px;
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 0 9px;
   border-radius: 999px;
-  background: var(--primary, #904951);
-  color: #fff;
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  box-shadow: 0 10px 22px rgba(144, 73, 81, 0.18);
+  border: 1px solid rgba(144, 73, 81, 0.14);
+  background: rgba(255, 250, 248, 0.84);
+  color: var(--primary);
+  font-size: 11.5px;
+  font-weight: 850;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
   pointer-events: none;
-  transition: transform 0.16s ease, box-shadow 0.16s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.tree-card:hover .tree-card-info::after,
-.tree-card:focus-visible .tree-card-info::after {
+.tree-card-open-link .material-symbols-outlined {
+  font-size: 14px;
+}
+
+.tree-card:hover .tree-card-open-link,
+.tree-card:focus-visible .tree-card-open-link {
+  background: rgba(144, 73, 81, 0.92);
+  border-color: rgba(144, 73, 81, 0.24);
+  color: var(--surface-container-lowest);
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(144, 73, 81, 0.24);
 }
 
 .tree-card-dropdown .dropdown-item.visibility,

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -1,6 +1,6 @@
 /**
  * LoveBud - My Trees UI Helpers
- * v20260421-4
+ * v20260514-1134-1
  *
  * Tree card rendering and summary UI utilities
  */
@@ -45,6 +45,20 @@
       0;
     count = Number(count);
     return Number.isFinite(count) ? count : 0;
+  }
+
+  function getTreeViewCount(tree) {
+    if (!tree) return 0;
+    var keys = [
+      'viewCount', 'viewsCount', 'views', 'view_count', 'views_count',
+      'visitorCount', 'visitorsCount', 'visitCount', 'visitsCount', 'visits',
+      'openCount', 'opensCount', 'open_count'
+    ];
+    for (var i = 0; i < keys.length; i++) {
+      var value = Number(tree[keys[i]]);
+      if (Number.isFinite(value) && value >= 0) return value;
+    }
+    return 0;
   }
 
   function getVisibilityActionLabel(tree, i18n) {
@@ -366,6 +380,8 @@
       normalizedTree.representativeMemo = normalizedTree.representativeMemo || (tree && (tree.representativeMemo || tree.representative_memo || ''));
     }
 
+    var momentCount = Number(normalizedTree.memoryCount) || 0;
+    var viewCount = getTreeViewCount(tree);
     var cardMeta = getTreeCardMeta(normalizedTree, i18n);
     var title = cardMeta.title;
 
@@ -430,6 +446,28 @@
         '</div>',
         '<div class="tree-card-subcopy">' + cardMeta.mood + '</div>',
         cardMeta.privateBadgeHtml,
+      '</div>',
+      '<div class="tree-card-footer">',
+        '<div class="tree-card-footer-left">',
+          '<div class="tree-card-footer-metrics">',
+            '<span class="tree-card-footer-metric" title="' + escapeHtml((i18n('myTrees.moment_count') || '순간') + ' ' + momentCount) + '">',
+              '<span class="material-symbols-outlined" aria-hidden="true">auto_awesome</span>',
+              '<span>' + momentCount + '</span>',
+            '</span>',
+            (viewCount > 0
+              ? '<span class="tree-card-footer-metric" title="' + escapeHtml((i18n('myTrees.view_count') || '조회수') + ' ' + viewCount) + '">'
+                  + '<span class="material-symbols-outlined" aria-hidden="true">visibility</span>'
+                  + '<span>' + viewCount + '</span>'
+                + '</span>'
+              : ''),
+          '</div>',
+        '</div>',
+        '<div class="tree-card-footer-right">',
+          '<span class="tree-card-open-link">',
+            '<span class="material-symbols-outlined" aria-hidden="true">account_tree</span>',
+            (i18n('myTrees.card_open') || '트리 열기'),
+          '</span>',
+        '</div>',
       '</div>'
     ].join('');
 
@@ -636,6 +674,7 @@
     closeAllDropdowns: closeAllDropdowns,
     buildMiniTreeSVG: buildMiniTreeSVG,
     getTreeMomentCount: getTreeMomentCount,
+    getTreeViewCount: getTreeViewCount,
     buildTreeThumbVisual: buildTreeThumbVisual,
     updateManageSummary: updateManageSummary,
     buildTreeCard: buildTreeCard,

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
-  <link rel="stylesheet" href="../css/my-trees.css?v=20260513-1138-1">
+  <link rel="stylesheet" href="../css/my-trees.css?v=20260514-1134-1">
   <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
 </head>
@@ -141,7 +141,7 @@
   <script src="../js/api/auth-policy.js?v=20260420-1"></script>
   <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
   <script src="../js/postgres-client.js?v=20260422-1"></script>
-  <script src="../js/my-trees/my-trees-ui.js?v=20260509-910-2"></script>
+  <script src="../js/my-trees/my-trees-ui.js?v=20260514-1134-2"></script>
   <script src="../js/my-trees/my-trees-actions.js?v=20260427-1"></script>
   <script src="../js/my-trees/my-trees-data.js?v=20260422-4"></script>
   <script src="../js/my-trees/my-trees-state.js?v=20260421-4"></script>


### PR DESCRIPTION


## Summary

Aligns My Trees card footer with the Browse engagement pattern from PR #1139. Adds a compact footer row with moment count, view count (when available), and a styled '트리 열기' CTA matching Browse's icon sizing, spacing, and bottom-row treatment.

## Changes

### JS: `js/my-trees/my-trees-ui.js`
- Added `getTreeViewCount()` helper (checks `viewCount`, `viewsCount`, `views`, `view_count`, `visits`, `openCount`, etc.)
- Added compact footer to `buildTreeCard()` with:
  - Moment count (`auto_awesome` icon)
  - View count (`visibility` icon, only if > 0)
  - '트리 열기' link (`account_tree` icon, matching Browse's `.tree-card-open-link`)
- Exported `getTreeViewCount` in public API
- Bumped version to v20260514-1134-1

### CSS: `css/my-trees/my-trees-visibility-gate.css`
- Removed `::after` pseudo-element approach for '트리 열기'
- Reduced `.tree-card-info` min-height from 136px to 96px
- Added `.tree-card-footer` row styles (flex, space-between, border-top)
- Added `.tree-card-footer-metrics` / `.tree-card-footer-metric` layout
- Added `.tree-card-open-link` pill styling matching Browse pattern:
  - 14px icons, 8px metric gap, 3px icon-text gap
  - Hover: solid primary background, white text, lift effect
  - `pointer-events: none` (card click handles navigation)

### HTML: `pages/my-trees.html`
- Bumped CSS cache-bust to `v20260514-1134-1`
- Bumped JS cache-bust to `v20260514-1134-2`

## Design consistency

| Feature | Browse (search-card-renderer.js) | My Trees (new) |
|---|---|---|
| Icon size | 14px | 14px |
| Metric gap | 8px | 8px |
| Icon-text gap | 3px | 3px |
| Separator | border-top | border-top |
| CTA pill | tree-card-open-link | tree-card-open-link |
| CTA hover | Solid primary bg + white text + lift | Same |

## Omitted (per issue scope)
- ❌ Visibility controls
- ❌ Overflow menu / three-dot menu
- ❌ Admin/management surface styling
- ❌ Backend/API/schema changes

Closes #1134

## Verification

- [x] `npm test` passes (274/274)
- [x] Card click preserves tree-open behavior
- [x] Moment count renders in footer
- [x] View count renders if data available
- [x] No visibility controls exposed
- [x] No overflow menu
- [x] Desktop layout passes
