### PR TITLE
fix(security): sanitize public viewer iframe sources

### DIFF
--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -320,8 +320,17 @@
             const ytVideoId = extractYouTubeVideoId(sourceUrl);
             if (ytVideoId) {
                 const embedUrl = `https://www.youtube.com/embed/${ytVideoId}?rel=0&modestbranding=1`;
-                const safeTitle = escapeHtml(memory.title || 'moment video');
-                mediaContainer.innerHTML = `<iframe src="${escapeHtml(embedUrl)}" class="viewer-preview-video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" title="${safeTitle}"></iframe>`;
+                // Sanitize embed URL before iframe src insertion (defense-in-depth)
+                var sanitizeUrl = window.LoveBudSecurity && window.LoveBudSecurity.sanitizeUrl;
+                var safeEmbedUrl = sanitizeUrl ? sanitizeUrl(embedUrl) : embedUrl;
+                if (safeEmbedUrl) {
+                    var safeTitle = escapeHtml(memory.title || 'moment video');
+                    mediaContainer.innerHTML = '<iframe src="' + escapeHtml(safeEmbedUrl) + '" class="viewer-preview-video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" title="' + safeTitle + '"></iframe>';
+                } else if (thumb) {
+                    mediaContainer.innerHTML = '<img src="' + escapeHtml(thumb) + '" alt="' + escapeHtml(memory.title || '') + '" class="viewer-preview-image" loading="lazy" />';
+                } else {
+                    mediaContainer.innerHTML = '<div class="viewer-preview-no-media"><span class="material-symbols-outlined">image</span></div>';
+                }
             } else if (thumb) {
                 mediaContainer.innerHTML = `<img src="${escapeHtml(thumb)}" alt="${escapeHtml(memory.title || '')}" class="viewer-preview-image" loading="lazy" />`;
             } else {

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -85,3 +85,23 @@ test('tree viewer scripts are scoped as viewer code', () => {
     const noEditorMarkers = !content.includes('editorCanvas') && !content.includes('nodeContextMenu') && !content.includes('addMemory');
     assert.ok(noEditorMarkers, 'tree-viewer.js must not reference Editor internals');
 });
+
+test('public-tree-viewer.js uses sanitizeUrl before iframe src insertion', () => {
+    const src = fs.readFileSync('js/viewer/public-tree-viewer.js', 'utf8');
+    const hasSanitizeRef = src.includes('window.LoveBudSecurity') && src.includes('sanitizeUrl');
+    assert.ok(hasSanitizeRef, 'public-tree-viewer.js must reference LoveBudSecurity.sanitizeUrl');
+});
+
+test('public-tree-viewer.js iframe branch has safeEmbedUrl guard', () => {
+    const src = fs.readFileSync('js/viewer/public-tree-viewer.js', 'utf8');
+    assert.ok(src.includes('if (safeEmbedUrl)'),
+        'iframe src must be gated behind safeEmbedUrl check');
+    assert.ok(src.includes('} else if (thumb)'),
+        'iframe rejection must fall back to thumbnail branch');
+});
+
+test('public-tree-viewer.js iframe src uses escapeHtml around safeEmbedUrl', () => {
+    const src = fs.readFileSync('js/viewer/public-tree-viewer.js', 'utf8');
+    assert.ok(src.includes('escapeHtml(safeEmbedUrl)'),
+        'iframe src value must pass through escapeHtml');
+});


### PR DESCRIPTION
## Summary

PR-B2-08: iframe src sanitizeUrl hardening on public-tree-viewer.js. Adds `LoveBudSecurity.sanitizeUrl` gate before iframe src insertion. If the embed URL is unsafe (defense-in-depth), falls through to thumbnail or no-media fallback state.

## Changes

### `js/viewer/public-tree-viewer.js`
- `renderPreviewMemory()`: embedUrl now validates through `LoveBudSecurity.sanitizeUrl` before iframe src assignment
- Unsafe URL → skip iframe, fall back to thumbnail if available, else no-media state
- `escapeHtml` still applied as second layer on the sanitized URL

### `tests/routes/viewer-route-contract.test.js` (+3 tests)
- `public-tree-viewer.js uses sanitizeUrl before iframe src insertion`
- `public-tree-viewer.js iframe branch has safeEmbedUrl guard`
- `public-tree-viewer.js iframe src uses escapeHtml around safeEmbedUrl`

## Sanitize URL Policy (via `js/utils/security.js`)
| Allowed | Blocked |
|---------|---------|
| ✅ `http://` absolute | ❌ `javascript:` |
| ✅ `https://` absolute | ❌ `data:` |
| | ❌ `blob:` |
| | ❌ `vbscript:` |
| | ❌ protocol-relative `//` |
| | ❌ relative URL |
| | ❌ malformed URL |

## Fallback Behavior
```
ytVideoId found
  → sanitizeUrl(embedUrl)
    → PASS: render <iframe>
    → REJECT: thumb? → <img> : <no-media icon>
no ytVideoId
  → thumb? → <img> : <no-media icon>
```

## Test Results
| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **338/338 PASS** (was 335, +3 new) |
| `npm run lint` | ✅ PASS (pre-existing warnings only) |
| `npm run build` | ✅ PASS |

## Scope
- ✅ public-tree-viewer.js iframe src sanitization only
- ❌ NOT auth/search/editor/detail/visitor/my-trees changes
- ❌ NOT public-tree-adapter sanitizeUrl policy changes
- ❌ NOT CSP / onclick migration
- ❌ NOT unrelated refactoring

Refs #1203