### PR TITLE
fix(editor): remove duplicate detail action buttons

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -413,20 +413,6 @@ function createEditorDetailUI(deps) {
         }
     };
 
-    const detailMoreBtn = document.getElementById('detailMoreBtn');
-    if (detailMoreBtn && detailMoreBtn.dataset.bound !== '1') {
-        detailMoreBtn.dataset.bound = '1';
-        detailMoreBtn.addEventListener('click', () => {
-            if (typeof openCurrentMomentDetail === 'function') {
-                openCurrentMomentDetail();
-                return;
-            }
-            if (typeof focusSelectedMoment === 'function') {
-                focusSelectedMoment();
-            }
-        });
-    }
-
     /* #1035: Wire up selected moment action buttons */
     const viewMomentDetailBtn = document.getElementById('viewMomentDetailBtn');
     if (viewMomentDetailBtn && viewMomentDetailBtn.dataset.bound !== '1') {

--- a/js/editor/editor-dom-selectors.js
+++ b/js/editor/editor-dom-selectors.js
@@ -89,7 +89,6 @@
 
         // Detail panel
         detailPanel: 'detailPanel',
-        detailMoreBtn: 'detailMoreBtn',
         detailEmptyState: 'detailEmptyState',
         detailEmptyTitle: 'detailEmptyTitle',
         detailEmptyDesc: 'detailEmptyDesc',

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -308,7 +308,6 @@
     setText('memoryMemoLabel', 'editor_memory_memo_optional', '감정 메모');
     setText('cancelAddMemory', 'editor_cancel', '취소');
     setText('confirmAddMemory', 'editor_confirm_add', '이 순간 심기');
-    setText('detailMoreBtn', 'editor_open_detail', '상세로 보기');
     setText('detailEmptyTitle', 'detail_empty_title', '첫 순간이 트리를 깨워요');
     setText('detailEmptyDesc', 'detail_empty_desc', '왼쪽 아래 버튼으로 첫 장면을 심으면, 이 패널이 현재 순간 허브로 바뀝니다.');
     setText('detailCurrentMomentBadge', 'editor_current_moment_badge', '현재 순간');
@@ -332,8 +331,6 @@
 
     setAttr('renameTreeBtn', 'aria-label', 'rename_tree_prompt', '새 트리 제목을 입력해 주세요.');
     setAttr('renameTreeBtn', 'title', 'rename_tree_prompt', '새 트리 제목을 입력해 주세요.');
-
-    setAttr('detailMoreBtn', 'aria-label', 'editor_open_detail', '상세로 보기');
 
     var playBtn = document.querySelector('.play-btn');
     if (playBtn) {

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -51,7 +51,6 @@ window.LoveBudEditorShellHelpers = {
         setText('addMemoryEyebrow', 'editor_add_memory_eyebrow', '다음 순간 심기');
         setText('addMemoryIntro', 'editor_add_memory_intro', '지금 마음이 머문 다음 장면을 이어 심어 보세요. 첫 순간이라면 여기서 러브트리가 시작됩니다.');
         setText('saveStatusText', 'save_saved', '저장됨');
-        setText('detailMoreBtn', 'editor_open_detail', '상세로 보기');
         setText('detailEmptyStartBtn', 'editor_add_first_memory', '첫 순간 심기');
         setText('canvasEmptyGuideEyebrow', 'editor_canvas_empty_eyebrow', '시작하기');
         setText('canvasEmptyGuideTitle', 'editor_canvas_empty_title', '이 트리의 첫 순간을 기록해볼까요?');

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -181,7 +181,6 @@
         <aside class="detail-panel memory-detail-section reveal-fade" id="detailPanel">
             <div class="panel-header">
                 <h3 class="headline editor-panel-headline"></h3>
-                <button type="button" class="icon-menu-btn editor-hidden-initial editor-detail-more-btn" aria-label="자세히 보기" id="detailMoreBtn">자세히 보기</button>
             </div>
 
             <div class="detail-content" id="detailContent">


### PR DESCRIPTION
## Summary

Remove `#detailMoreBtn` (`상세로 보기`) from the Editor right detail panel header. The same `openCurrentMomentDetail()` function is already bound to `#viewMomentDetailBtn` (`현재 순간 감상하기`) in the 주요 행동 section, making the header button a duplicate.

## Changes

| File | Change |
|------|--------|
| `pages/editor.html` | Remove `#detailMoreBtn` HTML element from `.panel-header` |
| `js/editor/editor-detail-ui.js` | Remove `detailMoreBtn` click event listener |
| `js/editor/editor-dom-selectors.js` | Remove `detailMoreBtn` selector |
| `js/editor/editor-shell-helpers.js` | Remove `detailMoreBtn` i18n text binding |
| `js/editor/editor-i18n-refresh.js` | Remove `detailMoreBtn` i18n text + aria-label bindings |

## Scope

- Editor right detail panel only
- No backend/API/schema/Auth/DB changes
- `#viewMomentDetailBtn` remains unchanged as the single detail entrypoint
- `continueFromMomentBtn` (`이 순간에서 이어가기`) remains unchanged

## Validation

- `npm run test`: 343/343 pass
- `npm run lint`: pass
- `npm run build`: pass

## Browser smoke needed

- test5 or PR preview deploy
- QA account login
- Moment selection → right panel
- `#detailMoreBtn` no longer present
- `#viewMomentDetailBtn` still functional
- 수정/저장 flow intact
- Console errors: 0

Refs #1236