### PR TITLE
feat(channel): enrich YouTube watch URLs via oEmbed

### DIFF
--- a/functions/api/youtube/oembed.js
+++ b/functions/api/youtube/oembed.js
@@ -1,0 +1,155 @@
+const YOUTUBE_OEMBED_ENDPOINT = 'https://www.youtube.com/oembed';
+const MAX_INPUT_URL_LENGTH = 2048;
+const MAX_CHANNEL_NAME_LENGTH = 200;
+
+function jsonResponse(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'public, max-age=3600',
+      ...extraHeaders
+    }
+  });
+}
+
+function normalizeYouTubeHost(hostname) {
+  return String(hostname || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, '')
+    .replace(/^m\./, '');
+}
+
+function isAllowedYouTubeHost(hostname) {
+  const host = normalizeYouTubeHost(hostname);
+  return host === 'youtube.com' || host === 'youtu.be';
+}
+
+function extractYouTubeVideoId(url) {
+  if (!url || typeof url !== 'string') return '';
+  try {
+    const parsed = new URL(url.trim());
+    const host = normalizeYouTubeHost(parsed.hostname);
+    if (host === 'youtu.be') {
+      const id = parsed.pathname.split('/').filter(Boolean)[0] || '';
+      return /^[0-9A-Za-z_-]{11}$/.test(id) ? id : '';
+    }
+    if (host !== 'youtube.com') return '';
+    const watchId = parsed.searchParams.get('v') || '';
+    if (/^[0-9A-Za-z_-]{11}$/.test(watchId)) return watchId;
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const markerIndex = segments.findIndex((segment) => ['embed', 'shorts', 'live', 'v'].includes(segment));
+    const id = markerIndex >= 0 ? (segments[markerIndex + 1] || '') : '';
+    return /^[0-9A-Za-z_-]{11}$/.test(id) ? id : '';
+  } catch (e) {
+    return '';
+  }
+}
+
+function isSafeYouTubeChannelPath(pathname) {
+  const path = String(pathname || '').trim();
+  return /^\/@[0-9A-Za-z._-]{3,100}$/.test(path) ||
+    /^\/channel\/UC[0-9A-Za-z_-]{10,100}$/.test(path);
+}
+
+function sanitizeYouTubeChannelUrl(url) {
+  if (!url || typeof url !== 'string') return '';
+  try {
+    const parsed = new URL(url.trim());
+    const host = normalizeYouTubeHost(parsed.hostname);
+    if (parsed.protocol !== 'https:' || host !== 'youtube.com') return '';
+    if (!isSafeYouTubeChannelPath(parsed.pathname)) return '';
+    parsed.hostname = 'www.youtube.com';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch (e) {
+    return '';
+  }
+}
+
+function deriveChannelIdFromUrl(channelUrl) {
+  try {
+    const parsed = new URL(channelUrl);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (segments[0] && /^@[0-9A-Za-z._-]{3,100}$/.test(segments[0])) return segments[0];
+    if (segments[0] === 'channel' && segments[1] && /^UC[0-9A-Za-z_-]{10,100}$/.test(segments[1])) return segments[1];
+  } catch (e) {}
+  return null;
+}
+
+function normalizeChannelName(value) {
+  const name = String(value || '').trim();
+  if (!name) return null;
+  return name.slice(0, MAX_CHANNEL_NAME_LENGTH);
+}
+
+function buildEmptyChannelPayload() {
+  return {
+    channelId: null,
+    channelName: null,
+    channelUrl: null
+  };
+}
+
+export async function onRequestGet(context) {
+  const sourceUrl = new URL(context.request.url);
+  const rawUrl = String(sourceUrl.searchParams.get('url') || '').trim();
+
+  if (!rawUrl || rawUrl.length > MAX_INPUT_URL_LENGTH) {
+    return jsonResponse({ error: 'Invalid YouTube URL' }, 400, { 'cache-control': 'no-store' });
+  }
+
+  let parsedInput;
+  try {
+    parsedInput = new URL(rawUrl);
+  } catch (e) {
+    return jsonResponse({ error: 'Invalid YouTube URL' }, 400, { 'cache-control': 'no-store' });
+  }
+
+  if (parsedInput.protocol !== 'https:' || !isAllowedYouTubeHost(parsedInput.hostname)) {
+    return jsonResponse({ error: 'Invalid YouTube URL' }, 400, { 'cache-control': 'no-store' });
+  }
+
+  const videoId = extractYouTubeVideoId(rawUrl);
+  if (!videoId) {
+    return jsonResponse({ error: 'YouTube video ID required' }, 400, { 'cache-control': 'no-store' });
+  }
+
+  const oembedUrl = new URL(YOUTUBE_OEMBED_ENDPOINT);
+  oembedUrl.searchParams.set('format', 'json');
+  oembedUrl.searchParams.set('url', rawUrl);
+
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(oembedUrl.toString(), {
+      headers: { accept: 'application/json' }
+    });
+  } catch (e) {
+    return jsonResponse(buildEmptyChannelPayload(), 200, { 'cache-control': 'no-store' });
+  }
+
+  if (!upstreamResponse.ok) {
+    return jsonResponse(buildEmptyChannelPayload(), 200, { 'cache-control': 'no-store' });
+  }
+
+  let upstreamJson;
+  try {
+    upstreamJson = await upstreamResponse.json();
+  } catch (e) {
+    return jsonResponse(buildEmptyChannelPayload(), 200, { 'cache-control': 'no-store' });
+  }
+
+  const channelUrl = sanitizeYouTubeChannelUrl(upstreamJson && upstreamJson.author_url);
+  const channelName = normalizeChannelName(upstreamJson && upstreamJson.author_name);
+  if (!channelUrl || !channelName) {
+    return jsonResponse(buildEmptyChannelPayload(), 200, { 'cache-control': 'no-store' });
+  }
+
+  return jsonResponse({
+    channelId: deriveChannelIdFromUrl(channelUrl),
+    channelName,
+    channelUrl
+  });
+}

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -401,6 +401,30 @@ function createEditorMemoryForm(deps) {
         setDetailEmptyState(false);
     }
 
+    function shouldEnrichChannelMetadata(payload, rawUrl) {
+        if (!payload || payload.sourceType !== 'youtube') return false;
+        if (!rawUrl) return false;
+        if (payload.channelName && payload.channelUrl) return false;
+        return !!(window.apiClient && typeof window.apiClient.getYouTubeOEmbedChannel === 'function');
+    }
+
+    async function enrichPayloadChannelMetadata(payload, rawUrl) {
+        if (!shouldEnrichChannelMetadata(payload, rawUrl)) return payload;
+        try {
+            const channel = await window.apiClient.getYouTubeOEmbedChannel(rawUrl);
+            if (!channel || !channel.channelName || !channel.channelUrl) return payload;
+            return {
+                ...payload,
+                channelId: payload.channelId || channel.channelId || null,
+                channelName: payload.channelName || channel.channelName,
+                channelUrl: payload.channelUrl || channel.channelUrl
+            };
+        } catch (e) {
+            editorDebugLog('[editor] YouTube channel enrichment skipped:', e?.message || e);
+            return payload;
+        }
+    }
+
     const addMemoryFromForm = async () => {
         if (!payloadHelper || typeof payloadHelper.buildMemoryPayload !== 'function') {
             console.error('[editor] memory form payload helper is not loaded');
@@ -408,6 +432,7 @@ function createEditorMemoryForm(deps) {
             return;
         }
 
+        const rawUrl = refs?.urlInput ? refs.urlInput.value.trim() : '';
         const payloadResult = payloadHelper.buildMemoryPayload({
             refs,
             currentInputMode,
@@ -429,7 +454,8 @@ function createEditorMemoryForm(deps) {
         updateSaveStatus('saving', i18n('save_saving'));
         hideAddMemoryForm();
 
-        const { createdMemory, useApi } = await createMemoryWithFallback(payloadResult.data);
+        const enrichedPayload = await enrichPayloadChannelMetadata(payloadResult.data, rawUrl);
+        const { createdMemory, useApi } = await createMemoryWithFallback(enrichedPayload);
         commitMemoryToTree(createdMemory, useApi);
     };
 
@@ -437,7 +463,8 @@ function createEditorMemoryForm(deps) {
         showAddMemoryForm,
         hideAddMemoryForm,
         addMemoryFromForm,
-        isFormOpen: () => isFormOpen
+        isFormOpen: () => isFormOpen,
+        enrichPayloadChannelMetadata
     };
 }
 

--- a/js/postgres-client.js
+++ b/js/postgres-client.js
@@ -42,6 +42,35 @@
         };
     }
 
+    function normalizeChannelMetadata(raw) {
+        if (!raw || typeof raw !== 'object') return null;
+        const channelName = String(raw.channelName || '').trim();
+        const channelUrl = String(raw.channelUrl || '').trim();
+        if (!channelName || !channelUrl) return null;
+        return {
+            channelId: raw.channelId || null,
+            channelName,
+            channelUrl
+        };
+    }
+
+    function createYouTubeApi() {
+        return {
+            getYouTubeOEmbedChannel: async (url) => {
+                const rawUrl = String(url || '').trim();
+                if (!rawUrl) return null;
+                try {
+                    const result = await BaseApiFetch.apiFetch(`/youtube/oembed?url=${encodeURIComponent(rawUrl)}`, {
+                        publicRead: true
+                    });
+                    return normalizeChannelMetadata(result);
+                } catch (e) {
+                    return null;
+                }
+            }
+        };
+    }
+
     function enrichBrowseSummaryTree(rawTree, fallbackTree) {
         const tree = (fallbackTree && typeof fallbackTree === 'object') ? { ...fallbackTree } : {};
         const source = rawTree?.data || rawTree || {};
@@ -177,12 +206,14 @@
     const memoryApi = createMemoryApi();
     const communityApi = createCommunityApi();
     const browseApi = createBrowseApi(communityApi);
+    const youtubeApi = createYouTubeApi();
 
     const apiClient = mergeApiGroupsWithCollisionWarning([
         { name: 'treeApi', api: treeApi },
         { name: 'memoryApi', api: memoryApi },
         { name: 'communityApi', api: communityApi },
-        { name: 'browseApi', api: browseApi }
+        { name: 'browseApi', api: browseApi },
+        { name: 'youtubeApi', api: youtubeApi }
     ]);
 
     window.apiClient = apiClient;
@@ -197,6 +228,7 @@
             getRecordTreeId: PublicTreeAdapter?.getRecordTreeId,
             normalizeBrowseTreeRecord: PublicTreeAdapter?.normalizeBrowseTreeRecord,
             normalizeBrowseMemoryRecord: PublicTreeAdapter?.normalizeBrowseMemoryRecord,
+            normalizeChannelMetadata,
         };
     }
 })();

--- a/tests/contracts/youtube-oembed-channel-enrichment-contract.test.js
+++ b/tests/contracts/youtube-oembed-channel-enrichment-contract.test.js
@@ -1,0 +1,195 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function loadOEmbedHandler(fetchImpl) {
+  const context = {
+    URL,
+    Response,
+    Headers,
+    TextEncoder,
+    fetch: fetchImpl
+  };
+  vm.createContext(context);
+  const source = fs.readFileSync(path.join(ROOT, 'functions/api/youtube/oembed.js'), 'utf8')
+    .replace(/export\s+async\s+function\s+onRequestGet/, 'async function onRequestGet');
+  vm.runInContext(`${source}\nwindow = {}; window.onRequestGet = onRequestGet;`, context);
+  return context.window.onRequestGet;
+}
+
+async function readJsonResponse(response) {
+  return {
+    status: response.status,
+    body: await response.json(),
+    cacheControl: response.headers.get('cache-control')
+  };
+}
+
+test('YouTube oEmbed proxy rejects non-YouTube URLs before upstream fetch', async () => {
+  let fetchCalled = false;
+  const handler = loadOEmbedHandler(async () => {
+    fetchCalled = true;
+    return new Response('{}', { status: 200 });
+  });
+
+  const response = await handler({
+    request: new Request('https://example.test/api/youtube/oembed?url=https%3A%2F%2Fexample.com%2Fwatch%3Fv%3DdQw4w9WgXcQ')
+  });
+  const result = await readJsonResponse(response);
+
+  assert.equal(result.status, 400);
+  assert.equal(result.body.error, 'Invalid YouTube URL');
+  assert.equal(fetchCalled, false);
+});
+
+test('YouTube oEmbed proxy returns sanitized channel metadata for standard watch URL', async () => {
+  let requestedUrl = '';
+  const handler = loadOEmbedHandler(async (url) => {
+    requestedUrl = String(url);
+    return new Response(JSON.stringify({
+      author_name: '우아한형제들',
+      author_url: 'https://www.youtube.com/@woowayoung?sub_confirmation=1#x'
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+  });
+
+  const response = await handler({
+    request: new Request('https://example.test/api/youtube/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ')
+  });
+  const result = await readJsonResponse(response);
+
+  assert.equal(result.status, 200);
+  assert.match(requestedUrl, /https:\/\/www\.youtube\.com\/oembed/);
+  assert.equal(result.body.channelId, '@woowayoung');
+  assert.equal(result.body.channelName, '우아한형제들');
+  assert.equal(result.body.channelUrl, 'https://www.youtube.com/@woowayoung');
+});
+
+test('YouTube oEmbed proxy degrades to null channel fields on upstream failure', async () => {
+  const handler = loadOEmbedHandler(async () => new Response('not found', { status: 404 }));
+
+  const response = await handler({
+    request: new Request('https://example.test/api/youtube/oembed?url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ')
+  });
+  const result = await readJsonResponse(response);
+
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, {
+    channelId: null,
+    channelName: null,
+    channelUrl: null
+  });
+});
+
+function createEditorFormContext(apiClient) {
+  const noopElement = {
+    style: {},
+    classList: { add() {}, remove() {}, toggle() {} },
+    dataset: {},
+    value: '',
+    addEventListener() {},
+    removeEventListener() {},
+    closest: () => null,
+    contains: () => false,
+    focus() {},
+    getAttribute: () => '',
+    setAttribute() {},
+    removeAttribute() {}
+  };
+
+  const context = {
+    console,
+    setTimeout,
+    window: {
+      apiClient,
+      LoveBudEditorMemoryFormMode: {},
+      LoveBudEditorMemoryFormPreview: {},
+      LoveBudEditorMemoryFormTime: {},
+      LoveBudEditorMemoryFormPayload: {}
+    },
+    document: {
+      getElementById: () => ({ ...noopElement }),
+      querySelector: () => ({ ...noopElement }),
+      addEventListener() {},
+      removeEventListener() {}
+    }
+  };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/editor/editor-memory-form.js'), 'utf8'), context);
+  return context;
+}
+
+function buildForm(context) {
+  return context.window.createEditorMemoryForm({
+    i18n: (key) => key,
+    treeId: 'tree-1',
+    getSelectedNodeId: () => 'root',
+    getCanonicalRootId: () => 'root',
+    resolveParentIdForCreate: () => 'root',
+    updateSaveStatus: () => {},
+    showToast: () => {},
+    getYouTubeInputErrorMessage: () => 'invalid',
+    nextMemoryId: () => 'memory-1',
+    normalizeMemory: (memory) => memory,
+    getTreeMemories: () => [],
+    setTreeMemories: () => {},
+    setLocalSaveMode: () => {},
+    drawNode: () => {},
+    drawBranch: () => {},
+    calcPosition: () => ({}),
+    updateSidebarStatus: () => {},
+    updateFocusSelectedBtn: () => {},
+    setDetailEmptyState: () => {},
+    selectNode: () => {},
+    treeMemories: () => [],
+    setCachedMemories: () => {},
+    rerenderCanvas: () => {},
+    focusNodeById: () => {}
+  });
+}
+
+test('editor memory form enriches YouTube payload when oEmbed channel metadata is available', async () => {
+  const context = createEditorFormContext({
+    getYouTubeOEmbedChannel: async () => ({
+      channelId: '@woowayoung',
+      channelName: '우아한형제들',
+      channelUrl: 'https://www.youtube.com/@woowayoung'
+    })
+  });
+  const form = buildForm(context);
+
+  const payload = await form.enrichPayloadChannelMetadata({
+    sourceType: 'youtube',
+    sourceUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ'
+  }, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+  assert.equal(payload.channelId, '@woowayoung');
+  assert.equal(payload.channelName, '우아한형제들');
+  assert.equal(payload.channelUrl, 'https://www.youtube.com/@woowayoung');
+});
+
+test('editor memory form keeps save payload when oEmbed channel enrichment fails', async () => {
+  const context = createEditorFormContext({
+    getYouTubeOEmbedChannel: async () => {
+      throw new Error('network down');
+    }
+  });
+  const form = buildForm(context);
+  const originalPayload = {
+    sourceType: 'youtube',
+    sourceUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+    title: 'Keep me'
+  };
+
+  const payload = await form.enrichPayloadChannelMetadata(originalPayload, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+  assert.equal(payload, originalPayload);
+  assert.equal(payload.channelName, undefined);
+  assert.equal(payload.title, 'Keep me');
+});


### PR DESCRIPTION
# Summary

Issue #1234 final enrichment slice — enrich standard YouTube `watch?v=` / `youtu.be` URLs with channel metadata via a same-origin Cloudflare oEmbed proxy.

## Scope

- Add `GET /api/youtube/oembed?url=...` Cloudflare Pages Function.
- Proxy YouTube oEmbed without requiring an API key.
- Return only sanitized channel metadata:
  - `channelId`
  - `channelName`
  - `channelUrl`
- Accept only HTTPS YouTube/youtu.be video URLs.
- Degrade gracefully to nullable channel fields if upstream oEmbed fails.
- Add `apiClient.getYouTubeOEmbedChannel(url)`.
- Enrich editor memory create payload immediately before save when:
  - `sourceType === 'youtube'`
  - channel fields are not already present from URL-visible parsing
  - the oEmbed API method is available
- Preserve save behavior if oEmbed enrichment fails.
- Add contract tests for route validation, upstream success, upstream failure, payload enrichment, and enrichment failure fallback.

## Not included

- No YouTube Data API key usage.
- No DB/schema/backend Modal changes.
- No public viewer/detail rendering changes.
- No search/card display changes.
- No backfill of existing memories.

## Files changed

- `functions/api/youtube/oembed.js`
- `js/postgres-client.js`
- `js/editor/editor-memory-form.js`
- `tests/contracts/youtube-oembed-channel-enrichment-contract.test.js`

## Safety / guardrails

- Same-origin frontend call only: `/api/youtube/oembed`.
- No credentials, cookies, tokens, DB URLs, or env values are exposed.
- The proxy only returns channel fields, never the full oEmbed payload.
- Input URLs must be HTTPS YouTube/youtu.be video URLs.
- Channel URLs are sanitized to HTTPS YouTube handle/channel paths only.
- Upstream oEmbed failure returns null channel fields and must not block saving.
- PR #7 / prototype / reference / demo / variant / quiet paths: untouched.
- Issue close keyword: not used.

## Validation

- Contract tests added.
- Needs CI confirmation.
- Needs test5/browser smoke before ready/merge.

Refs #1234