### PR TITLE
fix(editor): remove sidebar dead entrypoint wiring

### DIFF
--- a/css/editor/editor-overrides.css
+++ b/css/editor/editor-overrides.css
@@ -60,16 +60,6 @@
     line-height: 1.35;
 }
 
-.editor-sidebar-meta {
-    display: block;
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px dashed var(--outline-variant);
-    font-size: 11px;
-    line-height: 1.5;
-    color: var(--on-surface-variant);
-}
-
 .editor-status-card {
     background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(250,246,244,0.96));
     box-shadow: 0 8px 20px rgba(75, 64, 57, 0.05);
@@ -78,7 +68,6 @@
 .editor-status-card,
 .editor-status-card strong,
 .editor-status-card p,
-.editor-sidebar-meta,
 .detail-panel h3,
 .detail-panel label,
 .detail-panel p,
@@ -230,7 +219,6 @@ body .editor-memory-mode-chip.is-active {
 
 /* Editor page presentation overrides extracted from pages/editor.html */
 
-
 .editor-layout {
     background: linear-gradient(180deg, var(--surface) 0%, var(--surface-container-low) 52%, var(--surface-container) 100%);
     gap: 18px;
@@ -303,6 +291,7 @@ body .editor-memory-mode-chip.is-active {
     background: linear-gradient(180deg,rgba(255,253,249,0.96),rgba(255,246,239,0.88));
     border: 1px solid rgba(233,215,201,0.82);
     box-shadow: 0 18px 40px rgba(161,119,96,0.10);
+    margin-top: 0;
 }
 
 .editor-status-card .editor-reference-kicker {
@@ -380,19 +369,13 @@ body .editor-memory-mode-chip.is-active {
     text-align: center;
 }
 
-
 .editor-status-section > h3,
 .editor-flow-lead,
 #sidebarMomentCount,
-#sidebarSelectionHint,
 .editor-add-section-bottom,
 .editor-tree-meta-section,
 #detailEmptyStartBtn {
     display: none !important;
-}
-
-.editor-status-card {
-    margin-top: 0;
 }
 
 .editor-canvas-empty-guide__desc {

--- a/css/editor/editor-sidebar.css
+++ b/css/editor/editor-sidebar.css
@@ -109,67 +109,6 @@
     word-break: keep-all;
 }
 
-/* Quiet-first tree summary card polish — entrypoints */
-.editor-sidebar-entrypoints {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    margin-top: 10px;
-}
-
-.editor-sidebar-entry-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 9px 12px;
-    border-radius: 10px;
-    border: 1px solid rgba(144, 73, 81, 0.10);
-    background: rgba(144, 73, 81, 0.04);
-    color: var(--primary);
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1.4;
-    cursor: pointer;
-    transition: background .18s ease, border-color .18s ease;
-    text-align: left;
-}
-
-.editor-sidebar-entry-btn:hover:not(:disabled) {
-    background: rgba(144, 73, 81, 0.09);
-    border-color: rgba(144, 73, 81, 0.16);
-}
-
-.editor-sidebar-entry-btn:disabled {
-    opacity: 0.5;
-    cursor: default;
-    background: transparent;
-    border-color: rgba(144, 73, 81, 0.06);
-}
-
-.editor-sidebar-entry-btn .material-symbols-outlined {
-    font-size: 18px;
-    opacity: 0.8;
-}
-
-.editor-sidebar-entry-badge {
-    font-size: 10px;
-    font-weight: 700;
-    padding: 2px 7px;
-    border-radius: 999px;
-    background: var(--surface-container-low);
-    color: var(--on-surface-note);
-    margin-left: auto;
-    line-height: 1.3;
-}
-
-/* Issue #1128: keep the current MVP sidebar focused on tree summary, not placeholder actions. */
-.editor-status-card .editor-sidebar-entrypoints,
-.editor-status-card #sidebarPublicViewerBtn,
-.editor-status-card #sidebarInsightsBtn {
-    display: none !important;
-}
-
 .editor-status-card .editor-flow-summary {
     display: block !important;
 }

--- a/js/editor/editor-detail-sidebar-status-boundary.js
+++ b/js/editor/editor-detail-sidebar-status-boundary.js
@@ -8,19 +8,6 @@
             getTreeState
         } = deps;
 
-        const updateEntrypoints = () => {
-            const publicViewerBtn = document.getElementById('sidebarPublicViewerBtn');
-            const insightsBtn = document.getElementById('sidebarInsightsBtn');
-
-            // Hide sidebar action buttons; replaced by tree summary (#1128)
-            if (publicViewerBtn) {
-                publicViewerBtn.style.display = 'none';
-            }
-            if (insightsBtn) {
-                insightsBtn.style.display = 'none';
-            }
-        };
-
         const updateFlowSummary = (treeState) => {
             const flowSummaryEl = document.getElementById('sidebarFlowSummary');
             if (!flowSummaryEl) return;
@@ -48,8 +35,6 @@
 
         const updateSidebarStatus = () => {
             const treeTitleEl = document.getElementById('sidebarTreeTitle');
-            const flowSummaryEl = document.getElementById('sidebarFlowSummary');
-            const hintEl = document.getElementById('sidebarSelectionHint');
             const currentTreeData = getCurrentTreeData();
             const treeState = getTreeState();
 
@@ -59,28 +44,6 @@
 
             // Tree-level summary (replaces moment-selected summary, #1128)
             updateFlowSummary(treeState);
-
-            if (hintEl) {
-                // Tree cue based on first visible moment title
-                const firstMoment = treeState.treeMemories.find(m => m.id !== 'root' && m.parentId);
-                if (firstMoment?.title) {
-                    hintEl.textContent = formatI18nText(
-                        'sidebar_flow_cue_first_moment',
-                        '첫 순간 "{title}"에서 이어진 감정 흐름을 정리하고 있어요.',
-                        { title: firstMoment.title }
-                    );
-                } else {
-                    hintEl.textContent = formatI18nText(
-                        'sidebar_flow_cue_empty',
-                        '캔버스에서 순간을 선택하면 오른쪽 패널에서 자세히 볼 수 있어요.'
-                    );
-                }
-                hintEl.style.fontStyle = 'normal';
-                hintEl.style.color = 'var(--on-surface-variant)';
-            }
-
-            // Update entrypoints (public viewer, insights)
-            updateEntrypoints();
 
             const addMemoryBtnLabel = document.getElementById('addMemoryBtnLabel');
             const addMemoryEyebrow = document.getElementById('addMemoryEyebrow');

--- a/js/editor/editor-dom-selectors.js
+++ b/js/editor/editor-dom-selectors.js
@@ -30,12 +30,6 @@
         sidebarTreeTitle: 'sidebarTreeTitle',
         renameTreeBtn: 'renameTreeBtn',
         sidebarFlowSummary: 'sidebarFlowSummary',
-        sidebarSelectionHint: 'sidebarSelectionHint',
-        sidebarPublicViewerBtn: 'sidebarPublicViewerBtn',
-        sidebarPublicViewerLabel: 'sidebarPublicViewerLabel',
-        sidebarInsightsBtn: 'sidebarInsightsBtn',
-        sidebarInsightsLabel: 'sidebarInsightsLabel',
-        sidebarInsightsBadge: 'sidebarInsightsBadge',
 
         // Add memory section
         addMemoryEyebrow: 'addMemoryEyebrow',

--- a/js/editor/editor-i18n-refresh.js
+++ b/js/editor/editor-i18n-refresh.js
@@ -276,16 +276,6 @@
         flowSummaryEl.textContent = tText('sidebar_flow_summary_connected', '{count}개의 순간이 이어진 러브트리예요.').replace('{count}', String(count));
       }
     }
-
-    var selectionHintEl = document.getElementById('sidebarSelectionHint');
-    if (selectionHintEl) {
-      var firstMoment = memories.find(function(m) { return m && m.id !== rootId && m.parentId; });
-      if (firstMoment && firstMoment.title) {
-        selectionHintEl.textContent = tText('sidebar_flow_cue_first_moment', '첫 순간 "{title}"에서 이어진 감정 흐름을 정리하고 있어요.').replace('{title}', firstMoment.title);
-      } else {
-        selectionHintEl.textContent = tText('sidebar_flow_cue_empty', '캔버스에서 순간을 선택하면 오른쪽 패널에서 자세히 볼 수 있어요.');
-      }
-    }
   }
 
   function refreshEditorLanguage() {

--- a/js/editor/editor-rename-ui.js
+++ b/js/editor/editor-rename-ui.js
@@ -53,30 +53,13 @@ function bindEditorRenameButton(buttonEl) {
     });
 }
 
-function enhanceEditorSidebarHint() {
-    const i18n = getEditorRenameI18n();
-    const legacyButton = document.getElementById('renameTreeSidebarBtn');
-    const hintEl = document.getElementById('sidebarSelectionHint');
-
-    if (legacyButton) {
-        legacyButton.remove();
-    }
-
-    if (!hintEl) return;
-
-    const baseHint = hintEl.dataset.baseHintText || hintEl.textContent || (i18n('sidebar_first_moment_hint') || '첫 순간을 추가해 트리를 시작해 보세요.');
-    hintEl.dataset.baseHintText = baseHint;
-}
-
 function injectEditorRenameButton() {
     bindEditorRenameButton(document.getElementById('renameTreeBtn'));
     bindEditorRenameButton(document.getElementById('sidebarTitleEditBtn'));
-    enhanceEditorSidebarHint();
 }
 
 window.syncEditorTreeTitle = syncEditorTreeTitle;
 window.bindEditorRenameButton = bindEditorRenameButton;
-window.enhanceEditorSidebarHint = enhanceEditorSidebarHint;
 window.injectEditorRenameButton = injectEditorRenameButton;
 
 document.addEventListener('DOMContentLoaded', injectEditorRenameButton);

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -33,18 +33,6 @@
                     <button type="button" id="renameTreeBtn" class="icon-menu-btn editor-rename-btn" aria-label="트리 제목 수정" title="트리 제목 수정">제목 수정</button>
                     </div>
                     <p id="sidebarFlowSummary" class="editor-flow-summary"></p>
-                    <div class="editor-sidebar-entrypoints">
-                        <button type="button" class="editor-sidebar-entry-btn" id="sidebarPublicViewerBtn" disabled>
-                            <span class="material-symbols-outlined" aria-hidden="true">visibility</span>
-                            <span id="sidebarPublicViewerLabel">공개 화면 보기</span>
-                        </button>
-                        <button type="button" class="editor-sidebar-entry-btn editor-sidebar-entry-btn-disabled" id="sidebarInsightsBtn" disabled>
-                            <span class="material-symbols-outlined" aria-hidden="true">insights</span>
-                            <span id="sidebarInsightsLabel">트리 인사이트</span>
-                            <span class="editor-sidebar-entry-badge" id="sidebarInsightsBadge">준비 중</span>
-                        </button>
-                    </div>
-                    <span id="sidebarSelectionHint" class="editor-sidebar-meta"></span>
                 </div>
             </section>
 


### PR DESCRIPTION
# Summary

Follow-up cleanup for Issue #1128 — remove Editor left-sidebar placeholder action DOM and obsolete hidden wiring instead of keeping it CSS-hidden.

## Scope

- Remove dead sidebar entrypoint DOM from `pages/editor.html`:
  - `#sidebarPublicViewerBtn`
  - `#sidebarInsightsBtn`
  - related labels/badge wrapper
- Remove `#sidebarSelectionHint` from the Editor sidebar DOM.
- Remove dead selector registry entries from `js/editor/editor-dom-selectors.js`.
- Remove runtime wiring that only hid or updated removed sidebar elements:
  - `editor-detail-sidebar-status-boundary.js`
  - `editor-i18n-refresh.js`
  - `editor-rename-ui.js`
- Remove redundant CSS for removed sidebar elements from:
  - `css/editor/editor-overrides.css`
  - `css/editor/editor-sidebar.css`

## Not included

- No backend/API/Auth/DB/schema changes.
- No My Trees hub work.
- No Tree Insights implementation.
- No public viewer changes.
- No PR #7 / prototype / reference / demo / variant changes.

## Files changed

- `pages/editor.html`
- `js/editor/editor-dom-selectors.js`
- `js/editor/editor-detail-sidebar-status-boundary.js`
- `js/editor/editor-i18n-refresh.js`
- `js/editor/editor-rename-ui.js`
- `css/editor/editor-overrides.css`
- `css/editor/editor-sidebar.css`

## Validation

- Needs CI confirmation.
- Needs editor browser smoke before ready/merge.

## Smoke checklist

- Editor loads without fatal JS errors.
- `#sidebarPublicViewerBtn` does not exist in DOM.
- `#sidebarInsightsBtn` does not exist in DOM.
- `#sidebarSelectionHint` does not exist in DOM.
- Tree title still renders.
- Rename tree button still works.
- Sidebar flow summary still updates with moment count.
- Back to My Trees link still works.
- Desktop layout stable.
- Mobile/narrow layout not worsened.

Refs #1128