### PR TITLE
UI: fix Editor toolbar as full-width fixed-cell controls with compact mode

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -1,103 +1,55 @@
+
 /**
  * LoveBud Editor Canvas Toolbar Styles
  * Issue #515 - Canvas Toolbar CSS Relocation
  * Issue #1041 - Toolbar Cleanup
- * 
- * Extracted from css/editor/overrides.css for better role ownership
- * Contains Editor Canvas Topbar & Toolbar selectors
+ * Issue #1117 - Full-width fixed-cell toolbar with compact mode
  */
-
-/* Editor Canvas Topbar */
 .editor-canvas-topbar {
     position: absolute;
     top: 28px;
     left: 24px;
     right: 24px;
     z-index: 7;
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 18px;
     pointer-events: none;
 }
-
 .editor-canvas-topbar > * {
     pointer-events: auto;
 }
-
-/* Editor Canvas Title & Caption */
-.editor-canvas-title h2 {
-    margin: 10px 0 0;
-    font-size: 1.76rem;
-    line-height: 1.12;
-    letter-spacing: -0.05em;
-    color: var(--on-surface);
-}
-
-.editor-canvas-caption {
-    margin: 7px 0 0;
-    max-width: 360px;
-    color: var(--on-surface-soft);
-    font-size: 13px;
-    line-height: 1.6;
-}
-
-/* Editor Canvas Toolbar */
 .editor-canvas-toolbar {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    gap: 12px;
-    padding: 6px;
+    justify-content: space-between;
+    width: 100%;
+    gap: 6px;
+    padding: 6px 12px;
     border-radius: 20px;
     background: rgba(255,250,244,0.85);
     border: 1px solid rgba(230,207,194,0.78);
     box-shadow: 0 14px 30px rgba(161,119,96,0.10);
     backdrop-filter: blur(8px);
+    box-sizing: border-box;
 }
-
-/* ── Toolbar Groups ── */
 .editor-canvas-toolbar-group {
     display: flex;
     align-items: center;
     gap: 4px;
+    flex: 0 0 auto;
 }
-
-/* Viewport group: compact surface to visually unite zoom controls */
 .editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] {
-    background: rgba(255,255,255,0.5);
-    border-radius: 14px;
-    padding: 2px;
     gap: 0;
-    border: 1px solid rgba(221,198,184,0.3);
 }
-
 .editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] .editor-canvas-tool-btn {
-    background: transparent;
-    border-color: transparent;
-    border-radius: 12px;
     width: 34px;
     height: 34px;
     min-width: 34px;
 }
-
-.editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] .editor-canvas-tool-btn:hover:not(:disabled) {
-    background: rgba(144,73,81,0.08);
-    border-color: transparent;
-}
-
-/* Navigation group: allow wrap, wide buttons */
 .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] {
     gap: 6px;
 }
-
-/* Layout mode group: pill-style toggle */
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] {
     gap: 6px;
 }
-
-/* Layout toggle as a distinct mode pill */
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
     background: rgba(255,255,255,0.6);
     border: 1.5px solid rgba(144,73,81,0.18);
@@ -109,38 +61,30 @@
     gap: 8px;
     transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
-
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide:hover:not(:disabled) {
     background: rgba(144,73,81,0.08);
     border-color: rgba(144,73,81,0.35);
     transform: none;
 }
-
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide.is-active {
     background: var(--primary, rgba(144,73,81,0.92));
     border-color: var(--primary, rgba(144,73,81,0.92));
     color: #fff;
     box-shadow: 0 2px 8px rgba(144,73,81,0.2);
 }
-
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide.is-active:hover:not(:disabled) {
     background: var(--primary-hover, rgba(124,59,67,0.92));
 }
-
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide .material-symbols-outlined {
     font-size: 18px;
 }
-
-/* ── Separators ── */
 .editor-canvas-toolbar-separator {
     width: 1px;
     height: 30px;
     background: rgba(221,198,184,0.5);
-    margin: 0 6px;
+    margin: 0 4px;
     flex-shrink: 0;
 }
-
-/* ── Base Tool Button ── */
 .editor-canvas-tool-btn {
     position: relative;
     width: 36px;
@@ -160,7 +104,6 @@
     transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
     flex-shrink: 0;
 }
-
 .editor-canvas-tool-btn:hover:not(:disabled),
 .editor-canvas-tool-btn:focus-visible:not(:disabled) {
     background: rgba(255,255,255,0.96);
@@ -168,32 +111,26 @@
     color: var(--primary);
     transform: translateY(-1px);
 }
-
 .editor-canvas-tool-btn:active:not(:disabled) {
     transform: scale(0.92);
     background: rgba(144,73,81,0.08);
     border-color: rgba(144,73,81,0.35);
     transition: transform 0.08s ease, background 0.08s ease;
 }
-
 .editor-canvas-tool-btn:active:not(:disabled) .material-symbols-outlined {
     transform: scale(0.88);
     transition: transform 0.08s ease;
 }
-
 .editor-canvas-tool-btn:focus-visible {
     outline: 2px solid var(--control-focus-ring, rgba(144,73,81,0.32));
     outline-offset: 2px;
 }
-
 .editor-canvas-tool-btn:disabled,
 .editor-canvas-tool-btn.is-disabled {
     opacity: 0.46;
     cursor: not-allowed;
     transform: none;
 }
-
-/* Zoom indicator badge */
 .editor-canvas-zoom-indicator {
     display: inline-flex;
     align-items: center;
@@ -212,135 +149,171 @@
     user-select: none;
     transition: opacity 0.2s ease, transform 0.2s ease;
 }
-
 .editor-canvas-zoom-indicator.is-hidden {
     opacity: 0;
     transform: scale(0.8);
 }
-
-/* Button feedback flash — brief highlight after action */
 .editor-canvas-tool-btn.flash-feedback {
     background: rgba(144,73,81,0.15);
     border-color: rgba(144,73,81,0.35);
     transition: background 0.1s ease, border-color 0.1s ease;
 }
-
-/* Active state for layout mode toggle */
 .editor-canvas-tool-btn.is-active {
     background: var(--primary, rgba(144,73,81,0.92));
     border-color: var(--primary, rgba(144,73,81,0.92));
     color: #fff;
 }
-
 .editor-canvas-tool-btn.is-active:hover:not(:disabled) {
     background: var(--primary-hover, rgba(124,59,67,0.92));
     border-color: var(--primary-hover, rgba(124,59,67,0.92));
     color: #fff;
 }
-
 .editor-canvas-tool-btn .material-symbols-outlined {
     font-size: 20px;
     line-height: 1;
 }
-
 .editor-canvas-tool-btn-wide {
     width: auto;
     min-width: 36px;
     max-width: none;
     padding: 0 14px 0 10px;
 }
-
 .editor-canvas-tool-label {
     font-size: 13px;
     font-weight: 700;
     line-height: 1;
     white-space: nowrap;
+    transition: opacity 0.2s ease, width 0.2s ease, margin 0.2s ease;
 }
-
+.editor-canvas-toolbar.is-compact .editor-canvas-tool-label {
+    opacity: 0;
+    width: 0;
+    margin: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+.editor-canvas-toolbar.is-compact .editor-canvas-zoom-indicator {
+    opacity: 0;
+    transform: scale(0.8);
+    width: 0;
+    min-width: 0;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+}
+.editor-canvas-toolbar.is-compact .editor-canvas-tool-btn-wide {
+    padding: 0;
+    width: 36px;
+    min-width: 36px;
+    justify-content: center;
+}
+.editor-canvas-toolbar.is-compact .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
+    padding: 0;
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+    border-radius: 14px;
+    justify-content: center;
+    gap: 0;
+}
+@media (max-width: 1024px) {
+    .editor-canvas-topbar {
+        top: 14px;
+        left: 14px;
+        right: 14px;
+    }
+}
 @media (max-width: 768px) {
     .editor-canvas-topbar {
-        left: 16px;
-        right: 16px;
-        gap: 10px;
-        flex-direction: column;
-        align-items: stretch;
+        left: 12px;
+        right: 12px;
+        top: 12px;
     }
-
-    .editor-canvas-title {
-        text-align: left;
-    }
-
     .editor-canvas-toolbar {
-        max-width: 100%;
-        padding: 6px 8px;
-        gap: 8px;
-        justify-content: flex-start;
-        align-items: stretch;
+        width: 100%;
+        padding: 5px 8px;
+        gap: 4px;
         border-radius: 16px;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
     }
-
     .editor-canvas-toolbar-group {
-        flex-wrap: wrap;
-        flex: 1;
-        gap: 6px;
+        flex: 0 0 auto;
+        flex-wrap: nowrap;
+        gap: 4px;
     }
-
     .editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] {
         flex: 0 0 auto;
-        display: flex;
-        align-items: center;
-        background: rgba(255,255,255,0.5);
-        border-radius: 14px;
-        padding: 2px;
         gap: 0;
-        border: 1px solid rgba(221,198,184,0.3);
     }
-
     .editor-canvas-toolbar-group[aria-label="화면 줌 컨트롤"] .editor-canvas-tool-btn {
-        background: transparent;
-        border-color: transparent;
-        border-radius: 12px;
-        width: 36px;
-        height: 36px;
-        min-width: 36px;
+        width: 34px;
+        height: 34px;
+        min-width: 34px;
     }
-
     .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] {
-        flex: 1 1 auto;
-        flex-direction: column;
+        flex: 0 0 auto;
+        flex-direction: row;
     }
-
     .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] {
         flex: 0 0 auto;
         flex-direction: row;
     }
-
     .editor-canvas-toolbar-separator {
         display: none;
     }
-
     .editor-canvas-tool-btn {
-        width: 40px;
-        height: 40px;
-        min-width: 40px;
+        width: 34px;
+        height: 34px;
+        min-width: 34px;
     }
-
     .editor-canvas-tool-btn-wide {
         width: auto;
         flex: none;
-        padding: 0 12px;
+        padding: 0 10px;
         justify-content: center;
     }
-
     .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
-        padding: 0 18px 0 14px;
-        height: 38px;
+        padding: 0 12px 0 10px;
+        height: 34px;
     }
-
     .editor-canvas-tool-label {
         position: static;
         width: auto;
         height: auto;
         clip: auto;
+    }
+    .editor-canvas-toolbar.is-compact .editor-canvas-tool-label {
+        opacity: 0;
+        width: 0;
+        margin: 0;
+        overflow: hidden;
+        pointer-events: none;
+    }
+    .editor-canvas-toolbar.is-compact .editor-canvas-zoom-indicator {
+        opacity: 0;
+        transform: scale(0.8);
+        width: 0;
+        min-width: 0;
+        padding: 0;
+        margin: 0;
+        overflow: hidden;
+    }
+    .editor-canvas-toolbar.is-compact .editor-canvas-tool-btn-wide {
+        padding: 0;
+        width: 34px;
+        min-width: 34px;
+        justify-content: center;
+    }
+    .editor-canvas-toolbar.is-compact .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
+        padding: 0;
+        width: 34px;
+        min-width: 34px;
+        height: 34px;
+        border-radius: 14px;
+        justify-content: center;
+        gap: 0;
     }
 }

--- a/css/editor/editor-overrides.css
+++ b/css/editor/editor-overrides.css
@@ -226,9 +226,6 @@ body .editor-memory-mode-chip.is-active {
         font-size: 1.35rem;
     }
 
-body .editor-canvas-title h2 {
-        font-size: 1.3rem;
-    }
 }
 
 /* Editor page presentation overrides extracted from pages/editor.html */

--- a/css/editor/editor-responsive-tail.css
+++ b/css/editor/editor-responsive-tail.css
@@ -1,3 +1,3 @@
-@media (max-width:1024px) { .editor-layout { padding:12px; gap:12px; } .sidebar, .detail-panel, .canvas-area { border-radius:24px; } .editor-canvas-topbar { position:absolute; top:14px; left:14px; right:14px; flex-direction:column; } .editor-canvas-title h2 { font-size:1.42rem; } }
-@media (max-width:768px) { .editor-canvas-caption { display:none; } .editor-canvas-toolbar { width:100%; justify-content:center; box-sizing:border-box; } .editor-status-card { padding:18px 16px; } }
+@media (max-width:1024px) { .editor-layout { padding:12px; gap:12px; } .sidebar, .detail-panel, .canvas-area { border-radius:24px; } .editor-canvas-topbar { position:absolute; top:14px; left:14px; right:14px; } }
+@media (max-width:768px) { .editor-status-card { padding:18px 16px; } }
 @media (max-width:768px) { .editor-layout { width:100%; max-width:100%; min-width:0; overflow-x:hidden; overflow-x:clip; } .sidebar, .detail-panel, .canvas-area { box-sizing:border-box; min-width:0; max-width:100%; } .canvas-area { width:100%; flex:1 1 auto; } .canvas-svg { max-width:100%; } }

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -553,6 +553,8 @@ function createEditorCanvas(deps) {
         bindViewportControls();
         bindResizeHandling();
         bindLayoutModeToggle();
+        // Bind compact mode toggle
+        bindCompactModeToggle();
         viewportState.initialized = true;
     };
 
@@ -685,6 +687,41 @@ function createEditorCanvas(deps) {
         });
 
         toggleBtn.dataset.layoutBound = '1';
+    }
+
+    /**
+     * Bind the compact/detail mode toggle for the canvas toolbar.
+     * Toggles .is-compact class on .editor-canvas-toolbar and swaps the toggle icon.
+     * Preference is persisted in localStorage.
+     */
+    function bindCompactModeToggle() {
+        const toggleBtn = document.getElementById('compactModeToggleBtn');
+        const toolbar = document.querySelector('.editor-canvas-toolbar');
+        if (!toggleBtn || !toolbar) return;
+        if (toggleBtn.dataset.compactBound) return;
+
+        // Restore saved preference
+        var saved = localStorage.getItem('lovebud_toolbar_compact');
+        if (saved === 'true') {
+            toolbar.classList.add('is-compact');
+            var icon = toggleBtn.querySelector('.material-symbols-outlined');
+            if (icon) icon.textContent = 'unfold_less';
+        }
+
+        toggleBtn.addEventListener('click', function() {
+            var isCompact = toolbar.classList.toggle('is-compact');
+            var icon = toggleBtn.querySelector('.material-symbols-outlined');
+            if (icon) {
+                icon.textContent = isCompact ? 'unfold_less' : 'unfold_more';
+            }
+            try {
+                localStorage.setItem('lovebud_toolbar_compact', isCompact ? 'true' : 'false');
+            } catch (e) {
+                // localStorage may not be available
+            }
+        });
+
+        toggleBtn.dataset.compactBound = '1';
     }
 
     function bindCanvasPan() {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -64,10 +64,7 @@
 
         <main class="canvas-area reveal-scale reveal-up" id="canvasArea">
             <div class="editor-canvas-topbar" aria-label="러브트리 캔버스 도구">
-                <div class="editor-canvas-title">
-                    <h2>순간을 이어가는 중</h2>
-                    <!-- caption hidden per #1002: reduce empty-state density -->
-                </div>
+                
                 <div class="editor-canvas-toolbar" role="toolbar" aria-label="트리 화면 조정">
                     <div class="editor-canvas-toolbar-group" aria-label="화면 줌 컨트롤">
                         <button type="button" class="editor-canvas-tool-btn" id="zoomOutCanvasBtn" aria-label="축소" title="축소">
@@ -94,6 +91,12 @@
                         <button type="button" class="editor-canvas-tool-btn editor-canvas-tool-btn-wide" id="layoutModeToggleBtn" aria-label="레이아웃 전환" title="레이아웃 전환">
                             <span class="material-symbols-outlined" aria-hidden="true" id="layoutModeToggleIcon">auto_awesome</span>
                             <span class="editor-canvas-tool-label" id="layoutModeToggleLabel">자유 배치</span>
+                        </button>
+                    </div>
+                    <div class="editor-canvas-toolbar-separator" aria-hidden="true"></div>
+                    <div class="editor-canvas-toolbar-group" aria-label="툴바 표시 모드">
+                        <button type="button" class="editor-canvas-tool-btn" id="compactModeToggleBtn" aria-label="간략 모드 전환" title="간략 모드 전환">
+                            <span class="material-symbols-outlined" aria-hidden="true">unfold_more</span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #1117

Reorganizes the Editor canvas top toolbar to be a full-width fixed-cell control bar with a new compact/detail display mode.

### Changes

#### HTML (pages/editor.html)
- Removed the `순간을 이어가는 중` heading (`.editor-canvas-title`) that consumed visual priority without providing control context
- Added compact/detail toggle button at the end of the toolbar (`compactModeToggleBtn`) with `unfold_more` / `unfold_less` icons

#### CSS (css/editor/editor-canvas-toolbar.css)
- Toolbar now fills full available width with `justify-content: space-between`
- Removed over-emphasized visual grouping (zoom group background, heavy separators)
- Added `.is-compact` class styles:
  - Labels hidden with smooth opacity/width transition
  - Zoom percentage hidden
  - Wide buttons collapse to icon-only (36px)
  - Layout mode pill collapses to flat icon button
- Updated tablet (1024px) and mobile (768px) responsive breakpoints

#### CSS (editor-overrides.css, editor-responsive-tail.css)
- Removed stale `.editor-canvas-title h2` references
- Removed stale `.editor-canvas-caption` and `flex-direction:column` on topbar

#### JS (js/editor/editor-canvas.js)
- Added `bindCompactModeToggle()` function called during toolbar initialization
- Toggles `.is-compact` class on `.editor-canvas-toolbar`
- Swaps toggle icon between `unfold_more` (detail) and `unfold_less` (compact)
- Persists preference in localStorage (`lovebud_toolbar_compact`)
- Uses `dataset.compactBound` guard to avoid double-binding (same pattern as layout toggle)

### Verification
- [x] Toolbar fills full width with stable same-height cells
- [x] Left side no longer has empty-looking space from oversized heading
- [x] Controls align in predictable same-height cells
- [x] Detail mode shows readable labels
- [x] Compact mode shows icon-only controls and hides zoom percentage
- [x] Compact/detail toggle switches modes without breaking existing toolbar actions
- [x] Zoom controls remain functional
- [x] Tree overview remains functional
- [x] Selected moment view remains functional
- [x] Layout mode toggle remains functional
- [x] npm test: 274 passed, 0 failed

### Files Changed
- pages/editor.html
- css/editor/editor-canvas-toolbar.css
- css/editor/editor-overrides.css
- css/editor/editor-responsive-tail.css
- js/editor/editor-canvas.js