### PR TITLE
fix: suppress connector line for start moment in Editor growth affordance (Refs #1169)

### DIFF
--- a/js/editor/editor-canvas-edges.js
+++ b/js/editor/editor-canvas-edges.js
@@ -38,7 +38,10 @@
 
             const parentId = node.parentId || canonicalRootId;
             const parent = treeMemories.find((memory) => memory.id === parentId);
-            if (parent) {
+
+            // Skip branch if parent is the hidden canonical root — prevents orphan
+            // "tail" lines from invisible root to the first visible memory
+            if (parent && parent.id !== canonicalRootId) {
                 drawBranch(calcPosition(parent), calcPosition(node));
             }
         };

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -30,7 +30,7 @@ function createEditorCanvasGrowthAffordance(deps) {
 
     function isStartMoment(anchorMem, options) {
         if (!anchorMem) return false;
-        if (options && options.isFirstStep) return true;
+        if (options && (options.isStartMoment || options.isFirstStep)) return true;
         return anchorMem.parentId === null || anchorMem.parentId === undefined;
     }
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -28,6 +28,12 @@ function createEditorCanvasGrowthAffordance(deps) {
         return Math.max(min, Math.min(value, max));
     }
 
+    function isStartMoment(anchorMem, options) {
+        if (!anchorMem) return false;
+        if (options && options.isFirstStep) return true;
+        return anchorMem.parentId === null || anchorMem.parentId === undefined;
+    }
+
     function clearGrowthAffordance() {
         canvas.querySelectorAll('.memory-add-affordance').forEach((el) => el.remove());
         svg.querySelectorAll('.branch-line-affordance').forEach((el) => el.remove());
@@ -274,7 +280,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         svg.appendChild(path);
     }
 
-    function createPlusTipElement(anchorMem, labelText, helperText) {
+    function createPlusTipElement(anchorMem, labelText, helperText, options) {
         const anchorPos = calcPosition(anchorMem);
         const tipPos = getPlusTipPosition(anchorPos, anchorMem);
         const button = documentRef.createElement('button');
@@ -450,7 +456,11 @@ function createEditorCanvasGrowthAffordance(deps) {
             }
         });
 
-        drawConnectorLine(anchorPos, tipPos, tipPos.side);
+        const shouldDrawConnector = !isStartMoment(anchorMem, options);
+        if (shouldDrawConnector) {
+            drawConnectorLine(anchorPos, tipPos, tipPos.side);
+        }
+
         canvas.appendChild(button);
     }
 
@@ -465,7 +475,7 @@ function createEditorCanvasGrowthAffordance(deps) {
                 : (i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요'))
             || '';
 
-        createPlusTipElement(anchorMem, labelText, helperText);
+        createPlusTipElement(anchorMem, labelText, helperText, opts);
     }
 
     return {

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -311,7 +311,8 @@ function createEditorCanvas(deps) {
         const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
         clearGrowthAffordance();
         growthAffordance.renderGrowthAffordance(mem, {
-            isFirstStep: drawableMemories.length <= 1
+            isFirstStep: drawableMemories.length <= 1,
+            isStartMoment: mem.parentId === canonicalRootId
         });
     }
 

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -123,7 +123,7 @@ test('start moment detection suppresses connector line', () => {
   assert.match(source, /function\s+isStartMoment\s*\(/);
   assert.match(source, /anchorMem\.parentId\s*===\s*null/);
   assert.match(source, /anchorMem\.parentId\s*===\s*undefined/);
-  assert.match(source, /options\s*&&\s*options\.isFirstStep/);
+  assert.match(source, /options\s*&&\s*\(?\s*options\.isStartMoment/);
   assert.match(source, /shouldDrawConnector/);
   assert.match(source, /if\s*\([^)]*shouldDrawConnector[^)]*\)/);
   assert.match(source, /drawConnectorLine\s*\(/);
@@ -140,5 +140,5 @@ test('growth affordance keeps connector for non-start memories', () => {
 test('isStartMoment handles missing options gracefully', () => {
   const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
 
-  assert.match(source, /if\s*\([^)]*options\s*&&\s*options\.isFirstStep[^)]*\)/);
+  assert.match(source, /if\s*\([^)]*options\s*&&\s*\([^)]*options\.isStartMoment[^)]*\)/);
 });

--- a/tests/contracts/editor-growth-affordance-contract.test.js
+++ b/tests/contracts/editor-growth-affordance-contract.test.js
@@ -116,3 +116,29 @@ test('canvas pan binding excludes add affordance presses', () => {
 
   assert.match(interactionSource, /memory-add-affordance/);
 });
+
+test('start moment detection suppresses connector line', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /function\s+isStartMoment\s*\(/);
+  assert.match(source, /anchorMem\.parentId\s*===\s*null/);
+  assert.match(source, /anchorMem\.parentId\s*===\s*undefined/);
+  assert.match(source, /options\s*&&\s*options\.isFirstStep/);
+  assert.match(source, /shouldDrawConnector/);
+  assert.match(source, /if\s*\([^)]*shouldDrawConnector[^)]*\)/);
+  assert.match(source, /drawConnectorLine\s*\(/);
+});
+
+test('growth affordance keeps connector for non-start memories', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /const\s+shouldDrawConnector\s*=\s*!isStartMoment/);
+  assert.match(source, /if\s*\([^)]*shouldDrawConnector[^)]*\)/);
+  assert.match(source, /drawConnectorLine\s*\(/);
+});
+
+test('isStartMoment handles missing options gracefully', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'js/editor/editor-canvas-growth-affordance.js'), 'utf8');
+
+  assert.match(source, /if\s*\([^)]*options\s*&&\s*options\.isFirstStep[^)]*\)/);
+});


### PR DESCRIPTION
## Summary

Refs #1169
Supersedes #1170

Suppresses the dashed connector line from the + tip for the start/root moment in Editor canvas, AND prevents orphan branch lines from the hidden canonical root to the first visible memory.

## Changes

### js/editor/editor-canvas-growth-affordance.js
- Adds isStartMoment(anchorMem, options) helper to detect root (parentId===null) and first-step moments.
- Modifies createPlusTipElement() to accept an options parameter.
- Conditionally calls drawConnectorLine() only for non-start moments.
- isStartMoment now also checks options.isStartMoment (passed from editor-canvas.js).

### js/editor/editor-canvas.js
- renderAffordanceForMemory() now passes isStartMoment: mem.parentId === canonicalRootId to detect the first visible child of the hidden root.

### js/editor/editor-canvas-edges.js
- drawBranchForMemory() now skips drawing a branch line when the parent is the hidden canonical root (parent.id === canonicalRootId). This prevents orphan "tail" lines from the invisible root to the first visible memory.

### tests/contracts/editor-growth-affordance-contract.test.js
- Adds 3 contract tests for isStartMoment() start moment detection, non-start connector preservation, and graceful missing-options handling.
- Updated regex patterns to match new options.isStartMoment check.

## Behavior
- First/start moment: compact + tip appears WITHOUT dashed connector line.
- First visible memory: no orphan branch line from hidden root.
- Non-start moments: dashed connector line continues as before.
- Hover bubble expansion stays in place (no left/top repositioning).
- All keyboard/mouse event listeners preserved.

## Verification
- Browser verification PASS on test1/test5 (SHA 5aeba1b9)
- npm test: 281/281 pass
- Contract tests 81/82/83 all pass
- No CSS or HTML changes.
- Editor canvas only — no backend/data-layer changes.
