### PR TITLE
fix(api): enforce route write body limits by reading bounded bodies

### DIFF
--- a/functions/api/memories.js
+++ b/functions/api/memories.js
@@ -21,6 +21,27 @@ function buildPayloadTooLargeResponse() {
   });
 }
 
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -50,8 +71,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
-  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
-  if (contentLength > MAX_BODY_SIZE) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
     return buildPayloadTooLargeResponse();
   }
 
@@ -67,12 +90,12 @@ export async function onRequestPost(context) {
     method: 'POST',
     headers: {
       accept: 'application/json',
-      'content-type': context.request.headers.get('content-type') || 'application/json',
-      ...(context.request.headers.get('authorization')
-        ? { authorization: context.request.headers.get('authorization') }
+      'content-type': request.headers.get('content-type') || 'application/json',
+      ...(request.headers.get('authorization')
+        ? { authorization: request.headers.get('authorization') }
         : {})
     },
-    body: context.request.body
+    body: bodyResult.body
   });
 
   return withModalHeader(response);

--- a/functions/api/memories/[id].js
+++ b/functions/api/memories/[id].js
@@ -21,6 +21,27 @@ function buildPayloadTooLargeResponse() {
   });
 }
 
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -45,8 +66,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPut(context) {
-  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
-  if (contentLength > MAX_BODY_SIZE) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
     return buildPayloadTooLargeResponse();
   }
 
@@ -64,12 +87,12 @@ export async function onRequestPut(context) {
     method: 'PUT',
     headers: {
       accept: 'application/json',
-      'content-type': context.request.headers.get('content-type') || 'application/json',
-      ...(context.request.headers.get('authorization')
-        ? { authorization: context.request.headers.get('authorization') }
+      'content-type': request.headers.get('content-type') || 'application/json',
+      ...(request.headers.get('authorization')
+        ? { authorization: request.headers.get('authorization') }
         : {})
     },
-    body: context.request.body
+    body: bodyResult.body
   });
 
   return withModalHeader(response);

--- a/functions/api/trees.js
+++ b/functions/api/trees.js
@@ -21,6 +21,27 @@ function buildPayloadTooLargeResponse() {
   });
 }
 
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
 function buildModalUnavailableResponse() {
   return new Response(JSON.stringify({ error: 'Modal service temporarily unavailable' }), {
     status: 503,
@@ -64,8 +85,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
-  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
-  if (contentLength > MAX_BODY_SIZE) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
     return buildPayloadTooLargeResponse();
   }
 
@@ -83,12 +106,12 @@ export async function onRequestPost(context) {
       method: 'POST',
       headers: {
         accept: 'application/json',
-        'content-type': context.request.headers.get('content-type') || 'application/json',
-        ...(context.request.headers.get('authorization')
-          ? { authorization: context.request.headers.get('authorization') }
+        'content-type': request.headers.get('content-type') || 'application/json',
+        ...(request.headers.get('authorization')
+          ? { authorization: request.headers.get('authorization') }
           : {})
       },
-      body: context.request.body
+      body: bodyResult.body
     });
   } catch (error) {
     return buildModalUnavailableResponse();

--- a/functions/api/trees/[id].js
+++ b/functions/api/trees/[id].js
@@ -21,6 +21,27 @@ function buildPayloadTooLargeResponse() {
   });
 }
 
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
 export async function onRequestGet(context) {
   const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
   if (!modalBaseUrl) {
@@ -53,8 +74,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPut(context) {
-  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
-  if (contentLength > MAX_BODY_SIZE) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
     return buildPayloadTooLargeResponse();
   }
 
@@ -72,12 +95,12 @@ export async function onRequestPut(context) {
     method: 'PUT',
     headers: {
       accept: 'application/json',
-      'content-type': context.request.headers.get('content-type') || 'application/json',
-      ...(context.request.headers.get('authorization')
-        ? { authorization: context.request.headers.get('authorization') }
+      'content-type': request.headers.get('content-type') || 'application/json',
+      ...(request.headers.get('authorization')
+        ? { authorization: request.headers.get('authorization') }
         : {})
     },
-    body: context.request.body
+    body: bodyResult.body
   });
 
   return withModalHeader(response);


### PR DESCRIPTION
## Summary

Follow-up to the body-size guard work. Upgrade route-level POST/PUT handlers from content-length-only checks to bounded actual body reads before forwarding to Modal.

## Changes

- Add bounded body read helpers to route-level write handlers.
- Apply actual byte-size validation to:
  - `functions/api/trees.js`
  - `functions/api/trees/[id].js`
  - `functions/api/memories.js`
  - `functions/api/memories/[id].js`
- Preserve non-DELETE write guard behavior for POST/PUT.
- Preserve DELETE bypass behavior.
- Preserve safe 413 JSON without echoing request body.
- Preserve normal small-body forwarding by passing the bounded body to Modal.
- Leave `functions/api/[[path]].js` fork/catch-all guard unchanged.

## Scope

- API route-level body-size hardening only.
- No frontend UI changes.
- No database/schema/Auth changes.
- No PR #7 / prototype / reference / demo / variant path changes.
- No issue close keyword.

## Local validation reported

- `npm run test`: PASS, 338/338
- `npm run lint`: PASS
- `npm run build`: PASS

## Required before ready/merge

- GitHub CI must pass.
- Static review must confirm only the four route files changed.
- Runtime/API smoke should confirm:
  - oversized POST/PUT without relying solely on Content-Length returns 413 safe JSON,
  - small POST/PUT body still reaches the expected Modal/upstream/degraded path,
  - DELETE behavior is unchanged,
  - response does not echo request body,
  - no raw token/session/cookie/private payload/log exposure.

Related: PR #1207