### PR TITLE
Ops: gate Editor loader console diagnostics

### DIFF
--- a/js/editor/editor-data-loader-fallbacks.js
+++ b/js/editor/editor-data-loader-fallbacks.js
@@ -2,7 +2,17 @@
 // Extracted from js/editor.js to reduce entry file size
 // Used when LoveBudEditorDataLoader is not available
 
-window.LoveBudEditorDataLoaderFallbacks = {
+(function() {
+    function isEditorDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_EDITOR_DEBUG === true;
+    }
+
+    function editorDebugLog() {
+        if (!isEditorDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
+    window.LoveBudEditorDataLoaderFallbacks = {
     createInlineNormalizeMemoryFallback: () => (mem) => {
         if (!window.__editorNormalizeWarningShown) {
             console.warn('[editor] LoveBudNormalize not loaded, using local fallback');
@@ -52,7 +62,7 @@ window.LoveBudEditorDataLoaderFallbacks = {
                     tree = await apiClient.getTree(requestedTreeId);
                     if (tree) {
                         treeLoadStatus = 'loaded';
-                        console.log('[editor] Tree from URL loaded:', tree.id);
+                        editorDebugLog('[editor] Tree from URL loaded');
                     }
                 } else {
                     treeLoadStatus = 'api_unavailable';
@@ -84,9 +94,9 @@ window.LoveBudEditorDataLoaderFallbacks = {
                 if (apiTree) {
                     tree = apiTree;
                     treeLoadStatus = 'loaded';
-                    console.log('[editor] API tree loaded (getFirstTree)');
+                    editorDebugLog('[editor] API tree loaded');
                 } else {
-                    console.log('[editor] No tree found, creating default tree...');
+                    editorDebugLog('[editor] No tree found, creating default tree');
                     if (apiClient.createTree) {
                         const newTree = await apiClient.createTree({
                             title: createDefaultTreeTitle(),
@@ -95,7 +105,7 @@ window.LoveBudEditorDataLoaderFallbacks = {
                         tree = newTree;
                         isNewTree = true;
                         treeLoadStatus = 'created';
-                        console.log('[editor] Default tree created:', newTree);
+                        editorDebugLog('[editor] Default tree created');
                     }
                 }
             }
@@ -138,7 +148,7 @@ window.LoveBudEditorDataLoaderFallbacks = {
         const cachedMemories = cache ? cache.get(cacheKey) : null;
 
         if (cachedMemories && Array.isArray(cachedMemories)) {
-            console.log('[editor] Using cached memories:', cachedMemories.length);
+            editorDebugLog('[editor] Using cached memories:', cachedMemories.length);
             memories = cachedMemories;
             window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
         }
@@ -148,7 +158,7 @@ window.LoveBudEditorDataLoaderFallbacks = {
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
                     memories = apiMemories;
-                    console.log('[editor] API memories loaded:', apiMemories.length);
+                    editorDebugLog('[editor] API memories loaded:', apiMemories.length);
                     if (cache) {
                         cache.set(cacheKey, memories, 2 * 60 * 1000);
                     }
@@ -227,7 +237,7 @@ window.LoveBudEditorDataLoaderFallbacks = {
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
                     window.currentTreeMemories = apiMemories.map(normalizeMemory).filter(Boolean);
-                    console.log('[editor] Memories refreshed:', window.currentTreeMemories.length);
+                    editorDebugLog('[editor] Memories refreshed:', window.currentTreeMemories.length);
                     onMemoriesUpdated(window.currentTreeMemories);
                 }
             }
@@ -235,4 +245,5 @@ window.LoveBudEditorDataLoaderFallbacks = {
             console.warn('[editor] Failed to refresh memories:', e.message);
         }
     }
-};
+    };
+})();

--- a/js/editor/editor-tree-helpers.js
+++ b/js/editor/editor-tree-helpers.js
@@ -1,6 +1,15 @@
 (function() {
     const treeHelpers = window.LoveBudEditorTreeHelpers || (window.LoveBudEditorTreeHelpers = {});
 
+    function isEditorDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_EDITOR_DEBUG === true;
+    }
+
+    function editorDebugLog() {
+        if (!isEditorDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
     if (!treeHelpers.createInitialMemory) {
         treeHelpers.createInitialMemory = function createInitialMemory(options) {
             const opts = options || {};
@@ -59,7 +68,7 @@
                 ...tree,
                 visibility: tree && tree.visibility ? tree.visibility : 'public'
             };
-            console.log('[editor] currentTreeData set:', window.currentTreeData.visibility);
+            editorDebugLog('[editor] currentTreeData set');
         };
     }
 


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce normal Editor runtime console noise and avoid exposing raw identifiers from loader diagnostics.

## Changes

- Adds a narrow Editor debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_EDITOR_DEBUG === true`.
- Gates non-actionable Editor loader/tree helper `console.log` diagnostics behind debug mode.
- Removes raw tree/object logging from normal runtime diagnostics.
- Keeps actionable warning paths for API/auth/load failures.

## Verification

- Pending CI.
- Browser smoke recommended on Editor/test slot to confirm normal load has fatal JS errors: 0 and does not print raw tree/memory identifiers from these fallback diagnostics.

## Scope safety

- Editor diagnostics only.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session/token handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130