### PR TITLE
UI: remove selected moment helper copy

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -336,11 +336,8 @@ function createEditorDetailUI(deps) {
         }
 
         if (hintEl) {
-            hintEl.textContent = isEmptyState
-                ? formatI18nText('editor_current_moment_empty_hint', '첫 순간이 심어지면 여기서 감정 메모와 다음 행동이 자연스럽게 이어집니다.')
-                : isRootSelected
-                    ? formatI18nText('editor_current_moment_root_hint', '이 순간은 트리의 시작점이에요. 다음 장면을 이어 심으며 감정의 흐름을 키워보세요.')
-                    : '';
+            hintEl.textContent = '';
+            hintEl.hidden = true;
         }
 
         if (imgEl) {

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -312,7 +312,6 @@
     setText('detailEmptyTitle', 'detail_empty_title', '첫 순간이 트리를 깨워요');
     setText('detailEmptyDesc', 'detail_empty_desc', '왼쪽 아래 버튼으로 첫 장면을 심으면, 이 패널이 현재 순간 허브로 바뀝니다.');
     setText('detailCurrentMomentBadge', 'editor_current_moment_badge', '현재 순간');
-    setText('detailCurrentMomentHint', 'editor_current_moment_hint', '선택한 순간을 중심으로 감정 메모와 다음 행동이 정리됩니다.');
     setText('detailTreeStatusLabel', 'current_tree', '현재 트리');
     setText('detailMomentInfoLabel', 'editor_moment_info_label', '순간 정보');
     setText('detailDateLabel', 'editor_date_label', '기억한 날');


### PR DESCRIPTION
## Summary

Small follow-up for #1118 to remove non-functional helper copy from the selected moment panel.

## Changes

- Stops the language refresh pass from re-inserting the selected moment helper sentence.
- Clears and hides `detailCurrentMomentHint` during detail panel updates.
- Preserves the selected moment badge, title, media preview, primary actions, metadata, memo, edit flow, and save status.

## Verification

- Pending CI.
- Browser verification required on a fixed test slot because this changes Editor detail-panel UI.

## Scope safety

- Editor selected moment panel copy only.
- Changed files limited to `js/editor/editor-i18n-refresh.js` and `js/editor/editor-detail-ui.js`.
- No backend/API/schema/tree-data changes.
- No auth/session handling changes.
- No PR #7/prototype/reference/demo/variant changes.
- No raw identifiers or private payloads added to logs/reports.

Refs #1118