### PR TITLE
fix(search): add preview media shared utils fallback

### DIFF
--- a/js/search/search-preview-media-helper.js
+++ b/js/search/search-preview-media-helper.js
@@ -62,6 +62,10 @@
         return locale === 'en' ? fallbackEn : fallbackKo;
     }
 
+    function getSharedUtils() {
+        return window.LoveBudSearchSharedUtils || null;
+    }
+
     function getMomentLabel(memory, fallbackKo = '시작 순간', fallbackEn = 'Starting moment') {
         const helper = window.LoveBudSearchTitleHelper || null;
         const cleaned = helper?.cleanMomentTitle


### PR DESCRIPTION
## Summary

Refs #1244

Adds a local `getSharedUtils()` fallback inside `js/search/search-preview-media-helper.js` so preview thumbnail load handling can safely call shared Search utilities when available.

## Scope

- Search JS only
- No backend/API/schema/Auth/DB changes
- No inline image handler restoration
- No PR #7 / prototype / reference / demo / variant / quiet path changes

## Validation

- `npm run test` — 338/338 pass
- `npm run lint` — pass, with existing pre-issue warnings only
- `npm run build` — pass

## Runtime validation needed

- `/pages/search` loads
- Sort/filter re-render does not log `getSharedUtils is not defined`
- Preview panel remains stable after re-render
- No fatal console errors
- No sensitive log exposure