### PR TITLE
UI: keep My Trees navigation in Editor global header (Refs #1127)

### DIFF
--- a/js/shared-header.js
+++ b/js/shared-header.js
@@ -291,8 +291,8 @@
             navLinksHTML += '<a href="' + menuConfig.search.href + '"' + activeClass + '>' + t(menuConfig.search.textKey) + '</a>';
         }
 
-        // 내 러브트리 (에디터 페이지에서는 숨김)
-        if (menuConfig.myTrees && !isEditorPage()) {
+        // 내 러브트리
+        if (menuConfig.myTrees) {
             var myTreesClasses = ['nav-highlight'];
             if (activeKey === 'myTrees') myTreesClasses.unshift('active');
             var activeClass = ' class="' + myTreesClasses.join(' ') + '"';


### PR DESCRIPTION
Refs #1127

## Summary

Keeps the global `나의트리` navigation item visible in the Editor header so users have the same top-level return path used elsewhere.

## Changes

- Updates `js/shared-header.js` so `myTrees` nav is no longer hidden on the Editor page.
- Keeps the existing Editor active state unchanged.
- Keeps auth-gated My Trees routing behavior unchanged.
- Does not change Editor canvas, sidebar, right detail panel, backend, API, or schema behavior.

## Verification pending

- CI
- Browser verification on a deployed test slot

## Required browser checks

- Editor header shows `나의트리`.
- Clicking `나의트리` navigates to My Trees.
- Existing left-sidebar `내 러브트리로 돌아가기` still works.
- Header active/current styling does not regress on Editor/My Trees/Search/Settings.
- Mobile nav is not worsened.
- Console fatal JS errors: 0.