### PR TITLE
Fix My Trees sort data persistence

### DIFF
--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -449,6 +449,10 @@
     var buildTreeCardFn = (options && options.buildTreeCard) || buildTreeCard;
     var updateManageSummaryFn = (options && options.updateManageSummary) || updateManageSummary;
 
+    if (options && typeof options.setLastTreesData === 'function') {
+      options.setLastTreesData(Array.isArray(trees) ? trees : []);
+    }
+
     updateManageSummaryFn(trees, options);
 
     if (!trees || trees.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the My Trees sort empty-state regression reported after #1194 verification.

## Root cause

`my-trees.js` keeps a local `lastTreesData` closure value for sort changes. That value is updated through the `setLastTreesData` callback passed into `my-trees-ui.js`.

However, `my-trees-ui.js` only called `options.setLastTreesData(trees)` inside `updateManageSummary()`. If the summary bar is missing or hidden, `updateManageSummary()` returns early before calling the callback, leaving `lastTreesData` as `[]`.

Then changing sort runs:

```text
sortTrees(lastTreesData, sortValue)
```

with `lastTreesData === []`, causing the page to render an empty state even though trees exist.

## Changes

- Moves the `setLastTreesData` callback to the start of `renderTrees()`.
- Stores the full loaded tree list before summary-bar guards or empty-state rendering.
- Leaves the existing summary behavior, first-batch size, scroll continuation, card click, and navigation behavior unchanged.

## Verification

- Pending CI.
- Browser verification required on fixed test slot because My Trees requires login/live user data.

## Scope safety

- My Trees data persistence for sort rendering only.
- Changed file limited to `js/my-trees/my-trees-ui.js`.
- No backend/API/schema/Auth/DB changes.
- No PR #7/prototype/reference/demo/variant changes.
- No raw identifiers or private payloads added to reports.

Refs #1126