### PR TITLE
feat(my-trees): open editor directly on mobile card tap

### DIFF
--- a/js/my-trees/my-trees-ui.js
+++ b/js/my-trees/my-trees-ui.js
@@ -390,12 +390,32 @@
     };
 
     card.addEventListener('click', function (e) {
+      // Don't hijack clicks on inner interactive elements (buttons, links, menus)
+      if (e.target.closest('.tree-card-open-link, .tree-card-footer a, button, a[href]')) {
+        return;
+      }
+
+      // Mobile <480px: navigate directly to Editor
+      if (window.innerWidth < 480) {
+        window.location.href = openHref;
+        return;
+      }
+
+      // Desktop: existing Hub panel selection behavior
       handleCardSelect();
     });
 
     card.addEventListener('keydown', function (e) {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
+
+        // Mobile <480px: navigate directly to Editor
+        if (window.innerWidth < 480) {
+          window.location.href = openHref;
+          return;
+        }
+
+        // Desktop: existing Hub panel selection behavior
         handleCardSelect();
       }
     });


### PR DESCRIPTION
## Summary

* open My Trees cards directly in the Editor on mobile
* preserve desktop My Trees behavior
* avoid hijacking inner action/menu clicks

Refs #1271

## Verification

* npm run verify 또는 npm run verify-static
* mobile My Trees smoke: card tap opens Editor for the selected tree
* desktop My Trees smoke: existing behavior unchanged