### PR TITLE
fix(db): ensure memories table before reactions migration

### DIFF
--- a/scripts/migration-add-reactions-comments.sql
+++ b/scripts/migration-add-reactions-comments.sql
@@ -1,13 +1,41 @@
--- Migration: Add reactions and comments tables for moment-level interactions
+-- Migration: Add memories, reactions, and comments tables for moment-level interactions
 --
 -- Refs #1237
+-- Refs #1286
 --
--- This migration adds two new tables:
---   reactions  — emoji/type reactions on memories (like, love, laugh, etc.)
---   comments   — text comments on memories
+-- This migration is intentionally memory-level because the current Modal backend
+-- stores reactions/comments against memory IDs. Some test/runtime databases may
+-- have the trees table but not the memories table yet, so this script first
+-- ensures the memories table exists before creating reaction/comment FKs.
 --
 -- Usage:
 --   psql "$DATABASE_URL" -f scripts/migration-add-reactions-comments.sql
+
+CREATE TABLE IF NOT EXISTS memories (
+    id UUID PRIMARY KEY,
+    tree_id UUID NOT NULL REFERENCES trees(id) ON DELETE CASCADE,
+    parent_id UUID NULL REFERENCES memories(id) ON DELETE SET NULL,
+    title VARCHAR(200) NOT NULL DEFAULT '',
+    memo TEXT NOT NULL DEFAULT '',
+    artist VARCHAR(100) NOT NULL DEFAULT '',
+    source VARCHAR(200) NOT NULL DEFAULT '',
+    source_url VARCHAR(1000) NOT NULL DEFAULT '',
+    source_type VARCHAR(50) NOT NULL DEFAULT 'youtube',
+    thumbnail VARCHAR(500) NOT NULL DEFAULT '',
+    emotion_tags JSONB NOT NULL DEFAULT '[]'::jsonb,
+    timestamp VARCHAR(100) NOT NULL DEFAULT '',
+    visibility VARCHAR(20) NOT NULL DEFAULT 'public',
+    channel_id VARCHAR(100),
+    channel_name VARCHAR(200),
+    channel_url VARCHAR(1000),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_tree_id ON memories(tree_id);
+CREATE INDEX IF NOT EXISTS idx_memories_parent_id ON memories(parent_id);
+CREATE INDEX IF NOT EXISTS idx_memories_visibility ON memories(visibility);
+CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
 
 CREATE TABLE IF NOT EXISTS reactions (
     id UUID PRIMARY KEY,

--- a/tests/contracts/migration-reactions-comments-contract.test.js
+++ b/tests/contracts/migration-reactions-comments-contract.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const migrationPath = path.join(ROOT, 'scripts', 'migration-add-reactions-comments.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+
+test('reactions migration creates memories before memory-level foreign keys', () => {
+  const createMemoriesIndex = sql.indexOf('CREATE TABLE IF NOT EXISTS memories');
+  const createReactionsIndex = sql.indexOf('CREATE TABLE IF NOT EXISTS reactions');
+  const createCommentsIndex = sql.indexOf('CREATE TABLE IF NOT EXISTS comments');
+
+  assert.notEqual(createMemoriesIndex, -1, 'migration must create memories table first');
+  assert.notEqual(createReactionsIndex, -1, 'migration must create reactions table');
+  assert.notEqual(createCommentsIndex, -1, 'migration must create comments table');
+  assert.ok(createMemoriesIndex < createReactionsIndex, 'memories table must exist before reactions FK');
+  assert.ok(createMemoriesIndex < createCommentsIndex, 'memories table must exist before comments FK');
+});
+
+test('reactions migration keeps backend-compatible memory-level schema', () => {
+  assert.match(sql, /memory_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+memories\(id\)/i);
+  assert.match(sql, /CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_reactions_memory_owner_type\s+ON\s+reactions\(memory_id,\s*owner_id,\s*type\)/i);
+  assert.match(sql, /CREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_comments_memory_id\s+ON\s+comments\(memory_id\)/i);
+});
+
+test('memories table includes columns required by owner read and write handlers', () => {
+  const requiredColumns = [
+    'tree_id',
+    'parent_id',
+    'title',
+    'memo',
+    'artist',
+    'source',
+    'source_url',
+    'source_type',
+    'thumbnail',
+    'emotion_tags',
+    'timestamp',
+    'visibility',
+    'channel_id',
+    'channel_name',
+    'channel_url',
+    'created_at',
+    'updated_at'
+  ];
+
+  for (const column of requiredColumns) {
+    assert.match(sql, new RegExp(`\\b${column}\\b`, 'i'), `missing memories.${column}`);
+  }
+});


### PR DESCRIPTION
## Summary

Fix #1286 by making the reactions/comments migration safe for runtimes where `trees` exists but `memories` has not been created yet.

This keeps the current backend-compatible memory-level reactions/comments model. It does **not** switch reactions/comments to tree-level because `modal_compute/reactions.py`, `modal_compute/comments.py`, and current Modal routes still use `memory_id`.

## Changes

- Ensure `memories` table exists before creating `reactions` and `comments` tables.
- Add indexes for `memories.tree_id`, `parent_id`, `visibility`, and `created_at`.
- Preserve `reactions.memory_id -> memories(id)` and `comments.memory_id -> memories(id)` foreign keys.
- Add contract test guarding migration order and required `memories` columns.

## Safety

- No frontend changes.
- No Modal runtime behavior changes.
- No DB execution in this PR.
- No production/private data mutation.
- No PR #7, prototype, reference, demo, or variant changes.

Refs #1286
Refs #1296
Refs #628