### PR TITLE
fix(modal): bootstrap owner user before tree writes

### DIFF
--- a/modal_compute/owner_users.py
+++ b/modal_compute/owner_users.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import get_db_connection, run_db_with_retry
+
+
+def _fetch_users_table_columns(cur: Any) -> dict[str, dict[str, Any]]:
+    cur.execute(
+        """
+        SELECT column_name, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'users';
+        """
+    )
+    rows = cur.fetchall() or []
+    columns: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        name = str(row.get("column_name") or "").strip()
+        if name:
+            columns[name] = {
+                "is_nullable": row.get("is_nullable"),
+                "column_default": row.get("column_default"),
+            }
+    return columns
+
+
+def _has_required_unknown_columns(columns: dict[str, dict[str, Any]]) -> bool:
+    handled = {"id", "email", "created_at", "updated_at"}
+    for name, meta in columns.items():
+        if name in handled:
+            continue
+        is_nullable = str(meta.get("is_nullable") or "").upper() == "YES"
+        has_default = meta.get("column_default") is not None
+        if not is_nullable and not has_default:
+            return True
+    return False
+
+
+def ensure_owner_user_exists(uid: str, email: str = "") -> None:
+    safe_uid = str(uid or "").strip()
+    if not safe_uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    safe_email = str(email or "").strip()[:320]
+
+    def operation() -> None:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                columns = _fetch_users_table_columns(cur)
+                if "id" not in columns or _has_required_unknown_columns(columns):
+                    raise HTTPException(status_code=500, detail="Owner user bootstrap unavailable")
+
+                insert_columns = ["id"]
+                values = ["%s"]
+                params: list[Any] = [safe_uid]
+
+                if "email" in columns:
+                    insert_columns.append("email")
+                    values.append("%s")
+                    params.append(safe_email)
+                if "created_at" in columns:
+                    insert_columns.append("created_at")
+                    values.append("NOW()")
+                if "updated_at" in columns:
+                    insert_columns.append("updated_at")
+                    values.append("NOW()")
+
+                updates: list[str] = []
+                if "email" in insert_columns and safe_email:
+                    updates.append("email = EXCLUDED.email")
+                if "updated_at" in insert_columns:
+                    updates.append("updated_at = NOW()")
+
+                conflict_clause = "DO NOTHING"
+                if updates:
+                    conflict_clause = "DO UPDATE SET " + ", ".join(updates)
+
+                cur.execute(
+                    f"""
+                    INSERT INTO users ({', '.join(insert_columns)})
+                    VALUES ({', '.join(values)})
+                    ON CONFLICT (id) {conflict_clause};
+                    """,
+                    params,
+                )
+            conn.commit()
+
+    try:
+        run_db_with_retry(operation)
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(status_code=500, detail="Owner user bootstrap failed") from error

--- a/modal_compute/owner_writes.py
+++ b/modal_compute/owner_writes.py
@@ -14,6 +14,7 @@ from modal_compute.db import (
 from modal_compute.owner_reads import (
     fetch_owner_tree,
 )
+from modal_compute.owner_users import ensure_owner_user_exists
 from modal_compute.validation import (
     _to_isoformat,
     estimate_stage,
@@ -27,6 +28,7 @@ from modal_compute.validation import (
 
 
 def create_owner_tree(owner_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    ensure_owner_user_exists(owner_id)
     title = validate_optional_string(payload.get("title"), 200) or "My LoveTree"
     visibility = validate_visibility(payload.get("visibility"), "public")
     require_plus_for_private_storage(owner_id, visibility)
@@ -348,6 +350,7 @@ def delete_owner_memory(owner_id: str, memory_id: str) -> dict[str, Any]:
 
 def fork_public_tree(owner_id: str, source_tree_id: str) -> dict[str, Any]:
     """Copy a public LoveTree and its public memories into a new tree owned by owner_id."""
+    ensure_owner_user_exists(owner_id)
     safe_source_id = validate_required_uuid(source_tree_id, "sourceTreeId")
 
     # Fetch source tree — must exist and be public


### PR DESCRIPTION
## Summary

Refs #1304
Refs #1302
Refs #1300

Fix the owner tree creation blocker where a Firebase-authenticated user can hit `trees_owner_id_fkey` because the Postgres `users` row does not exist before inserting into `trees(owner_id)`.

## Changes

- Add `modal_compute/owner_users.py` with `ensure_owner_user_exists()`.
- Call `ensure_owner_user_exists(owner_id)` before owner tree INSERT paths:
  - `create_owner_tree()`
  - `fork_public_tree()`
- Do not modify `modal_compute/app.py`.
- Keep owner route auth flow unchanged.
- Keep public read behavior unchanged.

## Safety

- Backend Modal-only change.
- No frontend changes.
- No DB schema/migration changes.
- No auth boundary relaxation.
- No public read behavior changes.
- No PR #7 / prototype / reference / demo / variant changes.
- No raw UID, token, DB URL, cookie, or private payload exposure.

## Relationship to PR #1302

PR #1302 is still open/draft and changes `owner_writes.py` for emotionTags serialization.

This PR touches the same file but a different area:
- #1304: owner tree creation / fork bootstrap
- #1302: owner memory emotionTags serialization

After this PR lands, PR #1302 will need to rebase/update and rerun smoke.

## Verification needed

- CI / verify-static.
- Runtime smoke on test5:
  - authenticated owner can create a tree without `trees_owner_id_fkey` 500
  - `/modal/private/trees` still returns safe output
  - fork tree path does not regress
  - public browse/read unchanged
- After #1304 smoke passes, PR #1302 owner emotionTags smoke can resume.

## Non-goals

- No emotionTags serialization change here.
- No owner memory update change here.
- No user profile product redesign.
- No schema migration.
