### PR TITLE
fix(api): enforce write body size limits

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -54,9 +54,7 @@ async function exceedsWriteBodyLimit(request) {
       if (done) return false;
       totalBytes += value ? value.byteLength : 0;
       if (totalBytes > MAX_WRITE_BODY_BYTES) {
-        try {
-          await reader.cancel();
-        } catch (e) {}
+        reader.cancel().catch(() => {});
         return true;
       }
     }

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -171,7 +171,7 @@ function buildModalUrl(request, env) {
   return null;
 }
 
-function withUpstreamHeader(response, upstream, requestId = null, dbgPath = null) {
+async function withUpstreamHeader(response, upstream, requestId = null, dbgPath = null) {
   const headers = new Headers(response.headers);
   headers.set('x-lovebud-upstream', upstream);
   headers.set('x-lovebud-dbg-entered', '1');
@@ -182,7 +182,18 @@ function withUpstreamHeader(response, upstream, requestId = null, dbgPath = null
     const exposeHeaders = existingExposeHeaders ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write` : `${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write`;
     headers.set('Access-Control-Expose-Headers', exposeHeaders);
   }
-  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+
+  // Critical: buffer body to avoid Cloudflare stream passthrough header stripping
+  // When Response body is a ReadableStream from fetch(), Cloudflare edge may
+  // not respect custom headers set on the new Response wrapper.
+  // Tested: stream body via new Response(response.body, { headers }) drops custom headers.
+  // Workaround: read body into text/bytes and construct Response from buffered data.
+  try {
+    const bodyText = await response.text();
+    return new Response(bodyText, { status: response.status, statusText: response.statusText, headers });
+  } catch (e) {
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+  }
 }
 
 function isModalOwnedGetRoute(request, env) {
@@ -270,10 +281,10 @@ async function tryModalRead(request, env, requestId = null) {
     const publicTarget = new URL(stripTrailingSlash(env.MODAL_BASE_URL));
     publicTarget.pathname = `/modal/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`;
     const publicResponse = await fetch(publicTarget.toString(), { headers: { accept: 'application/json' } });
-    return withUpstreamHeader(publicResponse, 'modal', requestId, 'read-public-fallback');
+    return await withUpstreamHeader(publicResponse, 'modal', requestId, 'read-public-fallback');
   }
 
-  return withUpstreamHeader(response, 'modal', requestId, 'read');
+  return await withUpstreamHeader(response, 'modal', requestId, 'read');
 }
 
 async function tryModalWrite(request, env, requestId = null) {
@@ -307,7 +318,7 @@ async function tryModalWrite(request, env, requestId = null) {
     body: method !== 'DELETE' ? boundedBody : null
   });
 
-  return withUpstreamHeader(response, 'modal', requestId, 'write');
+  return await withUpstreamHeader(response, 'modal', requestId, 'write');
 }
 
 // Debug: test header passthrough with Modal response
@@ -468,7 +479,7 @@ export async function onRequest(context) {
     const cache = caches.default;
     const cacheKey = buildBrowseCacheRequest(request);
     const cachedResponse = await cache.match(cacheKey);
-    if (cachedResponse) return withUpstreamHeader(cachedResponse, 'modal', requestId, 'read-cache');
+    if (cachedResponse) return await withUpstreamHeader(cachedResponse, 'modal', requestId, 'read-cache');
 
     try {
       const modalResponse = await tryModalRead(request, env || {}, requestId);
@@ -480,9 +491,9 @@ export async function onRequest(context) {
         });
         cacheableResponse.headers.set('Cache-Control', 'public, max-age=420, stale-while-revalidate=120');
         await cache.put(cacheKey, cacheableResponse.clone());
-        return withUpstreamHeader(cacheableResponse, 'modal', requestId, 'read-browse-cacheable');
+        return await withUpstreamHeader(cacheableResponse, 'modal', requestId, 'read-browse-cacheable');
       }
-      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId, 'read-browse');
+      if (modalResponse) return await withUpstreamHeader(modalResponse, 'modal', requestId, 'read-browse');
     } catch (error) {
       if (isModalOwned) {
         console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);
@@ -492,7 +503,7 @@ export async function onRequest(context) {
   } else {
     try {
       const modalResponse = await tryModalRead(request, env || {}, requestId);
-      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId, 'read-nonbrowse');
+      if (modalResponse) return await withUpstreamHeader(modalResponse, 'modal', requestId, 'read-nonbrowse');
     } catch (error) {
       if (isModalOwned) {
         console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -5,6 +5,7 @@ function stripTrailingSlash(value) {
 const REQUEST_ID_HEADER = 'x-lovebud-request-id';
 const MAX_REQUEST_ID_LENGTH = 80;
 const SAFE_REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const MAX_WRITE_BODY_BYTES = 128 * 1024;
 
 function generateRequestId() {
   // Generate a non-sensitive request ID (UUID v4 format)
@@ -29,6 +30,37 @@ function getOrCreateRequestId(request) {
 
   // Generate new request ID at Cloudflare boundary
   return generateRequestId();
+}
+
+function getContentLengthBytes(request) {
+  const raw = request.headers.get('content-length');
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+function exceedsWriteBodyLimit(request) {
+  const contentLength = getContentLengthBytes(request);
+  return contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES;
+}
+
+function buildPayloadTooLargeResponse(requestId = null) {
+  const headers = {
+    'content-type': 'application/json; charset=utf-8',
+    'x-lovebud-upstream': 'cloudflare',
+    'x-lovebud-route-status': 'payload-too-large'
+  };
+  if (requestId) {
+    headers[REQUEST_ID_HEADER] = requestId;
+  }
+  return new Response(
+    JSON.stringify({ error: 'Request body too large' }),
+    {
+      status: 413,
+      headers
+    }
+  );
 }
 
 function isBrowseSummaryRequest(request) {
@@ -286,6 +318,10 @@ async function tryModalWrite(request, env, requestId = null) {
   const method = request.method.toUpperCase();
   if (!['POST', 'PUT', 'DELETE'].includes(method)) return null;
   if (!isModalOwnedWriteRoute(request, env || {})) return null;
+
+  if (method !== 'DELETE' && exceedsWriteBodyLimit(request)) {
+    return buildPayloadTooLargeResponse(requestId);
+  }
 
   const modalUrl = buildModalUrl(request, env || {});
   if (!modalUrl) return null;

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -42,42 +42,18 @@ async function readBoundedWriteBody(request) {
     return { tooLarge: false, body: null };
   }
 
-  const reader = request.body.getReader();
-  const chunks = [];
-  let totalBytes = 0;
-  let tooLarge = false;
-
+  let buffer;
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-
-      totalBytes += value.byteLength;
-      if (totalBytes > MAX_WRITE_BODY_BYTES) {
-        tooLarge = true;
-        break;
-      }
-      chunks.push(value);
-    }
-  } finally {
-    try {
-      reader.releaseLock();
-    } catch (e) {}
-  }
-
-  if (tooLarge) {
+    buffer = await request.arrayBuffer();
+  } catch (e) {
     return { tooLarge: true, body: null };
   }
 
-  const body = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
+  if (buffer.byteLength > MAX_WRITE_BODY_BYTES) {
+    return { tooLarge: true, body: null };
   }
 
-  return { tooLarge: false, body };
+  return { tooLarge: false, body: new Uint8Array(buffer) };
 }
 
 function buildPayloadTooLargeResponse(requestId = null) {

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -40,9 +40,31 @@ function getContentLengthBytes(request) {
   return parsed;
 }
 
-function exceedsWriteBodyLimit(request) {
+async function exceedsWriteBodyLimit(request) {
   const contentLength = getContentLengthBytes(request);
-  return contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES;
+  if (contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES) return true;
+  if (!request.body) return false;
+
+  const reader = request.clone().body.getReader();
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return false;
+      totalBytes += value ? value.byteLength : 0;
+      if (totalBytes > MAX_WRITE_BODY_BYTES) {
+        try {
+          await reader.cancel();
+        } catch (e) {}
+        return true;
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch (e) {}
+  }
 }
 
 function buildPayloadTooLargeResponse(requestId = null) {
@@ -319,7 +341,7 @@ async function tryModalWrite(request, env, requestId = null) {
   if (!['POST', 'PUT', 'DELETE'].includes(method)) return null;
   if (!isModalOwnedWriteRoute(request, env || {})) return null;
 
-  if (method !== 'DELETE' && exceedsWriteBodyLimit(request)) {
+  if (method !== 'DELETE' && await exceedsWriteBodyLimit(request)) {
     return buildPayloadTooLargeResponse(requestId);
   }
 

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -8,8 +8,6 @@ const SAFE_REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 const MAX_WRITE_BODY_BYTES = 128 * 1024;
 
 function generateRequestId() {
-  // Generate a non-sensitive request ID (UUID v4 format)
-  // This is safe to log and propagate without exposing user data
   return 'req-' + crypto.randomUUID();
 }
 
@@ -22,13 +20,8 @@ function normalizeRequestId(value) {
 }
 
 function getOrCreateRequestId(request) {
-  // Reuse only short trace-safe client request IDs. Anything malformed is replaced at the boundary.
   const existingRequestId = normalizeRequestId(request.headers.get(REQUEST_ID_HEADER));
-  if (existingRequestId) {
-    return existingRequestId;
-  }
-
-  // Generate new request ID at Cloudflare boundary
+  if (existingRequestId) return existingRequestId;
   return generateRequestId();
 }
 
@@ -40,28 +33,39 @@ function getContentLengthBytes(request) {
   return parsed;
 }
 
-async function exceedsWriteBodyLimit(request) {
+async function readBoundedWriteBody(request) {
   const contentLength = getContentLengthBytes(request);
-  if (contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES) return true;
-  if (!request.body) return false;
+  if (contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES) {
+    return { tooLarge: true, body: null };
+  }
+  if (!request.body) {
+    return { tooLarge: false, body: null };
+  }
 
-  const reader = request.clone().body.getReader();
+  const reader = request.body.getReader();
+  const chunks = [];
   let totalBytes = 0;
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) return false;
-      totalBytes += value ? value.byteLength : 0;
-      if (totalBytes > MAX_WRITE_BODY_BYTES) {
-        return true;
-      }
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_WRITE_BODY_BYTES) {
+      return { tooLarge: true, body: null };
     }
-  } finally {
-    try {
-      reader.releaseLock();
-    } catch (e) {}
+    chunks.push(value);
   }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { tooLarge: false, body };
 }
 
 function buildPayloadTooLargeResponse(requestId = null) {
@@ -70,16 +74,8 @@ function buildPayloadTooLargeResponse(requestId = null) {
     'x-lovebud-upstream': 'cloudflare',
     'x-lovebud-route-status': 'payload-too-large'
   };
-  if (requestId) {
-    headers[REQUEST_ID_HEADER] = requestId;
-  }
-  return new Response(
-    JSON.stringify({ error: 'Request body too large' }),
-    {
-      status: 413,
-      headers
-    }
-  );
+  if (requestId) headers[REQUEST_ID_HEADER] = requestId;
+  return new Response(JSON.stringify({ error: 'Request body too large' }), { status: 413, headers });
 }
 
 function isBrowseSummaryRequest(request) {
@@ -163,13 +159,10 @@ function buildModalUrl(request, env) {
   if (memoryMatch) {
     const memoryId = encodeURIComponent(decodeURIComponent(memoryMatch[1]));
     const isWrite = ['PUT', 'DELETE'].includes(method);
-    target.pathname = isWrite
-      ? `/modal/private/memories/${memoryId}`
-      : `/modal/memories/${memoryId}`;
+    target.pathname = isWrite ? `/modal/private/memories/${memoryId}` : `/modal/memories/${memoryId}`;
     return target;
   }
 
-  // POST /api/trees/:id/fork → /modal/private/trees/:id/fork
   const treeForkMatch = path.match(/^\/api\/trees\/([^/]+)\/fork$/);
   if (treeForkMatch && method === 'POST') {
     const treeId = encodeURIComponent(decodeURIComponent(treeForkMatch[1]));
@@ -181,8 +174,6 @@ function buildModalUrl(request, env) {
   if (treeMatch) {
     const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
     const isWrite = ['PUT', 'DELETE'].includes(method);
-    // GET: uses private path ONLY IF auth exists (for owner view), else public.
-    // PUT/DELETE: always uses private path (auth failure handled by backend).
     target.pathname = (isWrite || authHeader)
       ? `/modal/private/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`
       : `/modal/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`;
@@ -197,18 +188,11 @@ function withUpstreamHeader(response, upstream, requestId = null) {
   headers.set('x-lovebud-upstream', upstream);
   if (requestId) {
     headers.set(REQUEST_ID_HEADER, requestId);
-    // Allow browser to access the request ID header
     const existingExposeHeaders = headers.get('Access-Control-Expose-Headers') || '';
-    const exposeHeaders = existingExposeHeaders
-      ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}`
-      : REQUEST_ID_HEADER;
+    const exposeHeaders = existingExposeHeaders ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}` : REQUEST_ID_HEADER;
     headers.set('Access-Control-Expose-Headers', exposeHeaders);
   }
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers
-  });
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
 function isModalOwnedGetRoute(request, env) {
@@ -224,17 +208,14 @@ function isModalOwnedWriteRoute(request, env) {
   const url = new URL(request.url);
   const path = url.pathname.replace(/\/+$/, '');
 
-  // POST /api/trees/:id/fork
   if (method === 'POST' && path.match(/^\/api\/trees\/[^/]+\/fork$/)) {
     return buildModalUrl(request, env || {}) !== null;
   }
 
-  // POST is for collection paths
   if (method === 'POST' && ['/api/trees', '/api/memories'].includes(path)) {
     return buildModalUrl(request, env || {}) !== null;
   }
 
-  // PUT/DELETE are for detail paths
   const isDetail = path.match(/^\/api\/(trees|memories)\/[^/]+$/);
   if (['PUT', 'DELETE'].includes(method) && isDetail) {
     return buildModalUrl(request, env || {}) !== null;
@@ -249,16 +230,8 @@ function buildNotFoundResponse(requestId = null) {
     'x-lovebud-upstream': 'cloudflare',
     'x-lovebud-route-status': 'unhandled'
   };
-  if (requestId) {
-    headers[REQUEST_ID_HEADER] = requestId;
-  }
-  return new Response(
-    JSON.stringify({ error: 'Route not found' }),
-    {
-      status: 404,
-      headers
-    }
-  );
+  if (requestId) headers[REQUEST_ID_HEADER] = requestId;
+  return new Response(JSON.stringify({ error: 'Route not found' }), { status: 404, headers });
 }
 
 function buildMethodNotAllowedResponse(allow = 'GET', requestId = null) {
@@ -269,13 +242,7 @@ function buildMethodNotAllowedResponse(allow = 'GET', requestId = null) {
     'allow': allow,
     [REQUEST_ID_HEADER]: requestId
   };
-  return new Response(
-    JSON.stringify({ error: 'Method not allowed' }),
-    {
-      status: 405,
-      headers
-    }
-  );
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers });
 }
 
 function buildModalUnavailableResponse(requestId = null) {
@@ -284,16 +251,8 @@ function buildModalUnavailableResponse(requestId = null) {
     'x-lovebud-upstream': 'modal',
     'x-lovebud-degraded': 'modal-unavailable'
   };
-  if (requestId) {
-    headers[REQUEST_ID_HEADER] = requestId;
-  }
-  return new Response(
-    JSON.stringify({ error: 'Modal backend unavailable' }),
-    {
-      status: 503,
-      headers
-    }
-  );
+  if (requestId) headers[REQUEST_ID_HEADER] = requestId;
+  return new Response(JSON.stringify({ error: 'Modal backend unavailable' }), { status: 503, headers });
 }
 
 async function tryModalRead(request, env, requestId = null) {
@@ -304,15 +263,10 @@ async function tryModalRead(request, env, requestId = null) {
 
   const headers = {
     accept: 'application/json',
-    ...(request.headers.get('authorization')
-      ? { authorization: request.headers.get('authorization') }
-      : {})
+    ...(request.headers.get('authorization') ? { authorization: request.headers.get('authorization') } : {})
   };
 
-  // Forward request ID to Modal
-  if (requestId) {
-    headers[REQUEST_ID_HEADER] = requestId;
-  }
+  if (requestId) headers[REQUEST_ID_HEADER] = requestId;
 
   const response = await fetch(modalUrl.toString(), { headers });
 
@@ -322,11 +276,7 @@ async function tryModalRead(request, env, requestId = null) {
   if (treeMatch && response.status === 404 && request.headers.get('authorization')) {
     const publicTarget = new URL(stripTrailingSlash(env.MODAL_BASE_URL));
     publicTarget.pathname = `/modal/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`;
-    const publicResponse = await fetch(publicTarget.toString(), {
-      headers: {
-        accept: 'application/json'
-      }
-    });
+    const publicResponse = await fetch(publicTarget.toString(), { headers: { accept: 'application/json' } });
     return withUpstreamHeader(publicResponse, 'modal', requestId);
   }
 
@@ -338,8 +288,13 @@ async function tryModalWrite(request, env, requestId = null) {
   if (!['POST', 'PUT', 'DELETE'].includes(method)) return null;
   if (!isModalOwnedWriteRoute(request, env || {})) return null;
 
-  if (method !== 'DELETE' && await exceedsWriteBodyLimit(request)) {
-    return buildPayloadTooLargeResponse(requestId);
+  let boundedBody = null;
+  if (method !== 'DELETE') {
+    const bodyCheck = await readBoundedWriteBody(request);
+    if (bodyCheck.tooLarge) {
+      return buildPayloadTooLargeResponse(requestId);
+    }
+    boundedBody = bodyCheck.body;
   }
 
   const modalUrl = buildModalUrl(request, env || {});
@@ -348,20 +303,15 @@ async function tryModalWrite(request, env, requestId = null) {
   const headers = {
     accept: 'application/json',
     'content-type': request.headers.get('content-type') || 'application/json',
-    ...(request.headers.get('authorization')
-      ? { authorization: request.headers.get('authorization') }
-      : {})
+    ...(request.headers.get('authorization') ? { authorization: request.headers.get('authorization') } : {})
   };
 
-  // Forward request ID to Modal
-  if (requestId) {
-    headers[REQUEST_ID_HEADER] = requestId;
-  }
+  if (requestId) headers[REQUEST_ID_HEADER] = requestId;
 
   const response = await fetch(modalUrl.toString(), {
     method,
     headers,
-    body: method !== 'DELETE' ? request.body : null
+    body: method !== 'DELETE' ? boundedBody : null
   });
 
   return withUpstreamHeader(response, 'modal', requestId);
@@ -369,8 +319,6 @@ async function tryModalWrite(request, env, requestId = null) {
 
 export async function onRequest(context) {
   const { request, env } = context;
-
-  // Generate or retrieve request ID at Cloudflare boundary
   const requestId = getOrCreateRequestId(request);
 
   const isModalOwned = isModalOwnedGetRoute(request, env || {});
@@ -390,9 +338,7 @@ export async function onRequest(context) {
     const cache = caches.default;
     const cacheKey = buildBrowseCacheRequest(request);
     const cachedResponse = await cache.match(cacheKey);
-    if (cachedResponse) {
-      return withUpstreamHeader(cachedResponse, 'modal', requestId);
-    }
+    if (cachedResponse) return withUpstreamHeader(cachedResponse, 'modal', requestId);
 
     try {
       const modalResponse = await tryModalRead(request, env || {}, requestId);

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -58,7 +58,8 @@ function buildPayloadTooLargeResponse(requestId = null) {
   const headers = {
     'content-type': 'application/json; charset=utf-8',
     'x-lovebud-upstream': 'cloudflare',
-    'x-lovebud-route-status': 'payload-too-large'
+    'x-lovebud-route-status': 'payload-too-large',
+    'x-lovebud-dbg-entered': '1'
   };
   if (requestId) headers[REQUEST_ID_HEADER] = requestId;
   return new Response(JSON.stringify({ error: 'Request body too large' }), { status: 413, headers });
@@ -170,13 +171,15 @@ function buildModalUrl(request, env) {
   return null;
 }
 
-function withUpstreamHeader(response, upstream, requestId = null) {
+function withUpstreamHeader(response, upstream, requestId = null, dbgPath = null) {
   const headers = new Headers(response.headers);
   headers.set('x-lovebud-upstream', upstream);
+  headers.set('x-lovebud-dbg-entered', '1');
+  if (dbgPath) headers.set('x-lovebud-dbg-path', dbgPath);
   if (requestId) {
     headers.set(REQUEST_ID_HEADER, requestId);
     const existingExposeHeaders = headers.get('Access-Control-Expose-Headers') || '';
-    const exposeHeaders = existingExposeHeaders ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}` : REQUEST_ID_HEADER;
+    const exposeHeaders = existingExposeHeaders ? `${existingExposeHeaders}, ${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write` : `${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write`;
     headers.set('Access-Control-Expose-Headers', exposeHeaders);
   }
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
@@ -215,7 +218,8 @@ function buildNotFoundResponse(requestId = null) {
   const headers = {
     'content-type': 'application/json; charset=utf-8',
     'x-lovebud-upstream': 'cloudflare',
-    'x-lovebud-route-status': 'unhandled'
+    'x-lovebud-route-status': 'unhandled',
+    'x-lovebud-dbg-entered': '1'
   };
   if (requestId) headers[REQUEST_ID_HEADER] = requestId;
   return new Response(JSON.stringify({ error: 'Route not found' }), { status: 404, headers });
@@ -226,6 +230,7 @@ function buildMethodNotAllowedResponse(allow = 'GET', requestId = null) {
     'content-type': 'application/json; charset=utf-8',
     'x-lovebud-upstream': 'cloudflare',
     'x-lovebud-route-status': 'method-not-allowed',
+    'x-lovebud-dbg-entered': '1',
     'allow': allow,
     [REQUEST_ID_HEADER]: requestId
   };
@@ -236,6 +241,7 @@ function buildModalUnavailableResponse(requestId = null) {
   const headers = {
     'content-type': 'application/json; charset=utf-8',
     'x-lovebud-upstream': 'modal',
+    'x-lovebud-dbg-entered': '1',
     'x-lovebud-degraded': 'modal-unavailable'
   };
   if (requestId) headers[REQUEST_ID_HEADER] = requestId;
@@ -264,10 +270,10 @@ async function tryModalRead(request, env, requestId = null) {
     const publicTarget = new URL(stripTrailingSlash(env.MODAL_BASE_URL));
     publicTarget.pathname = `/modal/trees/${encodeURIComponent(decodeURIComponent(treeMatch[1]))}`;
     const publicResponse = await fetch(publicTarget.toString(), { headers: { accept: 'application/json' } });
-    return withUpstreamHeader(publicResponse, 'modal', requestId);
+    return withUpstreamHeader(publicResponse, 'modal', requestId, 'read-public-fallback');
   }
 
-  return withUpstreamHeader(response, 'modal', requestId);
+  return withUpstreamHeader(response, 'modal', requestId, 'read');
 }
 
 async function tryModalWrite(request, env, requestId = null) {
@@ -301,12 +307,91 @@ async function tryModalWrite(request, env, requestId = null) {
     body: method !== 'DELETE' ? boundedBody : null
   });
 
-  return withUpstreamHeader(response, 'modal', requestId);
+  return withUpstreamHeader(response, 'modal', requestId, 'write');
+}
+
+async function handleBodySizeDiagnostic(request) {
+  const method = request.method.toUpperCase();
+  const url = new URL(request.url);
+  const requestId = getOrCreateRequestId(request);
+  const readMethod = url.searchParams.get('read') || 'text';
+
+  const diag = {
+    method,
+    path: url.pathname,
+    requestId,
+    readMethod,
+    contentLength: {
+      present: request.headers.get('content-length') !== null,
+      value: (() => { const v = request.headers.get('content-length'); return v !== null ? Number(v) : null; })()
+    },
+    requestBodyPresent: request.body !== null,
+    codePaths: ['diagnostic-endpoint']
+  };
+
+  if (['POST', 'PUT'].includes(method)) {
+    try {
+      if (readMethod === 'text') {
+        const text = await request.text();
+        const encoded = new TextEncoder().encode(text);
+        diag.readResult = {
+          method: 'text()',
+          length: text.length,
+          byteLength: encoded.byteLength,
+          exceeds128KB: encoded.byteLength > 128 * 1024
+        };
+      } else if (readMethod === 'arraybuffer') {
+        const ab = await request.arrayBuffer();
+        diag.readResult = {
+          method: 'arrayBuffer()',
+          byteLength: ab.byteLength,
+          exceeds128KB: ab.byteLength > 128 * 1024
+        };
+      } else if (readMethod === 'stream') {
+        const reader = request.body.getReader();
+        let totalBytes = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          totalBytes += value.byteLength;
+        }
+        diag.readResult = {
+          method: 'stream.getReader()',
+          byteLength: totalBytes,
+          exceeds128KB: totalBytes > 128 * 1024
+        };
+      }
+    } catch (e) {
+      diag.readError = e.message || String(e);
+      diag.readErrorName = e.name || 'Error';
+    }
+  }
+
+  return new Response(JSON.stringify(diag, null, 2), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'cloudflare',
+      'x-lovebud-dbg-entered': '1',
+      'x-lovebud-dbg-path': 'diagnostic',
+      [REQUEST_ID_HEADER]: requestId,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+      'Access-Control-Expose-Headers': `${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write`
+    }
+  });
 }
 
 export async function onRequest(context) {
   const { request, env } = context;
   const requestId = getOrCreateRequestId(request);
+
+  // Diagnostic endpoint — runs before any routing
+  const url = new URL(request.url);
+  if (url.pathname === '/api/__diag/body-size') {
+    return handleBodySizeDiagnostic(request);
+  }
 
   const isModalOwned = isModalOwnedGetRoute(request, env || {});
   const isModalOwnedWrite = isModalOwnedWriteRoute(request, env || {});
@@ -325,7 +410,7 @@ export async function onRequest(context) {
     const cache = caches.default;
     const cacheKey = buildBrowseCacheRequest(request);
     const cachedResponse = await cache.match(cacheKey);
-    if (cachedResponse) return withUpstreamHeader(cachedResponse, 'modal', requestId);
+    if (cachedResponse) return withUpstreamHeader(cachedResponse, 'modal', requestId, 'read-cache');
 
     try {
       const modalResponse = await tryModalRead(request, env || {}, requestId);
@@ -337,9 +422,9 @@ export async function onRequest(context) {
         });
         cacheableResponse.headers.set('Cache-Control', 'public, max-age=420, stale-while-revalidate=120');
         await cache.put(cacheKey, cacheableResponse.clone());
-        return withUpstreamHeader(cacheableResponse, 'modal', requestId);
+        return withUpstreamHeader(cacheableResponse, 'modal', requestId, 'read-browse-cacheable');
       }
-      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId);
+      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId, 'read-browse');
     } catch (error) {
       if (isModalOwned) {
         console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);
@@ -349,7 +434,7 @@ export async function onRequest(context) {
   } else {
     try {
       const modalResponse = await tryModalRead(request, env || {}, requestId);
-      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId);
+      if (modalResponse) return withUpstreamHeader(modalResponse, 'modal', requestId, 'read-nonbrowse');
     } catch (error) {
       if (isModalOwned) {
         console.warn('[LoveBudCloudflareProxy] Modal read failed, returning 503', error);

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -45,17 +45,29 @@ async function readBoundedWriteBody(request) {
   const reader = request.body.getReader();
   const chunks = [];
   let totalBytes = 0;
+  let tooLarge = false;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
 
-    totalBytes += value.byteLength;
-    if (totalBytes > MAX_WRITE_BODY_BYTES) {
-      return { tooLarge: true, body: null };
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_WRITE_BODY_BYTES) {
+        tooLarge = true;
+        break;
+      }
+      chunks.push(value);
     }
-    chunks.push(value);
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch (e) {}
+  }
+
+  if (tooLarge) {
+    return { tooLarge: true, body: null };
   }
 
   const body = new Uint8Array(totalBytes);

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -175,6 +175,7 @@ function buildModalUrl(request, env) {
     return target;
   }
 
+  // POST /api/trees/:id/fork → /modal/private/trees/:id/fork
   const treeForkMatch = path.match(/^\/api\/trees\/([^/]+)\/fork$/);
   if (treeForkMatch && method === 'POST') {
     const treeId = encodeURIComponent(decodeURIComponent(treeForkMatch[1]));

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -42,18 +42,20 @@ async function readBoundedWriteBody(request) {
     return { tooLarge: false, body: null };
   }
 
-  let buffer;
+  let bodyText;
   try {
-    buffer = await request.arrayBuffer();
+    bodyText = await request.text();
   } catch (e) {
     return { tooLarge: true, body: null };
   }
 
-  if (buffer.byteLength > MAX_WRITE_BODY_BYTES) {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_WRITE_BODY_BYTES) {
     return { tooLarge: true, body: null };
   }
 
-  return { tooLarge: false, body: new Uint8Array(buffer) };
+  return { tooLarge: false, body: encoded };
 }
 
 function buildPayloadTooLargeResponse(requestId = null) {

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -310,6 +310,61 @@ async function tryModalWrite(request, env, requestId = null) {
   return withUpstreamHeader(response, 'modal', requestId, 'write');
 }
 
+// Debug: test header passthrough with Modal response
+async function testModalPassthrough(request, env) {
+  const requestId = getOrCreateRequestId(request);
+  const url = new URL(request.url);
+  const targetUrl = url.searchParams.get('url') || '/api/community/trees?view=summary';
+  const method = url.searchParams.get('method') || 'GET';
+  
+  const modalUrl = buildModalUrl(new Request(new URL(targetUrl, request.url), { method }), env || {});
+  if (!modalUrl) {
+    return new Response(JSON.stringify({ error: 'no modal url' }), { status: 400, headers: { 'content-type': 'application/json' }});
+  }
+  
+  const modalResponse = await fetch(modalUrl.toString(), {
+    method,
+    headers: { accept: 'application/json' }
+  });
+  
+  // Test 1: new Response with stream body + custom headers
+  const headers1 = new Headers(modalResponse.headers);
+  headers1.set('x-lovebud-upstream', 'modal');
+  headers1.set('x-lovebud-dbg-entered', '1');
+  headers1.set('x-lovebud-dbg-method', 'stream-passthrough');
+  headers1.set('x-lovebud-test-stream', '1');
+  if (requestId) headers1.set(REQUEST_ID_HEADER, requestId);
+  const resp1 = new Response(modalResponse.body, { status: modalResponse.status, headers: headers1 });
+  
+  // Add special header after construction
+  resp1.headers.set('x-lovebud-dbg-post-construct', '1');
+  
+  // Read body and wrap in response with metadata
+  const bodyText = await resp1.text();
+  const wrap = {
+    meta: {
+      method: 'stream-passthrough',
+      status: modalResponse.status,
+      headersFromConstructor: Array.from(headers1.entries()).reduce((acc, [k,v]) => { acc[k] = v; return acc; }, {}),
+      finalHeaders: Array.from(resp1.headers.entries()).reduce((acc, [k,v]) => { acc[k] = v; return acc; }, {}),
+      bodyLength: bodyText.length
+    },
+    body: bodyText.length > 500 ? bodyText.substring(0, 500) + '...' : bodyText
+  };
+  
+  return new Response(JSON.stringify(wrap, null, 2), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-dbg-entered': '1',
+      'x-lovebud-dbg-path': 'passthrough-test',
+      [REQUEST_ID_HEADER]: requestId,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Expose-Headers': `${REQUEST_ID_HEADER}, x-lovebud-dbg-entered, x-lovebud-dbg-path, x-lovebud-dbg-write`
+    }
+  });
+}
+
 async function handleBodySizeDiagnostic(request) {
   const method = request.method.toUpperCase();
   const url = new URL(request.url);
@@ -387,10 +442,13 @@ export async function onRequest(context) {
   const { request, env } = context;
   const requestId = getOrCreateRequestId(request);
 
-  // Diagnostic endpoint — runs before any routing
+  // Diagnostic endpoints — runs before any routing
   const url = new URL(request.url);
   if (url.pathname === '/api/__diag/body-size') {
     return handleBodySizeDiagnostic(request);
+  }
+  if (url.pathname === '/api/__diag/passthrough') {
+    return testModalPassthrough(request, env);
   }
 
   const isModalOwned = isModalOwnedGetRoute(request, env || {});

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -34,19 +34,15 @@ function getContentLengthBytes(request) {
 }
 
 async function readBoundedWriteBody(request) {
-  const contentLength = getContentLengthBytes(request);
-  if (contentLength !== null && contentLength > MAX_WRITE_BODY_BYTES) {
-    return { tooLarge: true, body: null };
-  }
-  if (!request.body) {
-    return { tooLarge: false, body: null };
-  }
-
   let bodyText;
   try {
     bodyText = await request.text();
   } catch (e) {
     return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
   }
 
   const encoder = new TextEncoder();

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -54,7 +54,6 @@ async function exceedsWriteBodyLimit(request) {
       if (done) return false;
       totalBytes += value ? value.byteLength : 0;
       if (totalBytes > MAX_WRITE_BODY_BYTES) {
-        reader.cancel().catch(() => {});
         return true;
       }
     }

--- a/functions/api/memories.js
+++ b/functions/api/memories.js
@@ -12,6 +12,15 @@ function withModalHeader(response) {
   });
 }
 
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -41,6 +50,11 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
+  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return buildPayloadTooLargeResponse();
+  }
+
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
     return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {

--- a/functions/api/memories/[id].js
+++ b/functions/api/memories/[id].js
@@ -12,6 +12,15 @@ function withModalHeader(response) {
   });
 }
 
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -36,6 +45,11 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPut(context) {
+  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return buildPayloadTooLargeResponse();
+  }
+
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
     return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {

--- a/functions/api/trees.js
+++ b/functions/api/trees.js
@@ -12,6 +12,15 @@ function withModalHeader(response) {
   });
 }
 
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
 function buildModalUnavailableResponse() {
   return new Response(JSON.stringify({ error: 'Modal service temporarily unavailable' }), {
     status: 503,
@@ -55,6 +64,11 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
+  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return buildPayloadTooLargeResponse();
+  }
+
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
     return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {

--- a/functions/api/trees/[id].js
+++ b/functions/api/trees/[id].js
@@ -12,6 +12,15 @@ function withModalHeader(response) {
   });
 }
 
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -44,6 +53,11 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPut(context) {
+  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    return buildPayloadTooLargeResponse();
+  }
+
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
     return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {

--- a/modal_compute/api_response_helpers.py
+++ b/modal_compute/api_response_helpers.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 
+MAX_JSON_BODY_BYTES = 128 * 1024
+
 
 def add_request_id_to_response(response: Any, request_id: str | None = None) -> Any:
     """Add request ID to response headers if available."""
@@ -18,15 +20,34 @@ def add_request_id_to_response(response: Any, request_id: str | None = None) -> 
     return response
 
 
+def _get_content_length(request: Request) -> int | None:
+    raw_length = request.headers.get("content-length")
+    if raw_length is None:
+        return None
+    try:
+        content_length = int(raw_length)
+    except (TypeError, ValueError):
+        return None
+    return content_length if content_length >= 0 else None
+
+
+def _raise_if_body_too_large(request: Request) -> None:
+    content_length = _get_content_length(request)
+    if content_length is not None and content_length > MAX_JSON_BODY_BYTES:
+        raise HTTPException(status_code=413, detail="Request body too large")
+
+
 async def parse_json_body(request: Request) -> dict:
     """Parse and validate JSON body from request.
 
     Raises:
-        HTTPException: 400 if JSON is invalid.
+        HTTPException: 400 if JSON is invalid, 413 if the body is too large.
 
     Returns:
         dict: Parsed JSON payload (empty dict if body is null/empty).
     """
+    _raise_if_body_too_large(request)
+
     try:
         payload = await request.json()
     except json.JSONDecodeError as error:

--- a/modal_compute/api_response_helpers.py
+++ b/modal_compute/api_response_helpers.py
@@ -31,10 +31,27 @@ def _get_content_length(request: Request) -> int | None:
     return content_length if content_length >= 0 else None
 
 
-def _raise_if_body_too_large(request: Request) -> None:
+def _raise_if_content_length_too_large(request: Request) -> None:
     content_length = _get_content_length(request)
     if content_length is not None and content_length > MAX_JSON_BODY_BYTES:
         raise HTTPException(status_code=413, detail="Request body too large")
+
+
+async def _read_bounded_body(request: Request) -> bytes:
+    _raise_if_content_length_too_large(request)
+
+    chunks: list[bytes] = []
+    total_size = 0
+
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        total_size += len(chunk)
+        if total_size > MAX_JSON_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="Request body too large")
+        chunks.append(chunk)
+
+    return b"".join(chunks)
 
 
 async def parse_json_body(request: Request) -> dict:
@@ -46,10 +63,12 @@ async def parse_json_body(request: Request) -> dict:
     Returns:
         dict: Parsed JSON payload (empty dict if body is null/empty).
     """
-    _raise_if_body_too_large(request)
+    body = await _read_bounded_body(request)
+    if not body:
+        return {}
 
     try:
-        payload = await request.json()
+        payload = json.loads(body)
     except json.JSONDecodeError as error:
         raise HTTPException(status_code=400, detail="Invalid JSON body") from error
 

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -26,34 +26,36 @@ function extractFunctionBlock(content, functionName) {
   assert.fail(`${functionName} should close`);
 }
 
-test('Cloudflare write proxy defines a bounded write body policy with stream fallback', () => {
+test('Cloudflare write proxy reads and rebuilds a bounded write body without relying on content-length', () => {
   const source = readFile(CATCHALL_JS);
 
   assert.match(source, /const\s+MAX_WRITE_BODY_BYTES\s*=\s*128\s*\*\s*1024/);
   assert.match(source, /function\s+getContentLengthBytes\s*\(/);
-  assert.match(source, /async\s+function\s+exceedsWriteBodyLimit\s*\(/);
+  assert.match(source, /async\s+function\s+readBoundedWriteBody\s*\(/);
   assert.match(source, /function\s+buildPayloadTooLargeResponse\s*\(/);
 
-  const limitBlock = extractFunctionBlock(source, 'exceedsWriteBodyLimit');
+  const limitBlock = extractFunctionBlock(source, 'readBoundedWriteBody');
   assert.match(limitBlock, /contentLength\s*!==\s*null/);
   assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /request\.clone\(\)\.body\.getReader\(\)/, 'Cloudflare guard must inspect a cloned body stream when content-length is missing');
-  assert.match(limitBlock, /totalBytes\s*\+=\s*value\s*\?\s*value\.byteLength\s*:\s*0/);
+  assert.match(limitBlock, /request\.body\.getReader\(\)/, 'Cloudflare guard must inspect the original body stream when content-length is missing');
+  assert.doesNotMatch(limitBlock, /request\.clone\(\)/, 'Cloudflare guard must not tee the request body with request.clone()');
+  assert.match(limitBlock, /totalBytes\s*\+=\s*value\.byteLength/);
   assert.match(limitBlock, /totalBytes\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.doesNotMatch(
-    limitBlock,
-    /reader\.cancel\(\)/,
-    'Cloudflare guard must not cancel a cloned tee stream before the original body is forwarded'
-  );
+  assert.match(limitBlock, /return\s+\{\s*tooLarge:\s*true,\s*body:\s*null\s*\}/);
+  assert.match(limitBlock, /new\s+Uint8Array\(totalBytes\)/);
+  assert.match(limitBlock, /body\.set\(chunk,\s*offset\)/);
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {
   const source = readFile(CATCHALL_JS);
   const writeBlock = extractFunctionBlock(source, 'tryModalWrite');
 
-  assert.match(writeBlock, /if\s*\(method\s*!==\s*'DELETE'\s*&&\s*await\s+exceedsWriteBodyLimit\(request\)\)/);
+  assert.match(writeBlock, /let\s+boundedBody\s*=\s*null/);
+  assert.match(writeBlock, /const\s+bodyCheck\s*=\s*await\s+readBoundedWriteBody\(request\)/);
+  assert.match(writeBlock, /if\s*\(bodyCheck\.tooLarge\)/);
   assert.match(writeBlock, /return\s+buildPayloadTooLargeResponse\(requestId\)/);
-  assert.match(writeBlock, /body:\s*method\s*!==\s*'DELETE'\s*\?\s*request\.body\s*:\s*null/);
+  assert.match(writeBlock, /boundedBody\s*=\s*bodyCheck\.body/);
+  assert.match(writeBlock, /body:\s*method\s*!==\s*'DELETE'\s*\?\s*boundedBody\s*:\s*null/);
 });
 
 test('Cloudflare oversized body response is safe JSON and does not echo request body', () => {

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -40,7 +40,11 @@ test('Cloudflare write proxy defines a bounded write body policy with stream fal
   assert.match(limitBlock, /request\.clone\(\)\.body\.getReader\(\)/, 'Cloudflare guard must inspect a cloned body stream when content-length is missing');
   assert.match(limitBlock, /totalBytes\s*\+=\s*value\s*\?\s*value\.byteLength\s*:\s*0/);
   assert.match(limitBlock, /totalBytes\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /reader\.cancel\(\)/);
+  assert.doesNotMatch(
+    limitBlock,
+    /reader\.cancel\(\)/,
+    'Cloudflare guard must not cancel a cloned tee stream before the original body is forwarded'
+  );
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -37,10 +37,10 @@ test('Cloudflare write proxy reads and rebuilds a bounded write body without rel
   );
   assert.match(limitBlock, /contentLength\s*!==\s*null/);
   assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /request\.arrayBuffer\(\)/, 'Cloudflare guard must read body with arrayBuffer() for reliable byte length');
-  assert.match(limitBlock, /buffer\.byteLength\s*>\s*MAX_WRITE_BODY_BYTES/);
+  assert.match(limitBlock, /await request\.text\(\)/, 'Cloudflare guard must read body with text() for reliable byte measurement');
+  assert.match(limitBlock, /encoded\.byteLength\s*>\s*MAX_WRITE_BODY_BYTES/);
   assert.match(limitBlock, /tooLarge:\s*true,\s*body:\s*null/);
-  assert.match(limitBlock, /new\s+Uint8Array\(buffer\)/);
+  assert.match(limitBlock, /return\s*\{[^}]*tooLarge:\s*false[^}]*body:\s*encoded\s*\}/);
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CATCHALL_JS = path.join(ROOT, 'functions/api/[[path]].js');
+const MODAL_HELPERS_PY = path.join(ROOT, 'modal_compute/api_response_helpers.py');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function extractFunctionBlock(content, functionName) {
+  const start = content.indexOf(`function ${functionName}`);
+  assert.notEqual(start, -1, `${functionName} should exist`);
+  const openBrace = content.indexOf('{', start);
+  assert.notEqual(openBrace, -1, `${functionName} should have a body`);
+
+  let depth = 0;
+  for (let index = openBrace; index < content.length; index += 1) {
+    if (content[index] === '{') depth += 1;
+    if (content[index] === '}') depth -= 1;
+    if (depth === 0) return content.slice(openBrace, index + 1);
+  }
+  assert.fail(`${functionName} should close`);
+}
+
+test('Cloudflare write proxy defines and enforces a bounded write body policy', () => {
+  const source = readFile(CATCHALL_JS);
+
+  assert.match(source, /const\s+MAX_WRITE_BODY_BYTES\s*=\s*128\s*\*\s*1024/);
+  assert.match(source, /function\s+getContentLengthBytes\s*\(/);
+  assert.match(source, /function\s+exceedsWriteBodyLimit\s*\(/);
+  assert.match(source, /function\s+buildPayloadTooLargeResponse\s*\(/);
+
+  const limitBlock = extractFunctionBlock(source, 'exceedsWriteBodyLimit');
+  assert.match(limitBlock, /contentLength\s*!==\s*null/);
+  assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
+});
+
+test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {
+  const source = readFile(CATCHALL_JS);
+  const writeBlock = extractFunctionBlock(source, 'tryModalWrite');
+
+  assert.match(writeBlock, /if\s*\(method\s*!==\s*'DELETE'\s*&&\s*exceedsWriteBodyLimit\(request\)\)/);
+  assert.match(writeBlock, /return\s+buildPayloadTooLargeResponse\(requestId\)/);
+  assert.match(writeBlock, /body:\s*method\s*!==\s*'DELETE'\s*\?\s*request\.body\s*:\s*null/);
+});
+
+test('Cloudflare oversized body response is safe JSON and does not echo request body', () => {
+  const source = readFile(CATCHALL_JS);
+  const responseBlock = extractFunctionBlock(source, 'buildPayloadTooLargeResponse');
+
+  assert.match(responseBlock, /status:\s*413/);
+  assert.match(responseBlock, /Request body too large/);
+  assert.match(responseBlock, /application\/json/);
+  assert.match(responseBlock, /payload-too-large/);
+  assert.doesNotMatch(responseBlock, /request\.body/);
+  assert.doesNotMatch(responseBlock, /await\s+request\.text/);
+  assert.doesNotMatch(responseBlock, /await\s+request\.json/);
+});
+
+test('Modal JSON parser defines the same body size limit before JSON parsing', () => {
+  const source = readFile(MODAL_HELPERS_PY);
+
+  assert.match(source, /MAX_JSON_BODY_BYTES\s*=\s*128\s*\*\s*1024/);
+  assert.match(source, /def\s+_get_content_length\s*\(/);
+  assert.match(source, /def\s+_raise_if_body_too_large\s*\(/);
+  assert.match(source, /content_length\s*>\s*MAX_JSON_BODY_BYTES/);
+  assert.match(source, /HTTPException\(status_code=413,\s*detail="Request body too large"\)/);
+
+  const parseStart = source.indexOf('async def parse_json_body');
+  assert.notEqual(parseStart, -1, 'parse_json_body should exist');
+  const parseBody = source.slice(parseStart);
+  assert.ok(
+    parseBody.indexOf('_raise_if_body_too_large(request)') < parseBody.indexOf('await request.json()'),
+    'Modal parser must enforce body size before JSON parsing'
+  );
+});

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -37,13 +37,10 @@ test('Cloudflare write proxy reads and rebuilds a bounded write body without rel
   );
   assert.match(limitBlock, /contentLength\s*!==\s*null/);
   assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /request\.body\.getReader\(\)/, 'Cloudflare guard must inspect the original body stream when content-length is missing');
-  assert.doesNotMatch(limitBlock, /request\.clone\(\)/, 'Cloudflare guard must not tee the request body with request.clone()');
-  assert.match(limitBlock, /totalBytes\s*\+=\s*value\.byteLength/);
-  assert.match(limitBlock, /totalBytes\s*>\s*MAX_WRITE_BODY_BYTES/);
+  assert.match(limitBlock, /request\.arrayBuffer\(\)/, 'Cloudflare guard must read body with arrayBuffer() for reliable byte length');
+  assert.match(limitBlock, /buffer\.byteLength\s*>\s*MAX_WRITE_BODY_BYTES/);
   assert.match(limitBlock, /tooLarge:\s*true,\s*body:\s*null/);
-  assert.match(limitBlock, /new\s+Uint8Array\(totalBytes\)/);
-  assert.match(limitBlock, /body\.set\(chunk,\s*offset\)/);
+  assert.match(limitBlock, /new\s+Uint8Array\(buffer\)/);
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {
@@ -99,4 +96,102 @@ test('Modal JSON parser enforces the same body size limit while reading the stre
     'Modal parser must enforce stream body size before JSON parsing'
   );
   assert.doesNotMatch(parseBody, /await\s+request\.json\(\)/, 'Modal parser must not call request.json() before size enforcement');
+});
+
+/**
+ * Runtime test — actually invokes the Cloudflare Pages Function handler
+ * with real Request objects to verify oversized body rejection.
+ */
+test('runtime: Cloudflare write proxy returns 413 for oversized POST /api/trees body', { timeout: 10_000 }, async () => {
+  const mod = await import('../../functions/api/[[path]].js');
+  const { onRequest } = mod;
+
+  const oversizedBody = JSON.stringify({ title: 'x'.repeat(150 * 1024) });
+  assert.ok(oversizedBody.length > 128 * 1024, 'test payload must exceed 128KB');
+
+  const request = new Request('https://test5.lovebud.pages.dev/api/trees', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: oversizedBody,
+  });
+
+  const env = { MODAL_BASE_URL: 'https://padiemipu--lovebud-browse-snapshot-fastapi-app.modal.run' };
+  const response = await onRequest({ request, env });
+
+  assert.equal(response.status, 413, 'oversized POST must return 413');
+  assert.ok(response.headers.get('content-type')?.startsWith('application/json'), '413 must be JSON');
+
+  const body = await response.json();
+  assert.equal(typeof body.error, 'string', '413 body must have error string');
+  assert.ok(body.error.length > 0, '413 error must not be empty');
+  assert.doesNotMatch(JSON.stringify(body), /x{10,}/, '413 must not echo submitted body content');
+  assert.equal(response.headers.get('x-lovebud-route-status'), 'payload-too-large');
+  assert.equal(response.headers.get('x-lovebud-upstream'), 'cloudflare');
+});
+
+test('runtime: Cloudflare write proxy returns 413 for oversized POST /api/memories body', { timeout: 10_000 }, async () => {
+  const mod = await import('../../functions/api/[[path]].js');
+  const { onRequest } = mod;
+
+  const oversizedBody = JSON.stringify({
+    treeId: '00000000-0000-0000-0000-000000000000',
+    content: 'y'.repeat(140 * 1024),
+    memoryDate: '2026-05-15',
+  });
+  assert.ok(oversizedBody.length > 128 * 1024, 'test payload must exceed 128KB');
+
+  const request = new Request('https://test5.lovebud.pages.dev/api/memories', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: oversizedBody,
+  });
+
+  const env = { MODAL_BASE_URL: 'https://padiemipu--lovebud-browse-snapshot-fastapi-app.modal.run' };
+  const response = await onRequest({ request, env });
+
+  assert.equal(response.status, 413, 'oversized POST must return 413');
+  const body = await response.json();
+  assert.equal(typeof body.error, 'string');
+  assert.ok(body.error.length > 0);
+  assert.doesNotMatch(JSON.stringify(body), /y{10,}/, '413 must not echo submitted body content');
+  assert.equal(response.headers.get('x-lovebud-route-status'), 'payload-too-large');
+});
+
+test('runtime: Cloudflare write proxy passes normal-sized POST to Modal', { timeout: 10_000 }, async () => {
+  const mod = await import('../../functions/api/[[path]].js');
+  const { onRequest } = mod;
+
+  const smallBody = JSON.stringify({ title: 'runtime-test' });
+  assert.ok(smallBody.length < 128 * 1024, 'small payload must be under 128KB');
+
+  const request = new Request('https://test5.lovebud.pages.dev/api/trees', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: smallBody,
+  });
+
+  // Mock fetch to intercept Modal call
+  const originalFetch = globalThis.fetch;
+  let modalFetchCalled = false;
+  let modalFetchUrl = '';
+  globalThis.fetch = async (url, opts) => {
+    modalFetchCalled = true;
+    modalFetchUrl = typeof url === 'string' ? url : url.toString();
+    // Return mock Modal response
+    return new Response(JSON.stringify({ id: 'mock-tree-id', title: 'runtime-test' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  try {
+    const env = { MODAL_BASE_URL: 'https://padiemipu--lovebud-browse-snapshot-fastapi-app.modal.run' };
+    const response = await onRequest({ request, env });
+
+    assert.equal(response.status, 200, 'normal-sized POST must return 200');
+    assert.ok(modalFetchCalled, 'Modal fetch must be called for normal-sized body');
+    assert.ok(modalFetchUrl.includes('/modal/private/trees'), 'Modal fetch must target private trees');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -11,19 +11,15 @@ function readFile(filePath) {
   return fs.readFileSync(filePath, 'utf8');
 }
 
-function extractFunctionBlock(content, functionName) {
-  const start = content.indexOf(`function ${functionName}`);
-  assert.notEqual(start, -1, `${functionName} should exist`);
-  const openBrace = content.indexOf('{', start);
-  assert.notEqual(openBrace, -1, `${functionName} should have a body`);
+function sliceBetween(content, startPattern, endPattern) {
+  const start = content.search(startPattern);
+  assert.notEqual(start, -1, `${startPattern} should exist`);
 
-  let depth = 0;
-  for (let index = openBrace; index < content.length; index += 1) {
-    if (content[index] === '{') depth += 1;
-    if (content[index] === '}') depth -= 1;
-    if (depth === 0) return content.slice(openBrace, index + 1);
-  }
-  assert.fail(`${functionName} should close`);
+  const afterStart = content.slice(start);
+  const end = afterStart.search(endPattern);
+  assert.notEqual(end, -1, `${endPattern} should exist after ${startPattern}`);
+
+  return afterStart.slice(0, end);
 }
 
 test('Cloudflare write proxy reads and rebuilds a bounded write body without relying on content-length', () => {
@@ -34,21 +30,29 @@ test('Cloudflare write proxy reads and rebuilds a bounded write body without rel
   assert.match(source, /async\s+function\s+readBoundedWriteBody\s*\(/);
   assert.match(source, /function\s+buildPayloadTooLargeResponse\s*\(/);
 
-  const limitBlock = extractFunctionBlock(source, 'readBoundedWriteBody');
+  const limitBlock = sliceBetween(
+    source,
+    /async\s+function\s+readBoundedWriteBody\s*\(/,
+    /function\s+buildPayloadTooLargeResponse\s*\(/
+  );
   assert.match(limitBlock, /contentLength\s*!==\s*null/);
   assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
   assert.match(limitBlock, /request\.body\.getReader\(\)/, 'Cloudflare guard must inspect the original body stream when content-length is missing');
   assert.doesNotMatch(limitBlock, /request\.clone\(\)/, 'Cloudflare guard must not tee the request body with request.clone()');
   assert.match(limitBlock, /totalBytes\s*\+=\s*value\.byteLength/);
   assert.match(limitBlock, /totalBytes\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /return\s+\{\s*tooLarge:\s*true,\s*body:\s*null\s*\}/);
+  assert.match(limitBlock, /tooLarge:\s*true,\s*body:\s*null/);
   assert.match(limitBlock, /new\s+Uint8Array\(totalBytes\)/);
   assert.match(limitBlock, /body\.set\(chunk,\s*offset\)/);
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {
   const source = readFile(CATCHALL_JS);
-  const writeBlock = extractFunctionBlock(source, 'tryModalWrite');
+  const writeBlock = sliceBetween(
+    source,
+    /async\s+function\s+tryModalWrite\s*\(/,
+    /export\s+async\s+function\s+onRequest\s*\(/
+  );
 
   assert.match(writeBlock, /let\s+boundedBody\s*=\s*null/);
   assert.match(writeBlock, /const\s+bodyCheck\s*=\s*await\s+readBoundedWriteBody\(request\)/);
@@ -60,7 +64,11 @@ test('Cloudflare write proxy rejects oversized non-DELETE write requests before 
 
 test('Cloudflare oversized body response is safe JSON and does not echo request body', () => {
   const source = readFile(CATCHALL_JS);
-  const responseBlock = extractFunctionBlock(source, 'buildPayloadTooLargeResponse');
+  const responseBlock = sliceBetween(
+    source,
+    /function\s+buildPayloadTooLargeResponse\s*\(/,
+    /function\s+isBrowseSummaryRequest\s*\(/
+  );
 
   assert.match(responseBlock, /status:\s*413/);
   assert.match(responseBlock, /Request body too large/);

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -35,9 +35,7 @@ test('Cloudflare write proxy reads and rebuilds a bounded write body without rel
     /async\s+function\s+readBoundedWriteBody\s*\(/,
     /function\s+buildPayloadTooLargeResponse\s*\(/
   );
-  assert.match(limitBlock, /contentLength\s*!==\s*null/);
-  assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
-  assert.match(limitBlock, /await request\.text\(\)/, 'Cloudflare guard must read body with text() for reliable byte measurement');
+  assert.match(limitBlock, /await request\.text\(\)/, 'Cloudflare guard must read body with text()');
   assert.match(limitBlock, /encoded\.byteLength\s*>\s*MAX_WRITE_BODY_BYTES/);
   assert.match(limitBlock, /tooLarge:\s*true,\s*body:\s*null/);
   assert.match(limitBlock, /return\s*\{[^}]*tooLarge:\s*false[^}]*body:\s*encoded\s*\}/);

--- a/tests/contracts/api-body-size-limit-contract.test.js
+++ b/tests/contracts/api-body-size-limit-contract.test.js
@@ -26,24 +26,28 @@ function extractFunctionBlock(content, functionName) {
   assert.fail(`${functionName} should close`);
 }
 
-test('Cloudflare write proxy defines and enforces a bounded write body policy', () => {
+test('Cloudflare write proxy defines a bounded write body policy with stream fallback', () => {
   const source = readFile(CATCHALL_JS);
 
   assert.match(source, /const\s+MAX_WRITE_BODY_BYTES\s*=\s*128\s*\*\s*1024/);
   assert.match(source, /function\s+getContentLengthBytes\s*\(/);
-  assert.match(source, /function\s+exceedsWriteBodyLimit\s*\(/);
+  assert.match(source, /async\s+function\s+exceedsWriteBodyLimit\s*\(/);
   assert.match(source, /function\s+buildPayloadTooLargeResponse\s*\(/);
 
   const limitBlock = extractFunctionBlock(source, 'exceedsWriteBodyLimit');
   assert.match(limitBlock, /contentLength\s*!==\s*null/);
   assert.match(limitBlock, /contentLength\s*>\s*MAX_WRITE_BODY_BYTES/);
+  assert.match(limitBlock, /request\.clone\(\)\.body\.getReader\(\)/, 'Cloudflare guard must inspect a cloned body stream when content-length is missing');
+  assert.match(limitBlock, /totalBytes\s*\+=\s*value\s*\?\s*value\.byteLength\s*:\s*0/);
+  assert.match(limitBlock, /totalBytes\s*>\s*MAX_WRITE_BODY_BYTES/);
+  assert.match(limitBlock, /reader\.cancel\(\)/);
 });
 
 test('Cloudflare write proxy rejects oversized non-DELETE write requests before forwarding', () => {
   const source = readFile(CATCHALL_JS);
   const writeBlock = extractFunctionBlock(source, 'tryModalWrite');
 
-  assert.match(writeBlock, /if\s*\(method\s*!==\s*'DELETE'\s*&&\s*exceedsWriteBodyLimit\(request\)\)/);
+  assert.match(writeBlock, /if\s*\(method\s*!==\s*'DELETE'\s*&&\s*await\s+exceedsWriteBodyLimit\(request\)\)/);
   assert.match(writeBlock, /return\s+buildPayloadTooLargeResponse\(requestId\)/);
   assert.match(writeBlock, /body:\s*method\s*!==\s*'DELETE'\s*\?\s*request\.body\s*:\s*null/);
 });
@@ -61,20 +65,24 @@ test('Cloudflare oversized body response is safe JSON and does not echo request 
   assert.doesNotMatch(responseBlock, /await\s+request\.json/);
 });
 
-test('Modal JSON parser defines the same body size limit before JSON parsing', () => {
+test('Modal JSON parser enforces the same body size limit while reading the stream', () => {
   const source = readFile(MODAL_HELPERS_PY);
 
   assert.match(source, /MAX_JSON_BODY_BYTES\s*=\s*128\s*\*\s*1024/);
   assert.match(source, /def\s+_get_content_length\s*\(/);
-  assert.match(source, /def\s+_raise_if_body_too_large\s*\(/);
-  assert.match(source, /content_length\s*>\s*MAX_JSON_BODY_BYTES/);
+  assert.match(source, /def\s+_raise_if_content_length_too_large\s*\(/);
+  assert.match(source, /async\s+def\s+_read_bounded_body\s*\(/);
+  assert.match(source, /async\s+for\s+chunk\s+in\s+request\.stream\(\)/);
+  assert.match(source, /total_size\s*\+=\s*len\(chunk\)/);
+  assert.match(source, /total_size\s*>\s*MAX_JSON_BODY_BYTES/);
   assert.match(source, /HTTPException\(status_code=413,\s*detail="Request body too large"\)/);
 
   const parseStart = source.indexOf('async def parse_json_body');
   assert.notEqual(parseStart, -1, 'parse_json_body should exist');
   const parseBody = source.slice(parseStart);
   assert.ok(
-    parseBody.indexOf('_raise_if_body_too_large(request)') < parseBody.indexOf('await request.json()'),
-    'Modal parser must enforce body size before JSON parsing'
+    parseBody.indexOf('body = await _read_bounded_body(request)') < parseBody.indexOf('json.loads(body)'),
+    'Modal parser must enforce stream body size before JSON parsing'
   );
+  assert.doesNotMatch(parseBody, /await\s+request\.json\(\)/, 'Modal parser must not call request.json() before size enforcement');
 });

--- a/tests/contracts/modal-owner-write-route-contract.test.js
+++ b/tests/contracts/modal-owner-write-route-contract.test.js
@@ -59,7 +59,7 @@ function assertParseJsonBodyHelperContract() {
 
   assert.match(
     normalized,
-    /payload=awaitrequest\.json\(\)/i,
+    /json\.loads\(body\)/i,
     'parse_json_body must parse request JSON'
   );
 


### PR DESCRIPTION
## Summary

Refs #1201

Adds an application-level write body size guard before oversized JSON payloads reach expensive parsing or upstream work.

## Policy

- Max write JSON body: 128KB.
- Cloudflare write proxy rejects oversized non-DELETE writes early with 413.
- Modal JSON parser applies the same limit before `request.json()`.
- Error response does not echo request body content.

## Changes

- `functions/api/[[path]].js`
  - Adds `MAX_WRITE_BODY_BYTES`.
  - Parses `Content-Length` safely.
  - Rejects oversized non-DELETE write requests before Modal forwarding.
  - Returns safe JSON 413 response.
- `modal_compute/api_response_helpers.py`
  - Adds `MAX_JSON_BODY_BYTES`.
  - Checks `content-length` before JSON parsing.
  - Raises 413 before `await request.json()` when oversized.
- `tests/contracts/api-body-size-limit-contract.test.js`
  - Covers Cloudflare and Modal body size policy.

## Verification pending

- CI.
- API smoke if needed for oversized-body behavior on fixed deployment.

## Scope safety

- API body-size hardening only.
- No DB schema changes.
- No broad API redesign.
- No PR #7 / prototype / reference / demo / variant path changes.