### PR TITLE
fix: resolve onSelect reference error in my-trees renderNextBatch (Refs #1157)

### DIFF
--- a/js/i18n/i18n-my-trees.js
+++ b/js/i18n/i18n-my-trees.js
@@ -55,6 +55,7 @@
     'myTrees.card_flow_empty_label': { ko: '첫 순간을 기다리는 러브트리 흐름', en: 'LoveTree flow waiting for the first moment' },
     'myTrees.card_waiting': { ko: '첫 순간을 기다리는 중', en: 'Waiting for the first moment' },
     'myTrees.card_growing': { ko: '차곡차곡 자라는 중', en: 'Growing layer by layer' },
+    'myTrees.moment_count': { ko: '순간', en: 'Moment' },
     'myTrees.moment_count_compact': { ko: '순간 {count}개', en: '{count} moments' },
     'myTrees.create_modal_kicker': { ko: '새 러브트리 시작', en: 'Start a new LoveTree' },
     'myTrees.create_modal_title': { ko: '어떤 러브트리를 남길까요?', en: 'What kind of LoveTree would you like to start?' },

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -552,6 +552,7 @@
 
   function renderTrees(trees, options) {
     var hubOnSelect = options && options.onSelect;
+    var hubOnNavigate = options && options.onNavigate;
     var container = document.getElementById('state-loaded');
     if (!container) return;
 
@@ -585,10 +586,10 @@
     grid.innerHTML = '';
 
     // Issue #616: Render first batch only
-    renderNextBatch(grid, buildTreeCardFn, setState, stateEnum);
+    renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, { onSelect: hubOnSelect, onNavigate: hubOnNavigate });
 
     // Issue #616: Set up scroll continuation
-    setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum);
+    setupScrollContinuation(grid, buildTreeCardFn, setState, stateEnum, { onSelect: hubOnSelect, onNavigate: hubOnNavigate });
 
     if (typeof setState === 'function' && stateEnum && stateEnum.LOADED) {
       setState(stateEnum.LOADED);
@@ -599,6 +600,9 @@
   function renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions) {
     var startIndex = currentVisibleCount;
     var endIndex = Math.min(startIndex + BATCH_SIZE, totalTreesCount);
+    
+    var onSelect = extraOptions && extraOptions.onSelect;
+    var onNavigate = extraOptions && extraOptions.onNavigate;
     
     for (var i = startIndex; i < endIndex; i++) {
       var tree = allTreesData[i];
@@ -654,7 +658,7 @@
       var observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (entry.isIntersecting && !isLoadingMore && currentVisibleCount < totalTreesCount) {
-            loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum, { onSelect: hubOnSelect, onNavigate: onNavigate });
+            loadMoreBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions);
           }
         });
       }, { rootMargin: '100px' });


### PR DESCRIPTION
## 버그 수정

**#1157** — `test2.lovebud.pages.dev/pages/my-trees`에서 `ReferenceError: onSelect is not defined` 발생

### 원인
PR #1157 (commit 42628eb38)에서 `renderTrees` 함수의 `options.onSelect`를 `hubOnSelect`로 이름 변경했지만, 다음 함수들이 여전히 정의되지 않은 변수를 참조하고 있었습니다:

1. **`renderNextBatch`** — `onSelect`와 `onNavigate`를 직접 참조하지만 두 변수 모두 스코프에 없음
2. **`setupScrollContinuation`** — `hubOnSelect`는 클로저로 접근 가능했지만, `onNavigate`는 정의되지 않음

### 수정 사항
1. **`renderTrees`**: `hubOnNavigate`를 `options.onNavigate`에서 추출하고, `{ onSelect: hubOnSelect, onNavigate: hubOnNavigate }`를 `extraOptions`로 `renderNextBatch`와 `setupScrollContinuation`에 전달
2. **`renderNextBatch`**: `extraOptions`에서 `onSelect`와 `onNavigate`를 읽어 로컬 변수에 할당
3. **`setupScrollContinuation`**: `loadMoreBatch` 호출 시 하드코딩된 객체 대신 전달받은 `extraOptions`를 그대로 사용

### 테스트
- `npm test` — 278/278 통과 ✅

DO NOT MERGE - Draft PR