### PR TITLE
Ops: gate index language toggle diagnostic

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
+    function isIndexDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_INDEX_DEBUG === true;
+    }
+
+    function indexDebugLog() {
+        if (!isIndexDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
     // Reveal Observer for scroll animations
     const observerOptions = {
         threshold: 0.1
@@ -20,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.addEventListener('click', () => {
             langBtns.forEach(b => b.classList.remove('active'));
             btn.classList.add('active');
-            console.log('Language changed to:', btn.textContent);
+            indexDebugLog('Language changed to:', btn.textContent);
             // In a real app, this would trigger i18n logic
         });
     });


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce a normal root-page language-toggle console trace.

## Changes

- Adds a narrow index-page debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_INDEX_DEBUG === true`.
- Gates the visual language-toggle diagnostic behind debug mode.
- Keeps the existing visual toggle behavior unchanged.
- Keeps browse prefetch initialization unchanged.

## Verification

- Pending CI.

## Scope safety

- Root page diagnostics only.
- Changed file limited to `js/index.js`.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130