### PR TITLE
fix(my-trees): make footer open CTA clickable

### DIFF
--- a/css/my-trees/my-trees-visibility-gate.css
+++ b/css/my-trees/my-trees-visibility-gate.css
@@ -71,7 +71,6 @@
   line-height: 1;
   text-decoration: none;
   white-space: nowrap;
-  pointer-events: none;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary

* make the My Trees footer open CTA clickable
* preserve card-level selection/direct-open behavior
* keep existing Browse-style footer visual treatment

Refs #1134

## Verification

* npm run verify 또는 npm run verify-static
* My Trees smoke: footer CTA opens Editor
* My Trees smoke: card body behavior unchanged