### PR TITLE
fix(security): consolidate visitor viewer escapeHtml usage

### DIFF
--- a/js/visitor-viewer/visitor-viewer-render-tree.js
+++ b/js/visitor-viewer/visitor-viewer-render-tree.js
@@ -18,6 +18,8 @@
     }
 
     function escapeHtml(value) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(value);
         return String(value == null ? '' : value).replace(/[&<>"']/g, function(char) {
             return { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[char];
         });

--- a/js/visitor-viewer/visitor-viewer.js
+++ b/js/visitor-viewer/visitor-viewer.js
@@ -8,6 +8,8 @@
     if (!renderTree || !panels) return;
 
     function escapeHtml(value) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(value);
         return String(value == null ? '' : value)
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')


### PR DESCRIPTION
## Summary

PR-B2-03: Visitor viewer escapeHtml consolidation. Both `visitor-viewer.js` and `visitor-viewer-render-tree.js` local `escapeHtml` implementations now delegate to canonical `window.LoveBudSecurity.escapeHtml` first, falling through to identical inline implementations.

## Changes

### `js/visitor-viewer/visitor-viewer.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first
- Fallback to identical inline implementation preserved (5 entities: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`)

### `js/visitor-viewer/visitor-viewer-render-tree.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first
- Fallback to identical character-map implementation preserved

## What is NOT in this PR

- `renderTree` / `renderLeaf` / `renderHierarchyTree` / `renderOrganicTree` / `buildShell` / `buildHierarchyLayout` — all **unchanged**
- Canvas v4 viewer rendering logic — **unchanged**
- iframe/src, media/embed, sanitizeUrl — **untouched**
- detail/my-trees/editor/public-tree-adapter — **not changed**

## Canonical Escape Policy

| Condition | Status |
|-----------|:------:|
| `&` → `&amp;` | ✅ |
| `<` → `&lt;` | ✅ |
| `>` → `&gt;` | ✅ |
| `"` → `&quot;` | ✅ |
| `'` → `&#39;` | ✅ |
| `0` / `false` preserved (`== null` guard) | ✅ |

## Test Results

| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **338/338 PASS** |
| `npm run lint` | ✅ Static lint passed |
| `npm run build` | ✅ Static build check passed |

## Scope

- ✅ Visitor viewer escapeHtml consolidation only (2 files)
- ❌ NOT rendering logic changes
- ❌ NOT iframe/src / sanitizeUrl changes
- ❌ NOT detail/my-trees/editor/public-tree-adapter
- ❌ NOT CSP / onclick migration

Refs #1203