### PR TITLE
UX: align My Trees initial batch size

### DIFF
--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -429,8 +429,8 @@
     return card;
   }
 
-  // Issue #616: first-batch rendering constants
-  var FIRST_BATCH_SIZE = 6;
+  // Issue #616/#1120: first-batch rendering constants
+  var FIRST_BATCH_SIZE = 4;
   var BATCH_SIZE = 6;
   var currentVisibleCount = 0;
   var totalTreesCount = 0;
@@ -473,7 +473,7 @@
     // Sort change or re-render: clear old cards before appending new ones
     grid.innerHTML = '';
 
-    // Issue #616: Render first batch only
+    // Issue #616/#1120: Render first two-row batch only
     renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, { onSelect: hubOnSelect, onNavigate: hubOnNavigate });
 
     // Issue #616: Set up scroll continuation
@@ -484,10 +484,11 @@
     }
   }
 
-  // Issue #616: Render next batch of trees
+  // Issue #616/#1120: Render next batch of trees
   function renderNextBatch(grid, buildTreeCardFn, setState, stateEnum, extraOptions) {
     var startIndex = currentVisibleCount;
-    var endIndex = Math.min(startIndex + BATCH_SIZE, totalTreesCount);
+    var batchSize = startIndex === 0 ? FIRST_BATCH_SIZE : BATCH_SIZE;
+    var endIndex = Math.min(startIndex + batchSize, totalTreesCount);
     
     var onSelect = extraOptions && extraOptions.onSelect;
     var onNavigate = extraOptions && extraOptions.onNavigate;


### PR DESCRIPTION
## Summary

Small follow-up for #1120 to align the My Trees initial render with the current two-column owner grid.

## Changes

- Sets `FIRST_BATCH_SIZE` to 4 for the initial two-row desktop batch.
- Keeps the continuation `BATCH_SIZE` at 6 for scroll loading.
- Makes `renderNextBatch()` use `FIRST_BATCH_SIZE` only when rendering from index 0.
- Keeps existing scroll continuation, sorting reset, card click, and summary behavior unchanged.

## Verification

- Pending CI.
- Browser verification required on a fixed test slot because My Trees requires login/live user data.

## Scope safety

- My Trees UI rendering logic only.
- Changed file limited to `js/my-trees/my-trees-ui.js`.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.
- No raw identifiers or private payloads added to logs/reports.

Refs #1120