### PR TITLE
ui(editor): remove non-functional selected moment helper copy (Refs #1118)

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -340,7 +340,7 @@ function createEditorDetailUI(deps) {
                 ? formatI18nText('editor_current_moment_empty_hint', '첫 순간이 심어지면 여기서 감정 메모와 다음 행동이 자연스럽게 이어집니다.')
                 : isRootSelected
                     ? formatI18nText('editor_current_moment_root_hint', '이 순간은 트리의 시작점이에요. 다음 장면을 이어 심으며 감정의 흐름을 키워보세요.')
-                    : formatI18nText('editor_current_moment_selected_hint', '지금 선택한 순간을 중심으로 메모를 읽고, 수정하거나 다음 장면을 이어갈 수 있어요.');
+                    : '';
         }
 
         if (imgEl) {
@@ -406,8 +406,6 @@ function createEditorDetailUI(deps) {
                 } else if (data.parentId) {
                     memoHint.style.paddingTop = '12px';
                     memoHint.style.borderTop = '1px solid var(--outline-variant)';
-                    memoHint.style.color = 'var(--on-surface-variant)';
-                    memoHint.innerHTML = `<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:4px;">account_tree</span> ${formatI18nText('path_moment_hint', '이 순간은 감정 경로 안에 연결되어 있습니다')}`;
                 }
 
                 if (memoHint.innerHTML) {

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -57,7 +57,7 @@
       } else if (selectedMemory.id === rootId) {
         selectionHintEl.textContent = tText('root_moment_hint', '이 순간은 현재 트리의 시작점입니다');
       } else {
-        selectionHintEl.textContent = tText('path_moment_hint', '이 순간은 감정 경로 안에 연결되어 있습니다');
+        selectionHintEl.textContent = '';
       }
     }
   }


### PR DESCRIPTION
Remove two non-functional helper copy blocks from the Editor selected-moment panel.

## Changes
- Removed editor_current_moment_selected_hint (normal selected state hint)
- Removed path_moment_hint from editor-detail-ui.js and editor-i18n-refresh.js
- Preserved empty state hint and root moment hint as they carry state transition value