### PR TITLE
fix(security): consolidate my-trees escapeHtml usage

### DIFF
--- a/js/my-trees/my-trees-preview-hub.js
+++ b/js/my-trees/my-trees-preview-hub.js
@@ -22,6 +22,8 @@
     /* ── Escape HTML ── */
 
     function escapeHtml(value) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(value);
         return String(value == null ? '' : value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 


### PR DESCRIPTION
## Summary

PR-B2-05: My Trees escapeHtml consolidation. `my-trees-preview-hub.js` local `escapeHtml` function now delegates to canonical `window.LoveBudSecurity.escapeHtml` first, falling through to identical inline implementation.

## Changes

### `js/my-trees/my-trees-preview-hub.js`
- Local `escapeHtml()` now delegates to `window.LoveBudSecurity.escapeHtml` first
- Fallback to identical inline one-liner preserved (5 entities: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`)
- `== null` guard preserves `0` / `false`

## What is NOT in this PR
- Preview/rendering logic (`showContent`, `showLoading`, `buildFlowStages`, `onCardClick`, etc.) — all **unchanged**
- iframe/src, sanitizeUrl, media/embed — **untouched**
- auth/viewer/visitor/detail/editor/public-tree-adapter — **not changed**

## Canonical Escape Policy

| Condition | Status |
|-----------|:------:|
| `&` → `&amp;` | ✅ |
| `<` → `&lt;` | ✅ |
| `>` → `&gt;` | ✅ |
| `"` → `&quot;` | ✅ |
| `'` → `&#39;` | ✅ |
| `0` / `false` preserved | ✅ |

## Test Results

| Check | Result |
|-------|:------:|
| `npm run test` | ✅ **338/338 PASS** |
| `npm run lint` | ✅ Static lint passed |
| `npm run build` | ✅ Static build check passed |

## Scope
- ✅ my-trees-preview-hub.js escapeHtml consolidation only (1 file)
- ❌ NOT preview/rendering logic changes
- ❌ NOT iframe/src / sanitizeUrl changes
- ❌ NOT auth/viewer/visitor/detail/editor
- ❌ NOT CSP / onclick migration

Refs #1203