### PR TITLE
fix(security): consolidate editor escapeHtml usage

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -127,12 +127,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees');
     const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
 
-    const escapeHtml = editorHelpers.escapeHtml || ((value) => String(value ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;'));
+    const escapeHtml = editorHelpers.escapeHtml || ((value) => {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(value);
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    });
 
     const inlineMediaResolvers = editorHelpers.safeUrl
         ? editorHelpers

--- a/js/editor/editor-helpers.js
+++ b/js/editor/editor-helpers.js
@@ -46,6 +46,8 @@
   }
 
   function escapeHtml(value) {
+    var sec = window.LoveBudSecurity;
+    if (sec) return sec.escapeHtml(value);
     return String(value ?? '')
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')


### PR DESCRIPTION
PR-B2-06: Editor escapeHtml consolidation

Consolidate editor-layer local escapeHtml implementations to reference canonical `window.LoveBudSecurity.escapeHtml`.

- `js/editor/editor-helpers.js`: delegate to LoveBudSecurity first, identical fallback
- `js/editor.js`: reference LoveBudSecurity before local fallback

All 5 entities preserved. No editor rendering/preview/save/load logic modified.
No safeUrl/allowDataImage/sanitizeUrl policies changed.
Public-tree-adapter sanitizeUrl policy review is a follow-up task.

```
npm run test   → 338/338 pass
npm run lint   → static lint passed
npm run build  → static build passed
```

Refs #1203