### PR TITLE
fix(my-trees): reveal hub content after selection

### DIFF
--- a/js/my-trees/my-trees-preview-hub.js
+++ b/js/my-trees/my-trees-preview-hub.js
@@ -194,6 +194,8 @@
         if (!els) return;
         els.panel.classList.add('is-empty');
         els.panel.classList.remove('is-loaded');
+        if (els.placeholder) els.placeholder.hidden = false;
+        if (els.content) els.content.hidden = true;
         if (els.badge) els.badge.textContent = i18nHub('', '내 트리', 'My Tree');
         _selectedTree = null;
         _expandedFlowKey = null;
@@ -213,6 +215,8 @@
 
         els.panel.classList.remove('is-empty');
         els.panel.classList.add('is-loaded');
+        if (els.placeholder) els.placeholder.hidden = true;
+        if (els.content) els.content.hidden = false;
 
         if (els.badge) {
             els.badge.textContent = hasMemories
@@ -351,6 +355,8 @@
 
         els.panel.classList.remove('is-empty');
         els.panel.classList.add('is-loaded');
+        if (els.placeholder) els.placeholder.hidden = true;
+        if (els.content) els.content.hidden = false;
 
         if (els.treeTitle) {
             els.treeTitle.textContent = String(tree && tree.title || '').trim() || t('default_tree_title', '나의 러브트리');


### PR DESCRIPTION
## Summary

Refs #1225

Fixes the My Trees appreciation hub content staying hidden after a tree card is selected.

## Changes

- Reveal `#myTreesHubContent` when `showContent()` renders a selected tree.
- Hide `#myTreesHubPlaceholder` when content is shown.
- Keep placeholder visible and content hidden when `showPlaceholder()` runs.
- Apply the same content reveal behavior to the loading skeleton path.

## Scope

- My Trees frontend JS only.
- Changed file: `js/my-trees/my-trees-preview-hub.js`.
- No backend/API/schema/Auth/DB changes.
- No PR #7 / prototype / reference / demo / variant / quiet path changes.
- No issue close keyword.

## Validation needed

- `npm run test`
- `npm run lint`
- `npm run build`
- Browser smoke on `/pages/my-trees`:
  - page loads
  - tree cards render
  - selecting a tree removes the hub placeholder
  - `#myTreesHubContent.hidden === false`
  - representative/flow/actions are visible when data exists
  - no fatal console errors
  - no sensitive log exposure