### PR TITLE
fix(api): sanitize request id header

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -2,16 +2,28 @@ function stripTrailingSlash(value) {
   return String(value || '').replace(/\/$/, '');
 }
 
+const REQUEST_ID_HEADER = 'x-lovebud-request-id';
+const MAX_REQUEST_ID_LENGTH = 80;
+const SAFE_REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
 function generateRequestId() {
   // Generate a non-sensitive request ID (UUID v4 format)
   // This is safe to log and propagate without exposing user data
   return 'req-' + crypto.randomUUID();
 }
 
+function normalizeRequestId(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_REQUEST_ID_LENGTH) return null;
+  if (!SAFE_REQUEST_ID_PATTERN.test(trimmed)) return null;
+  return trimmed;
+}
+
 function getOrCreateRequestId(request) {
-  // Check if request ID exists in incoming headers
-  const existingRequestId = request.headers.get('x-lovebud-request-id');
-  if (existingRequestId && typeof existingRequestId === 'string' && existingRequestId.length > 0) {
+  // Reuse only short trace-safe client request IDs. Anything malformed is replaced at the boundary.
+  const existingRequestId = normalizeRequestId(request.headers.get(REQUEST_ID_HEADER));
+  if (existingRequestId) {
     return existingRequestId;
   }
 
@@ -133,12 +145,12 @@ function withUpstreamHeader(response, upstream, requestId = null) {
   const headers = new Headers(response.headers);
   headers.set('x-lovebud-upstream', upstream);
   if (requestId) {
-    headers.set('x-lovebud-request-id', requestId);
+    headers.set(REQUEST_ID_HEADER, requestId);
     // Allow browser to access the request ID header
     const existingExposeHeaders = headers.get('Access-Control-Expose-Headers') || '';
     const exposeHeaders = existingExposeHeaders
-      ? `${existingExposeHeaders}, x-lovebud-request-id`
-      : 'x-lovebud-request-id';
+      ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}`
+      : REQUEST_ID_HEADER;
     headers.set('Access-Control-Expose-Headers', exposeHeaders);
   }
   return new Response(response.body, {
@@ -187,7 +199,7 @@ function buildNotFoundResponse(requestId = null) {
     'x-lovebud-route-status': 'unhandled'
   };
   if (requestId) {
-    headers['x-lovebud-request-id'] = requestId;
+    headers[REQUEST_ID_HEADER] = requestId;
   }
   return new Response(
     JSON.stringify({ error: 'Route not found' }),
@@ -204,7 +216,7 @@ function buildMethodNotAllowedResponse(allow = 'GET', requestId = null) {
     'x-lovebud-upstream': 'cloudflare',
     'x-lovebud-route-status': 'method-not-allowed',
     'allow': allow,
-    'x-lovebud-request-id': requestId
+    [REQUEST_ID_HEADER]: requestId
   };
   return new Response(
     JSON.stringify({ error: 'Method not allowed' }),
@@ -222,7 +234,7 @@ function buildModalUnavailableResponse(requestId = null) {
     'x-lovebud-degraded': 'modal-unavailable'
   };
   if (requestId) {
-    headers['x-lovebud-request-id'] = requestId;
+    headers[REQUEST_ID_HEADER] = requestId;
   }
   return new Response(
     JSON.stringify({ error: 'Modal backend unavailable' }),
@@ -248,7 +260,7 @@ async function tryModalRead(request, env, requestId = null) {
 
   // Forward request ID to Modal
   if (requestId) {
-    headers['x-lovebud-request-id'] = requestId;
+    headers[REQUEST_ID_HEADER] = requestId;
   }
 
   const response = await fetch(modalUrl.toString(), { headers });
@@ -288,7 +300,7 @@ async function tryModalWrite(request, env, requestId = null) {
 
   // Forward request ID to Modal
   if (requestId) {
-    headers['x-lovebud-request-id'] = requestId;
+    headers[REQUEST_ID_HEADER] = requestId;
   }
 
   const response = await fetch(modalUrl.toString(), {

--- a/tests/contracts/request-id-sanitization-contract.test.js
+++ b/tests/contracts/request-id-sanitization-contract.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CATCHALL_JS = path.join(ROOT, 'functions/api/[[path]].js');
+
+function readCatchallSource() {
+  return fs.readFileSync(CATCHALL_JS, 'utf8');
+}
+
+function extractFunctionBlock(content, functionName) {
+  const start = content.indexOf(`function ${functionName}`);
+  assert.notEqual(start, -1, `${functionName} should exist`);
+
+  const openBrace = content.indexOf('{', start);
+  assert.notEqual(openBrace, -1, `${functionName} should have body`);
+
+  let depth = 0;
+  for (let index = openBrace; index < content.length; index += 1) {
+    if (content[index] === '{') depth += 1;
+    if (content[index] === '}') depth -= 1;
+    if (depth === 0) return content.slice(openBrace, index + 1);
+  }
+
+  assert.fail(`${functionName} body should be closed`);
+}
+
+test('cloudflare request id policy defines a single canonical header and bounded max length', () => {
+  const content = readCatchallSource();
+
+  assert.match(content, /const\s+REQUEST_ID_HEADER\s*=\s*'x-lovebud-request-id'/);
+  assert.match(content, /const\s+MAX_REQUEST_ID_LENGTH\s*=\s*80/);
+  assert.match(content, /const\s+SAFE_REQUEST_ID_PATTERN\s*=\s*\/\^\[A-Za-z0-9\._:-\]\+\$\//);
+});
+
+test('normalizeRequestId accepts only trimmed trace-safe request ids', () => {
+  const content = readCatchallSource();
+  const normalizeBlock = extractFunctionBlock(content, 'normalizeRequestId');
+
+  assert.match(normalizeBlock, /typeof\s+value\s*!==\s*'string'/, 'non-string values must be rejected');
+  assert.match(normalizeBlock, /value\.trim\(\)/, 'request id values must be trimmed before reuse');
+  assert.match(normalizeBlock, /trimmed\.length\s*>\s*MAX_REQUEST_ID_LENGTH/, 'oversized request ids must be rejected');
+  assert.match(normalizeBlock, /!SAFE_REQUEST_ID_PATTERN\.test\(trimmed\)/, 'unsafe characters must be rejected');
+  assert.match(normalizeBlock, /return\s+trimmed/, 'safe request ids should remain usable for tracing');
+});
+
+test('getOrCreateRequestId reuses only normalized request ids and otherwise generates a boundary id', () => {
+  const content = readCatchallSource();
+  const requestIdBlock = extractFunctionBlock(content, 'getOrCreateRequestId');
+
+  assert.match(requestIdBlock, /normalizeRequestId\(request\.headers\.get\(REQUEST_ID_HEADER\)\)/);
+  assert.match(requestIdBlock, /if\s*\(existingRequestId\)/);
+  assert.match(requestIdBlock, /return\s+existingRequestId/);
+  assert.match(requestIdBlock, /return\s+generateRequestId\(\)/);
+  assert.doesNotMatch(requestIdBlock, /return\s+request\.headers\.get\('x-lovebud-request-id'\)/, 'raw client request id must not be returned directly');
+});
+
+test('sanitized/generated request id is the only value forwarded to Modal and response headers', () => {
+  const content = readCatchallSource();
+  const readBlock = extractFunctionBlock(content, 'tryModalRead');
+  const writeBlock = extractFunctionBlock(content, 'tryModalWrite');
+  const upstreamBlock = extractFunctionBlock(content, 'withUpstreamHeader');
+
+  assert.match(readBlock, /headers\[REQUEST_ID_HEADER\]\s*=\s*requestId/, 'read proxy should forward sanitized/generated request id');
+  assert.match(writeBlock, /headers\[REQUEST_ID_HEADER\]\s*=\s*requestId/, 'write proxy should forward sanitized/generated request id');
+  assert.match(upstreamBlock, /headers\.set\(REQUEST_ID_HEADER,\s*requestId\)/, 'response should expose sanitized/generated request id');
+  assert.doesNotMatch(readBlock, /request\.headers\.get\('x-lovebud-request-id'\)/, 'read proxy must not re-read raw request id');
+  assert.doesNotMatch(writeBlock, /request\.headers\.get\('x-lovebud-request-id'\)/, 'write proxy must not re-read raw request id');
+});


### PR DESCRIPTION
## Summary

Refs #1202

Sanitizes client-supplied `x-lovebud-request-id` values at the Cloudflare API boundary before reusing them for response headers or Modal upstream forwarding.

## Policy

- Reuse only trimmed request IDs that match trace-safe characters: letters, numbers, dot, underscore, colon, and hyphen.
- Reject missing, empty, unsafe-character, or oversized request IDs.
- Max accepted length: 80 characters.
- Generate a new server-side request ID when the incoming value is not accepted.

## Changes

- `functions/api/[[path]].js`
  - Adds a canonical request ID header constant.
  - Adds `MAX_REQUEST_ID_LENGTH` and `SAFE_REQUEST_ID_PATTERN`.
  - Adds `normalizeRequestId(...)` before request ID reuse.
  - Uses the sanitized/generated request ID for Modal forwarding and response headers.
- `tests/contracts/request-id-sanitization-contract.test.js`
  - Covers the policy constants, normalization guardrails, fallback generation, and forwarding contract.

## Verification pending

- CI.
- API/browser smoke if this moves beyond contract verification.

## Scope safety

- Cloudflare request ID boundary hardening only.
- No backend schema changes.
- No broad proxy rewrite.
- No PR #7 / prototype / reference / demo / variant path changes.