### PR TITLE
ops(fixtures): support legacy public tree fixture schema

### DIFF
--- a/scripts/seed-public-multi-branch-fixture.js
+++ b/scripts/seed-public-multi-branch-fixture.js
@@ -4,14 +4,14 @@
  *
  * Refs #1034, #1031, #976
  *
- * This script matches the current runtime read path:
- * - public trees are read from trees.visibility
- * - public moments are read from memories.visibility and memories.parent_id
+ * Supports both known storage shapes:
+ * - modern: trees.title / trees.visibility + memories table
+ * - legacy: trees.name / trees.is_public + trees.payload.nodes
  *
  * Safety:
  * - dry-run is default and does not require credentials
- * - no credentials are stored here
- * - owner/operator must provide runtime environment values only when executing
+ * - schema inspection mode never mutates data
+ * - execution requires owner/operator-supplied runtime values
  */
 
 const DB_URL = process.env.LOVEBUD_FIXTURE_DB_URL;
@@ -26,22 +26,89 @@ const RIGHT_ID = '10340000-0000-4000-8000-000000000103';
 const TREE = {
   id: TREE_ID,
   title: 'QA Safe Multi-Branch Public Fixture',
+  description: 'QA-safe multi-branch fixture for Public Viewer verification.',
+  stage: 'growth',
+  emotionTags: ['qa', 'fixture', 'multi-branch'],
   visibility: 'public',
   memories: [
-    { id: ROOT_ID, parentId: null, title: 'Seed moment', memo: 'QA-safe root moment.', tags: ['qa', 'seed'] },
-    { id: LEFT_ID, parentId: ROOT_ID, title: 'Left branch', memo: 'QA-safe left branch moment.', tags: ['qa', 'left'] },
-    { id: RIGHT_ID, parentId: ROOT_ID, title: 'Right branch', memo: 'QA-safe right branch moment.', tags: ['qa', 'right'] },
-    { id: '10340000-0000-4000-8000-000000000104', parentId: LEFT_ID, title: 'Left child', memo: 'QA-safe child under left branch.', tags: ['qa', 'left-child'] },
-    { id: '10340000-0000-4000-8000-000000000105', parentId: RIGHT_ID, title: 'Right child', memo: 'QA-safe child under right branch.', tags: ['qa', 'right-child'] }
+    { id: ROOT_ID, parentId: null, title: 'Seed moment', memo: 'QA-safe root moment.', tags: ['qa', 'seed'], order: 0 },
+    { id: LEFT_ID, parentId: ROOT_ID, title: 'Left branch', memo: 'QA-safe left branch moment.', tags: ['qa', 'left'], order: 1 },
+    { id: RIGHT_ID, parentId: ROOT_ID, title: 'Right branch', memo: 'QA-safe right branch moment.', tags: ['qa', 'right'], order: 2 },
+    { id: '10340000-0000-4000-8000-000000000104', parentId: LEFT_ID, title: 'Left child', memo: 'QA-safe child under left branch.', tags: ['qa', 'left-child'], order: 3 },
+    { id: '10340000-0000-4000-8000-000000000105', parentId: RIGHT_ID, title: 'Right child', memo: 'QA-safe child under right branch.', tags: ['qa', 'right-child'], order: 4 }
   ]
 };
+
+function printPlan() {
+  console.log(`Fixture tree: ${TREE.title}`);
+  console.log(`Execute: ${EXECUTE ? 'YES' : 'NO'}`);
+  console.log(`Memory count: ${TREE.memories.length}`);
+  console.log('Expected branch groups: root has 2 public children.');
+  console.log(`Route after approved seed: /pages/tree.html?treeId=${TREE.id}`);
+}
 
 function validateExecutionEnv() {
   if (!DB_URL) throw new Error('LOVEBUD_FIXTURE_DB_URL is required when execution is enabled.');
   if (!OWNER_ID) throw new Error('LOVEBUD_FIXTURE_OWNER_ID is required when execution is enabled.');
 }
 
-async function seed(client) {
+async function tableExists(client, tableName) {
+  const result = await client.query(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS exists`,
+    [tableName]
+  );
+  return Boolean(result.rows[0]?.exists);
+}
+
+async function getColumns(client, tableName) {
+  const result = await client.query(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1`,
+    [tableName]
+  );
+  return new Set(result.rows.map((row) => row.column_name));
+}
+
+async function detectSchema(client) {
+  const hasTrees = await tableExists(client, 'trees');
+  if (!hasTrees) return 'unsupported';
+
+  const treeColumns = await getColumns(client, 'trees');
+  const hasMemories = await tableExists(client, 'memories');
+
+  if (
+    treeColumns.has('title') &&
+    treeColumns.has('visibility') &&
+    treeColumns.has('owner_id') &&
+    hasMemories
+  ) {
+    const memoryColumns = await getColumns(client, 'memories');
+    if (
+      memoryColumns.has('tree_id') &&
+      memoryColumns.has('parent_id') &&
+      memoryColumns.has('visibility')
+    ) {
+      return 'modern';
+    }
+  }
+
+  if (
+    treeColumns.has('name') &&
+    treeColumns.has('is_public') &&
+    treeColumns.has('owner_id') &&
+    treeColumns.has('payload')
+  ) {
+    return 'legacy';
+  }
+
+  return 'unsupported';
+}
+
+async function seedModern(client) {
   await client.query(
     `INSERT INTO trees (id, owner_id, title, visibility, created_at, updated_at)
      VALUES ($1, $2, $3, $4, NOW(), NOW())
@@ -94,7 +161,48 @@ async function seed(client) {
   }
 }
 
-async function verify(client) {
+function legacyPayload() {
+  return {
+    description: TREE.description,
+    stage: TREE.stage,
+    emotion_tags: TREE.emotionTags,
+    nodes: TREE.memories.map((memory) => ({
+      id: memory.id,
+      title: memory.title,
+      description: memory.memo,
+      timestamp: '2026-05-18',
+      videoId: '',
+      thumbnail: '',
+      artist: 'QA Fixture',
+      emotion_tags: memory.tags,
+      parent_id: memory.parentId,
+      order: memory.order
+    }))
+  };
+}
+
+async function seedLegacy(client) {
+  await client.query(
+    `INSERT INTO trees (id, name, is_public, owner_id, node_count, created_at, updated_at, payload)
+     VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), $6::jsonb)
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       is_public = EXCLUDED.is_public,
+       owner_id = EXCLUDED.owner_id,
+       node_count = EXCLUDED.node_count,
+       payload = EXCLUDED.payload,
+       updated_at = NOW()`,
+    [TREE.id, TREE.title, true, OWNER_ID, TREE.memories.length, JSON.stringify(legacyPayload())]
+  );
+}
+
+async function seed(client, schema) {
+  if (schema === 'modern') return seedModern(client);
+  if (schema === 'legacy') return seedLegacy(client);
+  throw new Error('Unsupported schema for public multi-branch fixture seeding.');
+}
+
+async function verifyModern(client) {
   const treeResult = await client.query(
     `SELECT COUNT(*)::int AS count FROM trees WHERE id = $1 AND visibility = 'public'`,
     [TREE.id]
@@ -121,12 +229,30 @@ async function verify(client) {
   };
 }
 
-function printPlan() {
-  console.log(`Fixture tree: ${TREE.title}`);
-  console.log(`Execute: ${EXECUTE ? 'YES' : 'NO'}`);
-  console.log(`Memory count: ${TREE.memories.length}`);
-  console.log('Expected branch groups: root has 2 public children.');
-  console.log(`Route after approved seed: /pages/tree.html?treeId=${TREE.id}`);
+async function verifyLegacy(client) {
+  const result = await client.query(
+    `SELECT payload FROM trees WHERE id = $1 AND is_public = true`,
+    [TREE.id]
+  );
+  const payload = result.rows[0]?.payload || {};
+  const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+  const childCounts = new Map();
+  for (const node of nodes) {
+    if (!node.parent_id) continue;
+    childCounts.set(node.parent_id, (childCounts.get(node.parent_id) || 0) + 1);
+  }
+  const branchGroupCount = Array.from(childCounts.values()).filter((count) => count >= 2).length;
+  return {
+    treeCount: result.rowCount,
+    memoryCount: nodes.length,
+    branchGroupCount
+  };
+}
+
+async function verify(client, schema) {
+  if (schema === 'modern') return verifyModern(client);
+  if (schema === 'legacy') return verifyLegacy(client);
+  throw new Error('Unsupported schema for fixture verification.');
 }
 
 async function main() {
@@ -143,16 +269,27 @@ async function main() {
   const pool = new Pool({ connectionString: DB_URL, ssl: { rejectUnauthorized: false } });
   const client = await pool.connect();
   try {
+    const schema = await detectSchema(client);
+    console.log(`Detected schema: ${schema}`);
+    if (schema === 'unsupported') {
+      throw new Error('Unsupported DB schema. No fixture mutation performed.');
+    }
+
     await client.query('BEGIN');
-    await seed(client);
-    const result = await verify(client);
+    await seed(client, schema);
+    const result = await verify(client, schema);
     await client.query('COMMIT');
+
     console.log(`Tree count: ${result.treeCount}`);
     console.log(`Memory count: ${result.memoryCount}`);
     console.log(`Multi-branch parent groups: ${result.branchGroupCount}`);
     console.log(`Route: /pages/tree.html?treeId=${TREE.id}`);
   } catch (error) {
-    await client.query('ROLLBACK');
+    try {
+      await client.query('ROLLBACK');
+    } catch (_) {
+      // No active transaction may exist if schema detection failed before BEGIN.
+    }
     throw error;
   } finally {
     client.release();


### PR DESCRIPTION
Refs #1034
Refs #1031
Refs #976

## Summary

Updates `scripts/seed-public-multi-branch-fixture.js` to support both known public tree storage shapes:

- modern schema: `trees.title` / `trees.visibility` + `memories` table
- legacy schema: `trees.name` / `trees.is_public` + `trees.payload.nodes`

## Why

The approved DB seed attempt for #1034 found that the target DB still uses the legacy public tree schema:

- `trees.name`
- `trees.is_public`
- `trees.payload`
- no `memories` table

PR #1292 added a current-runtime oriented script, but that was not compatible with the approved DB currently available for fixture visibility work.

## Scope

- One script changed.
- Dry-run remains default and secret-free.
- Execute mode now detects schema before mutation.
- Unsupported schema fails before mutation.
- Legacy mode writes the fixture into `trees.payload.nodes`.
- Modern mode keeps the PR #1292 `trees` + `memories` path.

## Non-goals

- No DB execution in this PR.
- No production/private data mutation.
- No frontend/backend runtime behavior change.
- No migration.
- No test5 update.
- No issue close.

## Verification needed

CI first.

After merge, owner/operator should rerun the approved test DB seed. Expected result for the currently observed DB:

- detected schema: legacy
- tree count: 1
- memory count: 5
- multi-branch parent groups: 1

Then verify the Public Viewer route and continue #1031/#976 verification.

## Issue close keyword

None. This does not close #1034 because fixture execution and browser verification are still required.