### PR TITLE
UX: refine Editor start-moment continue tip connector

### DIFF
--- a/js/editor/editor-canvas-edges.js
+++ b/js/editor/editor-canvas-edges.js
@@ -37,6 +37,10 @@
             if (!node || typeof calcPosition !== 'function') return;
 
             const parentId = node.parentId || canonicalRootId;
+            if (parentId === canonicalRootId) {
+                return;
+            }
+
             const parent = treeMemories.find((memory) => memory.id === parentId);
             if (parent) {
                 drawBranch(calcPosition(parent), calcPosition(node));

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -20,6 +20,9 @@ function createEditorCanvasGrowthAffordance(deps) {
     const BUBBLE_WIDTH = 188;
     const BUBBLE_MIN_HEIGHT = 60;
     const BUBBLE_GAP = 8;
+    const BUBBLE_PADDING_X = 10;
+    const BUBBLE_PADDING_Y = 10;
+    const PLUS_ICON_SIZE = 32;
     const LOCK_CLASS = 'affordance-interaction-locked';
     const INTERACTING_CLASS = 'is-interacting';
 
@@ -32,7 +35,9 @@ function createEditorCanvasGrowthAffordance(deps) {
         const opts = options || {};
         if (opts.isFirstStep === true) return true;
         if (!anchorMem || typeof anchorMem !== 'object') return false;
-        return !anchorMem.parentId;
+        const parentId = anchorMem.parentId;
+        if (parentId === null || parentId === undefined || parentId === '') return true;
+        return !!opts.canonicalRootId && parentId === opts.canonicalRootId;
     }
 
     function clearGrowthAffordance() {
@@ -311,13 +316,13 @@ function createEditorCanvasGrowthAffordance(deps) {
         button.style.gap = '10px';
         button.style.overflow = 'hidden';
         button.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.25)';
-        button.style.transition = 'width 0.16s ease, min-height 0.16s ease, height 0.16s ease, border-radius 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, padding 0.16s ease';
+        button.style.transition = 'left 0.16s ease, top 0.16s ease, width 0.16s ease, min-height 0.16s ease, height 0.16s ease, border-radius 0.16s ease, background 0.16s ease, box-shadow 0.16s ease, padding 0.16s ease';
 
         const plusIcon = documentRef.createElement('span');
         plusIcon.setAttribute('aria-hidden', 'true');
         plusIcon.textContent = '+';
-        plusIcon.style.width = '32px';
-        plusIcon.style.height = '32px';
+        plusIcon.style.width = `${PLUS_ICON_SIZE}px`;
+        plusIcon.style.height = `${PLUS_ICON_SIZE}px`;
         plusIcon.style.borderRadius = '50%';
         plusIcon.style.display = 'inline-flex';
         plusIcon.style.alignItems = 'center';
@@ -390,12 +395,14 @@ function createEditorCanvasGrowthAffordance(deps) {
             lockMovement();
             if (bubbleExpanded) return;
             bubbleExpanded = true;
+            button.style.left = `${tipPos.x - BUBBLE_PADDING_X - (PLUS_ICON_SIZE / 2)}px`;
+            button.style.top = `${tipPos.y - (BUBBLE_MIN_HEIGHT / 2)}px`;
             button.style.width = `${BUBBLE_WIDTH}px`;
             button.style.minHeight = `${BUBBLE_MIN_HEIGHT}px`;
-            button.style.height = 'auto';
+            button.style.height = `${BUBBLE_MIN_HEIGHT}px`;
             button.style.borderRadius = '999px';
             button.style.justifyContent = 'flex-start';
-            button.style.padding = '10px 14px 10px 10px';
+            button.style.padding = `${BUBBLE_PADDING_Y}px 14px ${BUBBLE_PADDING_Y}px ${BUBBLE_PADDING_X}px`;
             button.style.border = '1px solid rgba(144, 73, 81, 0.18)';
             button.style.background = 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96))';
             button.style.boxShadow = '0 12px 28px rgba(75, 64, 57, 0.10)';
@@ -410,6 +417,8 @@ function createEditorCanvasGrowthAffordance(deps) {
                 return;
             }
             bubbleExpanded = false;
+            button.style.left = `${tipPos.x - TIP_HALF}px`;
+            button.style.top = `${tipPos.y - TIP_HALF}px`;
             button.style.width = `${TIP_SIZE}px`;
             button.style.minHeight = `${TIP_SIZE}px`;
             button.style.height = `${TIP_SIZE}px`;

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -28,6 +28,13 @@ function createEditorCanvasGrowthAffordance(deps) {
         return Math.max(min, Math.min(value, max));
     }
 
+    function isStartMoment(anchorMem, options) {
+        const opts = options || {};
+        if (opts.isFirstStep === true) return true;
+        if (!anchorMem || typeof anchorMem !== 'object') return false;
+        return !anchorMem.parentId;
+    }
+
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
         svg.querySelectorAll('.branch-line-affordance').forEach((el) => el.remove());
@@ -274,9 +281,10 @@ function createEditorCanvasGrowthAffordance(deps) {
         svg.appendChild(path);
     }
 
-    function createPlusTipElement(anchorMem, labelText, helperText) {
+    function createPlusTipElement(anchorMem, labelText, helperText, options) {
         const anchorPos = calcPosition(anchorMem);
         const tipPos = getPlusTipPosition(anchorPos, anchorMem);
+        const shouldDrawConnector = !isStartMoment(anchorMem, options);
         const button = documentRef.createElement('button');
         let unlockTimer = null;
         button.type = 'button';
@@ -450,7 +458,9 @@ function createEditorCanvasGrowthAffordance(deps) {
             }
         });
 
-        drawConnectorLine(anchorPos, tipPos, tipPos.side);
+        if (shouldDrawConnector) {
+            drawConnectorLine(anchorPos, tipPos, tipPos.side);
+        }
         canvas.appendChild(button);
     }
 
@@ -465,7 +475,7 @@ function createEditorCanvasGrowthAffordance(deps) {
                 : (i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요'))
             || '';
 
-        createPlusTipElement(anchorMem, labelText, helperText);
+        createPlusTipElement(anchorMem, labelText, helperText, opts);
     }
 
     return {

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -311,7 +311,8 @@ function createEditorCanvas(deps) {
         const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
         clearGrowthAffordance();
         growthAffordance.renderGrowthAffordance(mem, {
-            isFirstStep: drawableMemories.length <= 1
+            isFirstStep: drawableMemories.length <= 1 || mem.parentId === canonicalRootId,
+            canonicalRootId
         });
     }
 

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -111,6 +111,16 @@ test('plus tip and bubble interaction locks node-hover movement', () => {
   assert.match(canvasSource, /canvas\.classList\.contains\(AFFORDANCE_LOCK_CLASS\)/);
 });
 
+test('start moment plus tip avoids connector line', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /function\s+isStartMoment\s*\(/);
+  assert.match(source, /opts\.isFirstStep\s*===\s*true/);
+  assert.match(source, /!anchorMem\.parentId/);
+  assert.match(source, /shouldDrawConnector\s*=\s*!isStartMoment\(anchorMem, options\)/);
+  assert.match(source, /if \(shouldDrawConnector\)\s*{\s*drawConnectorLine/);
+});
+
 test('canvas pan binding excludes add affordance presses', () => {
   const interactionSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-interaction.js'), 'utf8');
 

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -116,9 +116,26 @@ test('start moment plus tip avoids connector line', () => {
 
   assert.match(source, /function\s+isStartMoment\s*\(/);
   assert.match(source, /opts\.isFirstStep\s*===\s*true/);
-  assert.match(source, /!anchorMem\.parentId/);
+  assert.match(source, /parentId === null \|\| parentId === undefined \|\| parentId === ''/);
+  assert.match(source, /parentId === opts\.canonicalRootId/);
   assert.match(source, /shouldDrawConnector\s*=\s*!isStartMoment\(anchorMem, options\)/);
-  assert.match(source, /if \(shouldDrawConnector\)\s*{\s*drawConnectorLine/);
+});
+
+test('root-to-start tree branch line is suppressed', () => {
+  const edgesSource = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-edges.js'), 'utf8');
+
+  assert.match(edgesSource, /if \(parentId === canonicalRootId\)\s*{\s*return;\s*}/);
+});
+
+test('expanded bubble keeps plus icon center fixed', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /BUBBLE_PADDING_X\s*=\s*10/);
+  assert.match(source, /PLUS_ICON_SIZE\s*=\s*32/);
+  assert.match(source, /button\.style\.left = `\$\{tipPos\.x - BUBBLE_PADDING_X - \(PLUS_ICON_SIZE \/ 2\)\}px`/);
+  assert.match(source, /button\.style\.top = `\$\{tipPos\.y - \(BUBBLE_MIN_HEIGHT \/ 2\)\}px`/);
+  assert.match(source, /button\.style\.left = `\$\{tipPos\.x - TIP_HALF\}px`/);
+  assert.match(source, /button\.style\.top = `\$\{tipPos\.y - TIP_HALF\}px`/);
 });
 
 test('canvas pan binding excludes add affordance presses', () => {


### PR DESCRIPTION
## Summary

Refs #1169

Refines the Editor start-moment continue `+` tip so the first/start moment does not look like it has an incoming parent branch.

## Changes

### `js/editor/editor-canvas-growth-affordance.js`
- Adds start-moment detection for the continue affordance.
- Suppresses the dashed connector line for the first/start moment.
- Keeps the compact `+` tip and hover bubble behavior unchanged.
- Keeps normal connector behavior for non-start moments.

### `tests/contracts/editor-growth-affordance-contract.test.js`
- Adds a contract check that start-moment continue affordance avoids drawing the connector line.

## Expected behavior

- First/start moment: compact `+` tip remains available, but no incoming-looking connector line appears.
- Non-start moments: existing short connector line remains.
- `+` hover/focus still expands the bubble in place.
- Continue flow remains unchanged.

## Verification pending

- CI `verify-static`.
- Runtime browser verification on fixed test slot because this is an Editor UI change.

## Scope safety

- Editor continue affordance only.
- No backend/API/schema changes.
- No toolbar redesign.
- No PR #7 or prototype/reference/demo/variant changes.
- No secret/private/raw identifier exposure.