### PR TITLE
feat(channel): add optional memory channel fields backend support

### DIFF
--- a/js/utils/normalize.js
+++ b/js/utils/normalize.js
@@ -42,6 +42,9 @@
             sourceUrl: mem.sourceUrl || mem.source_url || '',
             sourceType: mem.sourceType || mem.source_type || 'youtube',
             emotionTags: mem.emotionTags || mem.emotion_tags || [],
+            channelId: mem.channelId || mem.channel_id || null,
+            channelName: mem.channelName || mem.channel_name || null,
+            channelUrl: mem.channelUrl || mem.channel_url || null,
             createdAt: mem.createdAt || mem.created_at || null,
             updatedAt: mem.updatedAt || mem.updated_at || null,
             // Editor-specific fields (optional, undefined if not present)

--- a/modal_compute/owner_reads.py
+++ b/modal_compute/owner_reads.py
@@ -72,6 +72,7 @@ def fetch_owner_memories(owner_id: str, tree_id: str | None = None, limit: int =
     query = f"""
         SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
                m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.channel_id, m.channel_name, m.channel_url,
                m.created_at, m.updated_at
         FROM memories m
         INNER JOIN trees t

--- a/modal_compute/owner_writes.py
+++ b/modal_compute/owner_writes.py
@@ -66,11 +66,13 @@ def create_owner_memory(owner_id: str, payload: dict[str, Any]) -> dict[str, Any
         INSERT INTO memories (
             id, tree_id, parent_id, title, memo, artist, source, source_url,
             source_type, thumbnail, emotion_tags, timestamp, visibility,
+            channel_id, channel_name, channel_url,
             created_at, updated_at
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
         RETURNING id, tree_id, parent_id, title, memo, artist, source, source_url,
                   source_type, thumbnail, emotion_tags, timestamp, visibility,
+                  channel_id, channel_name, channel_url,
                   created_at, updated_at;
     """
     params = (
@@ -87,6 +89,9 @@ def create_owner_memory(owner_id: str, payload: dict[str, Any]) -> dict[str, Any
         json.dumps([str(tag).strip() for tag in emotion_tags if str(tag).strip()]),
         validate_optional_string(payload.get("timestamp"), 100),
         visibility,
+        validate_optional_string(payload.get("channelId"), 100) or None,
+        validate_optional_string(payload.get("channelName"), 200) or None,
+        validate_optional_string(payload.get("channelUrl"), 1000) or None,
     )
 
     with get_db_connection() as conn:
@@ -127,6 +132,7 @@ def fetch_memory_for_owner_check(memory_id: str) -> dict[str, Any] | None:
     query = """
         SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
                m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.channel_id, m.channel_name, m.channel_url,
                m.created_at, m.updated_at, t.owner_id AS tree_owner_id
         FROM memories m
         INNER JOIN trees t
@@ -263,6 +269,18 @@ def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) 
         updates.append("visibility = %s")
         params.append(visibility)
 
+    if "channelId" in payload:
+        updates.append("channel_id = %s")
+        params.append(validate_optional_string(payload.get("channelId"), 100) or None)
+
+    if "channelName" in payload:
+        updates.append("channel_name = %s")
+        params.append(validate_optional_string(payload.get("channelName"), 200) or None)
+
+    if "channelUrl" in payload:
+        updates.append("channel_url = %s")
+        params.append(validate_optional_string(payload.get("channelUrl"), 1000) or None)
+
     if not updates:
         memory = require_memory_owner(safe_memory_id, owner_id)
         return normalize_memory_row(memory)
@@ -279,6 +297,7 @@ def update_owner_memory(owner_id: str, memory_id: str, payload: dict[str, Any]) 
           )
         RETURNING id, tree_id, parent_id, title, memo, artist, source, source_url,
                   source_type, thumbnail, emotion_tags, timestamp, visibility,
+                  channel_id, channel_name, channel_url,
                   created_at, updated_at;
     """
 
@@ -379,7 +398,7 @@ def fork_public_tree(owner_id: str, source_tree_id: str) -> dict[str, Any]:
     # Fetch public memories from source tree
     fetch_source_memories_query = """
         SELECT id, parent_id, title, memo, artist, source, source_url, source_type,
-               thumbnail, emotion_tags, timestamp
+               thumbnail, emotion_tags, timestamp, channel_id, channel_name, channel_url
         FROM memories
         WHERE tree_id = %s
           AND visibility = 'public'
@@ -391,9 +410,10 @@ def fork_public_tree(owner_id: str, source_tree_id: str) -> dict[str, Any]:
         INSERT INTO memories (
             id, tree_id, parent_id, title, memo, artist, source, source_url,
             source_type, thumbnail, emotion_tags, timestamp, visibility,
+            channel_id, channel_name, channel_url,
             created_at, updated_at
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'public', NOW(), NOW());
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'public', %s, %s, %s, NOW(), NOW());
     """
 
     with get_db_connection() as conn:
@@ -431,6 +451,9 @@ def fork_public_tree(owner_id: str, source_tree_id: str) -> dict[str, Any]:
                         mem["thumbnail"],
                         mem["emotion_tags"],
                         mem["timestamp"],
+                        mem.get("channel_id") or None,
+                        mem.get("channel_name") or None,
+                        mem.get("channel_url") or None,
                     ),
                 )
         conn.commit()

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -123,6 +123,7 @@ def fetch_public_memories(tree_id: str | None = None, limit: int = 100) -> list[
     query = f"""
         SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
                m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.channel_id, m.channel_name, m.channel_url,
                m.created_at, m.updated_at
         FROM memories m
         INNER JOIN trees t
@@ -147,6 +148,7 @@ def fetch_public_memory(memory_id: str) -> dict[str, Any] | None:
     query = """
         SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
                m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.channel_id, m.channel_name, m.channel_url,
                m.created_at, m.updated_at
         FROM memories m
         INNER JOIN trees t

--- a/modal_compute/validation.py
+++ b/modal_compute/validation.py
@@ -85,6 +85,9 @@ def normalize_memory_row(row: dict[str, Any]) -> dict[str, Any]:
         "emotionTags": normalize_tags(row.get("emotion_tags")),
         "timestamp": row.get("timestamp") or "",
         "visibility": row.get("visibility") or "public",
+        "channelId": row.get("channel_id") or None,
+        "channelName": row.get("channel_name") or None,
+        "channelUrl": row.get("channel_url") or None,
         "createdAt": _to_isoformat(row.get("created_at")),
         "updatedAt": _to_isoformat(row.get("updated_at")),
     }

--- a/scripts/migration-add-channel-fields.sql
+++ b/scripts/migration-add-channel-fields.sql
@@ -1,0 +1,18 @@
+-- Migration: Add optional YouTube channel fields to memories table
+--
+-- Phase 1A of Issue #1234 — YouTube channel metadata
+--
+-- This migration adds three optional columns to the memories table:
+--   channel_id    VARCHAR(100)  — YouTube channel ID (e.g. @woowayoung or UC...)
+--   channel_name  VARCHAR(200)  — Human-readable channel name (e.g. "우아한형제들")
+--   channel_url   VARCHAR(1000) — Full channel URL (e.g. https://youtube.com/@woowayoung)
+--
+-- All columns are optional (DEFAULT NULL), so existing records are unaffected.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/migration-add-channel-fields.sql
+
+ALTER TABLE memories
+  ADD COLUMN IF NOT EXISTS channel_id   VARCHAR(100) DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS channel_name VARCHAR(200) DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS channel_url  VARCHAR(1000) DEFAULT NULL;

--- a/tests/contracts/modal-owner-public-guard-contract.test.js
+++ b/tests/contracts/modal-owner-public-guard-contract.test.js
@@ -67,5 +67,5 @@ test('Modal fork preserves public-only source and copied public memories', () =>
   assert.match(ownerWrites, /AND visibility = 'public'/);
   assert.match(ownerWrites, /id_map/);
   assert.match(ownerWrites, /new_parent_id/);
-  assert.match(ownerWrites, /'public', NOW\(\), NOW\(\)/);
+  assert.match(ownerWrites, /'public', %s, %s, %s, NOW\(\), NOW\(\)/);
 });

--- a/tests/contracts/test_fork_tree.py
+++ b/tests/contracts/test_fork_tree.py
@@ -59,6 +59,9 @@ MOCK_SOURCE_MEMORIES = [
         "thumbnail": "https://img.example.com/1.jpg",
         "emotion_tags": json.dumps(["joy"]),
         "timestamp": "1:23",
+        "channel_id": None,
+        "channel_name": None,
+        "channel_url": None,
     },
     {
         "id": str(uuid.uuid4()),
@@ -72,6 +75,9 @@ MOCK_SOURCE_MEMORIES = [
         "thumbnail": None,
         "emotion_tags": json.dumps([]),
         "timestamp": None,
+        "channel_id": None,
+        "channel_name": None,
+        "channel_url": None,
     },
 ]
 


### PR DESCRIPTION
# Summary

Phase 1A of Issue #1234 — Add optional YouTube channel metadata fields to memories backend.

## Scope

- DB migration: channel_id (VARCHAR 100), channel_name (VARCHAR 200), channel_url (VARCHAR 1000) — all nullable
- create_owner_memory: INSERT + RETURNING now includes 3 channel columns
- update_owner_memory: SET clause for channelId/Name/Url + RETURNING
- fetch_memory_for_owner_check: SELECT +3 columns
- fetch_owner_memories: SELECT +3 columns
- fetch_public_memories: SELECT +3 columns
- fetch_public_memory: SELECT +3 columns
- fork_public_tree: SELECT source + INSERT copy include channel columns
- normalize_memory_row: returns channelId, channelName, channelUrl
- JS normalizeMemory: channelId, channelName, channelUrl with fallback
- Fork contract test: mock data updated to include channel fields
- Modal public guard test: INSERT regex updated

## Not included (keep scope small)

- No oEmbed auto-fetch (Phase 1B/Phase 2)
- No frontend detail panel display (Phase 3)
- No Cloudflare API proxy changes (pass-through confirmed)
- No Auth/API schema/route changes
- No production data backfill

## Files changed (8)

| File | Type |
|------|------|
| scripts/migration-add-channel-fields.sql | new |
| modal_compute/validation.py | edit |
| modal_compute/owner_writes.py | edit |
| modal_compute/owner_reads.py | edit |
| modal_compute/public_reads.py | edit |
| js/utils/normalize.js | edit |
| tests/contracts/test_fork_tree.py | edit |
| tests/contracts/modal-owner-public-guard-contract.test.js | edit |

## Validation

- npm run test: 343/343 pass
- npm run lint: pass (pre-existing warnings only)
- npm run build: pass
- Backend/API/schema/Auth/DB: DB migration + backend only
- PR #7 / prototype / demo / variant / quiet paths: none
- Close keyword: not used

Refs #1234