### PR TITLE
fix(security): consolidate viewer escapeHtml usage

### DIFF
--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -56,6 +56,8 @@
 
     // escapeHtml
     function escapeHtml(value) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(value);
         return String(value ?? '')
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')

--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -27,6 +27,8 @@
     }
 
     function escapeHtml(v) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(v);
         return String(v == null ? '' : v).replace(/[&<>"']/g, function(c) {
             return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
         });


### PR DESCRIPTION
## Summary

PR-B2-02: Second micro PR of PR-B2 sanitizer migration. Consolidates viewer-layer local `escapeHtml` implementations to reference canonical `window.LoveBudSecurity.escapeHtml`.

## Changes

### `js/viewer/public-tree-viewer.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first
- Fallback to identical inline implementation preserved

### `js/viewer/tree-viewer.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first  
- Fallback to identical character-map implementation preserved

## What is NOT in this PR

- `iframe src` sanitization (public-tree-viewer.js:324) is **intentionally untouched**
- That fix is deferred to PR-B2-08 (separate micro PR)

## Test Results

| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **335/335 PASS** |
| `npm run lint` | ✅ Static lint passed |
| `npm run build` | ✅ Static build check passed |

## Scope

- ✅ Viewer `escapeHtml` consolidation only
- ❌ NOT iframe/src hardening (PR-B2-08)
- ❌ NOT visitor/detail/editor/my-trees/auth migration
- ❌ NOT inline onclick / CSP changes

Refs #1203