### PR TITLE
fix(security): consolidate detail escapeHtml usage

### DIFF
--- a/js/detail/detail-utils.js
+++ b/js/detail/detail-utils.js
@@ -28,12 +28,16 @@
             return translated;
         };
 
-        const escapeHtml = (value) => String(value ?? '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+        const escapeHtml = (value) => {
+            var sec = window.LoveBudSecurity;
+            if (sec) return sec.escapeHtml(value);
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/\"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
 
         const prettifyTagLabel = (tag) => {
             const raw = String(tag ?? '').trim();


### PR DESCRIPTION
## Summary

PR-B2-04: Detail escapeHtml consolidation. `detail-utils.js` local `escapeHtml` arrow function now delegates to canonical `window.LoveBudSecurity.escapeHtml` first, falling through to identical inline implementation.

## Changes

### `js/detail/detail-utils.js`
- `escapeHtml()` (arrow function) now checks `window.LoveBudSecurity` first
- Fallback to identical inline implementation preserved (5 entities: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`)
- `String(value ?? '')` preserves 0 and false (identical to canonical `== null` guard)

## What is NOT in this PR
- Detail rendering logic — **unchanged**
- `normalizeVideoSourceUrl` / `prettifyTagLabel` / `getLocalizedTagLabel` — all **unchanged**
- iframe/src, sanitizeUrl — **untouched**
- auth/viewer/visitor/editor/my-trees — **not changed**

## Canonical Escape Policy

| Condition | Status |
|-----------|:------:|
| `&` → `&amp;` | ✅ |
| `<` → `&lt;` | ✅ |
| `>` → `&gt;` | ✅ |
| `"` → `&quot;` | ✅ |
| `'` → `&#39;` | ✅ |
| `0` / `false` preserved (`value ?? ''` / `== null`) | ✅ |

## Test Results

| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **338/338 PASS** |
| `npm run lint` | ✅ Static lint passed |
| `npm run build` | ✅ Static build check passed |

## Scope
- ✅ detail-utils.js escapeHtml consolidation only (1 file)
- ❌ NOT rendering logic changes
- ❌ NOT iframe/src / sanitizeUrl changes
- ❌ NOT auth/viewer/visitor/editor/my-trees
- ❌ NOT CSP / onclick migration

Refs #1203