### PR TITLE
fix(search): migrate image handlers away from inline attributes

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -407,13 +407,23 @@
     function bindCardImageHandlers(root) {
         if (!root) return;
         root.querySelectorAll('[data-search-card-image]').forEach(img => {
+            if (img.dataset.searchCardImageHandlerBound === 'true') return;
+            img.dataset.searchCardImageHandlerBound = 'true';
+
+            if (img.complete) {
+                if (img.naturalWidth === 0) {
+                    showImageFallback(img);
+                } else {
+                    handleImageLoad(img);
+                }
+                return;
+            }
+
             img.addEventListener('error', function onCardImageError() {
                 showImageFallback(this);
             });
             img.addEventListener('load', function onCardImageLoad() {
-                if (isSuspiciousYouTubeThumbnailImage(this)) {
-                    showImageFallback(this);
-                }
+                handleImageLoad(this);
             });
         });
     }

--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -196,7 +196,7 @@
             return renderMediaFallback(tree, titleText);
         }
         return `
-            <img src="${src}" alt="${alt}" loading="lazy" onerror="window.LoveBudSearchCardRenderer?.showImageFallback?.(this)" onload="window.LoveBudSearchCardRenderer?.handleImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;">
+            <img src="${src}" alt="${alt}" loading="lazy" data-search-card-image="" style="width:100%;height:100%;object-fit:cover;">
             <div data-fallback-container hidden style="width:100%;height:100%;position:absolute;inset:0;">
                 ${renderMediaFallback(tree, titleText)}
             </div>
@@ -397,6 +397,27 @@
         document.head.appendChild(style);
     }
 
+    function handleImageLoad(img) {
+        if (!img) return;
+        if (isSuspiciousYouTubeThumbnailImage(img)) {
+            showImageFallback(img);
+        }
+    }
+
+    function bindCardImageHandlers(root) {
+        if (!root) return;
+        root.querySelectorAll('[data-search-card-image]').forEach(img => {
+            img.addEventListener('error', function onCardImageError() {
+                showImageFallback(this);
+            });
+            img.addEventListener('load', function onCardImageLoad() {
+                if (isSuspiciousYouTubeThumbnailImage(this)) {
+                    showImageFallback(this);
+                }
+            });
+        });
+    }
+
     window.LoveBudSearchCardRenderer = {
         init: init,
         renderTreeCard: renderTreeCard,
@@ -409,11 +430,8 @@
         getBasePath: getBasePath,
         getTreeViewerHref: getTreeViewerHref,
         showImageFallback: showImageFallback,
-        handleImageLoad: (img) => {
-            if (isSuspiciousYouTubeThumbnailImage(img)) {
-                showImageFallback(img);
-            }
-        }
+        handleImageLoad: handleImageLoad,
+        bindCardImageHandlers: bindCardImageHandlers
     };
 
 

--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -133,13 +133,23 @@
     function bindPreviewThumbnailHandlers(root) {
         if (!root) return;
         root.querySelectorAll('[data-preview-thumbnail-image]').forEach(img => {
+            if (img.dataset.previewImageHandlerBound === 'true') return;
+            img.dataset.previewImageHandlerBound = 'true';
+
+            if (img.complete) {
+                if (img.naturalWidth === 0) {
+                    showPreviewImageFallback(img);
+                } else {
+                    handlePreviewImageLoad(img);
+                }
+                return;
+            }
+
             img.addEventListener('error', function onPreviewImageError() {
                 showPreviewImageFallback(this);
             });
             img.addEventListener('load', function onPreviewImageLoad() {
-                if (isSuspiciousYouTubeThumbnailImage(this)) {
-                    showPreviewImageFallback(this);
-                }
+                handlePreviewImageLoad(this);
             });
         });
     }

--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -94,7 +94,7 @@
 
         return `
             <div class="preview-media-frame preview-media-frame-thumbnail" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
-                <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
+                <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" data-preview-thumbnail-image="" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
                 <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
                 <div data-preview-overlay style="position:absolute;left:18px;right:18px;bottom:18px;color:white;">
@@ -121,6 +121,27 @@
         }
         const overlays = wrapper.querySelectorAll('[data-preview-overlay]');
         overlays.forEach(overlay => overlay.style.display = 'none');
+    }
+
+    function handlePreviewImageLoad(img) {
+        if (!img) return;
+        if (isSuspiciousYouTubeThumbnailImage(img)) {
+            showPreviewImageFallback(img);
+        }
+    }
+
+    function bindPreviewThumbnailHandlers(root) {
+        if (!root) return;
+        root.querySelectorAll('[data-preview-thumbnail-image]').forEach(img => {
+            img.addEventListener('error', function onPreviewImageError() {
+                showPreviewImageFallback(this);
+            });
+            img.addEventListener('load', function onPreviewImageLoad() {
+                if (isSuspiciousYouTubeThumbnailImage(this)) {
+                    showPreviewImageFallback(this);
+                }
+            });
+        });
     }
 
     function isSuspiciousYouTubeThumbnailImage(img) {
@@ -208,6 +229,8 @@
         renderPreviewThumbnailFallback: renderPreviewThumbnailFallback,
         renderPreviewThumbnailMedia: renderPreviewThumbnailMedia,
         showPreviewImageFallback: showPreviewImageFallback,
+        handlePreviewImageLoad: handlePreviewImageLoad,
+        bindPreviewThumbnailHandlers: bindPreviewThumbnailHandlers,
         isSuspiciousYouTubeThumbnailImage: isSuspiciousYouTubeThumbnailImage,
         generateIframeSource: generateIframeSource,
         toPlayableEmbedUrl: toPlayableEmbedUrl,

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -314,7 +314,7 @@
 
         return `
             <div class="preview-media-frame preview-media-frame-thumbnail" style="position:relative;width:100%;height:100%;border-radius:1rem;overflow:hidden;box-shadow:0 8px 30px rgba(0,0,0,0.12);">
-                <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" onerror="window.LoveBudSearchPreviewRenderer?.showPreviewImageFallback?.(this)" onload="window.LoveBudSearchPreviewRenderer?.handlePreviewImageLoad?.(this)" style="width:100%;height:100%;object-fit:cover;display:block;">
+                <img src="${thumbnailUrl}" alt="${mediaTitle}" loading="lazy" data-preview-thumbnail-image="" style="width:100%;height:100%;object-fit:cover;display:block;">
                 <div data-preview-thumbnail-fallback hidden style="position:absolute;inset:0;">${fallbackHtml}</div>
                 <div data-preview-overlay style="position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.72),rgba(0,0,0,0.04) 58%);"></div>
                 <div data-preview-overlay style="position:absolute;left:18px;right:18px;bottom:18px;color:white;">
@@ -365,6 +365,23 @@
         }
         const overlays = wrapper.querySelectorAll('[data-preview-overlay]');
         overlays.forEach(overlay => overlay.style.display = 'none');
+    }
+
+    function bindPreviewThumbnailHandlers(root) {
+        if (!root) return;
+        root.querySelectorAll('[data-preview-thumbnail-image]').forEach(img => {
+            img.addEventListener('error', function onPreviewError() {
+                showPreviewImageFallback(this);
+            });
+            img.addEventListener('load', function onPreviewLoad() {
+                const helper = window.LoveBudSearchPreviewMediaHelper;
+                if (helper?.handlePreviewImageLoad) {
+                    helper.handlePreviewImageLoad(this);
+                } else if (isSuspiciousYouTubeThumbnailImage(this)) {
+                    showPreviewImageFallback(this);
+                }
+            });
+        });
     }
 
      function updatePreview(tree) {
@@ -438,8 +455,9 @@
                          : renderSelectedTreeMediaFallback(safeTreeTitle, displayMemoryCount));
                  }
              }
-             setPreviewState(previewState);
-         }
+            setPreviewState(previewState);
+            bindPreviewThumbnailHandlers(_dom.previewContainer);
+        }
 
         if (_dom.previewTitle) {
             const safeTimeRange = escapeHtml(String(tree?.timeRange || getSearchCopy('search.previewUnknownRange', '아직 흐름이 또렷하지 않아요', 'The flow is not clear yet')).trim());

--- a/js/search/search-preview-renderer.js
+++ b/js/search/search-preview-renderer.js
@@ -370,11 +370,26 @@
     function bindPreviewThumbnailHandlers(root) {
         if (!root) return;
         root.querySelectorAll('[data-preview-thumbnail-image]').forEach(img => {
+            if (img.dataset.previewImageHandlerBound === 'true') return;
+            img.dataset.previewImageHandlerBound = 'true';
+
+            var helper = window.LoveBudSearchPreviewMediaHelper;
+
+            if (img.complete) {
+                if (img.naturalWidth === 0) {
+                    showPreviewImageFallback(img);
+                } else if (helper?.handlePreviewImageLoad) {
+                    helper.handlePreviewImageLoad(img);
+                } else if (isSuspiciousYouTubeThumbnailImage(img)) {
+                    showPreviewImageFallback(img);
+                }
+                return;
+            }
+
             img.addEventListener('error', function onPreviewError() {
                 showPreviewImageFallback(this);
             });
             img.addEventListener('load', function onPreviewLoad() {
-                const helper = window.LoveBudSearchPreviewMediaHelper;
                 if (helper?.handlePreviewImageLoad) {
                     helper.handlePreviewImageLoad(this);
                 } else if (isSuspiciousYouTubeThumbnailImage(this)) {

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -526,6 +526,12 @@
 
             // Ensure container listener is bound
             bindDelegatedCardEvents(listElement);
+
+            // Bind image error/load handlers for inline handler migration
+            var cardRenderer = window.LoveBudSearchCardRenderer;
+            if (cardRenderer && cardRenderer.bindCardImageHandlers) {
+                cardRenderer.bindCardImageHandlers(listElement);
+            }
         }
 
         function bindShareCopyHandler() {


### PR DESCRIPTION
## Summary

PR-D-04 actual: migrate Search image `onload` / `onerror` inline handlers to JavaScript event bindings so the Search surface is compatible with stricter CSP hardening.

## Changes

- Remove inline image `onerror` / `onload` attributes from Search preview thumbnail rendering.
- Remove inline image `onerror` / `onload` attributes from Search card representative image rendering.
- Add `addEventListener`-based preview thumbnail image binding.
- Add `addEventListener`-based search card image binding.
- Preserve broken-image fallback behavior.
- Preserve suspicious YouTube thumbnail fallback behavior.
- Call card image binding from Search UI attachment flow so results and growing-list cards are covered.

## Changed files

- `js/search/search-card-renderer.js`
- `js/search/search-preview-media-helper.js`
- `js/search/search-preview-renderer.js`
- `js/search/search-ui.js`

## Scope

- Search frontend JS only.
- No backend/API/schema/Auth/DB changes.
- No `_headers` / CSP policy change.
- No PR #7 / prototype / reference / demo / variant path changes.
- No issue close keyword.

## Local validation reported

- `grep -R "onerror=" js/search`: 0 matches
- `grep -R "onload=" js/search`: 0 matches
- `npm run test`: PASS, 338/338
- `npm run lint`: PASS
- `npm run build`: PASS

## Required before ready/merge

- GitHub CI must pass.
- Static review must confirm no `onerror=` / `onload=` remains under `js/search`.
- Browser/Cloudflare smoke must confirm:
  - `/pages/search` loads.
  - Search cards render and select correctly.
  - Card image load and broken-image fallback work.
  - Preview image load and broken-image fallback work.
  - Suspicious YouTube thumbnail fallback still works.
  - Preview Hub flow toggle still works.
  - Tree Viewer/open links are unaffected.
  - No fatal console errors.
  - No inline image event-handler CSP report-only violations remain for Search.
  - No raw token/session/cookie/private payload/log exposure.

Refs #1203