### PR TITLE
UI: hide Editor sidebar placeholder actions

### DIFF
--- a/css/editor/editor-sidebar.css
+++ b/css/editor/editor-sidebar.css
@@ -163,6 +163,13 @@
     line-height: 1.3;
 }
 
+/* Issue #1128: keep the current MVP sidebar focused on tree summary, not placeholder actions. */
+.editor-status-card .editor-sidebar-entrypoints,
+.editor-status-card #sidebarPublicViewerBtn,
+.editor-status-card #sidebarInsightsBtn {
+    display: none !important;
+}
+
 .editor-status-card .editor-flow-summary {
     display: block !important;
 }


### PR DESCRIPTION
## Summary

Small follow-up for #1128 to keep the current Editor left sidebar focused on tree-level summary instead of disabled placeholder actions.

## Changes

- Hides the Editor sidebar entrypoints container in the current MVP UI.
- Hides the disabled `공개 화면 보기` button.
- Hides the disabled `트리 인사이트` / `준비 중` placeholder button.
- Keeps the existing tree title, tree summary copy, rename button, and My Trees return link intact.

## Existing tree-summary behavior

The sidebar already has tree-level summary behavior through `sidebarFlowSummary`, which reports empty/one/multiple moment tree state. This PR avoids a broader JS/data rewrite and only removes the placeholder action surface that made the panel feel unfinished.

## Verification

- Pending CI.
- Browser verification required on a fixed test slot because this changes Editor sidebar UI.

## Scope safety

- CSS-only Editor sidebar polish.
- Changed file limited to `css/editor/editor-sidebar.css`.
- No JS behavior changes.
- No backend/API/schema/Auth/DB changes.
- No selected moment right-panel changes.
- No My Trees hub implementation.
- No PR #7/prototype/reference/demo/variant changes.

Refs #1128