### PR TITLE
chore(editor): remove orphan sidebar entrypoint CSS

### DIFF
--- a/css/editor/editor-responsive.css
+++ b/css/editor/editor-responsive.css
@@ -201,8 +201,7 @@
     }
 
     .editor-flow-summary,
-    .editor-sidebar-meta,
-    .editor-sidebar-entrypoints {
+    .editor-sidebar-meta {
         display: none;
     }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup after #1128 final audit (PR #1262).

The final audit identified one harmless orphaned CSS selector that was not caught by the main cleanup:

- `.editor-sidebar-entrypoints` in `css/editor/editor-responsive.css`

This selector targets a class that no longer exists in any DOM element — the class definition was removed in PR #1262 (`css/editor/editor-sidebar.css` -61 lines) and no HTML/JS element references this class.

### Change

- Remove `.editor-sidebar-entrypoints` from the multi-selector rule in `@media (max-width: 768px)` block
- Live selectors (`.editor-flow-summary`, `.editor-sidebar-meta`) preserved

### Safety

| Item | Status |
|------|--------|
| 🟢 Runtime DOM already removed | #1262 (0d53a2e) |
| 🟢 No JS/HTML changes | ✅ |
| 🟢 No CSS class definition remaining | ✅ |
| 🟢 No backend/API/Auth/DB/schema changes | ✅ |
| 🟢 No feature changes | ✅ |
| 🟢 No issue close keywords used | ✅ |

### Verification

- `editor-sidebar-entrypoints`: not found in any file (non-md, non-node_modules)
- `editor-sidebar-entry-btn`: not found
- `editor-sidebar-entry-badge`: not found
- `sidebarPublicViewerBtn`: not found
- `sidebarInsightsBtn`: not found
- `sidebarSelectionHint`: not found

### Smoke

Draft PR — smoke required after CI PASS and test5 SHA matches PR head.