### PR TITLE
fix(editor): sync initial canvas selection state

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -585,9 +585,15 @@ function createEditorCanvas(deps) {
             }
 
             if (selectedMem) {
-                updateDetailPanel(selectedMem);
                 reapplySelection(selectedMem.id);
-                renderAffordanceForMemory(selectedMem);
+
+                const selectedEl = document.querySelector(`.memory-node[data-memory-id="${selectedMem.id}"]`);
+                if (selectedEl && typeof onNodeClick === 'function') {
+                    onNodeClick(selectedEl, selectedMem);
+                } else {
+                    updateDetailPanel(selectedMem);
+                    renderAffordanceForMemory(selectedMem);
+                }
             }
         }
 


### PR DESCRIPTION
Refs #1299

Fix initial Editor load where the canvas visually selects a moment but editor state remains unset.

- Reapply selected class before syncing selection
- Delegate initial selected moment through onNodeClick
- Sync selectedNodeId/currentEditingMemory on initial canvas render
- Preserve fallback updateDetailPanel/renderAffordance path

No backend/API/Auth/DB/schema changes.
No PR #7/prototype/reference/demo/variant changes.