### PR TITLE
fix(editor): remove unusable '내 러브트리에 기록하기' button from detail panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,3 @@ ops/slots/
 *.gif
 *.webp
 !*.svg
-.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ ops/slots/
 *.gif
 *.webp
 !*.svg
+.claude/worktrees/

--- a/js/editor.js
+++ b/js/editor.js
@@ -224,8 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ['editMemoLabel', 'editor_note_label', '감정 메모'],
             ['editTagsLabel', 'editor_edit_tag_label', '감정 태그 (쉼표로 구분)'],
             ['cancelEditBtn', 'editor_cancel', '취소'],
-            ['saveEditBtn', 'editor_save', '저장하기'],
-            ['detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기']
+            ['saveEditBtn', 'editor_save', '저장하기']
         ];
 
         const placeholderBindings = [

--- a/js/editor/editor-dom-selectors.js
+++ b/js/editor/editor-dom-selectors.js
@@ -116,7 +116,6 @@
         cancelEditBtn: 'cancelEditBtn',
         saveEditBtn: 'saveEditBtn',
         detailPanelFooter: 'detailPanelFooter',
-        detailSubmitBtn: 'detailSubmitBtn',
 
         // Save status
         saveStatusIndicator: 'saveStatusIndicator',

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -329,7 +329,6 @@
     setText('editTagsLabel', 'editor_edit_tag_label', '감정 태그 (쉼표로 구분)');
     setText('cancelEditBtn', 'editor_cancel', '취소');
     setText('saveEditBtn', 'editor_save', '저장하기');
-    setText('detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기');
 
     setAttr('renameTreeBtn', 'aria-label', 'rename_tree_prompt', '새 트리 제목을 입력해 주세요.');
     setAttr('renameTreeBtn', 'title', 'rename_tree_prompt', '새 트리 제목을 입력해 주세요.');

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -91,6 +91,5 @@ window.LoveBudEditorShellHelpers = {
         setPlaceholder('editTagsInput', 'editor_edit_tag_placeholder', '#감동, #행복, #그리움');
         setText('cancelEditBtn', 'editor_cancel', '취소');
         setText('saveEditBtn', 'editor_save', '저장하기');
-        setText('detailSubmitBtn', 'editor_record_submit', '내 러브트리에 기록하기');
     }
 };

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -279,9 +279,6 @@
                 </div>
             </div>
 
-            <div class="panel-footer editor-submit-wrap editor-submit-footer editor-hidden-initial" id="detailPanelFooter">
-                <button type="submit" class="primary-btn editor-submit-btn-full" id="detailSubmitBtn">...</button>
-            </div>
         </aside>
     </div>
 


### PR DESCRIPTION
## Summary
Removes the dead '#detailSubmitBtn' (내 러브트리에 기록하기) button from the editor detail panel footer. The button had no defined functionality and was visible during loading/empty states.

## Changes
- pages/editor.html - Removed button element
- editor-dom-selectors.js - Removed selector entry
- editor-shell-helpers.js, editor-i18n-refresh.js, editor.js - Removed i18n text references

## Verification
- npm run lint - passed
- npm run build - passed
- npm run test - 343/343 passed

Refs #1230
