### PR TITLE
feat(channel): show channel label in editor form preview

### DIFF
--- a/js/editor/editor-memory-form-preview.js
+++ b/js/editor/editor-memory-form-preview.js
@@ -90,6 +90,23 @@
         preview.classList.remove('is-enhanced');
     }
 
+    function resolveChannelPreviewLabel(url, media) {
+        if (!url || !media || typeof media.extractYouTubeChannelInfo !== 'function') return '';
+        const channelInfo = media.extractYouTubeChannelInfo(url);
+        const label = String(channelInfo?.channelName || channelInfo?.channelId || '').trim();
+        if (!label) return '';
+        return `from ${label}`;
+    }
+
+    function buildPreviewHintText(options = {}) {
+        const formatted = options.formatted || '';
+        const channelLabel = options.channelLabel || '';
+        const baseText = formatted
+            ? `${formatted}부터 재생돼요. 제목과 메모를 다듬어 주세요.`
+            : '제목과 메모를 다듬어 주세요.';
+        return channelLabel ? `${channelLabel} · ${baseText}` : baseText;
+    }
+
     function update(options) {
         const {
             currentInputMode,
@@ -132,11 +149,10 @@
         const formatted = typeof time.formatStartTime === 'function'
             ? time.formatStartTime(startSeconds)
             : '';
+        const channelLabel = resolveChannelPreviewLabel(url, media);
 
-        if (refs?.previewHint && formatted) {
-            refs.previewHint.textContent = `${formatted}부터 재생돼요. 제목과 메모를 다듬어 주세요.`;
-        } else if (refs?.previewHint) {
-            refs.previewHint.textContent = '제목과 메모를 다듬어 주세요.';
+        if (refs?.previewHint) {
+            refs.previewHint.textContent = buildPreviewHintText({ formatted, channelLabel });
         }
 
         if (refs?.startTimeHint) {
@@ -147,6 +163,8 @@
     window.LoveBudEditorMemoryFormPreview = {
         applyPreviewStyles,
         hide,
+        resolveChannelPreviewLabel,
+        buildPreviewHintText,
         update
     };
 })();

--- a/tests/contracts/editor-memory-form-preview-channel-contract.test.js
+++ b/tests/contracts/editor-memory-form-preview-channel-contract.test.js
@@ -1,0 +1,117 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function createPreviewContext({ url, formatted = '' } = {}) {
+  const previewClassList = new Set(['is-hidden']);
+  const preview = {
+    classList: {
+      add: (name) => previewClassList.add(name),
+      remove: (name) => previewClassList.delete(name),
+      contains: (name) => previewClassList.has(name)
+    },
+    style: {},
+    querySelector: () => null
+  };
+
+  const refs = {
+    preview,
+    urlInput: { value: url || '' },
+    startTimeInput: { value: '' },
+    previewHint: { textContent: '', style: {} },
+    previewTitle: { textContent: '', style: {} },
+    badge: { style: {} },
+    thumb: { src: '', style: {} },
+    thumbWrap: { style: {} },
+    playIcon: { style: {} },
+    previewBody: { style: {} },
+    startTimeHint: { textContent: '' }
+  };
+
+  const context = {
+    URL,
+    window: {
+      LoveBudEditorMemoryFormTime: {
+        resolveStartSeconds: () => formatted ? 83 : null,
+        formatStartTime: () => formatted
+      }
+    },
+    document: {
+      getElementById: () => preview
+    }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/utils/media.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-memory-form-preview.js'), 'utf8'), context);
+
+  return {
+    context,
+    refs,
+    previewClassList
+  };
+}
+
+test('memory form preview shows URL-visible YouTube handle channel label', () => {
+  const harness = createPreviewContext({
+    url: 'https://www.youtube.com/@woowayoung/shorts/dQw4w9WgXcQ'
+  });
+
+  harness.context.window.LoveBudEditorMemoryFormPreview.update({
+    currentInputMode: 'link',
+    refs: harness.refs,
+    userHasEditedStartTime: false
+  });
+
+  assert.equal(harness.refs.preview.classList.contains('is-hidden'), false);
+  assert.equal(harness.refs.previewHint.textContent, 'from @woowayoung · 제목과 메모를 다듬어 주세요.');
+  assert.equal(harness.refs.thumb.src, 'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg');
+});
+
+test('memory form preview does not invent channel label for standard watch URL', () => {
+  const harness = createPreviewContext({
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  });
+
+  harness.context.window.LoveBudEditorMemoryFormPreview.update({
+    currentInputMode: 'link',
+    refs: harness.refs,
+    userHasEditedStartTime: false
+  });
+
+  assert.equal(harness.refs.preview.classList.contains('is-hidden'), false);
+  assert.equal(harness.refs.previewHint.textContent, '제목과 메모를 다듬어 주세요.');
+});
+
+test('memory form preview combines channel label with start time hint', () => {
+  const harness = createPreviewContext({
+    url: 'https://www.youtube.com/@woowayoung/shorts/dQw4w9WgXcQ?t=83',
+    formatted: '1:23'
+  });
+
+  harness.context.window.LoveBudEditorMemoryFormPreview.update({
+    currentInputMode: 'link',
+    refs: harness.refs,
+    userHasEditedStartTime: false
+  });
+
+  assert.equal(harness.refs.previewHint.textContent, 'from @woowayoung · 1:23부터 재생돼요. 제목과 메모를 다듬어 주세요.');
+});
+
+test('memory form preview hides and clears no channel-specific row in text mode', () => {
+  const harness = createPreviewContext({
+    url: 'https://www.youtube.com/@woowayoung/shorts/dQw4w9WgXcQ'
+  });
+
+  harness.context.window.LoveBudEditorMemoryFormPreview.update({
+    currentInputMode: 'text',
+    refs: harness.refs,
+    userHasEditedStartTime: false
+  });
+
+  assert.equal(harness.refs.preview.classList.contains('is-hidden'), true);
+});


### PR DESCRIPTION
# Summary

Issue #1234 editor form preview slice — show URL-visible YouTube channel metadata before saving a memory.

## Scope

- Update `LoveBudEditorMemoryFormPreview.update()` to display a channel label in the existing preview hint when the pasted YouTube URL itself exposes channel identity.
- Reuse `LoveBudMedia.extractYouTubeChannelInfo(rawUrl)` from the prior payload slice.
- Display examples:
  - `from @woowayoung · 제목과 메모를 다듬어 주세요.`
  - `from @woowayoung · 1:23부터 재생돼요. 제목과 메모를 다듬어 주세요.`
- Do **not** invent channel labels for standard `watch?v=...` URLs without oEmbed/API data.
- Add contract tests for handle URL display, standard watch URL no-guess behavior, start-time composition, and text-mode hide behavior.

## Not included

- No oEmbed/network fetch.
- No YouTube API integration.
- No backend/schema/DB changes.
- No Cloudflare API proxy changes.
- No public viewer/detail page channel display.
- No new DOM row or unsafe HTML rendering.

## Files changed

- `js/editor/editor-memory-form-preview.js`
- `tests/contracts/editor-memory-form-preview-channel-contract.test.js`

## Validation

- Contract tests added.
- Needs CI confirmation.
- Needs test5/browser smoke before merge because this changes editor memory-form preview UI.

## Safety / guardrails

- Uses existing preview hint text node via `textContent`.
- No `innerHTML` or dynamic href added in this slice.
- PR #7 / prototype / reference / demo / variant / quiet paths: untouched.
- Issue close keyword: not used.
- Backend/API/schema/Auth/DB: unchanged.

Refs #1234