### PR TITLE
fix(editor): keep floating toolbar tooltip helper in scope

### DIFF
--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -42,6 +42,15 @@
   const AFFORDANCE_SELECTOR = '.memory-add-affordance';
 
   /**
+   * Find the currently selected memory node element on the canvas.
+   * Kept in outer scope because tooltip helpers run outside initFloatingToolbar's
+   * lexical scope and also need to resolve the selected node.
+   */
+  function getSelectedNodeEl() {
+    return document.querySelector(NODE_SELECTOR + '.' + SELECTED_CLASS);
+  }
+
+  /**
    * Check if connection mode is active (user is in a "continue" or "branch" flow).
    * Detected by presence of growth affordance elements on the canvas.
    */
@@ -109,13 +118,6 @@
     var positionTimer = null;
     var lastX = -1;
     var lastY = -1;
-
-    /**
-     * Find the currently selected memory node element on the canvas.
-     */
-    function getSelectedNodeEl() {
-      return document.querySelector(NODE_SELECTOR + '.' + SELECTED_CLASS);
-    }
 
     /**
      * Check if the floating toolbar should be visible based on contract §4.


### PR DESCRIPTION
## Summary

Fix #1303 by making the selected-node helper available to the floating toolbar tooltip path.

The previous structure defined `getSelectedMemory()` in the outer IIFE scope, but it called `getSelectedNodeEl()`, which was defined inside `initFloatingToolbar()`. Hover/focus tooltip paths can therefore throw `ReferenceError: getSelectedNodeEl is not defined`.

## Changes

- Move `getSelectedNodeEl()` to the same outer lexical scope as `getSelectedMemory()`.
- Reuse the same helper from visibility, positioning, edit, escape, and tooltip paths.
- Preserve existing toolbar behavior.

## Safety

- Frontend-only change.
- Changed file: `js/editor/editor-floating-toolbar.js` only.
- No backend/API/Auth/DB/schema changes.
- No PR #7, prototype, reference, demo, or variant changes.
- No #1300/#1302 owner-write changes.
- No #1304 owner user bootstrap changes.

## Verification needed

- CI / verify-static.
- Browser smoke: select a moment, hover/focus floating toolbar buttons, confirm no fatal JS errors.
- Confirm Edit / Continue / View still reuse existing flows.
- Confirm mobile <480px hidden behavior remains unchanged.

Refs #1303
Refs #1290
Refs #1150