### PR TITLE
Ops: gate My Trees retry diagnostic

### DIFF
--- a/js/my-trees/my-trees-page.js
+++ b/js/my-trees/my-trees-page.js
@@ -10,6 +10,15 @@
  */
 
 (function() {
+  function isMyTreesDebugEnabled() {
+    return window.LOVEBUD_DEBUG === true || window.LOVEBUD_MY_TREES_DEBUG === true;
+  }
+
+  function myTreesDebugLog() {
+    if (!isMyTreesDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+    console.log.apply(console, arguments);
+  }
+
   var STATE = {
     LOADING: 'loading',
     LOADED: 'loaded',
@@ -150,7 +159,7 @@
     if (!btn || typeof onRetry !== 'function') return;
 
     btn.addEventListener('click', function() {
-      console.log('[my-trees] Retry loading trees');
+      myTreesDebugLog('[my-trees] Retry loading trees');
       onRetry();
     });
   }


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce a normal My Trees retry-button console trace.

## Changes

- Adds a narrow My Trees debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_MY_TREES_DEBUG === true`.
- Gates the retry-button diagnostic behind debug mode.
- Keeps retry behavior unchanged.
- Keeps toast fallback warning behavior unchanged.

## Verification

- Pending CI.

## Scope safety

- My Trees diagnostics only.
- Changed file limited to `js/my-trees/my-trees-page.js`.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130