### PR TITLE
fix(modal): bootstrap owner user before tree creation

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -66,6 +66,7 @@ from modal_compute.owner_writes import (
     delete_owner_memory,
     fork_public_tree,
 )
+from modal_compute.owner_users import ensure_owner_user_exists
 from modal_compute.reactions import (
     toggle_reaction,
     fetch_reaction_summary,
@@ -211,6 +212,7 @@ async def post_private_tree(
 ) -> dict:
     user = require_firebase_user(authorization)
     payload = await parse_json_body(request)
+    ensure_owner_user_exists(user["uid"], user.get("email") or "")
     return create_owner_tree(user["uid"], payload)
 
 
@@ -233,6 +235,7 @@ def post_fork_tree(
     authorization: str | None = Header(default=None),
 ) -> dict:
     user = require_firebase_user(authorization)
+    ensure_owner_user_exists(user["uid"], user.get("email") or "")
     return fork_public_tree(user["uid"], tree_id)
 
 

--- a/modal_compute/owner_users.py
+++ b/modal_compute/owner_users.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import get_db_connection, run_db_with_retry
+
+
+_USER_BOOTSTRAP_ALLOWED_COLUMNS = {
+    "id",
+    "uid",
+    "email",
+    "created_at",
+    "updated_at",
+}
+
+
+def _fetch_users_table_columns(cur: Any) -> set[str]:
+    cur.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'users';
+        """
+    )
+    rows = cur.fetchall() or []
+    return {
+        str(row.get("column_name") or "").strip()
+        for row in rows
+        if str(row.get("column_name") or "").strip()
+    }
+
+
+def _build_owner_user_upsert_query(columns: set[str], email: str) -> tuple[str, list[Any]] | None:
+    if "id" not in columns:
+        return None
+
+    insert_columns: list[str] = ["id"]
+    value_expressions: list[str] = ["%s"]
+    params: list[Any] = []
+
+    if "email" in columns:
+        insert_columns.append("email")
+        value_expressions.append("%s")
+
+    if "created_at" in columns:
+        insert_columns.append("created_at")
+        value_expressions.append("NOW()")
+
+    if "updated_at" in columns:
+        insert_columns.append("updated_at")
+        value_expressions.append("NOW()")
+
+    update_expressions: list[str] = []
+    if "email" in insert_columns and email:
+        update_expressions.append("email = EXCLUDED.email")
+    if "updated_at" in insert_columns:
+        update_expressions.append("updated_at = NOW()")
+
+    conflict_clause = "DO NOTHING"
+    if update_expressions:
+        conflict_clause = "DO UPDATE SET " + ", ".join(update_expressions)
+
+    query = f"""
+        INSERT INTO users ({', '.join(insert_columns)})
+        VALUES ({', '.join(value_expressions)})
+        ON CONFLICT (id) {conflict_clause};
+    """
+
+    return query, params
+
+
+def ensure_owner_user_exists(uid: str, email: str = "") -> None:
+    """Ensure Firebase-authenticated owner has a matching Postgres users row.
+
+    The private tree write path stores ``trees.owner_id`` as the Firebase UID.
+    Some runtimes enforce ``trees.owner_id -> users(id)``. Without a user row,
+    first-time owners can hit a ForeignKeyViolation before tree creation.
+    """
+    safe_uid = str(uid or "").strip()
+    if not safe_uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    safe_email = str(email or "").strip()[:320]
+
+    def operation() -> None:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                columns = _fetch_users_table_columns(cur)
+                if not columns or "id" not in columns:
+                    return
+
+                unknown_required_columns = columns - _USER_BOOTSTRAP_ALLOWED_COLUMNS
+                if unknown_required_columns:
+                    # Unknown columns are not automatically populated. The upsert below
+                    # still proceeds because columns with defaults or nullable values are safe.
+                    pass
+
+                built = _build_owner_user_upsert_query(columns, safe_email)
+                if not built:
+                    return
+                query, params = built
+                cur.execute(query, [safe_uid, *([safe_email] if "email" in columns else []), *params])
+            conn.commit()
+
+    try:
+        run_db_with_retry(operation)
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(status_code=500, detail="Owner user bootstrap failed") from error

--- a/modal_compute/owner_users.py
+++ b/modal_compute/owner_users.py
@@ -7,34 +7,52 @@ from fastapi import HTTPException
 from modal_compute.db import get_db_connection, run_db_with_retry
 
 
-_USER_BOOTSTRAP_ALLOWED_COLUMNS = {
+_USER_BOOTSTRAP_INSERT_COLUMNS = {
     "id",
-    "uid",
     "email",
     "created_at",
     "updated_at",
 }
 
 
-def _fetch_users_table_columns(cur: Any) -> set[str]:
+def _fetch_users_table_columns(cur: Any) -> dict[str, dict[str, Any]]:
     cur.execute(
         """
-        SELECT column_name
+        SELECT column_name, is_nullable, column_default
         FROM information_schema.columns
         WHERE table_schema = current_schema()
           AND table_name = 'users';
         """
     )
     rows = cur.fetchall() or []
-    return {
-        str(row.get("column_name") or "").strip()
-        for row in rows
-        if str(row.get("column_name") or "").strip()
-    }
+    columns: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        name = str(row.get("column_name") or "").strip()
+        if not name:
+            continue
+        columns[name] = {
+            "is_nullable": row.get("is_nullable"),
+            "column_default": row.get("column_default"),
+        }
+    return columns
 
 
-def _build_owner_user_upsert_query(columns: set[str], email: str) -> tuple[str, list[Any]] | None:
+def _has_unhandled_required_columns(columns: dict[str, dict[str, Any]]) -> bool:
+    for name, meta in columns.items():
+        if name in _USER_BOOTSTRAP_INSERT_COLUMNS:
+            continue
+        is_nullable = str(meta.get("is_nullable") or "").upper() == "YES"
+        has_default = meta.get("column_default") is not None
+        if not is_nullable and not has_default:
+            return True
+    return False
+
+
+def _build_owner_user_upsert_query(columns: dict[str, dict[str, Any]], email: str) -> tuple[str, list[Any]] | None:
     if "id" not in columns:
+        return None
+
+    if _has_unhandled_required_columns(columns):
         return None
 
     insert_columns: list[str] = ["id"]
@@ -44,6 +62,7 @@ def _build_owner_user_upsert_query(columns: set[str], email: str) -> tuple[str, 
     if "email" in columns:
         insert_columns.append("email")
         value_expressions.append("%s")
+        params.append(email)
 
     if "created_at" in columns:
         insert_columns.append("created_at")
@@ -89,20 +108,11 @@ def ensure_owner_user_exists(uid: str, email: str = "") -> None:
         with get_db_connection() as conn:
             with conn.cursor() as cur:
                 columns = _fetch_users_table_columns(cur)
-                if not columns or "id" not in columns:
-                    return
-
-                unknown_required_columns = columns - _USER_BOOTSTRAP_ALLOWED_COLUMNS
-                if unknown_required_columns:
-                    # Unknown columns are not automatically populated. The upsert below
-                    # still proceeds because columns with defaults or nullable values are safe.
-                    pass
-
                 built = _build_owner_user_upsert_query(columns, safe_email)
                 if not built:
-                    return
+                    raise HTTPException(status_code=500, detail="Owner user bootstrap unavailable")
                 query, params = built
-                cur.execute(query, [safe_uid, *([safe_email] if "email" in columns else []), *params])
+                cur.execute(query, [safe_uid, *params])
             conn.commit()
 
     try:


### PR DESCRIPTION
## Summary

Refs #1304
Refs #1302
Refs #1300

Fix the owner tree creation blocker where a Firebase-authenticated user can hit `trees_owner_id_fkey` because the Postgres `users` row does not exist yet.

## Changes

- Add `modal_compute/owner_users.py` with `ensure_owner_user_exists()`.
- Bootstrap the owner user before:
  - `POST /modal/private/trees`
  - `POST /modal/private/trees/{tree_id}/fork`
- Keep `modal_compute/owner_writes.py` untouched to avoid conflict with PR #1302.
- Preserve owner/auth route flow and existing create/fork behavior.

## Safety

- Backend Modal-only change.
- No frontend changes.
- No DB schema/migration changes.
- No public read behavior changes.
- No PR #7 / prototype / reference / demo / variant changes.
- No raw user IDs, tokens, DB URLs, cookies, or private payloads in this PR.

## Important review note

This PR is intentionally **DRAFT**.

`modal_compute/app.py` currently shows a large diff because the file was rewritten through the GitHub contents API and the repository copy has mixed/CRLF line endings. The functional app.py change is intended to be only:

```text
+ from modal_compute.owner_users import ensure_owner_user_exists
+ ensure_owner_user_exists(user["uid"], user.get("email") or "")
```

before tree create/fork operations.

Before Ready, this needs either:

1. line-ending cleanup so `app.py` shows only the intended small diff, or
2. reviewer acceptance that the large app.py diff is line-ending-only plus the intended import/calls.

## Verification needed

- CI / verify-static.
- Contract tests still pass.
- Runtime smoke on test5:
  - authenticated owner can create a tree without `trees_owner_id_fkey` 500
  - `/modal/private/trees` still returns safe output
  - fork tree path does not regress
  - public browse/read unchanged
- After #1304 smoke passes, PR #1302 owner emotionTags smoke can resume.

## Non-goals

- No emotionTags serialization change here.
- No owner memory update change here.
- No user profile product redesign.
- No schema migration.