### PR TITLE
UI: simplify My Trees card cover preview

### DIFF
--- a/css/my-trees/my-trees-cards.css
+++ b/css/my-trees/my-trees-cards.css
@@ -32,3 +32,11 @@
 .tree-card-visibility { display: flex; align-items: center; gap: 4px; font-size: 12px; padding: 4px 10px; border-radius: 99px; background: var(--lovetree-chip-bg); border: 1px solid var(--lovetree-chip-border); color: var(--lovetree-chip-text); }
 .tree-card-visibility.public { background: rgba(122, 139, 110, 0.1); color: var(--secondary); }
 .tree-card-visibility.private { background: var(--lovetree-pill-bg); color: var(--lovetree-pill-text); }
+
+/* Issue #1125: keep owner cards focused on representative cover content. */
+.tree-card-thumb-initial,
+.tree-card-thumb-topline,
+.tree-card-thumb-caption,
+.tree-card-flow-bridge {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary

Small follow-up for #1125 to make My Trees cards read more like representative cover previews and less like mini timeline/control cards.

## Changes

- Hides the top-left title initial badge on My Trees cards.
- Hides the thumb-level moment badge/caption overlay.
- Hides the legacy mini-flow bridge/timeline styling if present.
- Keeps existing representative thumbnail and representative text cover rendering intact.
- Keeps card title, subcopy, footer metrics, and open-tree affordance intact.

## Verification

- Pending CI.
- Browser verification required on a fixed test slot because this changes My Trees card UI.

## Scope safety

- CSS-only My Trees card polish.
- Changed file limited to `css/my-trees/my-trees-cards.css`.
- No JS behavior changes.
- No backend/API/schema/Auth/DB changes.
- No stored data mutation.
- No Browse page changes.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1125