### PR TITLE
fix(search): define shared utils helper for preview builders

### DIFF
--- a/js/search/search-preview-renderer-builders.js
+++ b/js/search/search-preview-renderer-builders.js
@@ -57,6 +57,10 @@
         return window.LoveBudSearchTitleHelper || null;
     }
 
+    function getSharedUtils() {
+        return window.LoveBudSearchSharedUtils || null;
+    }
+
     function getMomentLabel(memory, fallbackKo, fallbackEn) {
         if (fallbackKo === undefined) fallbackKo = '시작 순간';
         if (fallbackEn === undefined) fallbackEn = 'Starting moment';


### PR DESCRIPTION
## Summary

Hotfix before PR-D-03 merge: define the missing `getSharedUtils()` helper in `js/search/search-preview-renderer-builders.js`.

Browser/Cloudflare smoke for PR #1233 surfaced a fatal Search runtime error:

```text
ReferenceError: getSharedUtils is not defined
```

Static review showed the helper was called and exported in the Search preview builders module, but not defined in that file.

## Changes

- Add local `getSharedUtils()` helper that safely returns `window.LoveBudSearchSharedUtils || null`
- Preserve existing fallback behavior when shared utils are absent

## Scope

- ✅ Search runtime hotfix only
- ✅ one JS file changed
- ✅ no CSP/header changes
- ✅ no `_headers` changes
- ✅ no backend/API/schema/Auth/DB changes
- ✅ no PR #7 / prototype / reference / demo / variant path changes
- ✅ no issue close keyword

## Local validation reported

- Commit SHA: `a6adf8f3d0efd15fe0652161d3dbb1aee4f25f9a`
- `npm run lint`: PASS
- `npm run build`: PASS
- `npm run test`: PASS

## Required before ready/merge

- CI must pass
- `/pages/search` browser smoke must confirm the fatal `ReferenceError: getSharedUtils is not defined` is gone
- Search/Browse card preview should still render or gracefully fall back
- no fatal console errors
- no raw token/session/cookie/private payload/log exposure

Refs #1203