### PR TITLE
UI: distribute Editor topbar controls

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -7,7 +7,7 @@
  */
 .editor-canvas-topbar {
     position: absolute;
-    top: 28px;
+    top: 18px;
     left: 24px;
     right: 24px;
     z-index: 7;
@@ -19,7 +19,7 @@
 .editor-canvas-toolbar {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     width: 100%;
     gap: 6px;
     padding: 6px 12px;
@@ -46,6 +46,13 @@
 }
 .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] {
     gap: 6px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] .editor-canvas-tool-btn-wide {
+    flex: 1 1 0;
+    min-width: 150px;
+    justify-content: center;
 }
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] {
     gap: 6px;
@@ -56,6 +63,8 @@
     border-radius: 20px;
     padding: 0 18px 0 14px;
     height: 38px;
+    min-width: 128px;
+    justify-content: center;
     color: var(--primary, rgba(144,73,81,0.92));
     font-weight: 700;
     gap: 8px;
@@ -77,6 +86,9 @@
 }
 .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide .material-symbols-outlined {
     font-size: 18px;
+}
+.editor-canvas-view-options-group {
+    margin-left: auto;
 }
 .editor-canvas-toolbar-separator {
     width: 1px;
@@ -207,6 +219,9 @@
     min-width: 36px;
     justify-content: center;
 }
+.editor-canvas-toolbar.is-compact .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] .editor-canvas-tool-btn-wide {
+    flex: 0 0 auto;
+}
 .editor-canvas-toolbar.is-compact .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
     padding: 0;
     width: 36px;
@@ -257,9 +272,16 @@
         flex: 0 0 auto;
         flex-direction: row;
     }
+    .editor-canvas-toolbar-group[aria-label="트리 뷰 컨트롤"] .editor-canvas-tool-btn-wide {
+        flex: none;
+        min-width: 0;
+    }
     .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] {
         flex: 0 0 auto;
         flex-direction: row;
+    }
+    .editor-canvas-view-options-group {
+        margin-left: 0;
     }
     .editor-canvas-toolbar-separator {
         display: none;
@@ -278,6 +300,7 @@
     .editor-canvas-toolbar-group[aria-label="레이아웃 모드"] .editor-canvas-tool-btn-wide {
         padding: 0 12px 0 10px;
         height: 34px;
+        min-width: 0;
     }
     .editor-canvas-tool-label {
         position: static;


### PR DESCRIPTION
## Summary

First small follow-up for #1164.

This PR keeps the existing Editor toolbar markup and behavior, but improves how the topbar uses horizontal space.

## Changes

- Moves the Editor canvas topbar slightly closer to the shared header.
- Changes toolbar distribution from evenly spaced islands to a left-to-right layout.
- Lets the main tree-view action buttons expand across available width.
- Keeps the View options group aligned to the right on desktop.
- Keeps compact/mobile toolbar behavior intact with mobile-specific overrides.

## Verification

- Pending CI.
- Fixed test slot browser verification is required before ready/merge because this changes Editor UI layout.

## Scope safety

- Editor CSS only.
- Changed file limited to `css/editor/editor-canvas-toolbar.css`.
- No JS behavior changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1164