### PR TITLE
fix(#1129): compact Editor selected moment record metadata layout

### DIFF
--- a/css/editor/editor-detail-panel.css
+++ b/css/editor/editor-detail-panel.css
@@ -314,6 +314,38 @@
     color: var(--on-surface);
 }
 
+
+/* Compact metadata row layout (#1129) */
+.detail-info-group.is-compact {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+.detail-info-group.is-compact label {
+    margin-bottom: 0;
+    flex-shrink: 0;
+    min-width: 60px;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+}
+
+.detail-info-group.is-compact p,
+.detail-info-group.is-compact .tags-container {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.detail-info-group.is-compact .tags-container {
+    gap: 4px;
+}
+
+.detail-info-group.is-compact .tags-container .tag {
+    padding: 2px 10px;
+    font-size: 11px;
+}
 .tags-container {
     display: flex;
     flex-wrap: wrap;

--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -350,10 +350,6 @@ function createEditorDetailUI(deps) {
 
         if (dateEl) {
             dateEl.textContent = isEmptyState ? '' : (data?.timestamp || '');
-            dateEl.style.fontSize = '0.85rem';
-            dateEl.style.color = 'var(--on-surface-variant)';
-            dateEl.style.opacity = '0.8';
-            dateEl.style.fontWeight = '500';
         }
 
         if (tagsContainer) {

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -225,12 +225,12 @@
                     <div class="editor-moment-info-card">
                         <div class="editor-section-eyebrow" id="detailMomentInfoLabel">...</div>
 
-                        <div class="detail-info-group">
+                        <div class="detail-info-group is-compact">
                             <label id="detailDateLabel">...</label>
                             <p id="detailDateText"></p>
                         </div>
 
-                        <div class="detail-info-group">
+                        <div class="detail-info-group is-compact">
                             <label id="detailTagsLabel">...</label>
                             <div class="tags-container" id="detailTags"></div>
                         </div>


### PR DESCRIPTION
## Summary

Compacts the selected moment metadata (date, emotion tags) in the Editor right panel so they use less vertical space.

### Changes

- **pages/editor.html**: Added `.is-compact` class to date and tags `.detail-info-group` elements
- **css/editor/editor-detail-panel.css**: Added CSS for `.detail-info-group.is-compact` — flex row layout, compact labels and values
- **js/editor/editor-detail-ui.js**: Removed inline style on date element, letting CSS handle compact styling

### Before

```
기억한 날
2026.05.12

감정 태그
첫 마음
```

### After

```
기억한 날  2026.05.12
감정 태그  첫 마음
```

Emotion memo remains as a separate readable block.

Closes #1129