### PR TITLE
feat(channel): show channel link in editor detail panel

### DIFF
--- a/js/editor/editor-detail-channel-link.js
+++ b/js/editor/editor-detail-channel-link.js
@@ -13,7 +13,7 @@
 
     function isSafeYouTubeChannelPath(pathname) {
         const path = String(pathname || '').trim();
-        return /^\/[0-9A-Za-z._-]*@[0-9A-Za-z._-]{3,100}$/.test(path) ||
+        return /^\/@[0-9A-Za-z._-]{3,100}$/.test(path) ||
             /^\/channel\/UC[0-9A-Za-z_-]{10,100}$/.test(path);
     }
 

--- a/js/editor/editor-detail-channel-link.js
+++ b/js/editor/editor-detail-channel-link.js
@@ -1,0 +1,137 @@
+(function() {
+    'use strict';
+
+    const CHANNEL_ROW_ID = 'detailCurrentMomentChannel';
+
+    function normalizeYouTubeHost(hostname) {
+        return String(hostname || '')
+            .trim()
+            .toLowerCase()
+            .replace(/^www\./, '')
+            .replace(/^m\./, '');
+    }
+
+    function isSafeYouTubeChannelPath(pathname) {
+        const path = String(pathname || '').trim();
+        return /^\/[0-9A-Za-z._-]*@[0-9A-Za-z._-]{3,100}$/.test(path) ||
+            /^\/channel\/UC[0-9A-Za-z_-]{10,100}$/.test(path);
+    }
+
+    function sanitizeYouTubeChannelUrl(url) {
+        if (!url || typeof url !== 'string') return '';
+        try {
+            const parsed = new URL(url.trim());
+            const host = normalizeYouTubeHost(parsed.hostname);
+            if (parsed.protocol !== 'https:' || host !== 'youtube.com') return '';
+            if (!isSafeYouTubeChannelPath(parsed.pathname)) return '';
+            parsed.search = '';
+            parsed.hash = '';
+            return parsed.toString();
+        } catch (e) {
+            return '';
+        }
+    }
+
+    function buildChannelUrlFromId(channelId) {
+        const id = String(channelId || '').trim();
+        if (/^@[0-9A-Za-z._-]{3,100}$/.test(id)) {
+            return `https://www.youtube.com/${id}`;
+        }
+        if (/^UC[0-9A-Za-z_-]{10,100}$/.test(id)) {
+            return `https://www.youtube.com/channel/${id}`;
+        }
+        return '';
+    }
+
+    function resolveChannelLabel(data) {
+        const label = String(data?.channelName || data?.channelId || '').trim();
+        if (!label) return '';
+        return label.startsWith('@') ? label : `from ${label}`;
+    }
+
+    function resolveSafeChannelUrl(data) {
+        const explicitUrl = sanitizeYouTubeChannelUrl(data?.channelUrl || '');
+        if (explicitUrl) return explicitUrl;
+        return sanitizeYouTubeChannelUrl(buildChannelUrlFromId(data?.channelId || ''));
+    }
+
+    function removeExistingChannelRow() {
+        const existing = document.getElementById(CHANNEL_ROW_ID);
+        if (existing) existing.remove();
+    }
+
+    function renderDetailChannelLink(data) {
+        removeExistingChannelRow();
+
+        const titleEl = document.getElementById('detailCurrentMomentTitle');
+        if (!titleEl || !data || data.isNewTree) return;
+
+        const label = resolveChannelLabel(data);
+        const safeUrl = resolveSafeChannelUrl(data);
+        if (!label || !safeUrl) return;
+
+        const row = document.createElement('div');
+        row.id = CHANNEL_ROW_ID;
+        row.className = 'editor-current-moment-channel';
+        row.style.display = 'flex';
+        row.style.alignItems = 'center';
+        row.style.gap = '6px';
+        row.style.margin = '-4px 0 12px';
+        row.style.fontSize = '12px';
+        row.style.lineHeight = '1.45';
+        row.style.color = 'var(--on-surface-variant)';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.style.fontSize = '14px';
+        icon.textContent = 'account_circle';
+        row.appendChild(icon);
+
+        const prefix = document.createElement('span');
+        prefix.textContent = 'from';
+        row.appendChild(prefix);
+
+        const link = document.createElement('a');
+        link.href = safeUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = 'editor-current-moment-channel-link';
+        link.textContent = label.replace(/^from\s+/i, '');
+        link.style.color = 'var(--primary)';
+        link.style.textDecoration = 'none';
+        link.style.fontWeight = '700';
+        row.appendChild(link);
+
+        titleEl.insertAdjacentElement('afterend', row);
+    }
+
+    function installDetailChannelLinkPatch() {
+        const originalFactory = window.createEditorDetailUI;
+        if (typeof originalFactory !== 'function' || originalFactory.__channelLinkPatched) return;
+
+        const patchedFactory = function(deps) {
+            const detailUI = originalFactory(deps);
+            if (!detailUI || typeof detailUI.updateDetailPanel !== 'function') return detailUI;
+
+            const originalUpdateDetailPanel = detailUI.updateDetailPanel;
+            detailUI.updateDetailPanel = function(data) {
+                originalUpdateDetailPanel(data);
+                renderDetailChannelLink(data);
+            };
+
+            return detailUI;
+        };
+
+        patchedFactory.__channelLinkPatched = true;
+        window.createEditorDetailUI = patchedFactory;
+    }
+
+    window.LoveBudEditorDetailChannelLink = {
+        renderDetailChannelLink,
+        sanitizeYouTubeChannelUrl,
+        buildChannelUrlFromId
+    };
+
+    installDetailChannelLinkPatch();
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -312,6 +312,7 @@
     <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
     <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>
     <script src="../js/editor/editor-memory-form-preview.js?v=20260510-1003"></script>

--- a/tests/contracts/editor-detail-channel-link-contract.test.js
+++ b/tests/contracts/editor-detail-channel-link-contract.test.js
@@ -1,0 +1,152 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function createDetailChannelContext() {
+  const elements = new Map();
+
+  function createElement(tagName) {
+    const children = [];
+    const element = {
+      tagName: String(tagName).toUpperCase(),
+      id: '',
+      className: '',
+      style: {},
+      attributes: {},
+      children,
+      parentElement: null,
+      textContent: '',
+      href: '',
+      target: '',
+      rel: '',
+      setAttribute(name, value) {
+        this.attributes[name] = String(value);
+      },
+      appendChild(child) {
+        child.parentElement = this;
+        children.push(child);
+        if (child.id) elements.set(child.id, child);
+        return child;
+      },
+      remove() {
+        if (this.parentElement) {
+          const index = this.parentElement.children.indexOf(this);
+          if (index >= 0) this.parentElement.children.splice(index, 1);
+        }
+        if (this.id) elements.delete(this.id);
+      },
+      insertAdjacentElement(position, child) {
+        child.parentElement = this.parentElement;
+        if (child.id) elements.set(child.id, child);
+        if (!this.parentElement || position !== 'afterend') return child;
+        const index = this.parentElement.children.indexOf(this);
+        this.parentElement.children.splice(index + 1, 0, child);
+        return child;
+      }
+    };
+    return element;
+  }
+
+  const title = createElement('h4');
+  title.id = 'detailCurrentMomentTitle';
+  elements.set(title.id, title);
+
+  const parent = createElement('div');
+  parent.appendChild(title);
+
+  const context = {
+    URL,
+    window: {
+      createEditorDetailUI: () => ({
+        updateDetailPanel: () => {}
+      })
+    },
+    document: {
+      createElement,
+      getElementById: (id) => elements.get(id) || null
+    }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-detail-channel-link.js'), 'utf8'), context);
+
+  return {
+    context,
+    title,
+    getChannelRow: () => elements.get('detailCurrentMomentChannel') || null
+  };
+}
+
+test('editor detail channel link renders safe YouTube handle link after title', () => {
+  const harness = createDetailChannelContext();
+
+  harness.context.window.LoveBudEditorDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+
+  const row = harness.getChannelRow();
+  assert.ok(row);
+  assert.equal(row.children[1].textContent, 'from');
+  assert.equal(row.children[2].tagName, 'A');
+  assert.equal(row.children[2].href, 'https://www.youtube.com/@woowayoung');
+  assert.equal(row.children[2].target, '_blank');
+  assert.equal(row.children[2].rel, 'noopener noreferrer');
+  assert.equal(row.children[2].textContent, '@woowayoung');
+});
+
+test('editor detail channel link does not render unsafe channel URL', () => {
+  const harness = createDetailChannelContext();
+
+  harness.context.window.LoveBudEditorDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'javascript:alert(1)'
+  });
+
+  const row = harness.getChannelRow();
+  assert.ok(row, 'safe channelId fallback should still render');
+  assert.equal(row.children[2].href, 'https://www.youtube.com/@woowayoung');
+});
+
+test('editor detail channel link removes stale row when selected memory lacks channel data', () => {
+  const harness = createDetailChannelContext();
+
+  harness.context.window.LoveBudEditorDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+  assert.ok(harness.getChannelRow());
+
+  harness.context.window.LoveBudEditorDetailChannelLink.renderDetailChannelLink({
+    title: 'No channel memory'
+  });
+
+  assert.equal(harness.getChannelRow(), null);
+});
+
+test('editor detail channel link patch wraps updateDetailPanel without replacing original behavior', () => {
+  const harness = createDetailChannelContext();
+  let originalCalled = false;
+
+  harness.context.window.createEditorDetailUI = () => ({
+    updateDetailPanel: () => { originalCalled = true; }
+  });
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-detail-channel-link.js'), 'utf8'), harness.context);
+
+  const detailUI = harness.context.window.createEditorDetailUI({});
+  detailUI.updateDetailPanel({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+
+  assert.equal(originalCalled, true);
+  assert.ok(harness.getChannelRow());
+});

--- a/tests/contracts/editor-detail-channel-link-contract.test.js
+++ b/tests/contracts/editor-detail-channel-link-contract.test.js
@@ -6,7 +6,7 @@ const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..', '..');
 
-function createDetailChannelContext() {
+function createDetailChannelContext(options = {}) {
   const elements = new Map();
 
   function createElement(tagName) {
@@ -61,9 +61,9 @@ function createDetailChannelContext() {
   const context = {
     URL,
     window: {
-      createEditorDetailUI: () => ({
+      createEditorDetailUI: options.createEditorDetailUI || (() => ({
         updateDetailPanel: () => {}
-      })
+      }))
     },
     document: {
       createElement,
@@ -100,7 +100,7 @@ test('editor detail channel link renders safe YouTube handle link after title', 
   assert.equal(row.children[2].textContent, '@woowayoung');
 });
 
-test('editor detail channel link does not render unsafe channel URL', () => {
+test('editor detail channel link does not use unsafe explicit channel URL', () => {
   const harness = createDetailChannelContext();
 
   harness.context.window.LoveBudEditorDetailChannelLink.renderDetailChannelLink({
@@ -132,13 +132,12 @@ test('editor detail channel link removes stale row when selected memory lacks ch
 });
 
 test('editor detail channel link patch wraps updateDetailPanel without replacing original behavior', () => {
-  const harness = createDetailChannelContext();
   let originalCalled = false;
-
-  harness.context.window.createEditorDetailUI = () => ({
-    updateDetailPanel: () => { originalCalled = true; }
+  const harness = createDetailChannelContext({
+    createEditorDetailUI: () => ({
+      updateDetailPanel: () => { originalCalled = true; }
+    })
   });
-  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-detail-channel-link.js'), 'utf8'), harness.context);
 
   const detailUI = harness.context.window.createEditorDetailUI({});
   detailUI.updateDetailPanel({


### PR DESCRIPTION
# Summary

Issue #1234 channel display slice — show saved YouTube channel metadata in the editor detail panel.

## Scope

- Add `js/editor/editor-detail-channel-link.js` as a small wrapper around `createEditorDetailUI()`.
- After the existing `updateDetailPanel()` render completes, append a safe `from @channel` link below the selected moment title when channel metadata exists.
- Load the wrapper immediately after `editor-detail-ui.js` in `pages/editor.html`.
- Add contract tests for:
  - rendering a safe YouTube handle link
  - rejecting unsafe explicit `channelUrl` while falling back to safe `channelId`
  - removing stale channel row when selecting a memory without channel data
  - preserving original `updateDetailPanel()` behavior when wrapping

## Not included

- No oEmbed/network fetch.
- No YouTube API integration.
- No backend/schema/DB changes.
- No Cloudflare API proxy changes.
- No public viewer/detail page channel display yet.
- No editor form preview channel display yet.

## Files changed

- `js/editor/editor-detail-channel-link.js`
- `pages/editor.html`
- `tests/contracts/editor-detail-channel-link-contract.test.js`

## Validation

- Contract tests added.
- Needs CI confirmation.
- Needs test5/browser smoke before merge because this changes editor detail-panel UI.

## Safety / guardrails

- Uses DOM `createElement`/`textContent`, not raw HTML injection.
- Sanitizes channel links to HTTPS YouTube channel/handle URLs only.
- `target=_blank` uses `rel="noopener noreferrer"`.
- PR #7 / prototype / reference / demo / variant / quiet paths: untouched.
- Issue close keyword: not used.
- Backend/API/schema/Auth/DB: unchanged.

Refs #1234