### PR TITLE
UI: center Editor continue bubble copy

### DIFF
--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -343,7 +343,8 @@ function createEditorCanvasGrowthAffordance(deps) {
         titleEl.style.fontWeight = '700';
         titleEl.style.color = 'var(--on-surface)';
         titleEl.style.lineHeight = '1.28';
-        titleEl.style.whiteSpace = 'nowrap';
+        titleEl.style.textAlign = 'center';
+        titleEl.style.width = '100%';
         textWrap.appendChild(titleEl);
 
         if (helperText) {
@@ -354,11 +355,8 @@ function createEditorCanvasGrowthAffordance(deps) {
             hintEl.style.color = 'var(--on-surface-variant)';
             hintEl.style.lineHeight = '1.32';
             hintEl.style.opacity = '0.82';
-            hintEl.style.whiteSpace = 'normal';
-            hintEl.style.display = '-webkit-box';
-            hintEl.style.webkitLineClamp = '2';
-            hintEl.style.webkitBoxOrient = 'vertical';
-            hintEl.style.overflow = 'hidden';
+            hintEl.style.whiteSpace = 'pre-line';
+            hintEl.style.display = 'block';
             textWrap.appendChild(hintEl);
         }
 
@@ -472,7 +470,7 @@ function createEditorCanvasGrowthAffordance(deps) {
         const helperText = opts.helperText
             || (isFirstStep
                 ? (i18n('growth_first_step_hint') || '첫 순간에서 이어지는 감정을 기록해보세요')
-                : (i18n('growth_continue_hint') || '선택한 순간 뒤로 감정이 이어져요'))
+                : (i18n('growth_continue_hint') || '선택한 순간 뒤로\n감정이 이어져요'))
             || '';
 
         createPlusTipElement(anchorMem, labelText, helperText, opts);

--- a/js/i18n/i18n-editor.js
+++ b/js/i18n/i18n-editor.js
@@ -76,7 +76,7 @@ Object.assign(window.i18nEditor, {
     continue_moment: { ko: '순간 이어가기', en: 'Continue this moment' },
     growth_start_hint: { ko: '여기서 다음 가지가 자라나요', en: 'The next branch grows from here' },
     growth_first_step_hint: { ko: '첫 순간에서 이어지는 감정을 기록해보세요', en: 'Record the feeling that continues from your first moment' },
-    growth_continue_hint: { ko: '선택한 순간 뒤로 감정이 이어져요', en: 'The feeling continues from the selected moment' },
+    growth_continue_hint: { ko: '선택한 순간 뒤로\n감정이 이어져요', en: 'The feeling continues from the selected moment' },
     detail_empty_desc: { ko: '가운데에서 첫 순간을 만들면 이곳에서 제목과 마음 기록을 다듬을 수 있어요.', en: 'Create the first moment from the center, then refine its title and note here.' },
     editor_make_private: { ko: '이 트리 비공개로 전환', en: 'Make this tree private' },
     editor_make_public: { ko: '이 트리 공개하기', en: 'Make this tree public' },


### PR DESCRIPTION
## Summary

Polishes the Editor continue bubble copy layout after the View options work.

## Changes

- Centers the continue bubble title text.
- Allows the helper text to honor an intentional line break.
- Removes the old webkit line clamp that conflicts with the intended multiline helper copy.
- Updates the Korean `growth_continue_hint` copy to split across two lines.

## Verification

- test5 deployment verified: https://test5.lovebud.pages.dev
- Continue bubble title is centered.
- Helper copy renders as two lines.
- Console fatal JS errors: 0.

## Scope safety

- UI copy/layout polish only.
- No tree data changes.
- No backend/API/schema changes.
- No public viewer changes.
- No PR #7/prototype/reference/demo/variant changes.