### PR TITLE
feat(editor): add mobile bottom action bar

### DIFF
--- a/css/editor/editor-canvas-toolbar.css
+++ b/css/editor/editor-canvas-toolbar.css
@@ -743,3 +743,71 @@
         right: 8px;
     }
 }
+
+/* ─── Mobile Bottom Action Bar (<480px) ───────────────────
+ * Issue #1272 — First slice
+ * Fixed bottom action button for mobile editor viewport.
+ * Hidden on desktop; hidden when form/edit mode is open.
+ */
+.editor-mobile-bottom-bar {
+    display: none;
+}
+
+@media (max-width: 479px) {
+    .editor-mobile-bottom-bar {
+        display: flex;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+        padding: 12px 16px;
+        padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+        background: var(--surface, #fdfbf7);
+        border-top: 1px solid var(--outline-variant, rgba(144,73,81,0.12));
+        justify-content: center;
+        align-items: center;
+        box-shadow: 0 -4px 20px rgba(75, 64, 57, 0.06);
+        box-sizing: border-box;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .editor-mobile-bottom-bar.is-hidden {
+        display: none !important;
+    }
+
+    .editor-mobile-bottom-action {
+        width: 100%;
+        max-width: 280px;
+        padding: 14px 28px;
+        border-radius: var(--radius-full, 9999px);
+        background: var(--primary, #904951);
+        color: var(--on-primary, #ffffff);
+        border: none;
+        font-family: var(--font-body, 'Noto Sans KR', sans-serif);
+        font-size: 16px;
+        font-weight: 600;
+        line-height: 1.4;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+        touch-action: manipulation;
+        user-select: none;
+        transition: background 0.15s ease, transform 0.1s ease;
+    }
+
+    .editor-mobile-bottom-action:active {
+        transform: scale(0.97);
+        background: var(--primary-vibrant, #b85c66);
+    }
+
+    /* iOS safe-area: account for home indicator */
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+        .editor-mobile-bottom-bar {
+            padding-bottom: calc(12px + env(safe-area-inset-bottom));
+        }
+    }
+}

--- a/js/editor/editor-mobile-bottom-bar.js
+++ b/js/editor/editor-mobile-bottom-bar.js
@@ -1,0 +1,168 @@
+/**
+ * LoveBud Editor — Mobile Bottom Action Bar
+ * Issue #1272 — First slice
+ *
+ * Displays a fixed bottom action button on mobile viewport (<480px):
+ *  - No selected moment / empty tree: "새 순간 만들기" → triggers addMemoryBtn
+ *  - Selected moment exists: "이어가기" → triggers continueFromMomentBtn
+ *  - Form open or edit mode: hidden
+ *
+ * Delegates to existing DOM buttons — no new flows or backend changes.
+ * No interaction with desktop floating toolbar.
+ * iOS safe-area handled via CSS env(safe-area-inset-bottom).
+ */
+
+(function () {
+  'use strict';
+
+  var BOTTOM_BAR_ID = 'mobileBottomBar';
+  var ACTION_BTN_ID = 'mobileBottomAction';
+  var ACTION_LABEL_ID = 'mobileBottomActionLabel';
+  var MOBILE_BREAKPOINT = 480;
+  var IS_HIDDEN_CLASS = 'is-hidden';
+  var UPDATE_DEBOUNCE = 120;
+
+  function initMobileBottomBar() {
+    var bar = document.getElementById(BOTTOM_BAR_ID);
+    var actionBtn = document.getElementById(ACTION_BTN_ID);
+    var actionLabel = document.getElementById(ACTION_LABEL_ID);
+    if (!bar || !actionBtn || !actionLabel) return;
+
+    // Prevent double-init
+    if (bar.dataset.mbbInitialized === '1') return;
+    bar.dataset.mbbInitialized = '1';
+
+    var iconEl = actionBtn.querySelector('.material-symbols-outlined');
+
+    /**
+     * Check if memory form or detail edit mode is currently open.
+     */
+    function isFormOrEditOpen() {
+      var addForm = document.getElementById('addMemoryForm');
+      if (addForm && addForm.style.display !== 'none' && addForm.style.display !== '') {
+        return true;
+      }
+      var editMode = document.getElementById('detailEditMode');
+      if (editMode && editMode.style.display !== 'none' && editMode.style.display !== '') {
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     * Check whether a moment node is currently selected.
+     */
+    function hasSelectedMoment() {
+      var selected = document.querySelector('.memory-node.selected');
+      if (selected) return true;
+      // If the empty guide is visible, there's no selected moment
+      var emptyGuide = document.getElementById('canvasEmptyGuide');
+      if (emptyGuide && !emptyGuide.classList.contains('editor-canvas-empty-guide-hidden')) {
+        return false;
+      }
+      // Tree has moments but none selected — count as "no selected moment"
+      return false;
+    }
+
+    /**
+     * Update bottom bar visibility and button state.
+     */
+    function updateBar() {
+      // Only show on mobile viewport
+      if (window.innerWidth >= MOBILE_BREAKPOINT) {
+        bar.classList.add(IS_HIDDEN_CLASS);
+        return;
+      }
+
+      // Hide when form or edit mode is open
+      if (isFormOrEditOpen()) {
+        bar.classList.add(IS_HIDDEN_CLASS);
+        return;
+      }
+
+      // Update label and icon based on selection state
+      if (hasSelectedMoment()) {
+        actionLabel.textContent = '이어가기';
+        if (iconEl) iconEl.textContent = 'arrow_forward';
+      } else {
+        actionLabel.textContent = '새 순간 만들기';
+        if (iconEl) iconEl.textContent = 'add';
+      }
+
+      bar.classList.remove(IS_HIDDEN_CLASS);
+    }
+
+    /**
+     * Handle click on the bottom action button.
+     * Delegates to existing DOM buttons.
+     */
+    function onActionClick(e) {
+      e.preventDefault();
+
+      if (hasSelectedMoment()) {
+        // "이어가기" → delegate to continueFromMomentBtn (detail panel)
+        var continueBtn = document.getElementById('continueFromMomentBtn');
+        if (continueBtn) {
+          continueBtn.click();
+          return;
+        }
+      }
+
+      // "새 순간 만들기" or fallback → delegate to addMemoryBtn (sidebar)
+      var addBtn = document.getElementById('addMemoryBtn');
+      if (addBtn) {
+        addBtn.click();
+        return;
+      }
+
+      // Last resort: canvas empty guide start button
+      var emptyStartBtn = document.getElementById('canvasEmptyStartBtn');
+      if (emptyStartBtn) {
+        emptyStartBtn.click();
+      }
+    }
+
+    // ── Bind events ──────────────────────────────────────
+
+    actionBtn.addEventListener('click', onActionClick);
+
+    // Debounced update to avoid rapid reflows
+    var updateTimer = null;
+    function scheduleUpdate() {
+      if (updateTimer) return;
+      updateTimer = setTimeout(function () {
+        updateTimer = null;
+        updateBar();
+      }, UPDATE_DEBOUNCE);
+    }
+
+    window.addEventListener('resize', scheduleUpdate);
+
+    // Observe DOM changes that could affect state:
+    // node selection (class changes), form/edit mode (style changes)
+    var canvasArea = document.getElementById('canvasArea');
+    if (canvasArea) {
+      var observer = new MutationObserver(function () {
+        scheduleUpdate();
+      });
+      observer.observe(canvasArea, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'style']
+      });
+    }
+
+    // Re-check after any click — catches state changes from user interaction
+    document.addEventListener('click', scheduleUpdate);
+
+    // Initial render
+    updateBar();
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMobileBottomBar);
+  } else {
+    initMobileBottomBar();
+  }
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -140,6 +140,14 @@
                 </button>
             </div>
 
+            <!-- Mobile bottom action bar (visible only <480px) -->
+            <div id="mobileBottomBar" class="editor-mobile-bottom-bar is-hidden" role="toolbar" aria-label="모바일 하단 도구">
+                <button type="button" id="mobileBottomAction" class="editor-mobile-bottom-action">
+                    <span class="material-symbols-outlined" aria-hidden="true">add</span>
+                    <span id="mobileBottomActionLabel">새 순간 만들기</span>
+                </button>
+            </div>
+
                         <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
                 <div class="editor-canvas-empty-guide__icon" id="canvasEmptyGuideIcon" aria-hidden="true">🌱</div>
                 <div class="editor-canvas-empty-guide__eyebrow" id="canvasEmptyGuideEyebrow">시작하기</div>
@@ -343,7 +351,8 @@
     <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
-    <script src="../js/editor/editor-floating-toolbar.js?v=20260517-1"></script>
+    <script src="../js/editor/editor-floating-toolbar.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas.js?v=20260507-655"></script>
     <script src="../js/editor/editor-rename-ui.js?v=20260422-2"></script>


### PR DESCRIPTION
## Summary

* add a mobile-only bottom action bar for quick moment creation
* reuse existing add/continue editor flows
* keep desktop toolbar behavior unchanged

Refs #1272

## Verification

* npm run verify
* mobile editor smoke: bottom action visible and opens existing create/continue flow
* desktop editor smoke: unchanged