### PR TITLE
feat(editor): make memory title input empty with placeholder

### DIFF
--- a/js/editor/editor-memory-form-payload.js
+++ b/js/editor/editor-memory-form-payload.js
@@ -137,10 +137,6 @@
         if (!mediaSource.ok) return mediaSource;
 
         const memories = getTreeMemories();
-        const isFirstMoment = !memories || memories.length === 0;
-        const defaultTitle = isFirstMoment
-            ? (i18n('editor_default_first_title') || '첫 순간')
-            : (i18n('editor_default_next_title') || '이어진 순간');
 
         const freshCanonicalRootId = window.LoveBudEditorUtils?.getCanonicalRootId
             ? window.LoveBudEditorUtils.getCanonicalRootId(memories)
@@ -150,7 +146,7 @@
             ok: true,
             data: {
                 treeId,
-                title: titleValue || defaultTitle,
+                title: titleValue || '',
                 memo: memoValue || '',
                 timestamp: todayDateString(),
                 sourceUrl: mediaSource.embedUrl,

--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -94,9 +94,6 @@
         const {
             currentInputMode,
             refs,
-            i18n,
-            isFirstMoment,
-            userHasEditedTitle,
             userHasEditedStartTime
         } = options || {};
         if (currentInputMode !== 'link') {
@@ -122,12 +119,6 @@
             refs.thumb.src = typeof media.getThumbnailUrl === 'function'
                 ? (media.getThumbnailUrl(url) || `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`)
                 : `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-        }
-
-        if (!userHasEditedTitle && refs?.titleInput) {
-            refs.titleInput.value = isFirstMoment
-                ? (i18n('editor_default_first_title') || '첫 순간')
-                : (i18n('editor_default_next_title') || '이어진 순간');
         }
 
         const time = window.LoveBudEditorMemoryFormTime || {};


### PR DESCRIPTION
## Summary
Removes automatic pre-fill of memory title field ('첫 순간' / '이어진 순간'). Title now starts empty with placeholder, allowing users to write their own title or save without one.

## Changes
- editor-memory-form-preview.js: Remove title value prefill logic
- editor-memory-form-payload.js: Remove fallback default title, use empty string

## Verification
- npm run lint - passed
- npm run build - passed
- npm run test - 343/343 passed

Refs #1221
