### PR TITLE
fix(editor): resolve first created moment disappearing after page refresh

### DIFF
--- a/js/editor/editor-memory-form-payload.js
+++ b/js/editor/editor-memory-form-payload.js
@@ -142,6 +142,10 @@
             ? (i18n('editor_default_first_title') || '첫 순간')
             : (i18n('editor_default_next_title') || '이어진 순간');
 
+        const freshCanonicalRootId = window.LoveBudEditorUtils?.getCanonicalRootId
+            ? window.LoveBudEditorUtils.getCanonicalRootId(memories)
+            : getCanonicalRootId();
+
         return {
             ok: true,
             data: {
@@ -152,7 +156,7 @@
                 sourceUrl: mediaSource.embedUrl,
                 sourceType: mediaSource.sourceType,
                 emotionTags: [],
-                parentId: resolveParentIdForCreate(getSelectedNodeId(), getCanonicalRootId()),
+                parentId: resolveParentIdForCreate(getSelectedNodeId(), freshCanonicalRootId),
                 thumbnail: mediaSource.thumbnailUrl,
                 artist: '',
                 source: mediaSource.sourceLabel,

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -50,6 +50,12 @@ function createEditorMemoryForm(deps) {
     let userHasEditedStartTime = false;
     let userHasEditedTitle = false;
 
+    function getFreshCanonicalRootId() {
+        return window.LoveBudEditorUtils?.getCanonicalRootId
+            ? window.LoveBudEditorUtils.getCanonicalRootId(getTreeMemories())
+            : getCanonicalRootId();
+    }
+
     const refs = {
         addMemoryForm: document.getElementById('addMemoryForm'),
         urlInput: document.getElementById('memoryUrlInput'),
@@ -379,7 +385,9 @@ function createEditorMemoryForm(deps) {
             el.classList.add('new-node-highlight');
             setTimeout(() => el.classList.remove('new-node-highlight'), 2000);
         }
-        if (typeof focusNodeById === 'function') focusNodeById(normalizedMemory.id);
+        const freshCanonicalRootId = getFreshCanonicalRootId();
+        const shouldFocusNewMemory = !freshCanonicalRootId || normalizedMemory.id !== freshCanonicalRootId;
+        if (shouldFocusNewMemory && typeof focusNodeById === 'function') focusNodeById(normalizedMemory.id);
 
         updateSaveStatus('saved', useApi ? i18n('save_saved') : (i18n('save_saved_local') || '로컬 저장됨'));
 


### PR DESCRIPTION
## Summary
Fixes a race condition where the first created moment would disappear after page refresh. The root cause was a stale canonical root ID being used during parentId resolution for the first memory.

## Changes
- editor-memory-form-payload.js: Use fresh canonical root ID from LoveBudEditorUtils instead of potentially stale in-memory value
- editor-memory-form.js: Prevent focus on canonical root node after creation (avoids navigation/scroll issues)
- editor-memory-form.js: Add getFreshCanonicalRootId() helper

## Verification
- npm run lint - passed
- npm run build - passed
- npm run test - 343/343 passed

Refs #1229
