### PR TITLE
feat(editor): add default title for URL-only moments

### DIFF
--- a/js/editor/editor-memory-form-payload.js
+++ b/js/editor/editor-memory-form-payload.js
@@ -101,6 +101,27 @@
         };
     }
 
+    function resolveUrlOnlyDefaultTitle(mediaSource, i18n) {
+        const sourceType = String(mediaSource?.sourceType || '').trim().toLowerCase();
+        const sourceLabel = String(mediaSource?.sourceLabel || '').trim();
+
+        if (sourceType === 'youtube' || /youtube/i.test(sourceLabel)) {
+            return (typeof i18n === 'function' && i18n('editor_url_only_youtube_title')) || 'YouTube 순간';
+        }
+
+        if (sourceLabel) {
+            return sourceLabel + ' 순간';
+        }
+
+        return (typeof i18n === 'function' && i18n('editor_url_only_default_title')) || '새 순간';
+    }
+
+    function resolveMemoryTitle(titleValue, rawUrl, usingLinkMode, mediaSource, i18n) {
+        if (titleValue) return titleValue;
+        if (usingLinkMode && rawUrl) return resolveUrlOnlyDefaultTitle(mediaSource, i18n);
+        return '';
+    }
+
     function buildMemoryPayload(options) {
         const {
             refs,
@@ -144,6 +165,8 @@
         });
         if (!mediaSource.ok) return mediaSource;
 
+        const resolvedTitle = resolveMemoryTitle(titleValue, rawUrl, usingLinkMode, mediaSource, i18n);
+
         const memories = getTreeMemories();
 
         const freshCanonicalRootId = window.LoveBudEditorUtils?.getCanonicalRootId
@@ -153,7 +176,7 @@
         const channelInfo = mediaSource.channelInfo || null;
         const data = {
             treeId,
-            title: titleValue || '',
+            title: resolvedTitle,
             memo: memoValue || '',
             timestamp: todayDateString(),
             sourceUrl: mediaSource.embedUrl,
@@ -180,6 +203,8 @@
 
     window.LoveBudEditorMemoryFormPayload = {
         buildMediaSource,
-        buildMemoryPayload
+        buildMemoryPayload,
+        resolveUrlOnlyDefaultTitle,
+        resolveMemoryTitle
     };
 })();

--- a/tests/contracts/channel-metadata-payload-contract.test.js
+++ b/tests/contracts/channel-metadata-payload-contract.test.js
@@ -6,7 +6,13 @@ const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..', '..');
 
-function createPayloadContext(url) {
+function createPayloadContext(url, options = {}) {
+  const {
+    titleValue = 'Channel moment',
+    memoValue = 'Channel metadata test',
+    i18n = (key) => key
+  } = options;
+
   const context = {
     console,
     URL,
@@ -29,14 +35,14 @@ function createPayloadContext(url) {
   return context.window.LoveBudEditorMemoryFormPayload.buildMemoryPayload({
     refs: {
       urlInput: { value: url },
-      titleInput: { value: 'Channel moment' },
-      memoInput: { value: 'Channel metadata test' },
+      titleInput: { value: titleValue },
+      memoInput: { value: memoValue },
       startTimeInput: { value: '' },
       endTimeInput: { value: '' }
     },
     currentInputMode: 'link',
     userHasEditedStartTime: false,
-    i18n: (key) => key,
+    i18n,
     treeId: 'tree-1',
     getYouTubeInputErrorMessage: () => 'invalid youtube url',
     getTreeMemories: () => [],
@@ -73,4 +79,20 @@ test('standard YouTube watch URL does not invent channel fields without oEmbed d
   assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelId'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelName'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(result.data, 'channelUrl'), false);
+});
+
+test('URL-only YouTube payload uses a safe default title when title is empty', () => {
+  const result = createPayloadContext('https://www.youtube.com/watch?v=dQw4w9WgXcQ', {
+    titleValue: '',
+    memoValue: '',
+    i18n: (key) => {
+      if (key === 'editor_url_only_youtube_title') return 'YouTube 순간';
+      if (key === 'editor_url_only_default_title') return '새 순간';
+      return key;
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.data.title, 'YouTube 순간');
+  assert.equal(result.data.memo, '');
 });


### PR DESCRIPTION
## Summary
- add safe default titles for URL-only moment creation
- preserve existing explicit title behavior
- add contract coverage for URL-only YouTube payload title fallback

Refs #1273

## Verification
- node --test tests/contracts/channel-metadata-payload-contract.test.js
- npm run verify