### PR TITLE
feat: implement moment-level reactions backend (DB schema + Modal + CF proxy) (Refs #1237)

### DIFF
--- a/functions/api/memories/[id]/comments.js
+++ b/functions/api/memories/[id]/comments.js
@@ -1,0 +1,122 @@
+function stripTrailingSlash(value) {
+  return String(value || '').replace(/\/$/, '');
+}
+
+function withModalHeader(response) {
+  const headers = new Headers(response.headers);
+  headers.set('x-lovebud-upstream', 'modal');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
+function buildModalUnavailableResponse() {
+  return new Response(JSON.stringify({ error: 'Modal service temporarily unavailable' }), {
+    status: 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-degraded': 'modal-unavailable'
+    }
+  });
+}
+
+export async function onRequestGet(context) {
+  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
+  if (!modalBaseUrl) {
+    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json; charset=utf-8' }
+    });
+  }
+
+  const memoryId = context.params?.id;
+  const target = new URL(`/modal/private/memories/${memoryId}/comments`, modalBaseUrl);
+
+  let response;
+  try {
+    response = await fetch(target.toString(), {
+      headers: {
+        accept: 'application/json',
+        ...(context.request.headers.get('authorization')
+          ? { authorization: context.request.headers.get('authorization') }
+          : {})
+      }
+    });
+  } catch (error) {
+    return buildModalUnavailableResponse();
+  }
+
+  return withModalHeader(response);
+}
+
+export async function onRequestPost(context) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
+    return buildPayloadTooLargeResponse();
+  }
+
+  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
+  if (!modalBaseUrl) {
+    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json; charset=utf-8' }
+    });
+  }
+
+  const memoryId = context.params?.id;
+  const target = new URL(`/modal/private/memories/${memoryId}/comments`, modalBaseUrl);
+
+  let response;
+  try {
+    response = await fetch(target.toString(), {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': request.headers.get('content-type') || 'application/json',
+        ...(request.headers.get('authorization')
+          ? { authorization: request.headers.get('authorization') }
+          : {})
+      },
+      body: bodyResult.body
+    });
+  } catch (error) {
+    return buildModalUnavailableResponse();
+  }
+
+  return withModalHeader(response);
+}

--- a/functions/api/memories/[id]/reactions.js
+++ b/functions/api/memories/[id]/reactions.js
@@ -1,0 +1,122 @@
+function stripTrailingSlash(value) {
+  return String(value || '').replace(/\/$/, '');
+}
+
+function withModalHeader(response) {
+  const headers = new Headers(response.headers);
+  headers.set('x-lovebud-upstream', 'modal');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+const MAX_BODY_SIZE = 131072; // 128KB
+
+function buildPayloadTooLargeResponse() {
+  return new Response(JSON.stringify({ error: 'Payload too large' }), {
+    status: 413,
+    headers: { 'content-type': 'application/json; charset=utf-8' }
+  });
+}
+
+async function readBoundedWriteBody(request) {
+  let bodyText;
+  try {
+    bodyText = await request.text();
+  } catch (e) {
+    return { tooLarge: true, body: null };
+  }
+
+  if (!bodyText) {
+    return { tooLarge: false, body: null };
+  }
+
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(bodyText);
+  if (encoded.byteLength > MAX_BODY_SIZE) {
+    return { tooLarge: true, body: null };
+  }
+
+  return { tooLarge: false, body: encoded };
+}
+
+function buildModalUnavailableResponse() {
+  return new Response(JSON.stringify({ error: 'Modal service temporarily unavailable' }), {
+    status: 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-degraded': 'modal-unavailable'
+    }
+  });
+}
+
+export async function onRequestGet(context) {
+  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
+  if (!modalBaseUrl) {
+    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json; charset=utf-8' }
+    });
+  }
+
+  const memoryId = context.params?.id;
+  const target = new URL(`/modal/private/memories/${memoryId}/reactions`, modalBaseUrl);
+
+  let response;
+  try {
+    response = await fetch(target.toString(), {
+      headers: {
+        accept: 'application/json',
+        ...(context.request.headers.get('authorization')
+          ? { authorization: context.request.headers.get('authorization') }
+          : {})
+      }
+    });
+  } catch (error) {
+    return buildModalUnavailableResponse();
+  }
+
+  return withModalHeader(response);
+}
+
+export async function onRequestPost(context) {
+  const { request } = context;
+
+  const bodyResult = await readBoundedWriteBody(request);
+  if (bodyResult.tooLarge) {
+    return buildPayloadTooLargeResponse();
+  }
+
+  const modalBaseUrl = stripTrailingSlash(context.env?.MODAL_BASE_URL);
+  if (!modalBaseUrl) {
+    return new Response(JSON.stringify({ error: 'MODAL_BASE_URL is not configured' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json; charset=utf-8' }
+    });
+  }
+
+  const memoryId = context.params?.id;
+  const target = new URL(`/modal/private/memories/${memoryId}/reactions`, modalBaseUrl);
+
+  let response;
+  try {
+    response = await fetch(target.toString(), {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': request.headers.get('content-type') || 'application/json',
+        ...(request.headers.get('authorization')
+          ? { authorization: request.headers.get('authorization') }
+          : {})
+      },
+      body: bodyResult.body
+    });
+  } catch (error) {
+    return buildModalUnavailableResponse();
+  }
+
+  return withModalHeader(response);
+}

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -66,6 +66,15 @@ from modal_compute.owner_writes import (
     delete_owner_memory,
     fork_public_tree,
 )
+from modal_compute.reactions import (
+    toggle_reaction,
+    fetch_reaction_summary,
+    fetch_reaction_counts,
+)
+from modal_compute.comments import (
+    create_comment,
+    fetch_comments,
+)
 
 
 def _allowed_origins() -> list[str]:
@@ -286,6 +295,54 @@ def delete_private_memory(
 ) -> dict:
     user = require_firebase_user(authorization)
     return delete_owner_memory(user["uid"], memory_id)
+
+
+# ---- Reactions ---------------------------------------------------------------
+
+
+@web_app.post("/modal/private/memories/{memory_id}/reactions")
+async def post_memory_reaction(
+    memory_id: str,
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    payload = await parse_json_body(request)
+    reaction_type = payload.get("type", "")
+    return toggle_reaction(memory_id, user["uid"], reaction_type)
+
+
+@web_app.get("/modal/private/memories/{memory_id}/reactions")
+def get_memory_reactions(
+    memory_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return fetch_reaction_summary(memory_id, user["uid"])
+
+
+# ---- Comments ----------------------------------------------------------------
+
+
+@web_app.post("/modal/private/memories/{memory_id}/comments")
+async def post_memory_comment(
+    memory_id: str,
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    payload = await parse_json_body(request)
+    body = payload.get("body", "")
+    return create_comment(memory_id, user["uid"], body)
+
+
+@web_app.get("/modal/private/memories/{memory_id}/comments")
+def get_memory_comments(
+    memory_id: str,
+    authorization: str | None = Header(default=None),
+) -> list[dict]:
+    user = require_firebase_user(authorization)
+    return fetch_comments(memory_id)
 
 
 @app.function(

--- a/modal_compute/comments.py
+++ b/modal_compute/comments.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import (
+    get_db_connection,
+    run_db_with_retry,
+)
+from modal_compute.validation import (
+    _to_isoformat,
+    validate_required_uuid,
+    validate_optional_string,
+)
+
+
+def normalize_comment_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw comments DB row into camelCase API response format."""
+    return {
+        "id": str(row["id"]),
+        "memoryId": str(row["memory_id"]),
+        "ownerId": str(row["owner_id"]),
+        "body": str(row["body"]),
+        "createdAt": _to_isoformat(row.get("created_at")),
+        "updatedAt": _to_isoformat(row.get("updated_at")),
+    }
+
+
+def create_comment(memory_id: str, owner_id: str, body: str) -> dict[str, Any]:
+    """Create a new comment on a memory."""
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+
+    safe_body = validate_optional_string(body, 5000)
+    if not safe_body:
+        raise HTTPException(status_code=400, detail="Comment body is required")
+
+    comment_id = str(uuid.uuid4())
+
+    query = """
+        INSERT INTO comments (id, memory_id, owner_id, body, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, NOW(), NOW())
+        RETURNING id, memory_id, owner_id, body, created_at, updated_at;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (comment_id, safe_memory_id, owner_id, safe_body))
+            row = cur.fetchone()
+        conn.commit()
+
+    return normalize_comment_row(row)
+
+
+def fetch_comments(memory_id: str, limit: int = 50) -> list[dict[str, Any]]:
+    """Fetch comments for a memory, ordered by creation time."""
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+    safe_limit = max(1, min(limit, 200))
+
+    def operation():
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, memory_id, owner_id, body, created_at, updated_at
+                    FROM comments
+                    WHERE memory_id = %s
+                    ORDER BY created_at ASC
+                    LIMIT %s
+                    """,
+                    (safe_memory_id, safe_limit),
+                )
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
+    return [normalize_comment_row(row) for row in rows]

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -13,6 +13,13 @@ from modal_compute.validation import (
 )
 
 
+def _build_reaction_counts(counts: dict[str, int]) -> dict[str, int]:
+    """Ensure reaction_counts dict includes the total key."""
+    result = dict(counts)
+    result["total"] = sum(counts.values())
+    return result
+
+
 def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") -> list[dict[str, Any]]:
     """Fetch the latest public tree snapshots using a robust join-lateral query."""
 
@@ -167,7 +174,15 @@ def fetch_public_memory(memory_id: str) -> dict[str, Any] | None:
 
     row = run_db_with_retry(operation)
 
-    return normalize_memory_row(row) if row else None
+    if not row:
+        return None
+
+    memory = normalize_memory_row(row)
+    # Add reaction counts
+    from modal_compute.reactions import fetch_reaction_counts
+    counts = fetch_reaction_counts(memory_id)
+    memory["reactionCounts"] = _build_reaction_counts(counts)
+    return memory
 
 
 def fetch_public_tree(tree_id: str) -> dict[str, Any] | None:

--- a/modal_compute/reactions.py
+++ b/modal_compute/reactions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import (
+    get_db_connection,
+    run_db_with_retry,
+)
+from modal_compute.validation import (
+    _to_isoformat,
+    validate_required_uuid,
+)
+
+
+def normalize_reaction_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw reactions DB row into camelCase API response format."""
+    return {
+        "id": str(row["id"]),
+        "memoryId": str(row["memory_id"]),
+        "ownerId": str(row["owner_id"]),
+        "type": str(row["type"]),
+        "createdAt": _to_isoformat(row.get("created_at")),
+    }
+
+
+def fetch_reaction_counts(memory_id: str) -> dict[str, int]:
+    """Fetch reaction counts grouped by type for a memory."""
+    def operation() -> list[dict[str, Any]]:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT type, COUNT(*)::int AS count
+                    FROM reactions
+                    WHERE memory_id = %s
+                    GROUP BY type
+                    ORDER BY type
+                    """,
+                    (memory_id,),
+                )
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
+    return {str(row["type"]): int(row["count"]) for row in rows}
+
+
+def toggle_reaction(memory_id: str, owner_id: str, reaction_type: str) -> dict[str, Any]:
+    """Toggle a reaction on a memory.
+
+    If the user already has a reaction of this type on this memory, remove it
+    (toggle off). Otherwise, add a new reaction (toggle on).
+
+    Returns a dict with active=True and the reaction data if created,
+    or active=False if removed.
+    """
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+
+    if not reaction_type or not isinstance(reaction_type, str):
+        raise HTTPException(status_code=400, detail="Reaction type is required")
+    safe_type = reaction_type.strip().lower()
+    if len(safe_type) > 32:
+        raise HTTPException(status_code=400, detail="Reaction type exceeds max 32 characters")
+    if not safe_type:
+        raise HTTPException(status_code=400, detail="Reaction type is required")
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            # Check if reaction already exists
+            cur.execute(
+                """
+                SELECT id, memory_id, owner_id, type, created_at
+                FROM reactions
+                WHERE memory_id = %s AND owner_id = %s AND type = %s
+                LIMIT 1
+                """,
+                (safe_memory_id, owner_id, safe_type),
+            )
+            existing = cur.fetchone()
+
+            if existing:
+                # Toggle off — delete existing reaction
+                cur.execute(
+                    "DELETE FROM reactions WHERE id = %s",
+                    (existing["id"],),
+                )
+                conn.commit()
+                return {"active": False, "type": safe_type}
+            else:
+                # Toggle on — insert new reaction
+                reaction_id = str(uuid.uuid4())
+                cur.execute(
+                    """
+                    INSERT INTO reactions (id, memory_id, owner_id, type, created_at)
+                    VALUES (%s, %s, %s, %s, NOW())
+                    RETURNING id, memory_id, owner_id, type, created_at
+                    """,
+                    (reaction_id, safe_memory_id, owner_id, safe_type),
+                )
+                row = cur.fetchone()
+                conn.commit()
+                reaction = normalize_reaction_row(row)
+                reaction["active"] = True
+                return reaction
+
+
+def fetch_reaction_summary(memory_id: str, owner_id: str) -> dict[str, Any]:
+    """Fetch reaction summary for a memory.
+
+    Returns counts by type and which types the requesting user has reacted with.
+    """
+    safe_memory_id = validate_required_uuid(memory_id, "memoryId")
+
+    def operation() -> list[dict[str, Any]]:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, memory_id, owner_id, type, created_at
+                    FROM reactions
+                    WHERE memory_id = %s
+                    ORDER BY created_at ASC
+                    """,
+                    (safe_memory_id,),
+                )
+                return cur.fetchall()
+
+    rows = run_db_with_retry(operation)
+
+    counts: dict[str, int] = {}
+    user_reactions: dict[str, bool] = {}
+
+    for r in rows:
+        r_type = str(r["type"])
+        counts[r_type] = counts.get(r_type, 0) + 1
+        if str(r["owner_id"]) == owner_id:
+            user_reactions[r_type] = True
+
+    return {
+        "counts": counts,
+        "userReactions": user_reactions,
+    }

--- a/scripts/migration-add-reactions-comments.sql
+++ b/scripts/migration-add-reactions-comments.sql
@@ -1,0 +1,36 @@
+-- Migration: Add reactions and comments tables for moment-level interactions
+--
+-- Refs #1237
+--
+-- This migration adds two new tables:
+--   reactions  — emoji/type reactions on memories (like, love, laugh, etc.)
+--   comments   — text comments on memories
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/migration-add-reactions-comments.sql
+
+CREATE TABLE IF NOT EXISTS reactions (
+    id UUID PRIMARY KEY,
+    memory_id UUID NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    owner_id VARCHAR(128) NOT NULL,
+    type VARCHAR(32) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reactions_memory_id ON reactions(memory_id);
+CREATE INDEX IF NOT EXISTS idx_reactions_owner_id ON reactions(owner_id);
+
+-- Ensure unique reaction per user per memory per type (toggle semantics)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reactions_memory_owner_type ON reactions(memory_id, owner_id, type);
+
+CREATE TABLE IF NOT EXISTS comments (
+    id UUID PRIMARY KEY,
+    memory_id UUID NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    owner_id VARCHAR(128) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_comments_memory_id ON comments(memory_id);
+CREATE INDEX IF NOT EXISTS idx_comments_owner_id ON comments(owner_id);

--- a/tests/contracts/modal-public-read-routes-contract.test.js
+++ b/tests/contracts/modal-public-read-routes-contract.test.js
@@ -116,7 +116,9 @@ test('modal public read helpers preserve public visibility filters and normaliza
   const memoryHelper = extractPythonFunction(content, 'fetch_public_memory');
   assert.ok(hasString(memoryHelper, "m.visibility = 'public'"));
   assert.ok(hasString(memoryHelper, "t.visibility = 'public'"));
-  assert.ok(hasString(memoryHelper, 'return normalize_memory_row(row) if row else None'));
+  assert.ok(hasString(memoryHelper, 'return None'));
+  assert.ok(hasString(memoryHelper, 'normalize_memory_row(row)'));
+  assert.ok(hasString(memoryHelper, 'reactionCounts'));
 
   const treeHelper = extractPythonFunction(content, 'fetch_public_tree');
   assert.ok(hasString(treeHelper, "t.visibility = 'public'"));


### PR DESCRIPTION
## Changes

Implements the backend for moment-level reactions (#1237): likes, comments, shares.

### DB Schema
- `scripts/migration-add-reactions-comments.sql` — reactions and comments tables
- reactions: `id, memory_id, owner_id, type, created_at` (unique on memory+owner+type)
- comments: `id, memory_id, owner_id, body, created_at, updated_at`

### Modal Backend
- `modal_compute/reactions.py` — toggle_reaction, fetch_reaction_summary, fetch_reaction_counts
- `modal_compute/comments.py` — create_comment, fetch_comments
- `modal_compute/app.py` — 4 new endpoints (toggle/list reactions, create/list comments)
- `modal_compute/public_reads.py` — reaction counts in public memory responses

### Cloudflare API Proxy
- `functions/api/memories/[id]/reactions.js` — GET/POST with 128KB body guard
- `functions/api/memories/[id]/comments.js` — GET/POST with 128KB body guard

### Contract Tests
- Updated `tests/contracts/modal-public-read-routes-contract.test.js` for new response shape

### Verification
- `npm test` — 363/363 PASS

Refs #1237