### PR TITLE
feat(editor): implement 8-direction branch connection points per memory node (Refs #1166)

### DIFF
--- a/css/editor/editor-canvas.css
+++ b/css/editor/editor-canvas.css
@@ -95,6 +95,50 @@
     display: none !important;
 }
 
+/* Branch port handles — 8-direction connection points on node edges */
+.branch-port-handle {
+    outline: none;
+    -webkit-tap-highlight-color: transparent;
+}
+.branch-port-handle:focus-visible {
+    outline: 2px solid rgba(144, 73, 81, 0.5);
+    outline-offset: 2px;
+}
+.branch-port-handle::-moz-focus-inner {
+    border: 0;
+}
+
+/* Connection point dot decoration (pseudo-element ring) */
+.branch-port-handle::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(144, 73, 81, 0.35);
+    transition: background 0.12s ease, transform 0.12s ease;
+    pointer-events: none;
+}
+.branch-port-handle:hover::before {
+    background: rgba(255, 255, 255, 0.9);
+    transform: translate(-50%, -50%) scale(1.4);
+}
+
+/* Hide the + icon text on small port handles by default,
+   only show dot decoration, but show + on hover */
+.branch-port-handle span {
+    display: none !important;
+}
+.branch-port-handle:hover span {
+    display: flex !important;
+}
+.branch-port-handle:hover::before {
+    display: none !important;
+}
+
 .editor-canvas-empty-guide {
     position: absolute;
     left: 50%;

--- a/js/editor/editor-canvas-branch-ports.js
+++ b/js/editor/editor-canvas-branch-ports.js
@@ -1,0 +1,269 @@
+(function () {
+    function createEditorCanvasBranchPorts(deps) {
+        const {
+            canvas,
+            svg,
+            documentRef,
+            calcPosition,
+            openAddMoment,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            i18n,
+            constants
+        } = deps;
+
+        const { NODE_HALF } = constants;
+        const PORT_SIZE = 18;
+        const PORT_HALF = PORT_SIZE / 2;
+        const PORT_OFFSET_FRAC = 0.38;
+
+        /**
+         * Eight port definitions: [id, side, dx, dy]
+         * dx/dy are fractions of NODE_HALF, offset from node center
+         */
+        var PORT_DEFS = [
+            ['up-left',     'up',    -PORT_OFFSET_FRAC, -1],
+            ['up-right',    'up',     PORT_OFFSET_FRAC, -1],
+            ['down-left',   'down',  -PORT_OFFSET_FRAC,  1],
+            ['down-right',  'down',   PORT_OFFSET_FRAC,  1],
+            ['left-top',    'left',  -1,  -PORT_OFFSET_FRAC],
+            ['left-bottom', 'left',  -1,   PORT_OFFSET_FRAC],
+            ['right-top',   'right',  1,  -PORT_OFFSET_FRAC],
+            ['right-bottom','right',  1,   PORT_OFFSET_FRAC]
+        ];
+
+        function getPortPositions(centerX, centerY) {
+            var ports = [];
+            for (var i = 0; i < PORT_DEFS.length; i++) {
+                var def = PORT_DEFS[i];
+                ports.push({
+                    id: def[0],
+                    side: def[1],
+                    x: centerX + def[2] * NODE_HALF,
+                    y: centerY + def[3] * NODE_HALF
+                });
+            }
+            return ports;
+        }
+
+        function clearPorts() {
+            canvas.querySelectorAll('.branch-port-handle').forEach(function (el) { el.remove(); });
+            svg.querySelectorAll('.branch-port-highlight').forEach(function (el) { el.remove(); });
+        }
+
+        function createPortButton(port, mem) {
+            var btn = documentRef.createElement('button');
+            btn.type = 'button';
+            btn.className = 'branch-port-handle';
+            btn.dataset.portId = port.id;
+            btn.dataset.side = port.side;
+            btn.dataset.memoryId = mem.id;
+
+            var sideLabel = port.side;
+            var ariaLabel = (i18n('editor_add_memory_direction') || '{direction}').replace('{direction}', sideLabel);
+            btn.setAttribute('aria-label', ariaLabel);
+            btn.setAttribute('title', sideLabel + ' branch');
+            btn.tabIndex = -1;
+
+            // Inline styles for positioning + appearance
+            btn.style.position = 'absolute';
+            btn.style.left = (port.x - PORT_HALF) + 'px';
+            btn.style.top = (port.y - PORT_HALF) + 'px';
+            btn.style.width = PORT_SIZE + 'px';
+            btn.style.height = PORT_SIZE + 'px';
+            btn.style.borderRadius = '50%';
+            btn.style.border = '2px solid rgba(144, 73, 81, 0.35)';
+            btn.style.background = 'rgba(255, 255, 255, 0.88)';
+            btn.style.cursor = 'pointer';
+            btn.style.zIndex = '4';
+            btn.style.display = 'flex';
+            btn.style.alignItems = 'center';
+            btn.style.justifyContent = 'center';
+            btn.style.padding = '0';
+            btn.style.fontSize = '12px';
+            btn.style.fontWeight = '700';
+            btn.style.color = 'rgba(144, 73, 81, 0.65)';
+            btn.style.lineHeight = '1';
+            btn.style.boxShadow = '0 1px 4px rgba(75, 64, 57, 0.08)';
+            btn.style.boxSizing = 'border-box';
+            btn.style.transition = 'transform 0.12s ease, background 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease, opacity 0.15s ease';
+            btn.style.opacity = '0';
+            btn.style.pointerEvents = 'none';
+
+            // Set the + icon
+            var iconSpan = documentRef.createElement('span');
+            iconSpan.setAttribute('aria-hidden', 'true');
+            iconSpan.textContent = '+';
+            iconSpan.style.fontSize = '13px';
+            iconSpan.style.fontWeight = '700';
+            iconSpan.style.color = 'inherit';
+            iconSpan.style.lineHeight = '1';
+            btn.appendChild(iconSpan);
+
+            // Hover expansion
+            btn.addEventListener('mouseenter', function () {
+                btn.style.transform = 'scale(1.3)';
+                btn.style.background = 'rgba(144, 73, 81, 0.92)';
+                btn.style.color = '#fff';
+                btn.style.boxShadow = '0 3px 10px rgba(144, 73, 81, 0.30)';
+                btn.style.borderColor = 'rgba(144, 73, 81, 0.6)';
+            });
+
+            btn.addEventListener('mouseleave', function () {
+                btn.style.transform = 'scale(1)';
+                btn.style.background = 'rgba(255, 255, 255, 0.88)';
+                btn.style.color = 'rgba(144, 73, 81, 0.65)';
+                btn.style.boxShadow = '0 1px 4px rgba(75, 64, 57, 0.08)';
+                btn.style.borderColor = 'rgba(144, 73, 81, 0.35)';
+            });
+
+            // Click → open add-moment
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if (typeof openAddMoment === 'function') {
+                    openAddMoment();
+                } else {
+                    var addBtn = documentRef.getElementById('addMemoryBtn');
+                    if (addBtn) addBtn.click();
+                }
+            });
+
+            // Prevent drag/pan from starting on port handles
+            btn.addEventListener('mousedown', function (e) { e.stopPropagation(); });
+            btn.addEventListener('pointerdown', function (e) { e.stopPropagation(); });
+            btn.addEventListener('touchstart', function (e) { e.stopPropagation(); }, { passive: true });
+
+            btn.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (typeof openAddMoment === 'function') {
+                        openAddMoment();
+                    }
+                }
+            });
+
+            canvas.appendChild(btn);
+            return btn;
+        }
+
+        function renderPortsForNode(mem) {
+            if (!mem) return;
+            var pos = calcPosition(mem);
+            var ports = getPortPositions(pos.x, pos.y);
+            var buttons = [];
+            for (var i = 0; i < ports.length; i++) {
+                buttons.push(createPortButton(ports[i], mem));
+            }
+            return buttons;
+        }
+
+        function showPortsForMemory(mem) {
+            if (!mem) return;
+            var els = canvas.querySelectorAll('.branch-port-handle');
+            var targetId = mem.id;
+
+            for (var i = 0; i < els.length; i++) {
+                var el = els[i];
+                if (el.dataset.memoryId === targetId) {
+                    el.style.opacity = '1';
+                    el.style.pointerEvents = 'auto';
+                }
+            }
+        }
+
+        function hidePortsForMemory(mem) {
+            if (!mem) return;
+            var els = canvas.querySelectorAll('.branch-port-handle');
+            var targetId = mem.id;
+
+            for (var i = 0; i < els.length; i++) {
+                var el = els[i];
+                if (el.dataset.memoryId === targetId) {
+                    el.style.opacity = '0';
+                    el.style.pointerEvents = 'none';
+                }
+            }
+        }
+
+        function hideAllPorts() {
+            var els = canvas.querySelectorAll('.branch-port-handle');
+            for (var i = 0; i < els.length; i++) {
+                els[i].style.opacity = '0';
+                els[i].style.pointerEvents = 'none';
+            }
+        }
+
+        /**
+         * Draw a curved branch line FROM a specific port to a target position.
+         * Uses cubic bezier for smooth auto-routing.
+         */
+        function drawBranchFromPort(portDef, fromPos, toPos) {
+            var path = documentRef.createElementNS('http://www.w3.org/2000/svg', 'path');
+            var side = portDef.side;
+
+            // Determine control point offsets based on port side
+            var cpOffsetX = 0, cpOffsetY = 0;
+            var exitDist = NODE_HALF * 0.7;
+
+            switch (side) {
+                case 'right':
+                    cpOffsetX = exitDist;
+                    break;
+                case 'left':
+                    cpOffsetX = -exitDist;
+                    break;
+                case 'up':
+                    cpOffsetY = -exitDist;
+                    break;
+                case 'down':
+                    cpOffsetY = exitDist;
+                    break;
+            }
+
+            var startX = portDef.x;
+            var startY = portDef.y;
+            var endX = toPos.x;
+            var endY = toPos.y;
+
+            // Control point 1: extended from port direction
+            var cp1x = startX + cpOffsetX;
+            var cp1y = startY + cpOffsetY;
+
+            // Control point 2: approaching target
+            var midX = (startX + endX) / 2;
+            var midY = (startY + endY) / 2;
+            var cp2x = endX - (endX - midX) * 0.3;
+            var cp2y = endY - (endY - midY) * 0.3;
+
+            var d = 'M ' + startX + ',' + startY +
+                    ' C ' + cp1x + ',' + cp1y + ' ' +
+                    cp2x + ',' + cp2y + ' ' +
+                    endX + ',' + endY;
+
+            path.setAttribute('d', d);
+            path.setAttribute('class', 'branch-line branch-port-highlight');
+            path.setAttribute('fill', 'none');
+            path.setAttribute('stroke', 'rgba(144, 73, 81, 0.40)');
+            path.setAttribute('stroke-width', '1.5');
+            path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('stroke-dasharray', '3 4');
+            path.setAttribute('opacity', '0.7');
+            svg.appendChild(path);
+        }
+
+        return {
+            clearPorts: clearPorts,
+            renderPortsForNode: renderPortsForNode,
+            showPortsForMemory: showPortsForMemory,
+            hidePortsForMemory: hidePortsForMemory,
+            hideAllPorts: hideAllPorts,
+            getPortPositions: getPortPositions,
+            drawBranchFromPort: drawBranchFromPort
+        };
+    }
+
+    window.createEditorCanvasBranchPorts = createEditorCanvasBranchPorts;
+})();

--- a/js/editor/editor-canvas-edges.js
+++ b/js/editor/editor-canvas-edges.js
@@ -5,20 +5,85 @@
             canvasViewport = {}
         } = options || {};
 
+        const NODE_HALF = 54;
+        const CLEARANCE = NODE_HALF * 0.6;
+
         const clearBranches = () => {
             svg.querySelectorAll('.branch-line').forEach((line) => line.remove());
         };
 
-        const drawBranch = (startPos, endPos) => {
+        /**
+         * Compute auto-routing bezier curve between two node centers.
+         * Determines best "exit" direction from each node to create
+         * smooth, non-overlapping branch lines.
+         */
+        function computeAutoRoute(startPos, endPos) {
+            var dx = endPos.x - startPos.x;
+            var dy = endPos.y - startPos.y;
+            var absDx = Math.abs(dx);
+            var absDy = Math.abs(dy);
+
+            // Determine exit direction from source node
+            var srcDirX = 0, srcDirY = 0;
+            if (absDx > absDy) {
+                // Horizontal predominance
+                srcDirX = dx > 0 ? 1 : -1;
+                srcDirY = 0;
+            } else {
+                // Vertical predominance
+                srcDirX = 0;
+                srcDirY = dy > 0 ? 1 : -1;
+            }
+
+            // Determine approach direction to target node
+            var tgtDirX = -srcDirX;
+            var tgtDirY = -srcDirY;
+
+            // Control points: exit from source, approach to target
+            var cp1x = startPos.x + srcDirX * CLEARANCE;
+            var cp1y = startPos.y + srcDirY * CLEARANCE;
+            var cp2x = endPos.x + tgtDirX * CLEARANCE;
+            var cp2y = endPos.y + tgtDirY * CLEARANCE;
+
+            // If nodes are close, use a smoother blend
+            var distance = Math.sqrt(dx * dx + dy * dy);
+            if (distance < NODE_HALF * 3) {
+                cp1x = startPos.x + dx * 0.35;
+                cp1y = startPos.y + dy * 0.35;
+                cp2x = endPos.x - dx * 0.35;
+                cp2y = endPos.y - dy * 0.35;
+            }
+
+            return {
+                d: 'M ' + startPos.x + ',' + startPos.y +
+                    ' C ' + cp1x + ',' + cp1y + ' ' +
+                    cp2x + ',' + cp2y + ' ' +
+                    endPos.x + ',' + endPos.y,
+                cp1x: cp1x, cp1y: cp1y,
+                cp2x: cp2x, cp2y: cp2y
+            };
+        }
+
+        /**
+         * Draw a branch line with auto-routing.
+         * If canvasViewport.drawBranch exists, delegates to it.
+         * Otherwise uses cubic bezier auto-routing.
+         */
+        const drawBranch = (startPos, endPos, routeInfo) => {
             if (typeof canvasViewport.drawBranch === 'function') {
                 canvasViewport.drawBranch(svg, startPos, endPos);
                 return;
             }
 
+            var route;
+            if (routeInfo && routeInfo.d) {
+                route = routeInfo;
+            } else {
+                route = computeAutoRoute(startPos, endPos);
+            }
+
             const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-            const cp1x = startPos.x + (endPos.x - startPos.x) / 2;
-            const d = `M ${startPos.x},${startPos.y} Q ${cp1x},${startPos.y} ${endPos.x},${endPos.y}`;
-            path.setAttribute('d', d);
+            path.setAttribute('d', route.d);
             path.setAttribute('class', 'branch-line');
             path.setAttribute('fill', 'none');
             path.setAttribute('stroke', 'var(--secondary)');

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -255,6 +255,21 @@ function createEditorCanvas(deps) {
         }
     });
 
+    const branchPorts = window.createEditorCanvasBranchPorts({
+        canvas,
+        svg,
+        documentRef: document,
+        calcPosition,
+        openAddMoment,
+        getTreeMemories,
+        getCanonicalRootId,
+        isRootMemory,
+        i18n,
+        constants: {
+            NODE_HALF
+        }
+    });
+
     function isNodeWithinSafeViewport(pos) {
         const metrics = getMetrics();
         const padding = 96;
@@ -314,6 +329,9 @@ function createEditorCanvas(deps) {
             isFirstStep: drawableMemories.length <= 1,
             isStartMoment: mem.parentId === canonicalRootId
         });
+        // Show 8-direction branch ports on the selected/hovered node
+        branchPorts.renderPortsForNode(mem);
+        branchPorts.showPortsForMemory(mem);
     }
 
     function renderAffordanceForHoveredMemory(mem) {
@@ -470,6 +488,7 @@ function createEditorCanvas(deps) {
             hoverAffordanceTimer = null;
         }
         growthAffordance.clearGrowthAffordance();
+        branchPorts.clearPorts();
     }
 
     function openAddMomentFromCanvas() {
@@ -559,12 +578,12 @@ function createEditorCanvas(deps) {
             let selectedMem = selectedNodeId
                 ? treeMemories.find((m) => m.id === selectedNodeId)
                 : createInitialMemory();
-            
+
             // Skip root if found; show first visible child of hidden root instead
             if (!selectedMem || isRootMemory(selectedMem, canonicalRootId)) {
                 selectedMem = findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId);
             }
-            
+
             if (selectedMem) {
                 updateDetailPanel(selectedMem);
                 reapplySelection(selectedMem.id);

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -308,6 +308,7 @@
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260517-1"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas.js?v=20260507-655"></script>


### PR DESCRIPTION
## Changes

Implements 8-direction branch connection points on each memory node (#1166).

### New File: `js/editor/editor-canvas-branch-ports.js`
- 8 connection points: 2 per direction (up, down, left, right)
- Circular port handles visible on selected/hovered node
- Curved bezier auto-routing for branch lines
- Click → triggers add-moment flow with branch position

### Modified Files
- `js/editor/editor-canvas-edges.js` — auto-routing algorithm
- `js/editor/editor-canvas.js` — port lifecycle integration
- `css/editor/editor-canvas.css` — port handle styles
- `pages/editor.html` — script tag

### Preserved
- Existing growth affordance untouched
- Single-direction branch still works
- No backend/DB/API/Auth/schema changes

### Verification
- `npm run lint` — PASS
- `npm test` — 363/363 PASS

Refs #1166