### PR TITLE
Product/UI: add My Trees selected tree appreciation hub (#1121)

### DIFF
--- a/css/my-trees.css
+++ b/css/my-trees.css
@@ -5,3 +5,4 @@
 @import url('./my-trees/my-trees-create-modal.css');
 @import url('./my-trees/my-trees-visibility-gate.css');
 @import url('./my-trees/my-trees-responsive.css');
+@import url('./my-trees/my-trees-preview-hub.css');

--- a/css/my-trees/my-trees-cards.css
+++ b/css/my-trees/my-trees-cards.css
@@ -1,6 +1,7 @@
 .trees-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
 .tree-card { display: block; position: relative; background: var(--lovetree-soft-surface); border-radius: var(--lovetree-card-radius); padding: 0; box-shadow: var(--lovetree-card-shadow); border: 1px solid var(--lovetree-soft-surface-border); overflow: hidden; cursor: pointer; transition: border-color 0.12s ease, box-shadow 0.12s ease; text-decoration: none; color: inherit; }
 .tree-card:hover { box-shadow: 0 20px 50px rgba(144, 73, 81, 0.12); border-color: var(--primary-soft); }
+.tree-card.is-selected { border-color: var(--primary); box-shadow: 0 0 0 2px var(--primary), 0 20px 50px rgba(144, 73, 81, 0.18); }
 .tree-card-thumb { width: 100%; height: 184px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; padding: 18px; }
 .tree-card-thumb::after { content: ""; position: absolute; inset: auto 0 0; height: 44%; background: linear-gradient(to top, rgba(75,64,57,0.18), transparent); pointer-events: none; z-index: 1; }
 .tree-card-thumb-glow { position: absolute; inset: auto auto 18px 18px; width: 128px; height: 128px; border-radius: 50%; filter: blur(10px); }

--- a/css/my-trees/my-trees-preview-hub.css
+++ b/css/my-trees/my-trees-preview-hub.css
@@ -1,0 +1,504 @@
+/* LoveBud - My Trees Appreciation Hub
+ * Follows Browse preview-sidebar visual grammar.
+ * Compact panel that appears when a My Trees card is selected.
+ */
+
+/* ── Hub layout wrapper ── */
+
+.my-trees-with-hub {
+    display: grid;
+    grid-template-columns: 1fr 400px;
+    gap: 32px;
+    align-items: start;
+}
+
+.my-trees-hub-panel {
+    position: sticky;
+    top: 96px;
+    height: fit-content;
+    width: 100%;
+    max-width: 100%;
+    background:
+        radial-gradient(circle at 28% 12%, rgba(255, 248, 246, 0.96), transparent 38%),
+        radial-gradient(circle at 80% 22%, rgba(242, 234, 228, 0.72), transparent 28%),
+        linear-gradient(180deg, rgba(255, 249, 245, 0.92), rgba(244, 248, 238, 0.96));
+    padding: 30px 24px;
+    border-radius: 2.25rem;
+    border: 1px solid rgba(144, 73, 81, 0.1);
+    box-shadow:
+        0 24px 60px rgba(75, 64, 57, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(14px);
+    min-width: 0;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.my-trees-hub-panel > * {
+    position: relative;
+    z-index: 1;
+}
+
+.my-trees-hub-panel.is-empty .my-trees-hub-content,
+.my-trees-hub-panel.is-empty .my-trees-hub-actions {
+    display: none;
+}
+
+.my-trees-hub-panel:not(.is-empty) .my-trees-hub-placeholder {
+    display: none;
+}
+
+/* ── Hub header ── */
+
+.my-trees-hub-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 14px;
+    border-bottom: 1px solid rgba(144, 73, 81, 0.08);
+    margin-bottom: 10px;
+    min-width: 0;
+}
+
+.my-trees-hub-header h3 {
+    font-size: 1.68rem;
+    font-weight: 900;
+    color: var(--on-surface);
+    margin: 0;
+    letter-spacing: -0.02em;
+}
+
+.my-trees-hub-badge {
+    font-size: 11px;
+    font-weight: 900;
+    color: var(--primary);
+    background: rgba(144, 73, 81, 0.08);
+    padding: 6px 11px;
+    border-radius: 99px;
+    white-space: nowrap;
+    box-shadow: 0 8px 18px rgba(144, 73, 81, 0.08);
+}
+
+/* ── Hub title group ── */
+
+.my-trees-hub-title-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+/* ── Placeholder state ── */
+
+.my-trees-hub-placeholder {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 4px;
+    padding: 22px;
+    color: var(--on-surface-variant);
+    font-size: 14px;
+    line-height: 1.65;
+    text-align: center;
+}
+
+.my-trees-hub-placeholder p:first-child {
+    color: var(--on-surface);
+    font-weight: 800;
+}
+
+.my-trees-hub-placeholder p {
+    margin: 0;
+    line-height: 1.7;
+}
+
+/* ── Hub tree title ── */
+
+.my-trees-hub-tree-title {
+    font-size: 1.34rem;
+    font-weight: 900;
+    color: var(--on-surface);
+    line-height: 1.18;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+/* ── Hub meta badge ── */
+
+.my-trees-hub-meta-badge {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    margin-top: 8px;
+    padding: 6px 10px;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.58);
+    color: var(--on-surface-variant);
+    font-weight: 800;
+    font-size: 12.5px;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+    gap: 4px;
+}
+
+.my-trees-hub-meta-badge .material-symbols-outlined {
+    font-size: 14px;
+}
+
+/* ── Hub representative block ── */
+
+.my-trees-hub-rep {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 16px;
+    padding: 16px 18px;
+    border-radius: 1.55rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.66), rgba(255, 248, 245, 0.52));
+    border: 1px solid rgba(144, 73, 81, 0.10);
+    box-shadow: 0 14px 28px rgba(75, 64, 57, 0.07), inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+.my-trees-hub-rep-label {
+    font-size: 12px;
+    font-weight: 800;
+    color: var(--on-surface-variant);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.my-trees-hub-rep-label .material-symbols-outlined {
+    font-size: 14px;
+}
+
+.my-trees-hub-rep-title {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--on-surface);
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+}
+
+.my-trees-hub-rep-memo {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--on-surface-variant);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: keep-all;
+}
+
+/* ── Hub moment flow list ── */
+
+.my-trees-hub-flow {
+    margin-top: 16px;
+}
+
+.my-trees-hub-flow-label {
+    font-size: 12px;
+    font-weight: 800;
+    color: var(--on-surface-variant);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.my-trees-hub-flow-label .material-symbols-outlined {
+    font-size: 14px;
+}
+
+.my-trees-hub-flow-list {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 7px;
+    min-width: 0;
+    max-width: 100%;
+    align-items: stretch;
+}
+
+.my-trees-hub-flow-stage {
+    display: flex !important;
+    align-items: center !important;
+    gap: 6px !important;
+    min-width: 0;
+    max-width: 100%;
+    min-height: 42px !important;
+    justify-content: flex-start;
+    overflow: hidden;
+    width: 100%;
+    padding: 8px 10px !important;
+    border-radius: 12px !important;
+    background: rgba(255, 255, 255, 0.56) !important;
+    border: 1px solid rgba(144, 73, 81, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66);
+    color: var(--on-surface-variant) !important;
+    font-size: 12.5px !important;
+    line-height: 1.35;
+}
+
+.my-trees-hub-flow-stage-icon {
+    font-size: 14px;
+    flex: 0 0 auto;
+}
+
+.my-trees-hub-flow-stage-label {
+    min-width: 0;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    line-height: 1.35;
+}
+
+/* ── Hub flow controls ── */
+
+.my-trees-hub-flow-controls {
+    margin-top: 11px;
+}
+
+.my-trees-hub-flow-toggle {
+    display: inline;
+    color: var(--primary);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.2;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    text-decoration: underline;
+    text-decoration-color: rgba(144, 73, 81, 0.25);
+    text-underline-offset: 3px;
+}
+
+.my-trees-hub-flow-toggle:hover {
+    color: var(--primary-vibrant);
+    text-decoration-color: var(--primary);
+}
+
+.my-trees-hub-flow-toggle:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* ── Hub summary line ── */
+
+.my-trees-hub-summary {
+    font-size: 14px;
+    color: var(--on-surface-variant);
+    line-height: 1.6;
+    padding: 0 4px;
+    margin-top: 14px;
+}
+
+/* ── Hub actions ── */
+
+.my-trees-hub-actions {
+    margin-top: 18px;
+}
+
+.my-trees-hub-open-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 54px;
+    margin-top: 20px;
+    border: 1px solid rgba(144, 73, 81, 0.16);
+    box-shadow: 0 16px 28px rgba(144, 73, 81, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.28);
+    padding: 14px 24px;
+    background: var(--primary);
+    color: white;
+    border-radius: 999px;
+    font-weight: 800;
+    font-size: 14px;
+    cursor: pointer;
+    text-decoration: none;
+    gap: 8px;
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.my-trees-hub-open-btn:hover {
+    background: var(--primary-vibrant);
+    transform: translateY(-1px);
+}
+
+.my-trees-hub-open-btn:active {
+    transform: translateY(0);
+}
+
+.my-trees-hub-open-btn .material-symbols-outlined {
+    font-size: 16px;
+}
+
+/* ── Hub empty/no-moments state ── */
+
+.my-trees-hub-no-moments {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 20px;
+    background: linear-gradient(135deg, var(--surface-container-low), white);
+    border-radius: 1rem;
+    color: var(--on-surface-variant);
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.my-trees-hub-no-moments .material-symbols-outlined {
+    font-size: 36px;
+    color: var(--primary);
+    margin-bottom: 4px;
+}
+
+.my-trees-hub-no-moments strong {
+    font-size: 14px;
+    font-weight: 800;
+    color: var(--on-surface);
+}
+
+.my-trees-hub-no-moments p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+/* ── Responsive: tablet ── */
+
+@media (max-width: 1024px) {
+    .my-trees-with-hub {
+        grid-template-columns: 1fr 340px;
+        gap: 24px;
+    }
+
+    .my-trees-hub-panel {
+        padding: 24px 20px;
+        border-radius: 2rem;
+    }
+
+    .my-trees-hub-header h3 {
+        font-size: 1.42rem;
+    }
+
+    .my-trees-hub-tree-title {
+        font-size: 1.15rem;
+    }
+
+    .my-trees-hub-flow-list {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+/* ── Responsive: mobile ── */
+
+@media (max-width: 768px) {
+    .my-trees-with-hub {
+        grid-template-columns: 1fr;
+    }
+
+    .my-trees-hub-panel {
+        position: relative;
+        top: auto;
+        margin-top: 20px;
+        padding: 20px 16px;
+        border-radius: 1.5rem;
+    }
+
+    .my-trees-hub-header h3 {
+        font-size: 1.34rem;
+    }
+
+    .my-trees-hub-tree-title {
+        font-size: 1.1rem;
+    }
+
+    .my-trees-hub-meta-badge {
+        font-size: 11.5px;
+        padding: 5px 9px;
+    }
+
+    .my-trees-hub-rep {
+        padding: 14px 16px;
+    }
+
+    .my-trees-hub-flow-stage {
+        min-height: 40px !important;
+        padding: 8px 9px !important;
+        font-size: 12px !important;
+    }
+
+    .my-trees-hub-goto-btn {
+        min-height: 48px;
+        font-size: 15px;
+    }
+}
+
+/* ── Responsive: 375px ── */
+
+@media (max-width: 375px) {
+    .my-trees-hub-panel {
+        padding: 16px 14px;
+        border-radius: 1.25rem;
+    }
+
+    .my-trees-hub-header h3 {
+        font-size: 1.2rem;
+    }
+
+    .my-trees-hub-tree-title {
+        font-size: 1.05rem;
+    }
+
+    .my-trees-hub-meta-badge {
+        font-size: 10.5px;
+        padding: 4px 8px;
+        margin-top: 6px;
+    }
+
+    .my-trees-hub-rep {
+        padding: 12px 14px;
+    }
+
+    .my-trees-hub-flow-stage {
+        min-height: 36px !important;
+        padding: 6px 8px !important;
+        font-size: 11.5px !important;
+        line-height: 1.3 !important;
+        border-radius: 10px !important;
+    }
+
+    .my-trees-hub-flow-list {
+        gap: 5px;
+    }
+
+    .my-trees-hub-flow-controls {
+        margin-top: 8px;
+    }
+
+    .my-trees-hub-flow-toggle {
+        font-size: 12px;
+    }
+
+    .my-trees-hub-open-btn {
+        min-height: 48px;
+        margin-top: 16px;
+        font-size: 13px;
+    }
+}

--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -193,6 +193,11 @@
         onRename: renameTree,
         onDelete: deleteTree,
         onToggleVisibility: toggleTreeVisibility,
+        onSelect: function(tree) {
+          if (window.LoveBudMyTreesPreviewHub && typeof window.LoveBudMyTreesPreviewHub.onCardClick === 'function') {
+            window.LoveBudMyTreesPreviewHub.onCardClick(tree);
+          }
+        },
         setLastTreesData: function(data) {
           lastTreesData = data;
         }
@@ -293,6 +298,20 @@
     if (!user || !user.uid) return;
 
     setupGlobalListeners();
+
+    // Initialize My Trees appreciation hub
+    if (window.LoveBudMyTreesPreviewHub && typeof window.LoveBudMyTreesPreviewHub.init === 'function') {
+      window.LoveBudMyTreesPreviewHub.init({
+        stateModule: myTreesState,
+        onOpenTree: function(tree) {
+          if (tree && tree.id) {
+            var basePath = (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath)
+              ? window.LoveBudPath.getBasePath() : 'pages/';
+            window.location.href = basePath + 'editor?treeId=' + encodeURIComponent(tree.id);
+          }
+        }
+      });
+    }
 
     var sortSelect = document.getElementById('sortTreesSelect');
     if (sortSelect) {

--- a/js/my-trees/my-trees-preview-hub.js
+++ b/js/my-trees/my-trees-preview-hub.js
@@ -1,0 +1,491 @@
+/**
+ * LoveBud - My Trees Appreciation Hub
+ * v20260514-1
+ *
+ * Selected-tree appreciation hub for My Trees page.
+ * Adapted from Browse's preview hub (search-preview-renderer.js) grammar.
+ *
+ * Responsibilities:
+ * - Show a compact appreciation panel when a tree card is selected
+ * - Display: tree title, moment count, representative info, flow preview
+ * - "트리 열기" primary action → opens Editor
+ * - No management controls (rename, delete, visibility)
+ */
+
+(function () {
+    'use strict';
+
+    /* ── Constants ── */
+
+    var VISIBLE_FLOW_MOMENT_COUNT = 4;
+
+    /* ── Escape HTML ── */
+
+    function escapeHtml(value) {
+        if (!value) return '';
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    /* ── i18n helpers ── */
+
+    function t(key, fallback) {
+        if (typeof window.t === 'function') {
+            var val = window.t(key);
+            if (typeof val === 'string' && val.trim() && val !== key) {
+                return val;
+            }
+        }
+        return fallback || key;
+    }
+
+    function getLocale() {
+        var locale = window.i18n && window.i18n.currentLang;
+        if (locale) return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+        var htmlLang = document.documentElement && document.documentElement.lang;
+        if (htmlLang) return String(htmlLang).toLowerCase().startsWith('en') ? 'en' : 'ko';
+        return 'ko';
+    }
+
+    function i18nHub(key, fallbackKo, fallbackEn) {
+        return getLocale() === 'en' ? fallbackEn : fallbackKo;
+    }
+
+    /* ── Private state ── */
+
+    var _selectedTree = null;
+    var _expandedFlowKey = null;
+    var _stateModule = null;
+    var _onOpenTree = null;
+    var _treeGridContainer = null;
+
+    /* ── Exposed setter for tree grid container ── */
+
+    function setTreeGridContainer(selectorOrEl) {
+        if (typeof selectorOrEl === 'string') {
+            _treeGridContainer = document.querySelector(selectorOrEl);
+        } else {
+            _treeGridContainer = selectorOrEl;
+        }
+    }
+
+    /* ── Get hub panel elements ── */
+
+    function getEls() {
+        var panel = document.getElementById('myTreesHubPanel');
+        if (!panel) return null;
+
+        return {
+            panel: panel,
+            header: document.getElementById('myTreesHubHeader'),
+            badge: document.getElementById('myTreesHubBadge'),
+            placeholder: document.getElementById('myTreesHubPlaceholder'),
+            content: document.getElementById('myTreesHubContent'),
+            treeTitle: document.getElementById('myTreesHubTreeTitle'),
+            metaBadge: document.getElementById('myTreesHubMetaBadge'),
+            repBlock: document.getElementById('myTreesHubRep'),
+            repLabel: document.getElementById('myTreesHubRepLabel'),
+            repTitle: document.getElementById('myTreesHubRepTitle'),
+            repMemo: document.getElementById('myTreesHubRepMemo'),
+            flowSection: document.getElementById('myTreesHubFlow'),
+            flowLabel: document.getElementById('myTreesHubFlowLabel'),
+            flowList: document.getElementById('myTreesHubFlowList'),
+            flowControls: document.getElementById('myTreesHubFlowControls'),
+            summary: document.getElementById('myTreesHubSummary'),
+            actions: document.getElementById('myTreesHubActions'),
+            openBtn: document.getElementById('myTreesHubOpenBtn'),
+            noMoments: document.getElementById('myTreesHubNoMoments')
+        };
+    }
+
+    /* ── Get tree key for flow expansion tracking ── */
+
+    function getTreeKey(tree) {
+        if (!tree) return '';
+        if (tree.id != null && tree.id !== '') {
+            return String(tree.id);
+        }
+        var title = String(tree.title || '').trim();
+        var memoryCount = Array.isArray(tree.memories) ? tree.memories.length : Number(tree.memoryCount || 0);
+        return title + ':' + memoryCount;
+    }
+
+    /* ── Get moment count ── */
+
+    function getTreeMomentCount(tree) {
+        if (!tree) return 0;
+        var count = tree.memoryCount ||
+            tree.memory_count ||
+            tree.nodeCount ||
+            tree.node_count ||
+            (Array.isArray(tree.memories) ? tree.memories.length : undefined) ||
+            (Array.isArray(tree.nodes) ? tree.nodes.length : undefined) ||
+            0;
+        count = Number(count);
+        return Number.isFinite(count) ? count : 0;
+    }
+
+    /* ── Get representative text meta ── */
+
+    function getRepTextMeta(tree) {
+        if (!tree) return null;
+        var repTitle = String(tree.representativeTitle || tree.representative_title || '').trim();
+        var repMemo = String(tree.representativeMemo || tree.representative_memo || '').trim();
+        if (!repTitle && !repMemo) return null;
+        return {
+            title: repTitle || t('editor_default_first_title', '첫 순간'),
+            memo: repMemo || t('myTrees.card_text_fallback', '처음 남긴 마음이 이 트리의 시작이 되었어요.')
+        };
+    }
+
+    /* ── Get moment label ── */
+
+    function getMomentLabel(memory, fallbackKo, fallbackEn) {
+        if (!memory) return i18nHub('', fallbackKo, fallbackEn);
+        var title = String(memory.title || '').trim();
+        if (title) {
+            // Clean title like Browse does
+            var cleaned = title.replace(/\s*-\s*.*$/, '').trim();
+            if (cleaned) return cleaned;
+        }
+        return i18nHub('', fallbackKo, fallbackEn);
+    }
+
+    /* ── Get tree icon for flow ── */
+
+    function getTreeIcon(stage) {
+        var icons = ['🌱', '🌿', '🌳', '🌸', '🍃', '✨', '💫', '🌟'];
+        var index = typeof stage === 'number' ? stage % icons.length : 0;
+        return icons[index];
+    }
+
+    /* ── Build flow stages HTML ── */
+
+    function buildFlowStages(memories, startIndex) {
+        if (!Array.isArray(memories) || memories.length === 0) return '';
+        var html = '';
+        for (var i = 0; i < memories.length; i++) {
+            var mem = memories[i];
+            var label = getMomentLabel(mem, '시작 순간', 'Starting moment');
+            var icon = getTreeIcon(startIndex + i);
+            html += '<div class="my-trees-hub-flow-stage" title="' + escapeHtml(label) + '">' +
+                '<span class="my-trees-hub-flow-stage-icon">' + icon + '</span>' +
+                '<span class="my-trees-hub-flow-stage-label">' + escapeHtml(label) + '</span>' +
+                '</div>';
+        }
+        return html;
+    }
+
+    /* ── Build flow toggle button ── */
+
+    function buildFlowToggle(hiddenCount, isExpanded) {
+        if (hiddenCount <= 0) return '';
+        return '<button type="button" class="my-trees-hub-flow-toggle" data-my-trees-flow-toggle>' +
+            (isExpanded
+                ? i18nHub('', '간략히 보기', 'Show less')
+                : i18nHub('', '더보기 (' + hiddenCount + ')', 'Show more (' + hiddenCount + ')')) +
+            '</button>';
+    }
+
+    /* ── Show hub (placeholder/content) ── */
+
+    function showPlaceholder() {
+        var els = getEls();
+        if (!els) return;
+        els.panel.classList.add('is-empty');
+        els.panel.classList.remove('is-loaded');
+        if (els.badge) els.badge.textContent = i18nHub('', '내 트리', 'My Tree');
+        _selectedTree = null;
+        _expandedFlowKey = null;
+    }
+
+    function showContent(tree) {
+        var els = getEls();
+        if (!els) return;
+
+        _selectedTree = tree || null;
+        var treeKey = getTreeKey(tree);
+        var isFlowExpanded = !!treeKey && _expandedFlowKey === treeKey;
+        var memories = Array.isArray(tree && tree.memories) ? tree.memories : [];
+        var memoryCount = Math.max(getTreeMomentCount(tree), memories.length);
+        var hasMemories = memories.length > 0 || memoryCount > 0;
+        var repMeta = getRepTextMeta(tree);
+
+        els.panel.classList.remove('is-empty');
+        els.panel.classList.add('is-loaded');
+
+        if (els.badge) {
+            els.badge.textContent = hasMemories
+                ? i18nHub('', '내 트리', 'My Tree')
+                : i18nHub('', '트리', 'Tree');
+        }
+
+        /* ── Update open button href ── */
+        if (els.openBtn && tree && tree.id) {
+            var basePath = '';
+            if (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath) {
+                basePath = window.LoveBudPath.getBasePath();
+            } else {
+                basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+            }
+            els.openBtn.href = basePath + 'editor?treeId=' + encodeURIComponent(tree.id);
+        }
+
+        /* ── Tree title ── */
+        if (els.treeTitle) {
+            var displayTitle = String(tree && tree.title || '').trim() || t('default_tree_title', '나의 러브트리');
+            els.treeTitle.textContent = displayTitle;
+        }
+
+        /* ── Meta badge ── */
+        if (els.metaBadge) {
+            var countStr = memoryCount > 0
+                ? memoryCount + i18nHub('', '개의 순간', ' moments')
+                : i18nHub('myTrees.card_waiting', '첫 순간을 기다리는 중', 'Waiting for the first moment');
+            els.metaBadge.innerHTML = '<span class="material-symbols-outlined">auto_stories</span> ' + escapeHtml(countStr);
+        }
+
+        /* ── Representative block ── */
+        if (els.repBlock) {
+            if (repMeta) {
+                els.repBlock.hidden = false;
+                if (els.repTitle) els.repTitle.textContent = repMeta.title;
+                if (els.repMemo) els.repMemo.textContent = repMeta.memo;
+            } else {
+                els.repBlock.hidden = true;
+            }
+        }
+
+        /* ── Flow section ── */
+        if (hasMemories && memories.length > 0) {
+            if (els.noMoments) els.noMoments.hidden = true;
+            if (els.flowSection) els.flowSection.hidden = false;
+
+            var visibleMemories = memories.slice(0, VISIBLE_FLOW_MOMENT_COUNT);
+            var hiddenMemories = memories.slice(VISIBLE_FLOW_MOMENT_COUNT);
+
+            if (els.flowList) {
+                els.flowList.innerHTML = buildFlowStages(visibleMemories, 0);
+            }
+
+            if (els.flowControls) {
+                if (hiddenMemories.length > 0 && isFlowExpanded) {
+                    // Show all hidden memories
+                    var hiddenHtml = buildFlowStages(hiddenMemories, VISIBLE_FLOW_MOMENT_COUNT);
+                    if (els.flowList) {
+                        els.flowList.insertAdjacentHTML('beforeend', hiddenHtml);
+                    }
+                    els.flowControls.innerHTML = buildFlowToggle(hiddenMemories.length, true);
+                } else if (hiddenMemories.length > 0) {
+                    els.flowControls.innerHTML = buildFlowToggle(hiddenMemories.length, false);
+                } else {
+                    els.flowControls.innerHTML = '';
+                }
+            }
+        } else {
+            // No moments — show waiting state
+            if (els.flowSection) els.flowSection.hidden = true;
+            if (els.noMoments) {
+                els.noMoments.hidden = false;
+                var titleText = String(tree && tree.title || '').trim() || t('default_tree_title', '나의 러브트리');
+                els.noMoments.innerHTML =
+                    '<span class="material-symbols-outlined">psychiatry</span>' +
+                    '<strong>' + escapeHtml(titleText) + '</strong>' +
+                    '<p>' + escapeHtml(i18nHub('',
+                        '아직 대표 순간이 남아 있지 않아요. 첫 순간을 남기면 이곳에서 흐름을 미리 볼 수 있어요.',
+                        'There is no featured moment yet. Once the first moment is added, the flow will preview here.'
+                    )) + '</p>';
+            }
+        }
+
+        /* ── Summary ── */
+        if (els.summary) {
+            if (hasMemories) {
+                var displayTitle = String(tree && tree.title || '').trim() || t('default_tree_title', '나의 러브트리');
+                els.summary.innerHTML = i18nHub('',
+                    '<strong style="color:var(--on-surface);">' + escapeHtml(displayTitle) + '</strong>에 담긴 <span style="color:var(--primary);font-weight:700;">' + memoryCount + '개의 순간</span>이 이어졌어요.',
+                    '<strong style="color:var(--on-surface);">' + memoryCount + ' moments</strong> in <strong style="color:var(--on-surface);">' + escapeHtml(displayTitle) + '</strong> are connected.'
+                );
+            } else {
+                els.summary.textContent = i18nHub('',
+                    '트리를 열어 첫 순간을 남기면 이곳에서 흐름을 확인할 수 있어요.',
+                    'Open the tree to add the first moment and preview the flow here.'
+                );
+            }
+        }
+
+        /* ── Actions ── */
+        if (els.actions) {
+            els.actions.hidden = false;
+            if (els.openBtn && tree && tree.id) {
+                var basePath = '';
+                if (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath) {
+                    basePath = window.LoveBudPath.getBasePath();
+                } else {
+                    basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+                }
+                els.openBtn.href = basePath + 'editor?treeId=' + encodeURIComponent(tree.id);
+                els.openBtn.innerHTML = '<span class="material-symbols-outlined">account_tree</span> ' +
+                    escapeHtml(i18nHub('', '트리 열기', 'Open tree'));
+            }
+        }
+    }
+    
+    /* ── Helper to navigate back to my trees after editor ── */
+    function getEditorUrl(treeId) {
+        if (!treeId) return '#';
+        var basePath = '';
+        if (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath) {
+            basePath = window.LoveBudPath.getBasePath();
+        } else {
+            basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+        }
+        return basePath + 'editor?treeId=' + encodeURIComponent(treeId);
+    }
+
+    /* ── Hub loader (loading skeleton) ── */
+
+    function showLoading(tree) {
+        var els = getEls();
+        if (!els) return;
+
+        els.panel.classList.remove('is-empty');
+        els.panel.classList.add('is-loaded');
+
+        if (els.treeTitle) {
+            els.treeTitle.textContent = String(tree && tree.title || '').trim() || t('default_tree_title', '나의 러브트리');
+        }
+
+        if (els.metaBadge) {
+            els.metaBadge.innerHTML = '<span class="material-symbols-outlined">sync</span> ' +
+                escapeHtml(i18nHub('', '불러오는 중…', 'Loading…'));
+        }
+
+        if (els.repBlock) els.repBlock.hidden = true;
+        if (els.flowSection) els.flowSection.hidden = true;
+        if (els.noMoments) els.noMoments.hidden = true;
+
+        if (els.summary) {
+            els.summary.textContent = i18nHub('',
+                '이 트리의 대표 순간과 이어진 감정을 불러오는 중이에요.',
+                'Loading the featured moment and connected feelings of this tree.'
+            );
+        }
+
+        if (els.actions) {
+            els.actions.hidden = false;
+            if (els.openBtn && tree && tree.id) {
+                var basePath = '';
+                if (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath) {
+                    basePath = window.LoveBudPath.getBasePath();
+                } else {
+                    basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+                }
+                els.openBtn.href = basePath + 'editor?treeId=' + encodeURIComponent(tree.id);
+                els.openBtn.innerHTML = '<span class="material-symbols-outlined">account_tree</span> ' +
+                    escapeHtml(i18nHub('', '트리 열기', 'Open tree'));
+            }
+        }
+    }
+    
+    /* ── Helper to navigate back to my trees after editor ── */
+    function getEditorUrl(treeId) {
+        if (!treeId) return '#';
+        var basePath = '';
+        if (typeof window.LoveBudPath !== 'undefined' && window.LoveBudPath.getBasePath) {
+            basePath = window.LoveBudPath.getBasePath();
+        } else {
+            basePath = window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/';
+        }
+        return basePath + 'editor?treeId=' + encodeURIComponent(treeId);
+    }
+
+    /* ── Card selection handler ── */
+
+    function onCardClick(tree, event) {
+        if (!tree) return;
+
+        // Update visual selection state
+        var grid = document.getElementById('trees-grid');
+        if (grid) {
+            var cards = grid.querySelectorAll('.tree-card');
+            cards.forEach(function (card) {
+                card.classList.remove('is-selected');
+            });
+            // Find and mark selected card
+            cards.forEach(function (card) {
+                if (card.dataset && card.dataset.treeId === String(tree.id)) {
+                    card.classList.add('is-selected');
+                }
+            });
+        }
+
+        // Update state module
+        if (_stateModule && typeof _stateModule.setSelectedTreeId === 'function') {
+            _stateModule.setSelectedTreeId(tree.id);
+        }
+
+        // Show appreciation hub
+        var hasMemories = Array.isArray(tree.memories) && tree.memories.length > 0;
+        if (hasMemories) {
+            showContent(tree);
+        } else {
+            showContent(tree);
+        }
+
+        // Scroll to hub on mobile
+        var panel = document.getElementById('myTreesHubPanel');
+        if (panel && window.innerWidth <= 768) {
+            setTimeout(function () {
+                panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 100);
+        }
+    }
+
+    /* ── Bind flow toggle events (delegated) ── */
+
+    function bindFlowToggle() {
+        document.addEventListener('click', function (event) {
+            var toggle = event.target && event.target.closest && event.target.closest('[data-my-trees-flow-toggle]');
+            if (!toggle) return;
+            if (!_selectedTree) return;
+
+            var treeKey = getTreeKey(_selectedTree);
+            _expandedFlowKey = _expandedFlowKey === treeKey ? null : treeKey;
+            showContent(_selectedTree);
+        });
+    }
+
+    /* ── Initialize hub ── */
+
+    function init(options) {
+        options = options || {};
+        _stateModule = options.stateModule || window.LoveBudMyTreesState || null;
+        _onOpenTree = options.onOpenTree || null;
+
+        bindFlowToggle();
+
+        // Show placeholder initially
+        showPlaceholder();
+    }
+
+    /* ── Public API ── */
+
+    var api = {
+        init: init,
+        showPlaceholder: showPlaceholder,
+        showContent: showContent,
+        showLoading: showLoading,
+        onCardClick: onCardClick,
+        getSelectedTree: function () { return _selectedTree; },
+        setTreeGridContainer: setTreeGridContainer
+    };
+
+    window.LoveBudMyTreesPreviewHub = api;
+    window.LoveTreeMyTreesPreviewHub = api;
+
+})();

--- a/js/my-trees/my-trees-render.js
+++ b/js/my-trees/my-trees-render.js
@@ -81,6 +81,7 @@
         onDelete: onDelete,
         onToggleVisibility: onToggleVisibility,
         onNavigate: onNavigate,
+        onSelect: options && options.onSelect,
         buildTreeCard: buildTreeCardFn,
         updateManageSummary: updateManageSummaryFn,
         getSelectedTreeId: function () { return getSelectedTreeId(stateModule); },

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -378,13 +378,12 @@
     card.style.cursor = 'pointer';
     card.setAttribute('role', 'button');
     card.setAttribute('tabindex', '0');
+        card.dataset.treeId = String(normalizedTree.id || '');
     card.dataset.visibility = normalizedTree.visibility;
 
-    var openTree = function () {
-      if (typeof onNavigate === 'function') {
-        onNavigate(normalizedTree);
-      } else {
-        window.location.href = 'editor?treeId=' + encodeURIComponent(normalizedTree.id);
+    var handleCardSelect = function () {
+      if (typeof onSelect === 'function') {
+        onSelect(normalizedTree);
       }
     };
 
@@ -392,7 +391,7 @@
       if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
         return;
       }
-      openTree();
+      handleCardSelect();
     });
 
     card.addEventListener('keydown', function (e) {
@@ -401,7 +400,7 @@
       }
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        openTree();
+        handleCardSelect();
       }
     });
 
@@ -442,7 +441,7 @@
           e.preventDefault();
           e.stopPropagation();
           if (typeof onSelect === 'function') {
-            onSelect(normalizedTree.id);
+            onSelect(normalizedTree);
           }
           closeDropdowns();
           dropdown.classList.toggle('show');
@@ -454,7 +453,7 @@
             e.stopPropagation();
 
             if (typeof onSelect === 'function') {
-              onSelect(normalizedTree.id);
+              onSelect(normalizedTree);
             }
 
             var action = this.getAttribute('data-action');
@@ -486,6 +485,7 @@
   var scrollSentinel = null;
 
   function renderTrees(trees, options) {
+    var hubOnSelect = options && options.onSelect;
     var container = document.getElementById('state-loaded');
     if (!container) return;
 
@@ -530,13 +530,13 @@
   }
 
   // Issue #616: Render next batch of trees
-  function renderNextBatch(grid, buildTreeCardFn, setState, stateEnum) {
+  function renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions) {
     var startIndex = currentVisibleCount;
     var endIndex = Math.min(startIndex + BATCH_SIZE, totalTreesCount);
     
     for (var i = startIndex; i < endIndex; i++) {
       var tree = allTreesData[i];
-      var card = buildTreeCardFn(tree, {});
+      var card = buildTreeCardFn(tree, { onSelect: onSelect, onNavigate: onNavigate });
       if (!(card instanceof Node)) {
         console.warn('[my-trees-ui] buildTreeCard returned a non-Node value:', card, tree);
         continue;
@@ -565,7 +565,7 @@
   }
 
   // Issue #616: Set up scroll continuation sentinel
-  function setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum) {
+  function setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum, extraOptions) {
     // Remove existing sentinel
     if (scrollSentinel) {
       scrollSentinel.remove();
@@ -588,18 +588,19 @@
       var observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (entry.isIntersecting && !isLoadingMore && currentVisibleCount < totalTreesCount) {
-            loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum);
+            loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum, { onSelect: hubOnSelect, onNavigate: onNavigate });
           }
         });
       }, { rootMargin: '100px' });
       
+      scrollSentinel._extraOptions = extraOptions;
       observer.observe(scrollSentinel);
       scrollSentinel._observer = observer;
     }
   }
 
   // Issue #616: Load more batch on scroll
-  function loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum) {
+  function loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions) {
     if (isLoadingMore || currentVisibleCount >= totalTreesCount) {
       return;
     }
@@ -611,10 +612,10 @@
       scrollSentinel._observer.disconnect();
     }
     
-    renderNextBatch(grid, buildTreeCardFn, setState, stateEnum);
+    renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions);
     
     // Set up new sentinel
-    setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum);
+    setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum, extraOptions);
     
     isLoadingMore = false;
   }

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <section class="dashboard-main reveal-fade">
+      <section class="dashboard-main reveal-fade my-trees-dashboard-container">
         <div id="treesContainer">
           <div id="state-loading" class="trees-loading">
             <div class="trees-loading-head">
@@ -91,6 +91,61 @@
           <div id="state-loaded"></div>
         </div>
       </section>
+      <!-- My Trees Appreciation Hub -->
+      <aside class="my-trees-hub-panel is-empty" id="myTreesHubPanel">
+        <div class="my-trees-hub-header">
+          <div class="my-trees-hub-title-group">
+            <h3>감상 허브</h3>
+            <span class="my-trees-hub-badge" id="myTreesHubBadge">내 트리</span>
+          </div>
+        </div>
+
+        <!-- Placeholder (no tree selected) -->
+        <div class="my-trees-hub-placeholder" id="myTreesHubPlaceholder">
+          <p>내 러브트리를 고르면</p>
+          <p>이어진 순간의 흐름이 여기에 열려요.</p>
+        </div>
+
+        <!-- Hub content (tree selected) -->
+        <div class="my-trees-hub-content" id="myTreesHubContent" hidden>
+          <div class="my-trees-hub-tree-title" id="myTreesHubTreeTitle"></div>
+          <div class="my-trees-hub-meta-badge" id="myTreesHubMetaBadge"></div>
+
+          <!-- Representative moment block -->
+          <div class="my-trees-hub-rep" id="myTreesHubRep" hidden>
+            <div class="my-trees-hub-rep-label">
+              <span class="material-symbols-outlined">favorite</span>
+              <span>첫 순간 기록</span>
+            </div>
+            <div class="my-trees-hub-rep-title" id="myTreesHubRepTitle"></div>
+            <div class="my-trees-hub-rep-memo" id="myTreesHubRepMemo"></div>
+          </div>
+
+          <!-- Flow preview -->
+          <div class="my-trees-hub-flow" id="myTreesHubFlow" hidden>
+            <div class="my-trees-hub-flow-label">
+              <span class="material-symbols-outlined">route</span>
+              <span>이어진 순간 흐름</span>
+            </div>
+            <div class="my-trees-hub-flow-list" id="myTreesHubFlowList"></div>
+            <div class="my-trees-hub-flow-controls" id="myTreesHubFlowControls"></div>
+          </div>
+
+          <!-- No moments state -->
+          <div class="my-trees-hub-no-moments" id="myTreesHubNoMoments" hidden></div>
+
+          <!-- Summary line -->
+          <div class="my-trees-hub-summary" id="myTreesHubSummary"></div>
+        </div>
+
+        <!-- Actions -->
+        <div class="my-trees-hub-actions" id="myTreesHubActions" hidden>
+          <a href="#" class="my-trees-hub-open-btn" id="myTreesHubOpenBtn">
+            <span class="material-symbols-outlined">account_tree</span>
+            트리 열기
+          </a>
+        </div>
+      </aside>
     </main>
   </div>
   <div class="create-tree-modal-backdrop" id="createTreeModalBackdrop" aria-hidden="true">
@@ -147,6 +202,7 @@
   <script src="../js/my-trees/my-trees-state.js?v=20260421-4"></script>
   <script src="../js/my-trees/my-trees-page.js?v=20260420-1"></script>
     <script src="../js/my-trees/my-trees-render.js?v=20260504-1"></script>
+    <script src="../js/my-trees/my-trees-preview-hub.js?v=20260514-1"></script>
     <script src="../js/my-trees.js?v=20260421-6"></script>
   <script src="../js/my-trees/my-trees-i18n-refresh.js?v=20260509-910-1"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>


### PR DESCRIPTION
## Summary

Implements issue #1121: adds a selected-tree appreciation hub to My Trees page, following the Browse 감상 허브 grammar.

## Changes

### New files
- **css/my-trees/my-trees-preview-hub.css** (504 lines) — Hub styling matching Browse's preview-sidebar visual vocabulary
- **js/my-trees/my-trees-preview-hub.js** (491 lines) — Hub rendering/controller adapted from search-preview-renderer.js

### Modified files
- **pages/my-trees.html** — Added hub panel DOM, imported new JS (hub CSS loaded via my-trees.css chain)
- **css/my-trees.css** — Added import for hub CSS
- **css/my-trees/my-trees-cards.css** — Added `.is-selected` card selection style
- **js/my-trees.js** — Wired onSelect callback and hub initialization
- **js/my-trees/my-trees-render.js** — Added onSelect passthrough to UI module
- **js/my-trees/my-trees-ui.js** — Changed card click from immediate Editor navigation to selection; added data-treeId attribute; batch loading support for extraOptions

## Behavior changes

| Before | After |
|--------|-------|
| Click card → Editor | Click card → selects card visually + shows appreciation hub |
| No preview of tree content | Hub shows: title, moment count, representative moment, flow preview |
| No `트리 열기` CTA | `트리 열기` button in hub opens Editor |

## What still works
- Sort (recent/oldest/name) — re-renders cards with hub cleared
- Batch loading (scroll continuation) — cards built with correct tree data
- Empty/error states — unchanged
- All existing card content — cover, thumb, footer, moment badge, flow bridge
- Dropdown menus — still functional (rename, delete, visibility)

## What's excluded (as specified in issue)
- No management controls in hub (rename, delete, visibility)
- No `트리 편집하기` wording
- No public/private status/toggle
- No sharing/insights actions
- No subscription-gated features

Closes #1121