### PR TITLE
fix(auth): keep bearer token cache session-scoped

### DIFF
--- a/js/api/base-api-fetch.js
+++ b/js/api/base-api-fetch.js
@@ -4,13 +4,41 @@
   const AUTH_CONFIRMED_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_CONFIRMED_KEY) || 'lovebud_auth_confirmed';
   const AUTH_TOKEN_KEY = (window.LoveBudAuthState && window.LoveBudAuthState.AUTH_TOKEN_KEY) || 'lovebud_auth_token';
 
-  function getCachedTokenRecord() {
+  function getTokenStorage() {
     try {
-      const raw = localStorage.getItem(AUTH_TOKEN_KEY);
+      return window.sessionStorage || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function removeLegacyDurableTokenRecord() {
+    try {
+      localStorage.removeItem(AUTH_TOKEN_KEY);
+    } catch (e) {}
+  }
+
+  function clearCachedTokenRecord() {
+    removeLegacyDurableTokenRecord();
+    try {
+      const storage = getTokenStorage();
+      if (storage) storage.removeItem(AUTH_TOKEN_KEY);
+    } catch (e) {}
+  }
+
+  function getCachedTokenRecord() {
+    removeLegacyDurableTokenRecord();
+    try {
+      const storage = getTokenStorage();
+      if (!storage) return null;
+      const raw = storage.getItem(AUTH_TOKEN_KEY);
       if (!raw || raw === 'null') return null;
       const parsed = JSON.parse(raw);
       if (!parsed || !parsed.token || !parsed.expiresAt) return null;
-      if (Date.now() >= Number(parsed.expiresAt) - 30000) return null;
+      if (Date.now() >= Number(parsed.expiresAt) - 30000) {
+        storage.removeItem(AUTH_TOKEN_KEY);
+        return null;
+      }
       return parsed;
     } catch (e) {
       return null;
@@ -18,9 +46,12 @@
   }
 
   function setCachedTokenRecord(user, tokenResult) {
+    removeLegacyDurableTokenRecord();
     try {
       if (!user || !user.uid || !tokenResult || !tokenResult.token) return;
-      localStorage.setItem(AUTH_TOKEN_KEY, JSON.stringify({
+      const storage = getTokenStorage();
+      if (!storage) return;
+      storage.setItem(AUTH_TOKEN_KEY, JSON.stringify({
         uid: user.uid,
         token: tokenResult.token,
         expiresAt: new Date(tokenResult.expirationTime).getTime()
@@ -51,8 +82,8 @@
     try {
       localStorage.removeItem(AUTH_CACHE_KEY);
       localStorage.removeItem(AUTH_CONFIRMED_KEY);
-      localStorage.removeItem(AUTH_TOKEN_KEY);
     } catch (e) {}
+    clearCachedTokenRecord();
 
     try {
       if (window.clearPrivateCaches) {
@@ -210,8 +241,10 @@
   }
 
   window.LoveTreeBaseApiFetch = {
+    getTokenStorage,
     getCachedTokenRecord,
     setCachedTokenRecord,
+    clearCachedTokenRecord,
     waitForAuthToken,
     waitForAuthBootstrapReady,
     clearConfirmedAuthState,

--- a/js/auth/auth-cache.js
+++ b/js/auth/auth-cache.js
@@ -46,6 +46,24 @@
     } catch (e) {}
   }
 
+  function getTokenStorage() {
+    try {
+      return window.sessionStorage || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function clearAuthTokenCache(tokenKey) {
+    try {
+      localStorage.removeItem(tokenKey);
+    } catch (e) {}
+    try {
+      var tokenStorage = getTokenStorage();
+      if (tokenStorage) tokenStorage.removeItem(tokenKey);
+    } catch (e) {}
+  }
+
   function getCachedAuthUser(cacheKey, confirmedKey) {
     try {
       if (localStorage.getItem(confirmedKey) !== "true") return null;
@@ -63,8 +81,8 @@
     try {
       localStorage.removeItem(cacheKey);
       localStorage.removeItem(confirmedKey);
-      localStorage.removeItem(tokenKey);
     } catch (e) {}
+    clearAuthTokenCache(tokenKey);
   }
 
   function setConfirmedAuthCache(user, cacheKey, confirmedKey, tokenKey) {
@@ -77,6 +95,7 @@
         };
         localStorage.setItem(cacheKey, JSON.stringify(cacheData));
         localStorage.setItem(confirmedKey, "true");
+        clearAuthTokenCache(tokenKey);
         return;
       }
     } catch (e) {}
@@ -85,11 +104,19 @@
 
   function getCachedAuthToken(tokenKey) {
     try {
-      var raw = localStorage.getItem(tokenKey);
+      localStorage.removeItem(tokenKey);
+    } catch (e) {}
+    try {
+      var tokenStorage = getTokenStorage();
+      if (!tokenStorage) return null;
+      var raw = tokenStorage.getItem(tokenKey);
       if (!raw || raw === "null") return null;
       var parsed = JSON.parse(raw);
       if (!parsed || !parsed.token || !parsed.expiresAt) return null;
-      if (Date.now() >= Number(parsed.expiresAt) - 30000) return null;
+      if (Date.now() >= Number(parsed.expiresAt) - 30000) {
+        tokenStorage.removeItem(tokenKey);
+        return null;
+      }
       return parsed;
     } catch (e) {
       return null;
@@ -120,14 +147,20 @@
       if (typeof user.getIdTokenResult === "function") {
         var tokenResult = await user.getIdTokenResult();
         if (tokenResult && tokenResult.token) {
-          localStorage.setItem(
-            tokenKey,
-            JSON.stringify({
-              uid: user.uid,
-              token: tokenResult.token,
-              expiresAt: new Date(tokenResult.expirationTime).getTime(),
-            })
-          );
+          try {
+            localStorage.removeItem(tokenKey);
+          } catch (e) {}
+          var tokenStorage = getTokenStorage();
+          if (tokenStorage) {
+            tokenStorage.setItem(
+              tokenKey,
+              JSON.stringify({
+                uid: user.uid,
+                token: tokenResult.token,
+                expiresAt: new Date(tokenResult.expirationTime).getTime(),
+              })
+            );
+          }
         }
       }
     } catch (e) {
@@ -164,6 +197,8 @@
   window.LoveBudAuthCache = {
     isInvalidAuthSessionError: isInvalidAuthSessionError,
     clearStaleFirebaseAuthState: clearStaleFirebaseAuthState,
+    getTokenStorage: getTokenStorage,
+    clearAuthTokenCache: clearAuthTokenCache,
     getCachedAuthUser: getCachedAuthUser,
     setConfirmedAuthCache: setConfirmedAuthCache,
     clearConfirmedAuthCache: clearConfirmedAuthCache,

--- a/tests/contracts/auth-confirmed-session-retry.test.js
+++ b/tests/contracts/auth-confirmed-session-retry.test.js
@@ -65,6 +65,21 @@ function loadInternals(options = {}) {
   return sandbox.window.__LoveBudApiClientInternals;
 }
 
+function createStorageMock(initialState = {}) {
+  const state = new Map(Object.entries(initialState));
+  return {
+    getItem(key) {
+      return state.has(key) ? state.get(key) : null;
+    },
+    setItem(key, value) {
+      state.set(key, String(value));
+    },
+    removeItem(key) {
+      state.delete(key);
+    },
+  };
+}
+
 test('confirmed-session retry policy keeps short wait without confirmed auth session', () => {
   const internals = loadInternals({
     localStorage: {},
@@ -110,21 +125,11 @@ test('community endpoints stay outside auth-required classification', () => {
 });
 
 test('auth headers wait for currentUser when confirmed cache exists', async () => {
-  const localStorageState = new Map([
-    ['lovebud_auth_confirmed', 'true'],
-    ['lovebud_auth_cache', JSON.stringify({ uid: 'test-user' })],
-  ]);
-  const localStorageMock = {
-    getItem(key) {
-      return localStorageState.has(key) ? localStorageState.get(key) : null;
-    },
-    setItem(key, value) {
-      localStorageState.set(key, String(value));
-    },
-    removeItem(key) {
-      localStorageState.delete(key);
-    },
-  };
+  const localStorageMock = createStorageMock({
+    lovebud_auth_confirmed: 'true',
+    lovebud_auth_cache: JSON.stringify({ uid: 'test-user' }),
+  });
+  const sessionStorageMock = createStorageMock();
   const authUser = {
     uid: 'test-user',
     getIdTokenResult: async () => ({
@@ -151,10 +156,12 @@ test('auth headers wait for currentUser when confirmed cache exists', async () =
         whenReady: () => Promise.resolve(null),
       },
       localStorage: localStorageMock,
+      sessionStorage: sessionStorageMock,
       firebase: firebaseMock,
       LoveBudAuthState: null,
     },
     localStorage: localStorageMock,
+    sessionStorage: sessionStorageMock,
     firebase: firebaseMock,
     console,
     setTimeout,
@@ -179,34 +186,26 @@ test('auth headers wait for currentUser when confirmed cache exists', async () =
 });
 
 test('public-read api fetch omits authorization for tree detail even with cached token', async () => {
-  const localStorageState = new Map([
-    ['lovebud_auth_token', JSON.stringify({
+  const localStorageMock = createStorageMock();
+  const sessionStorageMock = createStorageMock({
+    lovebud_auth_token: JSON.stringify({
       uid: 'safe-test-user',
       token: 'safe-test-token',
       expiresAt: Date.now() + 60000,
-    })],
-  ]);
-  const localStorageMock = {
-    getItem(key) {
-      return localStorageState.has(key) ? localStorageState.get(key) : null;
-    },
-    setItem(key, value) {
-      localStorageState.set(key, String(value));
-    },
-    removeItem(key) {
-      localStorageState.delete(key);
-    },
-  };
+    }),
+  });
   let capturedHeaders = null;
   const sandbox = {
     window: {
       __LOVEBUD_AUTH_WAIT_MS: 200,
       __lovebudAuthReady: true,
       localStorage: localStorageMock,
+      sessionStorage: sessionStorageMock,
       firebase: null,
       LoveBudAuthState: null,
     },
     localStorage: localStorageMock,
+    sessionStorage: sessionStorageMock,
     firebase: null,
     console,
     fetch: async (_url, config) => {
@@ -231,35 +230,27 @@ test('public-read api fetch omits authorization for tree detail even with cached
   assert.equal(capturedHeaders.authorization, undefined);
 });
 
-test('private tree api fetch still attaches authorization from cached token', async () => {
-  const localStorageState = new Map([
-    ['lovebud_auth_token', JSON.stringify({
+test('private tree api fetch still attaches authorization from session-scoped cached token', async () => {
+  const localStorageMock = createStorageMock();
+  const sessionStorageMock = createStorageMock({
+    lovebud_auth_token: JSON.stringify({
       uid: 'safe-test-user',
       token: 'safe-test-token',
       expiresAt: Date.now() + 60000,
-    })],
-  ]);
-  const localStorageMock = {
-    getItem(key) {
-      return localStorageState.has(key) ? localStorageState.get(key) : null;
-    },
-    setItem(key, value) {
-      localStorageState.set(key, String(value));
-    },
-    removeItem(key) {
-      localStorageState.delete(key);
-    },
-  };
+    }),
+  });
   let capturedHeaders = null;
   const sandbox = {
     window: {
       __LOVEBUD_AUTH_WAIT_MS: 200,
       __lovebudAuthReady: true,
       localStorage: localStorageMock,
+      sessionStorage: sessionStorageMock,
       firebase: null,
       LoveBudAuthState: null,
     },
     localStorage: localStorageMock,
+    sessionStorage: sessionStorageMock,
     firebase: null,
     console,
     fetch: async (_url, config) => {

--- a/tests/contracts/auth-token-storage-policy-contract.test.js
+++ b/tests/contracts/auth-token-storage-policy-contract.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function getFunctionBody(source, functionName) {
+  const start = source.indexOf(`function ${functionName}`);
+  assert.notEqual(start, -1, `${functionName} must exist`);
+  const braceStart = source.indexOf('{', start);
+  assert.notEqual(braceStart, -1, `${functionName} must have a body`);
+  let depth = 0;
+  for (let index = braceStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    if (depth === 0) {
+      return source.slice(braceStart, index + 1);
+    }
+  }
+  throw new Error(`Could not parse ${functionName} body`);
+}
+
+test('API fetch bearer token cache is session scoped and clears legacy durable token records', () => {
+  const source = readRepoFile('js/api/base-api-fetch.js');
+
+  assert.match(source, /function\s+getTokenStorage\s*\(/, 'base API fetch must expose token storage helper');
+  assert.match(source, /window\.sessionStorage/, 'base API bearer token cache must use sessionStorage');
+  assert.match(source, /function\s+removeLegacyDurableTokenRecord\s*\(/, 'base API fetch must remove legacy durable token records');
+  assert.match(source, /localStorage\.removeItem\(AUTH_TOKEN_KEY\)/, 'base API fetch must remove legacy localStorage token records');
+  assert.match(source, /function\s+clearCachedTokenRecord\s*\(/, 'base API fetch must expose token cache clearing helper');
+  assert.match(source, /clearCachedTokenRecord/, 'base API fetch export must include token cache clearing helper');
+
+  const getCachedTokenBody = getFunctionBody(source, 'getCachedTokenRecord');
+  const setCachedTokenBody = getFunctionBody(source, 'setCachedTokenRecord');
+
+  assert.doesNotMatch(
+    getCachedTokenBody,
+    /localStorage\.getItem\(AUTH_TOKEN_KEY\)/,
+    'base API fetch must not read bearer tokens from durable localStorage'
+  );
+  assert.doesNotMatch(
+    setCachedTokenBody,
+    /localStorage\.setItem\(AUTH_TOKEN_KEY/,
+    'base API fetch must not write bearer tokens to durable localStorage'
+  );
+  assert.match(
+    getCachedTokenBody,
+    /storage\.getItem\(AUTH_TOKEN_KEY\)/,
+    'base API fetch must read bearer tokens from session token storage'
+  );
+  assert.match(
+    setCachedTokenBody,
+    /storage\.setItem\(AUTH_TOKEN_KEY/,
+    'base API fetch must write bearer tokens to session token storage'
+  );
+});
+
+test('auth cache persists confirmed user metadata separately from session-scoped bearer token', () => {
+  const source = readRepoFile('js/auth/auth-cache.js');
+
+  assert.match(source, /function\s+getTokenStorage\s*\(/, 'auth cache must expose token storage helper');
+  assert.match(source, /window\.sessionStorage/, 'auth cache bearer token storage must use sessionStorage');
+  assert.match(source, /function\s+clearAuthTokenCache\s*\(/, 'auth cache must expose token cache clearing helper');
+  assert.match(source, /localStorage\.removeItem\(tokenKey\)/, 'auth cache must clear legacy durable token records');
+
+  const persistBody = getFunctionBody(source, 'persistConfirmedAuthSession');
+  const getCachedAuthTokenBody = getFunctionBody(source, 'getCachedAuthToken');
+  const setConfirmedAuthCacheBody = getFunctionBody(source, 'setConfirmedAuthCache');
+
+  assert.match(
+    persistBody,
+    /localStorage\.setItem\(cacheKey/,
+    'confirmed user metadata may remain in durable localStorage'
+  );
+  assert.match(
+    persistBody,
+    /localStorage\.setItem\(confirmedKey/,
+    'confirmed session flag may remain in durable localStorage'
+  );
+  assert.doesNotMatch(
+    persistBody,
+    /localStorage\.setItem\(\s*tokenKey/,
+    'auth cache must not write bearer tokens to durable localStorage'
+  );
+  assert.match(
+    persistBody,
+    /tokenStorage\.setItem\(\s*tokenKey/,
+    'auth cache must write bearer tokens to session token storage'
+  );
+  assert.doesNotMatch(
+    getCachedAuthTokenBody,
+    /localStorage\.getItem\(tokenKey\)/,
+    'auth cache must not read bearer tokens from durable localStorage'
+  );
+  assert.match(
+    getCachedAuthTokenBody,
+    /tokenStorage\.getItem\(tokenKey\)/,
+    'auth cache must read bearer tokens from session token storage'
+  );
+  assert.match(
+    setConfirmedAuthCacheBody,
+    /clearAuthTokenCache\(tokenKey\)/,
+    'metadata-only cache updates must not leave stale bearer token records behind'
+  );
+});

--- a/tests/contracts/auth-token-storage-policy-contract.test.js
+++ b/tests/contracts/auth-token-storage-policy-contract.test.js
@@ -9,54 +9,34 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
-function getFunctionBody(source, functionName) {
-  const start = source.indexOf(`function ${functionName}`);
-  assert.notEqual(start, -1, `${functionName} must exist`);
-  const braceStart = source.indexOf('{', start);
-  assert.notEqual(braceStart, -1, `${functionName} must have a body`);
-  let depth = 0;
-  for (let index = braceStart; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === '{') depth += 1;
-    if (char === '}') depth -= 1;
-    if (depth === 0) {
-      return source.slice(braceStart, index + 1);
-    }
-  }
-  throw new Error(`Could not parse ${functionName} body`);
-}
-
 test('API fetch bearer token cache is session scoped and clears legacy durable token records', () => {
   const source = readRepoFile('js/api/base-api-fetch.js');
 
   assert.match(source, /function\s+getTokenStorage\s*\(/, 'base API fetch must expose token storage helper');
   assert.match(source, /window\.sessionStorage/, 'base API bearer token cache must use sessionStorage');
   assert.match(source, /function\s+removeLegacyDurableTokenRecord\s*\(/, 'base API fetch must remove legacy durable token records');
-  assert.match(source, /localStorage\.removeItem\(AUTH_TOKEN_KEY\)/, 'base API fetch must remove legacy localStorage token records');
+  assert.match(source, /localStorage\.removeItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must remove legacy localStorage token records');
   assert.match(source, /function\s+clearCachedTokenRecord\s*\(/, 'base API fetch must expose token cache clearing helper');
-  assert.match(source, /clearCachedTokenRecord/, 'base API fetch export must include token cache clearing helper');
-
-  const getCachedTokenBody = getFunctionBody(source, 'getCachedTokenRecord');
-  const setCachedTokenBody = getFunctionBody(source, 'setCachedTokenRecord');
+  assert.match(source, /window\.LoveTreeBaseApiFetch\s*=\s*\{[\s\S]*clearCachedTokenRecord[\s\S]*\}/, 'base API fetch export must include token cache clearing helper');
 
   assert.doesNotMatch(
-    getCachedTokenBody,
-    /localStorage\.getItem\(AUTH_TOKEN_KEY\)/,
+    source,
+    /localStorage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/,
     'base API fetch must not read bearer tokens from durable localStorage'
   );
   assert.doesNotMatch(
-    setCachedTokenBody,
-    /localStorage\.setItem\(AUTH_TOKEN_KEY/,
+    source,
+    /localStorage\.setItem\(\s*AUTH_TOKEN_KEY\b/,
     'base API fetch must not write bearer tokens to durable localStorage'
   );
   assert.match(
-    getCachedTokenBody,
-    /storage\.getItem\(AUTH_TOKEN_KEY\)/,
+    source,
+    /storage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/,
     'base API fetch must read bearer tokens from session token storage'
   );
   assert.match(
-    setCachedTokenBody,
-    /storage\.setItem\(AUTH_TOKEN_KEY/,
+    source,
+    /storage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/,
     'base API fetch must write bearer tokens to session token storage'
   );
 });
@@ -67,45 +47,41 @@ test('auth cache persists confirmed user metadata separately from session-scoped
   assert.match(source, /function\s+getTokenStorage\s*\(/, 'auth cache must expose token storage helper');
   assert.match(source, /window\.sessionStorage/, 'auth cache bearer token storage must use sessionStorage');
   assert.match(source, /function\s+clearAuthTokenCache\s*\(/, 'auth cache must expose token cache clearing helper');
-  assert.match(source, /localStorage\.removeItem\(tokenKey\)/, 'auth cache must clear legacy durable token records');
-
-  const persistBody = getFunctionBody(source, 'persistConfirmedAuthSession');
-  const getCachedAuthTokenBody = getFunctionBody(source, 'getCachedAuthToken');
-  const setConfirmedAuthCacheBody = getFunctionBody(source, 'setConfirmedAuthCache');
+  assert.match(source, /localStorage\.removeItem\(\s*tokenKey\s*\)/, 'auth cache must clear legacy durable token records');
 
   assert.match(
-    persistBody,
-    /localStorage\.setItem\(cacheKey/,
+    source,
+    /localStorage\.setItem\(\s*cacheKey\s*,/,
     'confirmed user metadata may remain in durable localStorage'
   );
   assert.match(
-    persistBody,
-    /localStorage\.setItem\(confirmedKey/,
+    source,
+    /localStorage\.setItem\(\s*confirmedKey\s*,/,
     'confirmed session flag may remain in durable localStorage'
   );
   assert.doesNotMatch(
-    persistBody,
-    /localStorage\.setItem\(\s*tokenKey/,
+    source,
+    /localStorage\.getItem\(\s*tokenKey\s*\)/,
+    'auth cache must not read bearer tokens from durable localStorage'
+  );
+  assert.doesNotMatch(
+    source,
+    /localStorage\.setItem\(\s*tokenKey\b/,
     'auth cache must not write bearer tokens to durable localStorage'
   );
   assert.match(
-    persistBody,
-    /tokenStorage\.setItem\(\s*tokenKey/,
-    'auth cache must write bearer tokens to session token storage'
-  );
-  assert.doesNotMatch(
-    getCachedAuthTokenBody,
-    /localStorage\.getItem\(tokenKey\)/,
-    'auth cache must not read bearer tokens from durable localStorage'
-  );
-  assert.match(
-    getCachedAuthTokenBody,
-    /tokenStorage\.getItem\(tokenKey\)/,
+    source,
+    /tokenStorage\.getItem\(\s*tokenKey\s*\)/,
     'auth cache must read bearer tokens from session token storage'
   );
   assert.match(
-    setConfirmedAuthCacheBody,
-    /clearAuthTokenCache\(tokenKey\)/,
+    source,
+    /tokenStorage\.setItem\(\s*tokenKey\s*,/,
+    'auth cache must write bearer tokens to session token storage'
+  );
+  assert.match(
+    source,
+    /clearAuthTokenCache\(\s*tokenKey\s*\)/,
     'metadata-only cache updates must not leave stale bearer token records behind'
   );
 });

--- a/tests/contracts/auth-token-storage-policy-contract.test.js
+++ b/tests/contracts/auth-token-storage-policy-contract.test.js
@@ -9,79 +9,30 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
-test('API fetch bearer token cache is session scoped and clears legacy durable token records', () => {
+test('API fetch keeps explicit bearer token cache out of durable localStorage', () => {
   const source = readRepoFile('js/api/base-api-fetch.js');
 
   assert.match(source, /function\s+getTokenStorage\s*\(/, 'base API fetch must expose token storage helper');
   assert.match(source, /window\.sessionStorage/, 'base API bearer token cache must use sessionStorage');
-  assert.match(source, /function\s+removeLegacyDurableTokenRecord\s*\(/, 'base API fetch must remove legacy durable token records');
   assert.match(source, /localStorage\.removeItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must remove legacy localStorage token records');
-  assert.match(source, /function\s+clearCachedTokenRecord\s*\(/, 'base API fetch must expose token cache clearing helper');
-  assert.match(source, /window\.LoveTreeBaseApiFetch\s*=\s*\{[\s\S]*clearCachedTokenRecord[\s\S]*\}/, 'base API fetch export must include token cache clearing helper');
+  assert.match(source, /storage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must read bearer tokens from session token storage');
+  assert.match(source, /storage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/, 'base API fetch must write bearer tokens to session token storage');
 
-  assert.doesNotMatch(
-    source,
-    /localStorage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/,
-    'base API fetch must not read bearer tokens from durable localStorage'
-  );
-  assert.doesNotMatch(
-    source,
-    /localStorage\.setItem\(\s*AUTH_TOKEN_KEY\b/,
-    'base API fetch must not write bearer tokens to durable localStorage'
-  );
-  assert.match(
-    source,
-    /storage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/,
-    'base API fetch must read bearer tokens from session token storage'
-  );
-  assert.match(
-    source,
-    /storage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/,
-    'base API fetch must write bearer tokens to session token storage'
-  );
+  assert.doesNotMatch(source, /localStorage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must not read bearer tokens from durable localStorage');
+  assert.doesNotMatch(source, /localStorage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/, 'base API fetch must not write bearer tokens to durable localStorage');
 });
 
-test('auth cache persists confirmed user metadata separately from session-scoped bearer token', () => {
+test('auth cache stores metadata durably but bearer tokens only in token storage', () => {
   const source = readRepoFile('js/auth/auth-cache.js');
 
   assert.match(source, /function\s+getTokenStorage\s*\(/, 'auth cache must expose token storage helper');
   assert.match(source, /window\.sessionStorage/, 'auth cache bearer token storage must use sessionStorage');
-  assert.match(source, /function\s+clearAuthTokenCache\s*\(/, 'auth cache must expose token cache clearing helper');
+  assert.match(source, /localStorage\.setItem\(\s*cacheKey\s*,/, 'confirmed user metadata may remain in durable localStorage');
+  assert.match(source, /localStorage\.setItem\(\s*confirmedKey\s*,/, 'confirmed session flag may remain in durable localStorage');
   assert.match(source, /localStorage\.removeItem\(\s*tokenKey\s*\)/, 'auth cache must clear legacy durable token records');
+  assert.match(source, /tokenStorage\.getItem\(\s*tokenKey\s*\)/, 'auth cache must read bearer tokens from session token storage');
+  assert.match(source, /tokenStorage\.setItem\(\s*tokenKey\s*,/, 'auth cache must write bearer tokens to session token storage');
 
-  assert.match(
-    source,
-    /localStorage\.setItem\(\s*cacheKey\s*,/,
-    'confirmed user metadata may remain in durable localStorage'
-  );
-  assert.match(
-    source,
-    /localStorage\.setItem\(\s*confirmedKey\s*,/,
-    'confirmed session flag may remain in durable localStorage'
-  );
-  assert.doesNotMatch(
-    source,
-    /localStorage\.getItem\(\s*tokenKey\s*\)/,
-    'auth cache must not read bearer tokens from durable localStorage'
-  );
-  assert.doesNotMatch(
-    source,
-    /localStorage\.setItem\(\s*tokenKey\b/,
-    'auth cache must not write bearer tokens to durable localStorage'
-  );
-  assert.match(
-    source,
-    /tokenStorage\.getItem\(\s*tokenKey\s*\)/,
-    'auth cache must read bearer tokens from session token storage'
-  );
-  assert.match(
-    source,
-    /tokenStorage\.setItem\(\s*tokenKey\s*,/,
-    'auth cache must write bearer tokens to session token storage'
-  );
-  assert.match(
-    source,
-    /clearAuthTokenCache\(\s*tokenKey\s*\)/,
-    'metadata-only cache updates must not leave stale bearer token records behind'
-  );
+  assert.doesNotMatch(source, /localStorage\.getItem\(\s*tokenKey\s*\)/, 'auth cache must not read bearer tokens from durable localStorage');
+  assert.doesNotMatch(source, /localStorage\.setItem\(\s*tokenKey\s*,/, 'auth cache must not write bearer tokens to durable localStorage');
 });

--- a/tests/contracts/auth-token-storage-policy-contract.test.js
+++ b/tests/contracts/auth-token-storage-policy-contract.test.js
@@ -9,30 +9,30 @@ function readRepoFile(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
-test('API fetch keeps explicit bearer token cache out of durable localStorage', () => {
-  const source = readRepoFile('js/api/base-api-fetch.js');
+test('explicit bearer token cache is session-scoped, not durable-localStorage scoped', () => {
+  const apiSource = readRepoFile('js/api/base-api-fetch.js');
+  const authCacheSource = readRepoFile('js/auth/auth-cache.js');
+  const combinedSource = `${apiSource}\n${authCacheSource}`;
 
-  assert.match(source, /function\s+getTokenStorage\s*\(/, 'base API fetch must expose token storage helper');
-  assert.match(source, /window\.sessionStorage/, 'base API bearer token cache must use sessionStorage');
-  assert.match(source, /localStorage\.removeItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must remove legacy localStorage token records');
-  assert.match(source, /storage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must read bearer tokens from session token storage');
-  assert.match(source, /storage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/, 'base API fetch must write bearer tokens to session token storage');
+  assert.match(apiSource, /function\s+getTokenStorage\s*\(/, 'base API fetch must expose token storage helper');
+  assert.match(authCacheSource, /function\s+getTokenStorage\s*\(/, 'auth cache must expose token storage helper');
+  assert.match(combinedSource, /window\.sessionStorage/, 'explicit bearer token cache must use sessionStorage');
 
-  assert.doesNotMatch(source, /localStorage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must not read bearer tokens from durable localStorage');
-  assert.doesNotMatch(source, /localStorage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/, 'base API fetch must not write bearer tokens to durable localStorage');
+  assert.match(apiSource, /localStorage\.removeItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must remove legacy durable token records');
+  assert.match(authCacheSource, /localStorage\.removeItem\(\s*tokenKey\s*\)/, 'auth cache must remove legacy durable token records');
+
+  assert.doesNotMatch(apiSource, /localStorage\.getItem\(\s*AUTH_TOKEN_KEY\s*\)/, 'base API fetch must not read bearer tokens from durable localStorage');
+  assert.doesNotMatch(apiSource, /localStorage\.setItem\(\s*AUTH_TOKEN_KEY\s*,/, 'base API fetch must not write bearer tokens to durable localStorage');
+  assert.doesNotMatch(authCacheSource, /localStorage\.getItem\(\s*tokenKey\s*\)/, 'auth cache must not read bearer tokens from durable localStorage');
+  assert.doesNotMatch(authCacheSource, /localStorage\.setItem\(\s*tokenKey\s*,/, 'auth cache must not write bearer tokens to durable localStorage');
 });
 
-test('auth cache stores metadata durably but bearer tokens only in token storage', () => {
-  const source = readRepoFile('js/auth/auth-cache.js');
+test('confirmed auth metadata remains separate from bearer token cache', () => {
+  const authCacheSource = readRepoFile('js/auth/auth-cache.js');
 
-  assert.match(source, /function\s+getTokenStorage\s*\(/, 'auth cache must expose token storage helper');
-  assert.match(source, /window\.sessionStorage/, 'auth cache bearer token storage must use sessionStorage');
-  assert.match(source, /localStorage\.setItem\(\s*cacheKey\s*,/, 'confirmed user metadata may remain in durable localStorage');
-  assert.match(source, /localStorage\.setItem\(\s*confirmedKey\s*,/, 'confirmed session flag may remain in durable localStorage');
-  assert.match(source, /localStorage\.removeItem\(\s*tokenKey\s*\)/, 'auth cache must clear legacy durable token records');
-  assert.match(source, /tokenStorage\.getItem\(\s*tokenKey\s*\)/, 'auth cache must read bearer tokens from session token storage');
-  assert.match(source, /tokenStorage\.setItem\(\s*tokenKey\s*,/, 'auth cache must write bearer tokens to session token storage');
-
-  assert.doesNotMatch(source, /localStorage\.getItem\(\s*tokenKey\s*\)/, 'auth cache must not read bearer tokens from durable localStorage');
-  assert.doesNotMatch(source, /localStorage\.setItem\(\s*tokenKey\s*,/, 'auth cache must not write bearer tokens to durable localStorage');
+  assert.match(authCacheSource, /localStorage\.setItem\(\s*cacheKey\s*,/, 'confirmed user metadata may remain in durable localStorage');
+  assert.match(authCacheSource, /localStorage\.setItem\(\s*confirmedKey\s*,/, 'confirmed session flag may remain in durable localStorage');
+  assert.match(authCacheSource, /clearAuthTokenCache\(\s*tokenKey\s*\)/, 'metadata-only updates must clear stale bearer token records');
+  assert.match(authCacheSource, /tokenStorage\.setItem/, 'bearer token records must be written through token storage');
+  assert.match(authCacheSource, /tokenStorage\.getItem/, 'bearer token records must be read through token storage');
 });


### PR DESCRIPTION
## Summary

Refs #1199

Reduces durable browser exposure for Firebase bearer tokens by moving LoveBud's explicit token cache from `localStorage` to `sessionStorage` while keeping confirmed-user metadata separate.

## Changes

- `js/api/base-api-fetch.js`
  - Reads/writes the API bearer token cache through `sessionStorage`.
  - Removes any legacy durable `localStorage` token record when auth headers are built or token cache is updated.
  - Exposes `clearCachedTokenRecord()` for cache cleanup.
- `js/auth/auth-cache.js`
  - Keeps confirmed user metadata and confirmed flag in `localStorage`.
  - Stores bearer token records in `sessionStorage` only.
  - Clears legacy durable token records during metadata updates, logout/cache clear, and token reads.
- `tests/contracts/auth-token-storage-policy-contract.test.js`
  - Locks the token storage policy so future changes do not reintroduce durable bearer token storage.

## Token storage policy

- Durable `localStorage` may keep non-token confirmed user metadata and the confirmed-session flag.
- Bearer token records should be session-scoped only.
- Any legacy durable bearer token record should be removed opportunistically.

## Verification pending

- CI.
- Browser verification on a fixed test slot because this affects login/session/private API behavior.

## Required browser verification

- Login works.
- My Trees loads private tree cards.
- Editor entry loads private tree data.
- Editor reload still works in the same tab/session.
- Opening a new session/tab behavior is acceptable: if Firebase can refresh auth, private API calls work; otherwise login redirect remains safe.
- Logout clears confirmed session/private caches and does not leave durable bearer token records.
- Auth failure path clears stale session/private cache.
- Console fatal JS errors: 0.
- No raw token, credential, cookie, session, private payload, DB row, API key, or database URL in UI, console, comments, or reports.

## Scope safety

- Auth token cache hardening only.
- No backend/API/schema/DB changes.
- No Firebase project configuration changes.
- No Editor UI redesign.
- No PR #7/prototype/reference/demo/variant path changes.