### PR TITLE
feat(browse): open public viewer directly on mobile card tap

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -481,6 +481,22 @@
                 const interactiveChild = event.target.closest(interactiveSelector);
                 if (interactiveChild && interactiveChild !== card) return;
 
+                // Mobile <480px: navigate directly to public viewer
+                if (window.innerWidth < 480) {
+                    const tree = treeDataMap.get(card);
+                    if (tree && tree.id) {
+                        var cardRenderer = window.LoveBudSearchCardRenderer;
+                        var viewerHref = cardRenderer && typeof cardRenderer.getTreeViewerHref === 'function'
+                            ? cardRenderer.getTreeViewerHref(tree)
+                            : '';
+                        if (viewerHref) {
+                            event.preventDefault();
+                            window.location.href = viewerHref;
+                            return;
+                        }
+                    }
+                }
+
                 const tree = treeDataMap.get(card);
                 if (tree) {
                     callbacks.selectTree(tree, card);
@@ -498,6 +514,22 @@
                 if (interactiveChild && interactiveChild !== card) return;
 
                 event.preventDefault();
+
+                // Mobile <480px: navigate directly to public viewer
+                if (window.innerWidth < 480) {
+                    const tree = treeDataMap.get(card);
+                    if (tree && tree.id) {
+                        var cardRenderer = window.LoveBudSearchCardRenderer;
+                        var viewerHref = cardRenderer && typeof cardRenderer.getTreeViewerHref === 'function'
+                            ? cardRenderer.getTreeViewerHref(tree)
+                            : '';
+                        if (viewerHref) {
+                            window.location.href = viewerHref;
+                            return;
+                        }
+                    }
+                }
+
                 const tree = treeDataMap.get(card);
                 if (tree) {
                     callbacks.selectTree(tree, card);


### PR DESCRIPTION
## Summary

* open public tree cards directly in the public viewer on mobile
* preserve desktop Browse preview behavior
* avoid hijacking inner action/menu clicks

Refs #1270

## Verification

* npm run verify 또는 npm run verify-static
* mobile Browse smoke: card tap opens public viewer for the selected tree
* desktop Browse smoke: existing preview behavior unchanged