### PR TITLE
feat(my-trees): hub auto-selects first tree on page load

### DIFF
--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -159,6 +159,18 @@
   function setupGlobalListeners() {
   }
 
+  function autoSelectFirstTree(trees) {
+    if (!Array.isArray(trees) || trees.length === 0) return;
+    var previewHub = window.LoveBudMyTreesPreviewHub;
+    if (!previewHub || typeof previewHub.onCardClick !== 'function') return;
+    if (typeof previewHub.getSelectedTree === 'function' && previewHub.getSelectedTree()) return;
+
+    setTimeout(function() {
+      if (typeof previewHub.getSelectedTree === 'function' && previewHub.getSelectedTree()) return;
+      previewHub.onCardClick(trees[0]);
+    }, 0);
+  }
+
   function renderTrees(trees) {
     if (myTreesRender && typeof myTreesRender.renderTrees === 'function') {
       myTreesRender.renderTrees(trees, {
@@ -179,6 +191,7 @@
           lastTreesData = data;
         }
       });
+      autoSelectFirstTree(trees);
       return;
     }
 
@@ -208,6 +221,7 @@
     if (myTreesPage && typeof myTreesPage.setState === 'function') {
       myTreesPage.setState(myTreesPage.STATE.LOADED);
     }
+    autoSelectFirstTree(trees);
   }
 
   function sortTrees(trees, sortBy) {


### PR DESCRIPTION
## Summary
My Trees page now auto-selects the first tree on page load, matching the search page behavior. No more empty placeholder state when trees exist.

## Changes
- my-trees.js: Added autoSelectFirstTree() called after renderTrees
- Guards against already-selected tree
- Uses existing previewHub.onCardClick pattern

## Verification
- npm run lint - passed
- npm run build - passed
- npm run test - 343/343 passed

Refs #1227
