### PR TITLE
fix(security): migrate settings logout inline onclick

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -335,6 +335,11 @@
     loadSettings();
     bindCloseInteractions();
 
+    var logoutBtn = document.getElementById('logout-btn');
+    if (logoutBtn) {
+      logoutBtn.addEventListener('click', handleLogout);
+    }
+
     setTimeout(function() {
       applyI18nText();
       if (typeof window.applyI18n === 'function') window.applyI18n();

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -46,7 +46,7 @@
         <div class="settings-divider"></div>
 
         <div class="settings-section">
-          <button class="logout-btn" onclick="handleLogout()">
+          <button class="logout-btn" id="logout-btn">
             <span class="material-symbols-outlined">logout</span>
             로그아웃
           </button>

--- a/tests/contracts/auth-bootstrap-contract.test.js
+++ b/tests/contracts/auth-bootstrap-contract.test.js
@@ -121,13 +121,6 @@ test('settings page preserves auth submodules, root auth.js, then settings.js or
     'js/auth.js',
     'js/settings.js',
   ]);
-
-  const source = readRepoFile('pages/settings.html');
-  assert.match(
-    source,
-    /onclick\s*=\s*["']handleLogout\s*\(\s*\)["']/i,
-    'settings.html currently has inline handleLogout(); observe only and do not clean it up in this auth contract PR'
-  );
 });
 
 test('shared header keeps optional/idempotent initAuth handoff after dynamic auth container render', () => {


### PR DESCRIPTION
## Summary

PR-C-01: migrate the Settings logout button away from inline `onclick` as the first low-risk step in Issue #1203 PR-C inline onclick migration.

## Changes

- `pages/settings.html`
  - Remove inline `onclick="handleLogout()"` from the logout button
  - Add `id="logout-btn"`
- `js/settings.js`
  - Bind the logout button with `addEventListener('click', handleLogout)` during settings startup
  - Keep a null guard so the page does not fail if the button is absent
- `tests/contracts/auth-bootstrap-contract.test.js`
  - Remove the prior contract assertion that required the inline `handleLogout()` attribute to remain

## Scope

- ✅ Settings page logout inline handler migration only
- ✅ No backend/API/schema/Auth/DB changes
- ✅ No PR #7 / prototype / reference / demo / variant changes
- ✅ No broad auth rewrite
- ✅ No user-controlled rendering changes

## Validation reported by local executor

- Branch pushed: `feature/issue-1203-pr-c-onclick-migration`
- Commit SHA: `9dad8457251059ffa0516f280db460791b49d4f2`
- Changed files:
  - `js/settings.js`
  - `pages/settings.html`
  - `tests/contracts/auth-bootstrap-contract.test.js`

## Required verification before merge

- CI must pass
- Changed files must remain limited to the three listed files
- Settings page loads without fatal console errors
- Logout button still triggers the existing logout flow
- No raw token/session/cookie/private payload/log exposure
- Deployed SHA must match PR head SHA if browser/runtime smoke is performed on a deployment

Refs #1203