### PR TITLE
UI: polish Editor View options popover

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -88,7 +88,68 @@
     font-size: 18px;
 }
 .editor-canvas-view-options-group {
+    position: relative;
     margin-left: auto;
+}
+.editor-canvas-view-options-group .editor-canvas-tool-btn-wide {
+    min-width: 92px;
+    padding: 0 16px 0 12px;
+    justify-content: center;
+    background: rgba(255,255,255,0.72);
+    border-color: rgba(144,73,81,0.18);
+    color: var(--primary, rgba(144,73,81,0.92));
+    gap: 8px;
+}
+.editor-canvas-view-options-group .editor-canvas-tool-btn-wide[aria-expanded="true"],
+.editor-canvas-view-options-group .editor-canvas-tool-btn-wide.is-active {
+    background: rgba(144,73,81,0.10);
+    border-color: rgba(144,73,81,0.34);
+    color: var(--primary, rgba(144,73,81,0.92));
+    box-shadow: inset 0 0 0 1px rgba(144,73,81,0.08);
+}
+.editor-canvas-view-options-group .editor-canvas-tool-btn-wide[aria-expanded="true"] .material-symbols-outlined,
+.editor-canvas-view-options-group .editor-canvas-tool-btn-wide.is-active .material-symbols-outlined {
+    font-variation-settings: 'FILL' 1, 'wght' 500, 'GRAD' 0, 'opsz' 24;
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-options-panel {
+    left: auto;
+    right: 0;
+    top: calc(100% + 10px);
+    width: 240px;
+    padding: 14px;
+    border-radius: 18px;
+    background: rgba(255,250,244,0.98);
+    border: 1px solid rgba(230,207,194,0.9);
+    box-shadow: 0 18px 38px rgba(75,64,57,0.18);
+    backdrop-filter: blur(12px);
+    gap: 9px;
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-options-title {
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 850;
+    color: var(--primary, rgba(144,73,81,0.92));
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-option-row {
+    min-height: 28px;
+    padding: 4px 6px;
+    border-radius: 10px;
+    transition: background 0.16s ease, color 0.16s ease;
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-option-row:hover,
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-option-row:focus-within {
+    background: rgba(144,73,81,0.08);
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-option-row input {
+    flex: 0 0 auto;
+}
+.editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-options-help {
+    margin-top: 2px;
+    padding-top: 10px;
+    text-align: left;
+}
+.editor-view-options-separator {
+    margin-left: 8px;
 }
 .editor-canvas-toolbar-separator {
     width: 1px;
@@ -237,6 +298,10 @@
         left: 14px;
         right: 14px;
     }
+    .editor-canvas-view-options-group .editor-canvas-tool-btn-wide {
+        min-width: 84px;
+        padding: 0 14px 0 11px;
+    }
 }
 @media (max-width: 768px) {
     .editor-canvas-topbar {
@@ -282,6 +347,19 @@
     }
     .editor-canvas-view-options-group {
         margin-left: 0;
+    }
+    .editor-canvas-view-options-group .editor-canvas-tool-btn-wide {
+        min-width: 0;
+        padding: 0 10px;
+    }
+    .editor-canvas-toolbar .editor-canvas-view-options-group .editor-view-options-panel {
+        position: fixed;
+        left: 16px;
+        right: 16px;
+        top: 76px;
+        width: auto;
+        max-width: none;
+        z-index: 80;
     }
     .editor-canvas-toolbar-separator {
         display: none;


### PR DESCRIPTION
## Summary

Small follow-up for #1164 after the Editor topbar distribution work.

This PR keeps the existing View options behavior, but makes the right-side View control read more like an integrated toolbar menu.

## Changes

- Gives the View options toolbar button a clearer right-side menu treatment.
- Adds active/open visual treatment for the View options button.
- Refines the View options popover width, spacing, shadow, hover states, and help text layout.
- Improves mobile popover placement so it opens as a readable fixed panel instead of being constrained by the horizontal toolbar.

## Verification

- Pending CI.
- Browser verification required on fixed test slot because this changes Editor UI layout.

## Scope safety

- CSS-only Editor UI polish.
- Changed file limited to `css/editor/editor-canvas-toolbar.css`.
- No JS behavior changes.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1164