### PR TITLE
Ops: gate settings initialization diagnostic

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -6,6 +6,15 @@
  */
 
 (function() {
+  function isSettingsDebugEnabled() {
+    return window.LOVEBUD_DEBUG === true || window.LOVEBUD_SETTINGS_DEBUG === true;
+  }
+
+  function settingsDebugLog() {
+    if (!isSettingsDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+    console.log.apply(console, arguments);
+  }
+
   var SETTINGS_KEY = 'lovebud_user_settings';
   var SETTINGS_AUTH_RECOVERY_TIMEOUT_MS = 1200;
   var DEFAULT_SETTINGS = {
@@ -323,7 +332,7 @@
     settingsStarted = true;
     document.body.classList.remove('settings-auth-pending');
 
-    var settings = loadSettings();
+    loadSettings();
     bindCloseInteractions();
 
     setTimeout(function() {
@@ -332,7 +341,7 @@
       applyHeaderNavFallbacks();
     }, 0);
 
-    console.log('[settings] Initialized and staying on settings route:', settings);
+    settingsDebugLog('[settings] Initialized and staying on settings route');
   }
 
   function initSettings() {


### PR DESCRIPTION
## Summary

Small follow-up for #1130 to reduce Settings page initialization console output.

## Changes

- Adds a narrow Settings debug check using `window.LOVEBUD_DEBUG === true` or `window.LOVEBUD_SETTINGS_DEBUG === true`.
- Gates the Settings initialization diagnostic behind debug mode.
- Removes settings object logging from normal runtime output.
- Keeps authentication gating and settings page behavior unchanged.

## Verification

- Pending CI.

## Scope safety

- Settings diagnostics only.
- Changed file limited to `js/settings.js`.
- No UI layout changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130