### PR TITLE
test(security): add frontend DOM XSS guardrails

### DIFF
--- a/docs/security/FRONTEND_RENDERING_DOM_XSS_GUARDRAILS.md
+++ b/docs/security/FRONTEND_RENDERING_DOM_XSS_GUARDRAILS.md
@@ -1,0 +1,57 @@
+# Frontend Rendering DOM XSS Guardrails
+
+## Purpose
+
+This document defines the rendering contract for user-controlled LoveBud fields in frontend UI code.
+
+The goal is not to redesign renderers or replace all `innerHTML` usage. The goal is to make future Editor, Public Viewer, Tree Viewer, and shared UI changes fail review or tests when user-controlled data is routed into HTML sinks without an explicit safe boundary.
+
+## User-controlled fields
+
+Treat the following values as user-controlled unless a caller proves they are static product copy:
+
+- LoveTree title, label, description, visibility text, and owner-facing metadata.
+- Memory title, memo, note, quote, diary content, and localized display text derived from saved tree or memory records.
+- Emotion tags, custom labels, dates typed or imported by a user, and source names.
+- Thumbnail URLs, source URLs, image alt text, embed URLs, and other media metadata.
+- Any API payload, local draft value, imported fixture, or browser storage value that can be created or edited outside the current renderer.
+
+## Safe rendering defaults
+
+Use these defaults for all new UI work:
+
+- Text nodes: assign with `textContent`.
+- Form fields: assign with `value`.
+- URLs and media sources: validate or normalize first, then use `setAttribute`, `src`, `href`, or a named URL helper.
+- Lists and repeated UI: create elements with `document.createElement`, then assign text through `textContent`.
+- Dataset values: store identifiers or normalized values only; do not store private payloads.
+
+## `innerHTML` policy
+
+`innerHTML`, `outerHTML`, and `insertAdjacentHTML` are allowed only for one of these cases:
+
+1. Static templates that contain no user-controlled interpolation.
+2. HTML fragments where every interpolated user-controlled value is passed through an explicit escaping helper such as `escapeHtml` before entering the string.
+3. Narrow legacy renderers that already have a documented safe boundary and are covered by a contract test.
+
+Do not interpolate these objects or fields directly into HTML strings:
+
+- `tree`, `treeData`, `currentTree`, `memory`, `memories`, `node`, `item`, `record`, `payload`, `draft`, `formData`, `tag`, `title`, `memo`, `note`, `quote`, `diary`, `thumbnail`, `sourceUrl`, `url`, or `label`.
+
+When HTML is unavoidable, make the boundary visible in the code review diff by using a named helper. Reviewers should be able to see that escaping, URL validation, or static-template-only rendering is intentional.
+
+## Review checklist
+
+Before approving frontend render changes, check:
+
+- Does the diff add `innerHTML`, `outerHTML`, or `insertAdjacentHTML`?
+- Does the sink contain template interpolation or string concatenation?
+- Could the value come from a tree, memory, diary, tag, date, thumbnail, source URL, localized payload, local draft, API payload, or browser storage?
+- If yes, is the value assigned through `textContent`, validated URL attributes, DOM node creation, or an explicit escaping helper?
+- Does the change avoid printing credential-bearing values, private payloads, or database connection details in UI logs, comments, tests, or reports?
+
+## Contract-test boundary
+
+The contract test for this policy scans representative high-risk frontend files. It is intentionally conservative: it does not ban all `innerHTML`, but it fails on obvious direct interpolation of user-controlled field names into HTML sinks without a safe helper.
+
+If a future renderer legitimately needs dynamic HTML, add a small safe helper or extend the test with a narrow allowlist and a comment explaining the safe boundary.

--- a/tests/contracts/frontend-dom-xss-guardrails.test.js
+++ b/tests/contracts/frontend-dom-xss-guardrails.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const POLICY_DOC = path.join(ROOT, 'docs/security/FRONTEND_RENDERING_DOM_XSS_GUARDRAILS.md');
+
+const HIGH_RISK_FRONTEND_FILES = [
+  'js/editor/editor-detail-ui.js',
+  'js/editor/editor-canvas-node.js',
+  'js/viewer/public-tree-viewer.js',
+  'js/viewer/tree-viewer.js',
+  'js/editor/editor-memory-form-preview.js'
+];
+
+const USER_CONTROLLED_FIELD_PATTERN = /\b(?:tree|treeData|currentTree|memory|memories|node|item|record|payload|draft|formData|tag|tags|title|memo|note|quote|diary|thumbnail|sourceUrl|url|label|emotionTags)\b/;
+const HTML_SINK_PATTERN = /\.(?:innerHTML|outerHTML)\s*=|\.insertAdjacentHTML\s*\(/;
+const SAFE_BOUNDARY_PATTERN = /\b(?:escapeHtml|sanitize|safeHtml|textContent|createTextNode|setAttribute|safeUrl|sanitizeUrl|normalizeUrl|resolveMemoryThumbnail|resolveTreeTitleText|formatI18nText)\b/;
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function getLineNumber(content, index) {
+  return content.slice(0, index).split('\n').length;
+}
+
+function getStatementWindow(content, index) {
+  const before = content.lastIndexOf('\n', index - 1);
+  const after = content.indexOf('\n', index);
+  const start = Math.max(0, before === -1 ? 0 : before + 1);
+  const end = after === -1 ? content.length : after;
+  return content.slice(start, end);
+}
+
+function findUnsafeHtmlSinkWindows(content) {
+  const matches = [];
+  const sinkRegex = new RegExp(HTML_SINK_PATTERN.source, 'g');
+  let match;
+
+  while ((match = sinkRegex.exec(content)) !== null) {
+    const windowText = getStatementWindow(content, match.index);
+    const isDynamicHtml = windowText.includes('${') || windowText.includes(' + ') || windowText.includes('+=');
+    const mentionsUserField = USER_CONTROLLED_FIELD_PATTERN.test(windowText);
+    const hasSafeBoundary = SAFE_BOUNDARY_PATTERN.test(windowText);
+
+    if (isDynamicHtml && mentionsUserField && !hasSafeBoundary) {
+      matches.push({
+        line: getLineNumber(content, match.index),
+        snippet: windowText.trim()
+      });
+    }
+  }
+
+  return matches;
+}
+
+test('frontend DOM XSS rendering policy document exists', () => {
+  assert.ok(fs.existsSync(POLICY_DOC), 'frontend rendering DOM XSS guardrails policy should exist');
+
+  const content = fs.readFileSync(POLICY_DOC, 'utf8');
+  assert.match(content, /User-controlled fields/, 'policy should define user-controlled fields');
+  assert.match(content, /textContent/, 'policy should prefer textContent for text rendering');
+  assert.match(content, /innerHTML/, 'policy should document innerHTML boundaries');
+  assert.match(content, /escapeHtml/, 'policy should require explicit escaping for unavoidable HTML');
+});
+
+test('representative high-risk frontend render files exist', () => {
+  HIGH_RISK_FRONTEND_FILES.forEach((relativePath) => {
+    assert.ok(fs.existsSync(path.join(ROOT, relativePath)), `${relativePath} should exist`);
+  });
+});
+
+test('high-risk frontend files do not directly interpolate obvious user-controlled fields into HTML sinks', () => {
+  const violations = [];
+
+  HIGH_RISK_FRONTEND_FILES.forEach((relativePath) => {
+    const content = read(relativePath);
+    const fileViolations = findUnsafeHtmlSinkWindows(content);
+    fileViolations.forEach((violation) => {
+      violations.push(`${relativePath}:${violation.line} ${violation.snippet}`);
+    });
+  });
+
+  assert.deepEqual(
+    violations,
+    [],
+    `User-controlled fields must use textContent, DOM node creation, URL validation, or explicit escaping before HTML sinks:\n${violations.join('\n')}`
+  );
+});
+
+test('Editor detail render path keeps obvious user text on textContent or escaped boundaries', () => {
+  const content = read('js/editor/editor-detail-ui.js');
+
+  assert.match(content, /headerEl\.textContent\s*=/, 'detail header should be assigned through textContent');
+  assert.match(content, /dateEl\.textContent\s*=/, 'detail date text should be assigned through textContent');
+  assert.match(content, /textEl\.textContent\s*=/, 'save status text should be assigned through textContent');
+  assert.match(content, /escapeHtml/, 'editor detail UI should keep an explicit escaped HTML boundary available');
+});
+
+test('Public viewer render path keeps escaped HTML boundary visible when HTML templates are used', () => {
+  const content = read('js/viewer/public-tree-viewer.js');
+
+  if (HTML_SINK_PATTERN.test(content)) {
+    assert.match(content, /escapeHtml|textContent|createElement|setAttribute/, 'public viewer HTML sinks should keep visible safe-rendering boundaries');
+  }
+});


### PR DESCRIPTION
## Summary

Refs #1203

Adds a frontend rendering DOM XSS guardrail policy and representative contract tests for high-risk Editor and Viewer render files.

## Scope

- Documentation-only security policy file
- Contract tests under `tests/contracts/`
- No runtime UI behavior changes
- No backend/API/schema/Auth/DB changes
- No PR #7 / prototype / reference / demo / variant / quiet path changes

## Guardrail intent

This is frontend hardening, not a confirmed active XSS fix. The new contract checks are intentionally conservative: they do not ban every `innerHTML`, but they fail on obvious direct interpolation of user-controlled field names into HTML sinks when no visible safe boundary is present.

## Validation needed

- `npm run test`
- `npm run lint`
- `npm run build`
- Browser smoke for representative pages:
  - `/pages/editor.html`
  - `/pages/tree.html` or public viewer route available in the current deployment
- Confirm console fatal JS errors: 0
- Confirm no sensitive log exposure

## Notes

The PR intentionally avoids close keywords until verification is complete.