### PR TITLE
Docs: update runtime console hygiene hold status

### DIFF
--- a/docs/ops/RUNTIME_CONSOLE_HYGIENE_FOLLOWUP_2026-05-15.md
+++ b/docs/ops/RUNTIME_CONSOLE_HYGIENE_FOLLOWUP_2026-05-15.md
@@ -105,9 +105,11 @@ UI layout PRs remain subject to separate fixed test slot browser verification.
 
 ---
 
-## 7. Remaining Known Hold
+## 7. Resolved Prior Hold
 
-PR #1180 remains draft/open because it changes Editor UI layout. It has CI success, but it still requires fixed test slot browser verification before ready/merge.
+PR #1180 was previously held because it changed Editor UI layout and required fixed test slot browser verification before ready/merge.
+
+That hold is now resolved. PR #1180 was verified separately as an Editor UI polish change and merged after the browser verification requirement was reported as passing.
 
 ---
 
@@ -124,5 +126,5 @@ Future runtime console hygiene should be handled in the same pattern:
 
 ---
 
-**Document version**: 1.0  
+**Document version**: 1.1  
 **Last updated**: 2026-05-15


### PR DESCRIPTION
## Summary

Updates the runtime console hygiene follow-up note now that PR #1180 has been verified and merged.

## Changes

- Replaces the stale `Remaining Known Hold` section with `Resolved Prior Hold`.
- Records that #1180 was previously held for Editor UI browser verification but has since been verified and merged.
- Bumps the document version from 1.0 to 1.1.

## Verification

- Docs-only.
- No runtime/code/CSS/JS changes.
- No backend/API/schema/tree-data changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1130