### PR TITLE
chore(security): add CSP report-only header candidate

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; media-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https:; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests


### PR DESCRIPTION
## Summary

PR-D-03: add a Cloudflare Pages `_headers` candidate with `Content-Security-Policy-Report-Only` only.

This is intentionally report-only. It must not block production resources.

## Changes

- Add root `_headers`
- Add `Content-Security-Policy-Report-Only` for all routes (`/*`)

## Scope

- Report-Only CSP only
- no enforcing `Content-Security-Policy`
- no JS/CSS/HTML runtime changes
- no backend/API/schema/Auth/DB changes
- no PR #7 / prototype / reference / demo / variant path changes
- no issue close keyword

## Current sequencing note

This supersedes the earlier draft PR #1233, which was accidentally auto-closed when its branch was temporarily moved to match updated `main` before the `_headers` commit was re-applied.

Current branch is now based on latest `main` after PR #1235 merge:

- base main SHA: `368c22a5c04f0cef31f156c983b69728c782809d`
- head SHA: `154d30873b707d35003d54a07b18076eeb99aaa3`

## Required before ready/merge

This PR must remain draft/hold until Cloudflare preview/browser validation confirms:

- deployed/tested SHA matches PR head SHA
- preview response includes `Content-Security-Policy-Report-Only`
- preview response does not include enforcing `Content-Security-Policy`
- Home page loads
- shared header renders
- Login page loads
- Firebase Auth initialization does not fail
- Search/Browse page loads
- public tree/detail preview opens
- no fatal console errors
- only report-only CSP observations, no blocking regressions
- no raw token/session/cookie/private payload/log exposure

Refs #1203