### PR TITLE
feat(channel): include parsed channel metadata in editor payload

### DIFF
--- a/js/editor/editor-memory-form-payload.js
+++ b/js/editor/editor-memory-form-payload.js
@@ -19,8 +19,14 @@
         return {
             ok: true,
             embedUrl: `https://www.youtube.com/embed/${videoId}`,
-            thumbnailUrl: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+            thumbnailUrl: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`,
+            channelInfo: null
         };
+    }
+
+    function resolveChannelInfo(rawUrl, media) {
+        if (!rawUrl || !media || typeof media.extractYouTubeChannelInfo !== 'function') return null;
+        return media.extractYouTubeChannelInfo(rawUrl);
     }
 
     function buildMediaSource(options) {
@@ -37,7 +43,8 @@
                 embedUrl: '',
                 thumbnailUrl: '',
                 sourceType: 'other',
-                sourceLabel: ''
+                sourceLabel: '',
+                channelInfo: null
             };
         }
 
@@ -89,7 +96,8 @@
             embedUrl,
             thumbnailUrl: media.getThumbnailUrl(rawUrl, 'youtube', 'mqdefault'),
             sourceType: 'youtube',
-            sourceLabel: 'YouTube'
+            sourceLabel: 'YouTube',
+            channelInfo: resolveChannelInfo(rawUrl, media)
         };
     }
 
@@ -142,22 +150,31 @@
             ? window.LoveBudEditorUtils.getCanonicalRootId(memories)
             : getCanonicalRootId();
 
+        const channelInfo = mediaSource.channelInfo || null;
+        const data = {
+            treeId,
+            title: titleValue || '',
+            memo: memoValue || '',
+            timestamp: todayDateString(),
+            sourceUrl: mediaSource.embedUrl,
+            sourceType: mediaSource.sourceType,
+            emotionTags: [],
+            parentId: resolveParentIdForCreate(getSelectedNodeId(), freshCanonicalRootId),
+            thumbnail: mediaSource.thumbnailUrl,
+            artist: '',
+            source: mediaSource.sourceLabel,
+            visibility: 'public'
+        };
+
+        if (channelInfo) {
+            data.channelId = channelInfo.channelId || null;
+            data.channelName = channelInfo.channelName || null;
+            data.channelUrl = channelInfo.channelUrl || null;
+        }
+
         return {
             ok: true,
-            data: {
-                treeId,
-                title: titleValue || '',
-                memo: memoValue || '',
-                timestamp: todayDateString(),
-                sourceUrl: mediaSource.embedUrl,
-                sourceType: mediaSource.sourceType,
-                emotionTags: [],
-                parentId: resolveParentIdForCreate(getSelectedNodeId(), freshCanonicalRootId),
-                thumbnail: mediaSource.thumbnailUrl,
-                artist: '',
-                source: mediaSource.sourceLabel,
-                visibility: 'public'
-            }
+            data
         };
     }
 

--- a/js/utils/media.js
+++ b/js/utils/media.js
@@ -23,6 +23,77 @@
         return (match && match[2].length === 11) ? match[2] : null;
     }
 
+    function normalizeYouTubeHost(hostname) {
+        return String(hostname || '')
+            .trim()
+            .toLowerCase()
+            .replace(/^www\./, '')
+            .replace(/^m\./, '');
+    }
+
+    function safeDecodePathSegment(segment) {
+        try {
+            return decodeURIComponent(segment || '').trim();
+        } catch (e) {
+            return String(segment || '').trim();
+        }
+    }
+
+    function normalizeYouTubeChannelUrl(channelId) {
+        if (!channelId) return '';
+        if (String(channelId).startsWith('@')) {
+            return `https://www.youtube.com/${channelId}`;
+        }
+        return `https://www.youtube.com/channel/${channelId}`;
+    }
+
+    /**
+     * YouTube URL에서 채널 식별자를 안전하게 추출한다.
+     *
+     * 네트워크/oEmbed 호출 없이 URL 자체에 드러난 채널 정보만 반환한다.
+     * 예: https://www.youtube.com/@woowayoung/shorts/{videoId}
+     * 예: https://www.youtube.com/channel/UCxxxx
+     *
+     * 일반 watch URL은 채널 정보가 URL에 없으므로 null을 반환한다.
+     * @param {string} url - YouTube URL
+     * @returns {{channelId: string, channelName: string, channelUrl: string}|null}
+     */
+    function extractYouTubeChannelInfo(url) {
+        if (!url || typeof url !== 'string') return null;
+        try {
+            const parsed = new URL(url.trim());
+            const host = normalizeYouTubeHost(parsed.hostname);
+            if (host !== 'youtube.com') return null;
+
+            const segments = parsed.pathname
+                .split('/')
+                .map(safeDecodePathSegment)
+                .filter(Boolean);
+            if (!segments.length) return null;
+
+            const first = segments[0];
+            if (/^@[0-9A-Za-z._-]{3,100}$/.test(first)) {
+                return {
+                    channelId: first,
+                    channelName: first,
+                    channelUrl: normalizeYouTubeChannelUrl(first)
+                };
+            }
+
+            if (first === 'channel' && segments[1] && /^UC[0-9A-Za-z_-]{10,100}$/.test(segments[1])) {
+                const channelId = segments[1];
+                return {
+                    channelId,
+                    channelName: '',
+                    channelUrl: normalizeYouTubeChannelUrl(channelId)
+                };
+            }
+        } catch (e) {
+            return null;
+        }
+        return null;
+    }
+
     /**
      * YouTube 시간 문자열을 초 단위로 변환
      * 지원 예: 83, 83초, 1:23, 01:23, 1m23s, 2h1m3s
@@ -180,6 +251,7 @@
     // 전역 노출
     window.LoveBudMedia = {
         extractYouTubeId,
+        extractYouTubeChannelInfo,
         parseYouTubeTimeToSeconds,
         extractYouTubeStartSeconds,
         formatYouTubeStartTime,

--- a/tests/contracts/channel-metadata-payload-contract.test.js
+++ b/tests/contracts/channel-metadata-payload-contract.test.js
@@ -30,7 +30,7 @@ function createPayloadContext(url) {
     refs: {
       urlInput: { value: url },
       titleInput: { value: 'Channel moment' },
-      memoInput: { value: 'Captured from a channel URL' },
+      memoInput: { value: 'Channel metadata test' },
       startTimeInput: { value: '' },
       endTimeInput: { value: '' }
     },
@@ -58,7 +58,7 @@ test('YouTube handle URL populates optional channel fields in memory payload', (
 });
 
 test('YouTube channel ID URL populates channel id and URL without guessing a display name', () => {
-  const result = createPayloadContext('https://youtube.com/channel/UC1234567890abcdefghi/videos/dQw4w9WgXcQ');
+  const result = createPayloadContext('https://youtube.com/channel/UC1234567890abcdefghi/shorts/dQw4w9WgXcQ');
 
   assert.equal(result.ok, true);
   assert.equal(result.data.channelId, 'UC1234567890abcdefghi');

--- a/tests/contracts/channel-metadata-payload-contract.test.js
+++ b/tests/contracts/channel-metadata-payload-contract.test.js
@@ -1,0 +1,76 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function createPayloadContext(url) {
+  const context = {
+    console,
+    URL,
+    URLSearchParams,
+    Date,
+    window: {
+      LoveBudEditorMemoryFormTime: {
+        resolveStartSeconds: () => null,
+        validateEndTime: () => ({ ok: true, endSeconds: null })
+      },
+      LoveBudEditorUtils: {
+        getCanonicalRootId: () => 'root-1'
+      }
+    }
+  };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/utils/media.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-memory-form-payload.js'), 'utf8'), context);
+
+  return context.window.LoveBudEditorMemoryFormPayload.buildMemoryPayload({
+    refs: {
+      urlInput: { value: url },
+      titleInput: { value: 'Channel moment' },
+      memoInput: { value: 'Captured from a channel URL' },
+      startTimeInput: { value: '' },
+      endTimeInput: { value: '' }
+    },
+    currentInputMode: 'link',
+    userHasEditedStartTime: false,
+    i18n: (key) => key,
+    treeId: 'tree-1',
+    getYouTubeInputErrorMessage: () => 'invalid youtube url',
+    getTreeMemories: () => [],
+    resolveParentIdForCreate: () => 'root-1',
+    getSelectedNodeId: () => 'root-1',
+    getCanonicalRootId: () => 'root-1'
+  });
+}
+
+test('YouTube handle URL populates optional channel fields in memory payload', () => {
+  const result = createPayloadContext('https://www.youtube.com/@woowayoung/shorts/dQw4w9WgXcQ');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.data.sourceType, 'youtube');
+  assert.equal(result.data.sourceUrl, 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+  assert.equal(result.data.channelId, '@woowayoung');
+  assert.equal(result.data.channelName, '@woowayoung');
+  assert.equal(result.data.channelUrl, 'https://www.youtube.com/@woowayoung');
+});
+
+test('YouTube channel ID URL populates channel id and URL without guessing a display name', () => {
+  const result = createPayloadContext('https://youtube.com/channel/UC1234567890abcdefghi/videos/dQw4w9WgXcQ');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.data.channelId, 'UC1234567890abcdefghi');
+  assert.equal(result.data.channelName, null);
+  assert.equal(result.data.channelUrl, 'https://www.youtube.com/channel/UC1234567890abcdefghi');
+});
+
+test('standard YouTube watch URL does not invent channel fields without oEmbed data', () => {
+  const result = createPayloadContext('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+  assert.equal(result.ok, true);
+  assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelId'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelName'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelUrl'), false);
+});


### PR DESCRIPTION
# Summary

Phase 1B slice for Issue #1234 — include optional YouTube channel metadata in the editor memory payload when the channel identity is already present in the pasted YouTube URL.

## Scope

- Add `LoveBudMedia.extractYouTubeChannelInfo(rawUrl)`.
- Parse only channel information that is directly present in the URL:
  - `https://www.youtube.com/@handle/...`
  - `https://www.youtube.com/channel/UC.../...`
- Include `channelId`, `channelName`, and `channelUrl` in `buildMemoryPayload()` when parser data exists.
- Do **not** invent channel metadata for normal `watch?v=...` URLs where the channel is not present in the URL.
- Add contract tests for handle URL, channel ID URL, and standard watch URL fallback behavior.

## Not included

- No oEmbed/network fetch.
- No YouTube API integration.
- No backend/schema/DB changes.
- No Cloudflare API proxy changes.
- No detail panel display yet.
- No editor preview UI yet.

## Files changed

- `js/utils/media.js`
- `js/editor/editor-memory-form-payload.js`
- `tests/contracts/channel-metadata-payload-contract.test.js`

## Validation

- Contract test added for payload behavior.
- Needs CI confirmation.
- Needs test5/browser smoke before merge because this affects editor payload creation.

## Safety / guardrails

- PR #7 / prototype / reference / demo / variant / quiet paths: untouched.
- Issue close keyword: not used.
- Backend/API/schema/Auth/DB: unchanged.

Refs #1234