### PR TITLE
fix(auth): preserve early Editor auth callback

### DIFF
--- a/js/auth/auth-callbacks.js
+++ b/js/auth/auth-callbacks.js
@@ -7,9 +7,25 @@
 
   window.__onAuthReadyCallbacks = window.__onAuthReadyCallbacks || [];
 
+  function preserveEarlyAuthReadyFallback() {
+    if (typeof window.onAuthReady !== "function") return;
+    if (window.onAuthReady.__lovebudPreservedAuthReadyFallback === true) return;
+
+    var earlyCallback = window.onAuthReady;
+    earlyCallback.__lovebudPreservedAuthReadyFallback = true;
+
+    if (window.__onAuthReadyCallbacks.indexOf(earlyCallback) === -1) {
+      window.__onAuthReadyCallbacks.push(earlyCallback);
+    }
+  }
+
+  preserveEarlyAuthReadyFallback();
+
   function registerOnAuthReady(callback, authReadyFlagKey) {
     if (typeof callback !== "function") return;
-    window.__onAuthReadyCallbacks.push(callback);
+    if (window.__onAuthReadyCallbacks.indexOf(callback) === -1) {
+      window.__onAuthReadyCallbacks.push(callback);
+    }
 
     if (authReadyFlagKey && window[authReadyFlagKey]) {
       var user = window.__lastAuthUser || null;
@@ -38,6 +54,7 @@
 
     return {
       registerOnAuthReady: function (callback) {
+        preserveEarlyAuthReadyFallback();
         registerOnAuthReady(callback, authReadyFlagKey);
       },
       fireAuthReadyCallbacks: fireAuthReadyCallbacks,
@@ -48,5 +65,6 @@
     registerOnAuthReady: registerOnAuthReady,
     fireAuthReadyCallbacks: fireAuthReadyCallbacks,
     createAuthReadyCallbackBridge: createAuthReadyCallbackBridge,
+    preserveEarlyAuthReadyFallback: preserveEarlyAuthReadyFallback,
   };
 })();

--- a/tests/contracts/editor-auth-early-callback-contract.test.js
+++ b/tests/contracts/editor-auth-early-callback-contract.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+test('auth callbacks preserve editor onAuthReady fallback registered before auth bootstrap loads', () => {
+  const editorSource = readRepoFile('js/editor.js');
+  const callbacksSource = readRepoFile('js/auth/auth-callbacks.js');
+
+  assert.match(
+    editorSource,
+    /if\s*\(typeof\s+window\.registerOnAuthReady\s*===\s*['"]function['"]\)/,
+    'Editor must prefer registerOnAuthReady when auth callbacks are already available'
+  );
+  assert.match(
+    editorSource,
+    /window\.onAuthReady\s*=\s*tryStartEditor/,
+    'Editor currently falls back to window.onAuthReady when loaded before auth callbacks'
+  );
+
+  assert.match(
+    callbacksSource,
+    /function\s+preserveEarlyAuthReadyFallback\s*\(/,
+    'auth callbacks must define a helper to preserve early window.onAuthReady fallback'
+  );
+  assert.match(
+    callbacksSource,
+    /typeof\s+window\.onAuthReady\s*!==\s*["']function["']/,
+    'preservation helper must ignore missing non-function fallback values'
+  );
+  assert.match(
+    callbacksSource,
+    /window\.__onAuthReadyCallbacks\.push\(earlyCallback\)/,
+    'early Editor callback must be pushed into the shared auth-ready callback registry'
+  );
+  assert.match(
+    callbacksSource,
+    /window\.onAuthReady\.__lovebudPreservedAuthReadyFallback\s*===\s*true/,
+    'preservation helper must be idempotent for repeated auth bootstrap calls'
+  );
+  assert.match(
+    callbacksSource,
+    /window\.__onAuthReadyCallbacks\.indexOf\(callback\)\s*===\s*-1/,
+    'registerOnAuthReady must avoid duplicate callback registration'
+  );
+  assert.match(
+    callbacksSource,
+    /preserveEarlyAuthReadyFallback\(\);[\s\S]*function\s+registerOnAuthReady/,
+    'early fallback preservation must run before normal auth callback registration is used'
+  );
+});


### PR DESCRIPTION
## Summary

Refs #1200

Fixes the Editor/auth bootstrap race where `pages/editor.html` intentionally loads `js/editor.js` before the auth callback registry. When Editor loads first, it falls back to assigning `window.onAuthReady = tryStartEditor`. The auth callback registry now preserves that early fallback and moves it into the shared `window.__onAuthReadyCallbacks` array when auth callbacks load.

## Changes

- `js/auth/auth-callbacks.js`
  - Adds `preserveEarlyAuthReadyFallback()`.
  - Captures a pre-existing `window.onAuthReady` callback if Editor registered it before auth bootstrap.
  - Adds idempotency guard to avoid duplicate callback registration.
  - Makes `registerOnAuthReady(...)` avoid duplicate callbacks.
- `tests/contracts/editor-auth-early-callback-contract.test.js`
  - Adds contract coverage for the current Editor-before-auth load boundary.
  - Locks the early callback preservation behavior.

## Why this shape

This keeps the current documented Editor-before-auth script boundary intact and avoids a risky broad `pages/editor.html` script reorder. The fix is intentionally narrow and only touches the auth callback compatibility layer plus contract coverage.

## Verification pending

- CI.
- Browser verification on a fixed test slot because this affects Editor auth/runtime entry.

## Required browser verification

- Logged-out Editor entry redirects to login.
- Logged-in Editor cold load reaches the Editor without false empty/error state.
- Logged-in Editor reload still loads private tree and memories.
- Private tree URL load behaves correctly for owner access.
- Access denied/not found states remain safe.
- My Trees remains unaffected.
- Console fatal JS errors: 0.
- No raw token, credential, cookie, session, private payload, DB row, API key, or database URL in UI, console, comments, or reports.

## Scope safety

- Auth callback compatibility only.
- No backend/API/schema/DB changes.
- No token storage policy changes; tracked separately in #1199.
- No Editor UI redesign.
- No PR #7/prototype/reference/demo/variant path changes.