### PR TITLE
fix(security): targeted DOM XSS hardening

### DIFF
--- a/js/editor/editor-canvas-node.js
+++ b/js/editor/editor-canvas-node.js
@@ -28,7 +28,10 @@
     skeleton.className = 'node-skeleton';
     imgWrapper.appendChild(skeleton);
     var img = document.createElement('img');
-    img.src = typeof resolveThumbnail === 'function' ? resolveThumbnail(mem) : (mem.thumbnail || '');
+    img.src = typeof resolveThumbnail === 'function' ? resolveThumbnail(mem) :
+        (window.LoveBudEditorHelpers && window.LoveBudEditorHelpers.safeUrl
+            ? window.LoveBudEditorHelpers.safeUrl(mem && mem.thumbnail || '')
+            : (mem && mem.thumbnail || ''));
     img.alt = mem.title || '';
     img.draggable = false;
     img.addEventListener('dragstart', function (e) { e.preventDefault(); });

--- a/js/search/search-preview-playable-hub-patch.js
+++ b/js/search/search-preview-playable-hub-patch.js
@@ -123,9 +123,9 @@
         var shares = getCount(tree, ['shareCount', 'sharesCount', 'shares', 'sharedCount', 'shared_count']);
         return '<div class="preview-social-shell" data-preview-social-shell>' +
             '<div class="preview-social-bar" aria-label="트리 반응">' +
-                '<button type="button" class="preview-social-action" data-preview-like disabled aria-label="좋아요 ' + likes + '"><span class="material-symbols-outlined" aria-hidden="true">favorite</span><strong>' + likes + '</strong><span>좋아요</span></button>' +
-                '<button type="button" class="preview-social-action" data-preview-comments aria-expanded="false" aria-label="댓글 ' + comments + '"><span class="material-symbols-outlined" aria-hidden="true">mode_comment</span><strong>' + comments + '</strong><span>댓글</span></button>' +
-                '<button type="button" class="preview-social-action" data-preview-share disabled aria-label="공유 ' + shares + '"><span class="material-symbols-outlined" aria-hidden="true">share</span><strong>' + shares + '</strong><span>공유</span></button>' +
+                '<button type="button" class="preview-social-action" data-preview-like disabled aria-label="좋아요 ' + escapeHtml(String(likes)) + '"><span class="material-symbols-outlined" aria-hidden="true">favorite</span><strong>' + escapeHtml(String(likes)) + '</strong><span>좋아요</span></button>' +
+                '<button type="button" class="preview-social-action" data-preview-comments aria-expanded="false" aria-label="댓글 ' + escapeHtml(String(comments)) + '"><span class="material-symbols-outlined" aria-hidden="true">mode_comment</span><strong>' + escapeHtml(String(comments)) + '</strong><span>댓글</span></button>' +
+                '<button type="button" class="preview-social-action" data-preview-share disabled aria-label="공유 ' + escapeHtml(String(shares)) + '"><span class="material-symbols-outlined" aria-hidden="true">share</span><strong>' + escapeHtml(String(shares)) + '</strong><span>공유</span></button>' +
             '</div>' +
             '<div class="preview-comments-panel" data-preview-comments-panel hidden>' +
                 '<div class="preview-comments-title">댓글</div>' +

--- a/js/visitor-viewer/visitor-viewer-panels.js
+++ b/js/visitor-viewer/visitor-viewer-panels.js
@@ -62,7 +62,7 @@
             '<div class="vv-panel-header">' +
             '  <p class="vv-panel-eyebrow">Tree overview</p>' +
             '  <h2 class="vv-panel-title-lg">' + escape(branch.name) + '</h2>' +
-            '  <p class="vv-panel-meta">' + branch.count + '개의 순간</p>' +
+            '  <p class="vv-panel-meta">' + escape(String(branch.count)) + '개의 순간</p>' +
             '</div>' +
             '<div class="vv-panel-caption">' + escape(branch.caption || '이 가지의 순간들') + '</div>' +
             '<div class="vv-branch-moment-grid">' +

--- a/js/visitor-viewer/visitor-viewer.js
+++ b/js/visitor-viewer/visitor-viewer.js
@@ -7,6 +7,15 @@
     var panels = window.LoveBudVisitorViewerPanels;
     if (!renderTree || !panels) return;
 
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/\"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function getAllMoments() {
         var results = [];
         var s = data.rootSeed;
@@ -139,8 +148,8 @@
         container.innerHTML =
             '<header class="vv-header">' +
             '  <div><p class="vv-eyebrow">Public LoveTree Viewer IA v4</p>' +
-            '  <h1 class="vv-title">' + data.tree.title + '</h1>' +
-            '  <div class="vv-meta-row"><span>' + data.tree.creator + '</span><span class="vv-dot">·</span><span>' + data.tree.meta + '</span></div></div>' +
+            '  <h1 class="vv-title">' + escapeHtml(data.tree.title) + '</h1>' +
+            '  <div class="vv-meta-row"><span>' + escapeHtml(data.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(data.tree.meta) + '</span></div></div>' +
             '</header>' +
             '<div class="vv-action-dock" data-action-dock>' +
             '  <div class="vv-action-group">' +


### PR DESCRIPTION
## Summary

Targeted frontend DOM XSS hardening for Issue #1203. No broad sanitizer refactors, no new dependencies, no CSP changes.

## Changes

### H1 — visitor-viewer.js
- Added local `escapeHtml()` utility
- Wrapped `data.tree.title`, `data.tree.creator`, `data.tree.meta` with `escapeHtml()` in `buildShell()` innerHTML

### L1 — visitor-viewer-panels.js
- Wrapped `branch.count` with `escape(String())` in panel meta rendering

### L1 — search-preview-playable-hub-patch.js
- Wrapped `likes`, `comments`, `shares` counter values with `escapeHtml(String())` in `renderSocialBar()`

### L2 — editor-canvas-node.js
- Fallback `mem.thumbnail` now passes through `window.LoveBudEditorHelpers.safeUrl()` for URL validation

## Validation
- ✅ npm test: 295/295 PASS
- ✅ npm run lint: PASS (no new warnings)
- ✅ npm run build: PASS
- ✅ Deployed to test5 slot
- ✅ Browser smoke: visitor viewer renders correctly, tree viewer renders, no console JS errors across all pages

## Scope
- NO sanitizer consolidation
- NO new dependencies
- No inline handler migration
- No CSP rewrite

Refs #1203