### PR TITLE
Ops: gate Editor DOM selector boot log

### DIFF
--- a/js/editor/editor-dom-selectors.js
+++ b/js/editor/editor-dom-selectors.js
@@ -11,6 +11,15 @@
 (function() {
     'use strict';
 
+    function isEditorDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_EDITOR_DEBUG === true;
+    }
+
+    function editorDebugLog() {
+        if (!isEditorDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
     // DOM element ID constants
     const SELECTORS = {
         // Sidebar elements
@@ -170,6 +179,6 @@
         hasElement: hasElement
     };
 
-    // Log successful registration for debugging
-    console.log('[editor-dom-selectors] DOM selector registry loaded');
+    // Debug-only registration trace for local diagnostics.
+    editorDebugLog('[editor-dom-selectors] DOM selector registry loaded');
 })();


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce a remaining Editor module boot log during normal runtime.

## Changes

- Adds a narrow Editor debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_EDITOR_DEBUG === true`.
- Gates the Editor DOM selector registry boot log behind debug mode.
- Keeps the selector registry export and behavior unchanged.
- Keeps actionable warning paths unchanged.

## Verification

- Pending CI.

## Scope safety

- Editor diagnostics only.
- Changed file limited to `js/editor/editor-dom-selectors.js`.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130