### PR TITLE
chore(editor): remove orphan detail panel CSS

### DIFF
--- a/css/editor/editor-detail-panel.css
+++ b/css/editor/editor-detail-panel.css
@@ -368,8 +368,7 @@
 
 .editor-form-field,
 .editor-form-field-grid,
-.editor-form-stack,
-.editor-form-field-last {
+.editor-form-stack {
     display: flex;
     flex-direction: column;
     gap: 10px;


### PR DESCRIPTION
### Summary

Remove orphan CSS selector from editor detail panel.

### Changes

```diff
- .editor-form-field-last {
+ (removed — no JS/HTML runtime references)
```

### Details

- `.editor-form-field-last` was defined in a combined CSS rule but never referenced by any JS/HTML file
- Only this orphan selector removed; all other selectors in the combined rule preserved
- Verified zero JS/HTML references across full codebase
- **Feature change:** none
- **UX change:** none
- **JS/HTML/backend/API/Auth/DB/schema change:** none
- Sidebar orphan CSS excluded from this PR
- Issue close keyword not used

### Smoke needed

- [ ] editor.html existing tree access
- [ ] No fatal JS errors
- [ ] Detail panel normal display
- [ ] Moment selection → detail panel content updates correctly
- [ ] Memo/detail area normal display
- [ ] Inline edit related actions no regression
- [ ] Action button area no regression
- [ ] Desktop layout no regression
- [ ] Narrow/mobile layout no regression
- [ ] No sensitive info exposure