### PR TITLE
fix(security): consolidate auth escapeHtml usage

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -397,6 +397,8 @@ function getBasePath() {
 window.getBasePath = getBasePath;
 
 function escapeHtml(value) {
+  var sec = window.LoveBudSecurity;
+  if (sec) return sec.escapeHtml(value);
   if (__authUiModule) return __authUiModule.escapeHtml(value);
   return String(value == null ? '' : value)
     .replace(/&/g, '&amp;')

--- a/js/auth/auth-ui.js
+++ b/js/auth/auth-ui.js
@@ -49,6 +49,8 @@
   }
 
   function escapeHtml(value) {
+    var sec = window.LoveBudSecurity;
+    if (sec) return sec.escapeHtml(value);
     return String(value == null ? "" : value)
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")


### PR DESCRIPTION
## Summary

PR-B2-01: First micro PR of PR-B2 sanitizer migration. Consolidates auth-layer local `escapeHtml` implementations to reference the canonical `window.LoveBudSecurity.escapeHtml`.

## Changes

### `js/auth/auth-ui.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first
- Fallback to identical inline implementation preserved for safety

### `js/auth.js`
- Global `escapeHtml()` references `LoveBudSecurity.escapeHtml` before `__authUiModule` delegation
- Fallback chain: LoveBudSecurity → `__authUiModule.escapeHtml` → inline

## Behavioral Guarantee

All 5 entities preserved: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`
`0`/`false` preserved via `== null` guard.
No rendering logic modified.

## Test Results

| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **335/335 PASS** |
| `npm run lint` | ✅ Static lint passed |
| `npm run build` | ✅ Static build check passed |

## Scope

- ✅ Auth-layer `escapeHtml` consolidation only
- ❌ NOT viewer/detail/editor migration
- ❌ NOT iframe/src hardening
- ❌ NOT inline onclick migration
- ❌ NOT CSP changes

Refs #1203