### PR TITLE
chore(security): add CSP report-only header candidate

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; media-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https:; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests


### PR DESCRIPTION
## Summary

Re-open PR-D-03 CSP Report-Only candidate on the latest `main` after PR #1240 merged.

This supersedes PR #1239, which became behind/diverged after PR #1240 changed `main`.

## Changes

- Add root `_headers`
- Add `Content-Security-Policy-Report-Only` for all routes (`/*`)

## Scope

- Report-Only CSP only
- no enforcing `Content-Security-Policy`
- no JS/CSS/HTML runtime changes
- no backend/API/schema/Auth/DB changes
- no PR #7 / prototype / reference / demo / variant path changes
- no issue close keyword

## Base/head

- base main SHA: `7cab26e26fad8300bcff0f7121a0fb960b018f45`
- head SHA: `07ecd445df679b461cd4ed0a776b190c569a6ff8`

## Required before ready/merge

This PR must remain draft/hold until Cloudflare preview/browser validation confirms:

- deployed/tested SHA matches PR head SHA
- preview response includes `Content-Security-Policy-Report-Only`
- preview response does not include enforcing `Content-Security-Policy`
- Home page loads
- shared header renders
- Login page loads
- Firebase Auth initialization does not fail
- Search/Browse page loads
- public tree/detail preview opens
- no fatal console errors
- only report-only CSP observations, no blocking regressions
- no raw token/session/cookie/private payload/log exposure

Refs #1203
Supersedes #1239