### PR TITLE
fix: finalize My Trees card simplification — remove stray menu/dropdown HTML and fix hub layout (Refs #1125)

### DIFF
--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -290,6 +290,12 @@
       });
     }
 
+    // Apply hub layout: place hub in right sidebar instead of page bottom
+    var hubLayoutShell = document.querySelector('.my-trees-dashboard-grid-shell');
+    if (hubLayoutShell) {
+      hubLayoutShell.classList.add('my-trees-with-hub');
+    }
+
     var sortSelect = document.getElementById('sortTreesSelect');
     if (sortSelect) {
       sortSelect.addEventListener('change', function() {

--- a/js/my-trees/my-trees-i18n-refresh.js
+++ b/js/my-trees/my-trees-i18n-refresh.js
@@ -71,23 +71,6 @@
       }
     });
 
-    document.querySelectorAll('.tree-card-dropdown').forEach(function(dropdown) {
-      var card = dropdown.closest('.tree-card');
-      var isPublic = card?.dataset?.visibility !== 'private';
-      var visibilityItem = dropdown.querySelector('.dropdown-item.visibility');
-      var renameItem = dropdown.querySelector('.dropdown-item.rename');
-      var deleteItem = dropdown.querySelector('.dropdown-item.delete');
-      if (visibilityItem) {
-        visibilityItem.innerHTML = '<span class="material-symbols-outlined" style="font-size:16px;">' + (isPublic ? 'lock' : 'public') + '</span>' + (isPublic ? tText('visibility_make_private', '비공개로 전환') : tText('visibility_make_public', '공개로 전환'));
-      }
-      if (renameItem) {
-        renameItem.innerHTML = '<span class="material-symbols-outlined" style="font-size:16px;">edit</span>' + tText('rename', '이름 변경');
-      }
-      if (deleteItem) {
-        deleteItem.innerHTML = '<span class="material-symbols-outlined" style="font-size:16px;">delete</span>' + tText('delete', '삭제');
-      }
-    });
-
     document.querySelectorAll('.tree-card-count-pill, .tree-card-moment-badge').forEach(function(el) {
       var count = el.getAttribute('data-count');
       if (count !== null) {
@@ -95,15 +78,6 @@
       }
     });
 
-    document.querySelectorAll('.tree-card-select-btn').forEach(function(el) {
-      el.textContent = el.closest('.tree-card') && el.closest('.tree-card').classList.contains('is-selected')
-        ? tText('myTrees.card_selected', '보고 있는 트리')
-        : tText('myTrees.card_select', '고르기');
-    });
-
-    document.querySelectorAll('.tree-card-open-btn').forEach(function(el) {
-      el.textContent = tText('myTrees.card_open', '트리 열기');
-    });
   }
 
   function refreshMyTreesLanguage() {

--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -17,12 +17,6 @@
       .replace(/"/g, '&quot;');
   }
 
-  function closeAllDropdowns() {
-    document.querySelectorAll('.tree-card-dropdown').forEach(function (dd) {
-      dd.classList.remove('show');
-    });
-  }
-
   function hashSeed(value) {
     var source = String(value || 'lovetree');
     var hash = 0;
@@ -206,45 +200,6 @@
     ].join('');
   }
 
-  function getRepresentativeThumbnail(tree) {
-    if (!tree) return '';
-    return tree.representativeThumbnail || tree.representative_thumbnail || tree.thumbnail || '';
-  }
-
-  function clipText(value, maxLength) {
-    var text = String(value || '').trim();
-    if (!text) return '';
-    if (text.length <= maxLength) return text;
-    return text.slice(0, maxLength).trim() + '…';
-  }
-
-  function getRepresentativeTextMeta(tree, i18n) {
-    if (!tree) return null;
-
-    var repTitle = clipText(tree.representativeTitle || tree.representative_title || '', 40);
-    var repMemo = clipText(tree.representativeMemo || tree.representative_memo || '', 82);
-
-    if (!repTitle && !repMemo) return null;
-
-    return {
-      title: repTitle || (i18n('editor_default_first_title') || '첫 순간'),
-      memo: repMemo || (i18n('myTrees.card_text_fallback') || '처음 남긴 마음이 이 트리의 시작이 되었어요.')
-    };
-  }
-
-  function buildRepresentativeTextVisual(tree, palette, i18n) {
-    var textMeta = getRepresentativeTextMeta(tree, i18n);
-    if (!textMeta) return '';
-
-    return [
-      '<div class="tree-card-text-visual" style="border-color:' + palette.leafSoft + ';background:rgba(255,255,255,0.84);">',
-        '<div class="tree-card-text-kicker" style="color:' + palette.accent + ';">' + escapeHtml(i18n('myTrees.card_first_moment') || '첫 순간 기록') + '</div>',
-        '<div class="tree-card-text-title">' + escapeHtml(textMeta.title) + '</div>',
-        '<div class="tree-card-text-memo">' + escapeHtml(textMeta.memo) + '</div>',
-      '</div>'
-    ].join('');
-  }
-
   function buildTreeThumbVisual(tree, i18n) {
     var palette = getTreeMoodPalette(tree);
     var momentCount = getTreeMomentCount(tree);
@@ -381,13 +336,8 @@
   function buildTreeCard(tree, options) {
     var i18n = (options && options.i18n) || window.t || function (k) { return k; };
     var normalizeTree = options && options.normalizeTree;
-    var onRename = options && options.onRename;
-    var onDelete = options && options.onDelete;
-    var onToggleVisibility = options && options.onToggleVisibility;
-    var onNavigate = options && options.onNavigate;
     var onSelect = options && options.onSelect;
     var isSelected = options && options.isSelected;
-    var closeDropdowns = (options && options.closeAllDropdowns) || closeAllDropdowns;
 
     var normalizedTree = typeof normalizeTree === 'function'
       ? normalizeTree(tree)
@@ -416,8 +366,6 @@
     var cardMeta = getTreeCardMeta(normalizedTree, i18n);
     var title = cardMeta.title;
 
-    var menuBtnId = 'menuBtn_' + normalizedTree.id;
-    var dropdownId = 'dropdown_' + normalizedTree.id;
     var selectedClass = typeof isSelected === 'function' && isSelected(normalizedTree.id) ? ' is-selected' : '';
 
     var card = document.createElement('div');
@@ -435,9 +383,6 @@
     };
 
     card.addEventListener('click', function (e) {
-      if (e.target.closest('.tree-card-menu') || e.target.closest('.tree-card-dropdown')) {
-        return;
-      }
       handleCardSelect();
     });
 
@@ -450,23 +395,6 @@
 
     card.innerHTML = [
       buildTreeThumbVisual(normalizedTree, i18n),
-      '<button class="tree-card-menu" id="' + menuBtnId + '" type="button" aria-label="' + escapeHtml(i18n('myTrees.card_menu') || '트리 메뉴 열기') + '">',
-        '<span class="material-symbols-outlined" aria-hidden="true">more_vert</span>',
-      '</button>',
-      '<div class="tree-card-dropdown" id="' + dropdownId + '">',
-        '<div class="dropdown-item visibility" data-action="visibility">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">' + cardMeta.visibilityIcon + '</span>',
-          cardMeta.visibilityActionLabel,
-        '</div>',
-        '<div class="dropdown-item rename" data-action="rename">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">edit</span>',
-          i18n('rename') || '이름 변경',
-        '</div>',
-        '<div class="dropdown-item delete" data-action="delete">',
-          '<span class="material-symbols-outlined" style="font-size:16px;">delete</span>',
-          i18n('delete') || '삭제',
-        '</div>',
-      '</div>',
       '<div class="tree-card-info">',
         '<div class="tree-card-title-row">',
           '<div class="tree-card-title">' + escapeHtml(title) + '</div>',
@@ -497,46 +425,6 @@
         '</div>',
       '</div>'
     ].join('');
-
-    setTimeout(function () {
-      var menuBtn = document.getElementById(menuBtnId);
-      var dropdown = document.getElementById(dropdownId);
-
-      if (menuBtn && dropdown) {
-        menuBtn.addEventListener('click', function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (typeof onSelect === 'function') {
-            onSelect(normalizedTree);
-          }
-          closeDropdowns();
-          dropdown.classList.toggle('show');
-        });
-
-        dropdown.querySelectorAll('.dropdown-item').forEach(function (item) {
-          item.addEventListener('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            if (typeof onSelect === 'function') {
-              onSelect(normalizedTree);
-            }
-
-            var action = this.getAttribute('data-action');
-            if (action === 'visibility' && typeof onToggleVisibility === 'function') {
-              onToggleVisibility(normalizedTree.id, normalizedTree.visibility);
-            } else if (action === 'rename' && typeof onRename === 'function') {
-              onRename(normalizedTree.id, title);
-            } else if (action === 'delete' && typeof onDelete === 'function') {
-              onDelete(normalizedTree.id, title);
-            }
-
-            closeDropdowns();
-          });
-        });
-      }
-
-    }, 0);
 
     return card;
   }

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -37,6 +37,7 @@
         </div>
       </div>
 
+      <div class="my-trees-dashboard-grid-shell">
       <section class="dashboard-main reveal-fade my-trees-dashboard-container">
         <div id="treesContainer">
           <div id="state-loading" class="trees-loading">
@@ -146,6 +147,7 @@
           </a>
         </div>
       </aside>
+      </div>
     </main>
   </div>
   <div class="create-tree-modal-backdrop" id="createTreeModalBackdrop" aria-hidden="true">


### PR DESCRIPTION
## Summary\n\nFinalizes the My Trees card simplification (#1125) by completing work that PR #1152 and #1153 left incomplete.\n\n## Problems Fixed\n\n### 1. 점 3개 메뉴 + 드롭다운이 항상 표시됨\nPR #1152 removed CSS rules for `.tree-card-menu` and `.tree-card-dropdown` but left the HTML/JS generation code intact. Without `display: none` CSS, the dropdown was always visible.\n\n**Fix:** Removed the entire `.tree-card-menu` button, `.tree-card-dropdown` HTML, and their event listener setup from `buildTreeCard()` in `my-trees-ui.js`. Also removed `closeAllDropdowns` function and related cleanup in `my-trees-i18n-refresh.js`.\n\n### 2. 감상 허브가 페이지 하단에 위치\nBrowse 페이지는 감상 허브가 오른쪽 사이드바(400px)에 위치하지만, My Trees 페이지는 하단에 위치함. `preview-hub.css`에 `.my-trees-with-hub` 클래스가 정의되어 있지만 JS에서 적용되지 않음.\n\n**Fix:** Wrapped dashboard + hub sections in a `.my-trees-dashboard-grid-shell` container and applied `.my-trees-with-hub` class in `my-trees.js`.\n\n### 3. 카드 너비 문제\n2열 그리드 + 하단 hub로 인해 카드가 Browse보다 넓었음. Hub를 오른쪽 sidebar로 이동하여 해결됨.\n\n## Changes\n\n| File | Changes |\n|------|---------|\n| `js/my-trees/my-trees-ui.js` | -112 lines: removed menu button, dropdown HTML, event listeners, `closeAllDropdowns`, related utilities |\n| `js/my-trees/my-trees-i18n-refresh.js` | -26 lines: removed dropdown i18n refresh code |\n| `js/my-trees.js` | +6 lines: apply `.my-trees-with-hub` class to dashboard grid shell |\n| `pages/my-trees.html` | +2 lines: wrap dashboard + hub in `.my-trees-dashboard-grid-shell` |\n\n## Verification\n- [x] npm test\n- [x] Deploy to test2\n- [x] Browser verification\n\nRefs #1125