### PR TITLE
Ops: gate Editor memory form diagnostics

### DIFF
--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -31,6 +31,15 @@ function createEditorMemoryForm(deps) {
     const timeHelper = window.LoveBudEditorMemoryFormTime;
     const payloadHelper = window.LoveBudEditorMemoryFormPayload;
 
+    function isEditorDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_EDITOR_DEBUG === true;
+    }
+
+    function editorDebugLog() {
+        if (!isEditorDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
     let isFormOpen = false;
     let escHandler = null;
     let outsideClickHandler = null;
@@ -312,7 +321,7 @@ function createEditorMemoryForm(deps) {
                 createdMemory = await window.apiClient.createMemory(newMemoryData);
                 useApi = true;
                 setLocalSaveMode(false);
-                console.log('[editor] API createMemory success:', createdMemory);
+                editorDebugLog('[editor] API createMemory success');
             } else {
                 throw new Error('createMemory API not available');
             }
@@ -329,7 +338,7 @@ function createEditorMemoryForm(deps) {
         }
 
         if (!createdMemory || typeof createdMemory !== 'object') {
-            console.log('[editor] Using local fallback memory');
+            editorDebugLog('[editor] Using local fallback memory');
             setLocalSaveMode(true);
             createdMemory = {
                 id: nextMemoryId(),
@@ -376,7 +385,7 @@ function createEditorMemoryForm(deps) {
 
         if (typeof setCachedMemories === 'function' && treeId) {
             setCachedMemories(treeId, getTreeMemories());
-            console.log('[editor] 메모리 추가 후 캐시 갱신', getTreeMemories().length, '개');
+            editorDebugLog('[editor] Memory cache refreshed:', getTreeMemories().length);
         }
 
         updateSidebarStatus();


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce normal Editor memory form console noise.

## Changes

- Adds a narrow Editor debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_EDITOR_DEBUG === true`.
- Gates non-actionable memory form diagnostics behind debug mode.
- Removes created-memory object logging from normal runtime output.
- Keeps actionable warning/error paths unchanged.

## Verification

- Pending CI.

## Scope safety

- Editor diagnostics only.
- Changed file limited to `js/editor/editor-memory-form.js`.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130