### PR TITLE
feat: add isolated chat-first workspace shell

### DIFF
--- a/css/chat-first-workspace.css
+++ b/css/chat-first-workspace.css
@@ -1,0 +1,847 @@
+/* ─────────────────────────────────────────────────────────────
+   Chat-First Workspace Shell — Isolated UX Prototype
+   기준 문서: docs/product/CHAT_FIRST_TREE_WORKSPACE_CONTRACT.md
+   Issue #1321
+   ⚡ Mock data only — no DB/API/AI
+   ───────────────────────────────────────────────────────────── */
+
+/* ── Layout ──────────────────────────────────────────────── */
+.cfw-body {
+  background: var(--background, #fdfbf7);
+  color: var(--on-background, #3e342f);
+  font-family: var(--font-body, 'Noto Sans KR', sans-serif);
+  margin: 0;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.cfw-screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* ── Header (minimal, no shared-header) ────────────────── */
+.cfw-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  background: rgba(253, 251, 247, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.cfw-header-logo {
+  font-family: var(--font-heading, 'Outfit', sans-serif);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--primary, #904951);
+  letter-spacing: -0.3px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cfw-header-logo-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.cfw-header-nav {
+  display: flex;
+  gap: 6px;
+}
+
+.cfw-header-back-btn {
+  background: none;
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  border-radius: var(--radius-full, 9999px);
+  padding: 6px 14px;
+  font-size: 13px;
+  color: var(--on-surface-variant, #6c5953);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.18s ease;
+}
+
+.cfw-header-back-btn:hover {
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+}
+
+.cfw-header-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full, 9999px);
+  background: rgba(144, 73, 81, 0.08);
+  color: var(--primary, #904951);
+}
+
+/* ── Entry State ────────────────────────────────────────── */
+.cfw-entry {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+}
+
+.cfw-entry-card {
+  max-width: 520px;
+  width: 100%;
+  text-align: center;
+}
+
+.cfw-entry-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  display: block;
+}
+
+.cfw-entry-title {
+  font-family: var(--font-heading, 'Outfit', sans-serif);
+  font-size: clamp(26px, 4vw, 34px);
+  font-weight: 700;
+  color: var(--on-surface, #483934);
+  margin: 0 0 8px;
+  line-height: 1.2;
+}
+
+.cfw-entry-desc {
+  font-size: 15px;
+  color: var(--on-surface-variant, #6c5953);
+  line-height: 1.6;
+  margin: 0 0 28px;
+}
+
+.cfw-entry-input-wrap {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.cfw-entry-input {
+  flex: 1;
+  padding: 14px 18px;
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.12));
+  border-radius: var(--radius-lg, 2rem);
+  font-size: 15px;
+  font-family: inherit;
+  background: var(--surface-container, #f2efe9);
+  color: var(--on-surface, #483934);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cfw-entry-input:focus {
+  border-color: var(--primary, #904951);
+  box-shadow: 0 0 0 3px rgba(144, 73, 81, 0.12);
+}
+
+.cfw-entry-input::placeholder {
+  color: var(--on-surface-note, #9c8080);
+}
+
+.cfw-entry-submit {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-full, 9999px);
+  border: none;
+  background: var(--primary, #904951);
+  color: var(--on-primary, #ffffff);
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform 0.15s ease, background 0.18s ease;
+}
+
+.cfw-entry-submit:hover {
+  background: var(--primary-vibrant, #b85c66);
+  transform: translateY(-1px);
+}
+
+.cfw-entry-submit:active {
+  transform: translateY(0);
+}
+
+.cfw-entry-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.cfw-action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--lovetree-chip-bg, rgba(255,255,255,0.84));
+  border: 1px solid var(--lovetree-chip-border, rgba(144,73,81,0.12));
+  color: var(--lovetree-chip-text, #6c5953);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.18s ease;
+  user-select: none;
+}
+
+.cfw-action-chip:hover {
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+  border-color: var(--lovetree-pill-border, rgba(144,73,81,0.22));
+  color: var(--primary, #904951);
+}
+
+.cfw-action-chip:active {
+  transform: scale(0.97);
+}
+
+.cfw-action-chip-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* ── Workspace State (desktop 80/20 split) ─────────────── */
+.cfw-workspace {
+  flex: 1;
+  display: none; /* shown via JS */
+  height: calc(100vh - 53px); /* header height */
+}
+
+.cfw-workspace.active {
+  display: flex;
+}
+
+.cfw-workspace-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow-y: auto;
+}
+
+.cfw-workspace-panel {
+  width: 360px;
+  min-width: 300px;
+  max-width: 400px;
+  border-left: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  background: var(--surface-container-low, #f8f5f0);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+/* ── Workspace: Top bar ─────────────────────────────────── */
+.cfw-workspace-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  flex-shrink: 0;
+}
+
+.cfw-search-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--surface-container, #f2efe9);
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.cfw-search-box:focus-within {
+  border-color: var(--primary, #904951);
+}
+
+.cfw-search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--on-surface, #483934);
+  outline: none;
+}
+
+.cfw-search-input::placeholder {
+  color: var(--on-surface-note, #9c8080);
+}
+
+.cfw-search-icon {
+  color: var(--on-surface-note, #9c8080);
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* ── Workspace: Content grid ────────────────────────────── */
+.cfw-content-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto 1fr auto;
+  gap: 16px;
+  padding: 16px 24px;
+  overflow-y: auto;
+  align-content: start;
+}
+
+.cfw-card {
+  background: var(--lovetree-soft-surface, #f8f5f0);
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  border-radius: var(--radius-default, 1rem);
+  padding: 18px;
+  box-shadow: var(--lovetree-card-shadow, 0 4px 20px rgba(75,64,57,0.05));
+}
+
+.cfw-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.cfw-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--on-surface-note, #9c8080);
+}
+
+.cfw-tree-summary {
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.cfw-moment-browser {
+  grid-column: 2 / 3;
+  grid-row: 1 / 3;
+}
+
+.cfw-moment-card {
+  grid-column: 1 / 3;
+  grid-row: 3 / 4;
+}
+
+.cfw-tree-viz {
+  grid-column: 1 / 2;
+  grid-row: 2 / 3;
+}
+
+/* ── Tree Summary ───────────────────────────────────────── */
+.cfw-tree-name {
+  font-family: var(--font-heading, 'Outfit', sans-serif);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--on-surface, #483934);
+  margin: 0 0 4px;
+}
+
+.cfw-tree-meta {
+  font-size: 12px;
+  color: var(--on-surface-note, #9c8080);
+  margin: 0 0 12px;
+}
+
+.cfw-tree-stats {
+  display: flex;
+  gap: 16px;
+}
+
+.cfw-stat {
+  text-align: center;
+}
+
+.cfw-stat-value {
+  font-family: var(--font-heading, 'Outfit', sans-serif);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--primary, #904951);
+  display: block;
+}
+
+.cfw-stat-label {
+  font-size: 11px;
+  color: var(--on-surface-note, #9c8080);
+}
+
+/* ── Moment Browser ─────────────────────────────────────── */
+.cfw-moment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cfw-moment-item {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--surface-container, #f2efe9);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.cfw-moment-item:hover {
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+}
+
+.cfw-moment-item.active {
+  background: rgba(144, 73, 81, 0.06);
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.18));
+  padding: 9px 11px;
+}
+
+.cfw-moment-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+
+.cfw-moment-dot.warm { background: var(--accent-warm, #c9a87c); }
+.cfw-moment-dot.rose { background: var(--accent-rose, #e8c4c8); }
+.cfw-moment-dot.green { background: var(--secondary, #7a8b6e); }
+
+.cfw-moment-text {
+  font-size: 13px;
+  color: var(--on-surface, #483934);
+  line-height: 1.4;
+}
+
+.cfw-moment-date {
+  font-size: 11px;
+  color: var(--on-surface-note, #9c8080);
+  margin-top: 2px;
+}
+
+/* ── Mini Tree Viz ──────────────────────────────────────── */
+.cfw-tree-viz-canvas {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 0;
+  min-height: 60px;
+}
+
+.cfw-viz-node {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--primary-soft, #d4a5a9);
+  flex-shrink: 0;
+}
+
+.cfw-viz-node.core {
+  width: 18px;
+  height: 18px;
+  background: var(--primary, #904951);
+}
+
+.cfw-viz-node.branch {
+  background: var(--accent-warm, #c9a87c);
+}
+
+.cfw-viz-edge {
+  width: 20px;
+  height: 2px;
+  background: var(--lovetree-soft-surface-border, rgba(144,73,81,0.12));
+  flex-shrink: 0;
+}
+
+/* ── Selected Moment Card ───────────────────────────────── */
+.cfw-selected-moment {
+  display: flex;
+  flex-direction: column;
+}
+
+.cfw-selected-moment-header {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--on-surface, #483934);
+  margin-bottom: 6px;
+}
+
+.cfw-selected-moment-body {
+  font-size: 13px;
+  color: var(--on-surface-variant, #6c5953);
+  line-height: 1.6;
+}
+
+.cfw-selected-moment-tags {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.cfw-moment-tag {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+  color: var(--primary, #904951);
+}
+
+/* ── Chat Panel (right 20%) ─────────────────────────────── */
+.cfw-chat-header {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--on-surface, #483934);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cfw-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cfw-chat-msg {
+  max-width: 85%;
+  padding: 10px 14px;
+  border-radius: 14px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.cfw-chat-msg.system {
+  align-self: flex-start;
+  background: var(--lovetree-soft-surface, #f8f5f0);
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  color: var(--on-surface-variant, #6c5953);
+}
+
+.cfw-chat-msg.user {
+  align-self: flex-end;
+  background: var(--primary, #904951);
+  color: var(--on-primary, #ffffff);
+  border-bottom-right-radius: 4px;
+}
+
+.cfw-chat-msg.lovebud {
+  align-self: flex-start;
+  background: var(--accent-rose, #e8c4c8);
+  color: var(--on-surface, #483934);
+  border-bottom-left-radius: 4px;
+}
+
+.cfw-chat-suggestions {
+  padding: 0 18px 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cfw-chat-suggestion {
+  font-size: 11px;
+  padding: 6px 12px;
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid var(--lovetree-chip-border, rgba(144,73,81,0.12));
+  background: var(--surface-container, #f2efe9);
+  color: var(--on-surface-variant, #6c5953);
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s ease;
+}
+
+.cfw-chat-suggestion:hover {
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+  color: var(--primary, #904951);
+  border-color: var(--lovetree-pill-border, rgba(144,73,81,0.22));
+}
+
+.cfw-chat-input-bar {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  flex-shrink: 0;
+}
+
+.cfw-chat-input {
+  flex: 1;
+  padding: 10px 14px;
+  border: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.12));
+  border-radius: var(--radius-lg, 2rem);
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--surface-container, #f2efe9);
+  color: var(--on-surface, #483934);
+  outline: none;
+}
+
+.cfw-chat-input:focus {
+  border-color: var(--primary, #904951);
+}
+
+.cfw-chat-send {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-full, 9999px);
+  border: none;
+  background: var(--primary, #904951);
+  color: var(--on-primary, #ffffff);
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.18s ease;
+}
+
+.cfw-chat-send:hover {
+  background: var(--primary-vibrant, #b85c66);
+}
+
+/* ── Mobile Tab Bar ──────────────────────────────────────── */
+.cfw-mobile-tabs {
+  display: none; /* shown on mobile */
+  border-bottom: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  background: var(--surface-container-lowest, #ffffff);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.cfw-mobile-tab {
+  flex: 1;
+  text-align: center;
+  padding: 12px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--on-surface-variant, #6c5953);
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-family: inherit;
+  position: relative;
+  transition: color 0.18s ease;
+}
+
+.cfw-mobile-tab.active {
+  color: var(--primary, #904951);
+}
+
+.cfw-mobile-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 20%;
+  right: 20%;
+  height: 2px;
+  background: var(--primary, #904951);
+  border-radius: 1px;
+}
+
+/* ── Bottom Sheet ────────────────────────────────────────── */
+.cfw-bottom-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--surface-container-lowest, #ffffff);
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -4px 30px rgba(75, 64, 57, 0.1);
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+  z-index: 200;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.cfw-bottom-sheet.open {
+  transform: translateY(0);
+}
+
+.cfw-bottom-sheet-handle {
+  width: 40px;
+  height: 4px;
+  background: var(--lovetree-soft-surface-border, rgba(144,73,81,0.15));
+  border-radius: 2px;
+  margin: 10px auto 8px;
+}
+
+.cfw-bottom-sheet-content {
+  padding: 0 20px 24px;
+}
+
+.cfw-bottom-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(60, 50, 40, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 199;
+}
+
+.cfw-bottom-sheet-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── Mobile moment strip (default state) ───────────────── */
+.cfw-moment-strip {
+  display: none; /* shown on mobile */
+  padding: 8px 16px;
+  background: var(--surface-container-low, #f8f5f0);
+  border-top: 1px solid var(--lovetree-soft-surface-border, rgba(144,73,81,0.08));
+  font-size: 12px;
+  color: var(--on-surface-variant, #6c5953);
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cfw-moment-strip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary, #904951);
+  flex-shrink: 0;
+}
+
+.cfw-moment-strip-expand {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--primary, #904951);
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: var(--radius-full, 9999px);
+  transition: background 0.15s ease;
+}
+
+.cfw-moment-strip-expand:hover {
+  background: var(--lovetree-pill-bg, rgba(144,73,81,0.08));
+}
+
+/* ── Mobile tab panels ───────────────────────────────────── */
+.cfw-mobile-panel {
+  display: none;
+}
+
+.cfw-mobile-panel.active {
+  display: block;
+}
+
+/* ── Responsive: Mobile ──────────────────────────────────── */
+@media (max-width: 768px) {
+  .cfw-workspace.active {
+    flex-direction: column;
+  }
+
+  .cfw-workspace-panel {
+    display: none;
+  }
+
+  .cfw-mobile-tabs {
+    display: flex;
+  }
+
+  .cfw-moment-strip {
+    display: flex;
+  }
+
+  .cfw-content-grid {
+    grid-template-columns: 1fr;
+    padding: 12px 16px;
+    gap: 12px;
+  }
+
+  .cfw-tree-summary { grid-column: 1; grid-row: auto; }
+  .cfw-tree-viz { grid-column: 1; grid-row: auto; }
+  .cfw-moment-browser { grid-column: 1; grid-row: auto; }
+  .cfw-moment-card { grid-column: 1; grid-row: auto; }
+
+  .cfw-entry-card {
+    max-width: 100%;
+  }
+
+  .cfw-entry {
+    padding: 24px 16px;
+  }
+
+  .cfw-workspace-topbar {
+    padding: 12px 16px;
+  }
+
+  .cfw-header {
+    padding: 10px 16px;
+  }
+
+  .cfw-chat-messages {
+    max-height: 50vh;
+  }
+}
+
+/* ── Animation helpers ────────────────────────────────────── */
+.cfw-fade-in {
+  animation: cfwFadeIn 0.4s ease both;
+}
+
+@keyframes cfwFadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.cfw-stagger > * {
+  animation: cfwFadeIn 0.35s ease both;
+}
+
+.cfw-stagger > *:nth-child(1) { animation-delay: 0.04s; }
+.cfw-stagger > *:nth-child(2) { animation-delay: 0.08s; }
+.cfw-stagger > *:nth-child(3) { animation-delay: 0.12s; }
+.cfw-stagger > *:nth-child(4) { animation-delay: 0.16s; }
+.cfw-stagger > *:nth-child(5) { animation-delay: 0.20s; }
+.cfw-stagger > *:nth-child(6) { animation-delay: 0.24s; }
+
+/* ── State transitions ────────────────────────────────────── */
+.cfw-entry-exit {
+  animation: cfwEntryExit 0.35s ease forwards;
+}
+
+@keyframes cfwEntryExit {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to { opacity: 0; transform: translateY(-12px) scale(0.98); }
+}
+
+.cfw-workspace-enter {
+  animation: cfwWorkspaceEnter 0.4s ease both;
+}
+
+@keyframes cfwWorkspaceEnter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/js/chat-first-workspace.js
+++ b/js/chat-first-workspace.js
@@ -1,0 +1,439 @@
+/**
+ * LoveBud — Chat-First Workspace Shell
+ * =====================================
+ * Isolated UX prototype for Issue #1321
+ * 기준 문서: docs/product/CHAT_FIRST_TREE_WORKSPACE_CONTRACT.md
+ *
+ * ⚡ Mock data only — no DB/API/AI
+ * ⚡ No editor/runtime modification
+ * ⚡ No production route change
+ *
+ * v20260518-1
+ */
+(function () {
+  'use strict';
+
+  /* ── Mock Data ──────────────────────────────────────────── */
+  var MOCK_TREE = {
+    id: 'tree-mock-001',
+    name: '봄날의 산책',
+    created: '2026-03-15',
+    momentCount: 5,
+    branchCount: 2,
+  };
+
+  var MOCK_MOMENTS = [
+    {
+      id: 'mom-001',
+      text: '처음 만난 날, 벚꽃이 흩날리던 공원 벤치에서 — 그날의 온도, 바람, 햇살이 아직도 선명해.',
+      date: '2026-03-15',
+      type: 'warm',
+      tags: ['첫만남', '벚꽃', '공원'],
+    },
+    {
+      id: 'mom-002',
+      text: '함께 만든 첫 요리. 파스타는 소금을 너무 많이 넣었지만 웃음이 더 많았던 저녁.',
+      date: '2026-03-22',
+      type: 'rose',
+      tags: ['요리', '첫경험', '웃음'],
+    },
+    {
+      id: 'mom-003',
+      text: '비 오는 날, 우산 없이 걸으며 했던 수다. 젖은 어깨보다 따뜻했던 말들.',
+      date: '2026-04-02',
+      type: 'warm',
+      tags: ['비', '대화', '일상'],
+    },
+    {
+      id: 'mom-004',
+      text: '함께 본 첫 영화, 그리고 그날 밤 늦도록 이어진 전화 통화. 장르는 기억나지 않지만 네 목소리는 기억나.',
+      date: '2026-04-10',
+      type: 'green',
+      tags: ['영화', '전화', '로맨스'],
+    },
+    {
+      id: 'mom-005',
+      text: '네가 나를 처음으로 "우리"라고 말한 순간. 아주 사소한 문장이었지만 가슴이 뛰었어.',
+      date: '2026-04-18',
+      type: 'rose',
+      tags: ['말투', '특별한순간', '설렘'],
+    },
+  ];
+
+  var MOCK_CHAT_HISTORY = [
+    { role: 'system', text: '안녕하세요! 오늘은 어떤 순간을 기록하고 싶으신가요?' },
+  ];
+
+  /* ── State ──────────────────────────────────────────────── */
+  var state = {
+    screen: 'entry', // 'entry' | 'workspace'
+    mobileTab: 'chat', // 'chat' | 'tree' | 'moments'
+    selectedMomentId: 'mom-001',
+    chatMessages: JSON.parse(JSON.stringify(MOCK_CHAT_HISTORY)),
+    entryText: '',
+    chatInputText: '',
+    bottomSheetOpen: false,
+  };
+
+  /* ── DOM Cache ──────────────────────────────────────────── */
+  var $ = function (sel) { return document.querySelector(sel); };
+  var $$ = function (sel) { return document.querySelectorAll(sel); };
+
+  var els = {};
+
+  function cacheDom() {
+    els.entry = $('.cfw-entry');
+    els.workspace = $('.cfw-workspace');
+    els.entryInput = $('.cfw-entry-input');
+    els.entrySubmit = $('.cfw-entry-submit');
+    els.entryActions = $('.cfw-entry-actions');
+    els.chatMessages = $('.cfw-chat-messages');
+    els.chatInput = $('.cfw-chat-input');
+    els.chatSend = $('.cfw-chat-send');
+    els.chatSuggestions = $('.cfw-chat-suggestions');
+    els.momentList = $('.cfw-moment-list');
+    els.treeName = $('.cfw-tree-name');
+    els.treeMeta = $('.cfw-tree-meta');
+    els.statMoments = $('.cfw-stat-moments');
+    els.statBranches = $('.cfw-stat-branches');
+    els.selectedMomentHeader = $('.cfw-selected-moment-header');
+    els.selectedMomentBody = $('.cfw-selected-moment-body');
+    els.selectedMomentTags = $('.cfw-selected-moment-tags');
+    els.mobileTabs = $('.cfw-mobile-tabs');
+    els.momentStripName = $('.cfw-moment-strip-name');
+    els.momentStripExpand = $('.cfw-moment-strip-expand');
+    els.bottomSheet = $('.cfw-bottom-sheet');
+    els.bottomSheetOverlay = $('.cfw-bottom-sheet-overlay');
+    els.bottomSheetContent = $('.cfw-bottom-sheet-content');
+    els.mobileTabChat = $('.cfw-mobile-tab[data-tab="chat"]');
+    els.mobileTabTree = $('.cfw-mobile-tab[data-tab="tree"]');
+    els.mobileTabMoments = $('.cfw-mobile-tab[data-tab="moments"]');
+    els.mobilePanelChat = $('.cfw-mobile-panel[data-panel="chat"]');
+    els.mobilePanelTree = $('.cfw-mobile-panel[data-panel="tree"]');
+    els.mobilePanelMoments = $('.cfw-mobile-panel[data-panel="moments"]');
+  }
+
+  /* ── Render Functions ───────────────────────────────────── */
+
+  function renderTreeSummary() {
+    if (els.treeName) els.treeName.textContent = MOCK_TREE.name;
+    if (els.treeMeta) els.treeMeta.textContent = 'created ' + MOCK_TREE.created;
+    if (els.statMoments) els.statMoments.textContent = MOCK_MOMENTS.length;
+    if (els.statBranches) els.statBranches.textContent = MOCK_TREE.branchCount;
+  }
+
+  function renderMomentList() {
+    if (!els.momentList) return;
+    els.momentList.innerHTML = '';
+    MOCK_MOMENTS.forEach(function (mom) {
+      var item = document.createElement('div');
+      item.className = 'cfw-moment-item' + (mom.id === state.selectedMomentId ? ' active' : '');
+      item.dataset.momentId = mom.id;
+      item.innerHTML =
+        '<div class="cfw-moment-dot ' + mom.type + '"></div>' +
+        '<div><div class="cfw-moment-text">' + mom.text + '</div>' +
+        '<div class="cfw-moment-date">' + mom.date + '</div></div>';
+      item.addEventListener('click', function () {
+        selectMoment(mom.id);
+      });
+      els.momentList.appendChild(item);
+    });
+  }
+
+  function renderSelectedMoment() {
+    var mom = MOCK_MOMENTS.find(function (m) { return m.id === state.selectedMomentId; });
+    if (!mom) return;
+    if (els.selectedMomentHeader) els.selectedMomentHeader.textContent = formatDate(mom.date);
+    if (els.selectedMomentBody) els.selectedMomentBody.textContent = mom.text;
+    if (els.selectedMomentTags) {
+      els.selectedMomentTags.innerHTML = '';
+      mom.tags.forEach(function (tag) {
+        var span = document.createElement('span');
+        span.className = 'cfw-moment-tag';
+        span.textContent = tag;
+        els.selectedMomentTags.appendChild(span);
+      });
+    }
+    if (els.momentStripName) els.momentStripName.textContent = mom.text.slice(0, 30) + '…';
+  }
+
+  function renderChatMessages() {
+    if (!els.chatMessages) return;
+    els.chatMessages.innerHTML = '';
+    state.chatMessages.forEach(function (msg) {
+      var div = document.createElement('div');
+      div.className = 'cfw-chat-msg ' + msg.role;
+      div.textContent = msg.text;
+      els.chatMessages.appendChild(div);
+    });
+    els.chatMessages.scrollTop = els.chatMessages.scrollHeight;
+  }
+
+  function renderMobileTabs() {
+    var tabs = [els.mobileTabChat, els.mobileTabTree, els.mobileTabMoments];
+    var panels = [els.mobilePanelChat, els.mobilePanelTree, els.mobilePanelMoments];
+    tabs.forEach(function (t) { if (t) t.classList.remove('active'); });
+    panels.forEach(function (p) { if (p) p.classList.remove('active'); });
+    var activeTab = document.querySelector('.cfw-mobile-tab[data-tab="' + state.mobileTab + '"]');
+    var activePanel = document.querySelector('.cfw-mobile-panel[data-panel="' + state.mobileTab + '"]');
+    if (activeTab) activeTab.classList.add('active');
+    if (activePanel) activePanel.classList.add('active');
+  }
+
+  function renderAll() {
+    renderTreeSummary();
+    renderMomentList();
+    renderSelectedMoment();
+    renderChatMessages();
+    renderMobileTabs();
+  }
+
+  /* ── Actions ────────────────────────────────────────────── */
+
+  function selectMoment(momentId) {
+    state.selectedMomentId = momentId;
+    renderMomentList();
+    renderSelectedMoment();
+  }
+
+  function transitionToWorkspace(triggerText) {
+    if (state.screen === 'workspace') return;
+    state.screen = 'workspace';
+
+    // entry exit animation
+    if (els.entry) els.entry.classList.add('cfw-entry-exit');
+
+    var lovebudMsg = '좋아요! "' + triggerText + '"에 대해 이야기해볼까요?\n트리에 기록된 순간들을 보여드릴게요.';
+
+    setTimeout(function () {
+      if (els.entry) {
+        els.entry.style.display = 'none';
+        els.entry.classList.remove('cfw-entry-exit');
+      }
+      if (els.workspace) {
+        els.workspace.classList.add('active', 'cfw-workspace-enter');
+      }
+      // initial chat message
+      state.chatMessages = JSON.parse(JSON.stringify(MOCK_CHAT_HISTORY));
+      addChatMessage('lovebud', lovebudMsg);
+      renderAll();
+    }, 300);
+  }
+
+  function addChatMessage(role, text) {
+    state.chatMessages.push({ role: role, text: text });
+    renderChatMessages();
+  }
+
+  function handleEntrySubmit(text) {
+    var trimmed = (text || state.entryText || '').trim();
+    if (!trimmed) return;
+
+    addChatMessage('user', trimmed);
+    transitionToWorkspace(trimmed);
+
+    // Simulate lovebud response after transition
+    setTimeout(function () {
+      var lovebuds = [
+        '이 순간을 트리에 어떻게 기록하면 좋을까요? 떠오른 감정이나 생각이 있나요?',
+        '기억 속 비슷한 순간이 더 떠오르면 알려주세요. 함께 트리를 만들어가요.',
+        '이 내용을 기반으로 관계 흐름을 분석해볼까요? 아니면 비슷한 순간을 더 찾아볼까요?',
+      ];
+      addChatMessage('lovebud', lovebuds[Math.floor(Math.random() * lovebuds.length)]);
+    }, 600);
+  }
+
+  function handleChatSubmit(text) {
+    var trimmed = (text || state.chatInputText || '').trim();
+    if (!trimmed) return;
+    addChatMessage('user', trimmed);
+    if (els.chatInput) els.chatInput.value = '';
+    state.chatInputText = '';
+
+    // Simulated lovebud response
+    setTimeout(function () {
+      var lovebuds = [
+        '그런 기억이 있었군요. 관련된 순간들을 트리에서 찾아볼게요.',
+        '좋아요. 이 감정을 트리의 새 순간으로 기록해볼까요?',
+        '흥미로운 점이네요. 이전 순간들과 연결되는 패턴을 발견했어요.',
+      ];
+      addChatMessage('lovebud', lovebuds[Math.floor(Math.random() * lovebuds.length)]);
+    }, 500 + Math.random() * 800);
+  }
+
+  function openBottomSheet() {
+    state.bottomSheetOpen = true;
+    if (els.bottomSheet) {
+      els.bottomSheet.classList.add('open');
+      // Render moment detail in sheet
+      var mom = MOCK_MOMENTS.find(function (m) { return m.id === state.selectedMomentId; });
+      if (mom && els.bottomSheetContent) {
+        els.bottomSheetContent.innerHTML =
+          '<div style="font-weight:600;font-size:16px;margin-bottom:8px;">' + formatDate(mom.date) + '</div>' +
+          '<div style="font-size:14px;color:var(--on-surface-variant);line-height:1.6;margin-bottom:12px;">' + mom.text + '</div>' +
+          '<div style="display:flex;gap:6px;flex-wrap:wrap;">' +
+          mom.tags.map(function (t) { return '<span class="cfw-moment-tag">' + t + '</span>'; }).join('') +
+          '</div>' +
+          '<div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--lovetree-soft-surface-border);">' +
+          '<div style="font-size:12px;color:var(--on-surface-note);margin-bottom:8px;">이 순간의 미니 트리</div>' +
+          '<div style="display:flex;align-items:center;gap:6px;">' +
+          '<div class="cfw-viz-node core"></div>' +
+          '<div class="cfw-viz-edge"></div>' +
+          '<div class="cfw-viz-node"></div>' +
+          '<div class="cfw-viz-edge"></div>' +
+          '<div class="cfw-viz-node branch"></div>' +
+          '<div class="cfw-viz-edge"></div>' +
+          '<div class="cfw-viz-node"></div>' +
+          '</div></div>';
+      }
+    }
+    if (els.bottomSheetOverlay) els.bottomSheetOverlay.classList.add('open');
+  }
+
+  function closeBottomSheet() {
+    state.bottomSheetOpen = false;
+    if (els.bottomSheet) els.bottomSheet.classList.remove('open');
+    if (els.bottomSheetOverlay) els.bottomSheetOverlay.classList.remove('open');
+  }
+
+  function switchMobileTab(tab) {
+    state.mobileTab = tab;
+    renderMobileTabs();
+  }
+
+  function formatDate(dateStr) {
+    var d = new Date(dateStr + 'T00:00:00');
+    var months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
+    return d.getFullYear() + '년 ' + months[d.getMonth()] + ' ' + d.getDate() + '일';
+  }
+
+  /* ── Event Binding ──────────────────────────────────────── */
+
+  function bindEvents() {
+    // Entry submit
+    if (els.entrySubmit) {
+      els.entrySubmit.addEventListener('click', function () {
+        if (els.entryInput) {
+          state.entryText = els.entryInput.value;
+          handleEntrySubmit();
+        }
+      });
+    }
+
+    if (els.entryInput) {
+      els.entryInput.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') {
+          state.entryText = els.entryInput.value;
+          handleEntrySubmit();
+          els.entryInput.value = '';
+        }
+      });
+    }
+
+    // Action chips
+    if (els.entryActions) {
+      els.entryActions.addEventListener('click', function (e) {
+        var chip = e.target.closest('.cfw-action-chip');
+        if (!chip) return;
+        var text = chip.dataset.action || chip.textContent.trim();
+        if (els.entryInput) els.entryInput.value = '';
+        handleEntrySubmit(text);
+      });
+    }
+
+    // Chat send
+    if (els.chatSend) {
+      els.chatSend.addEventListener('click', function () {
+        if (els.chatInput) {
+          state.chatInputText = els.chatInput.value;
+          handleChatSubmit();
+        }
+      });
+    }
+
+    if (els.chatInput) {
+      els.chatInput.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') {
+          state.chatInputText = els.chatInput.value;
+          handleChatSubmit();
+          els.chatInput.value = '';
+        }
+      });
+    }
+
+    // Chat suggestions
+    if (els.chatSuggestions) {
+      els.chatSuggestions.addEventListener('click', function (e) {
+        var btn = e.target.closest('.cfw-chat-suggestion');
+        if (!btn) return;
+        handleChatSubmit(btn.textContent.trim());
+      });
+    }
+
+    // Mobile tabs
+    if (els.mobileTabs) {
+      els.mobileTabs.addEventListener('click', function (e) {
+        var tab = e.target.closest('.cfw-mobile-tab');
+        if (!tab) return;
+        switchMobileTab(tab.dataset.tab);
+      });
+    }
+
+    // Bottom sheet
+    if (els.momentStripExpand) {
+      els.momentStripExpand.addEventListener('click', openBottomSheet);
+    }
+    if (els.bottomSheetOverlay) {
+      els.bottomSheetOverlay.addEventListener('click', closeBottomSheet);
+    }
+
+    // Back to entry button in workspace
+    var backBtn = document.getElementById('cfwBackToEntry');
+    if (backBtn) {
+      backBtn.addEventListener('click', function () {
+        state.screen = 'entry';
+        if (els.workspace) {
+          els.workspace.classList.remove('active', 'cfw-workspace-enter');
+        }
+        if (els.entry) {
+          els.entry.style.display = 'flex';
+          els.entry.classList.add('cfw-fade-in');
+        }
+        state.chatMessages = JSON.parse(JSON.stringify(MOCK_CHAT_HISTORY));
+        renderAll();
+      });
+    }
+
+    // Keyboard close bottom sheet with Escape
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && state.bottomSheetOpen) {
+        closeBottomSheet();
+      }
+    });
+  }
+
+  /* ── Responsive tab auto-switch ─────────────────────────── */
+  function handleResize() {
+    var isMobile = window.innerWidth <= 768;
+    if (!isMobile && state.mobileTab !== 'chat') {
+      // On desktop, just show chat panel
+      els.mobileTabChat = document.querySelector('.cfw-mobile-tab[data-tab="chat"]');
+      state.mobileTab = 'chat';
+      renderMobileTabs();
+    }
+  }
+
+  /* ── Init ───────────────────────────────────────────────── */
+  function init() {
+    cacheDom();
+    renderAll();
+    bindEvents();
+    window.addEventListener('resize', handleResize);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/pages/chat-first-workspace.html
+++ b/pages/chat-first-workspace.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>대화로 시작하는 러브트리 | LoveTree Prototype</title>
+  <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico" sizes="32x32">
+  <!-- Design system tokens -->
+  <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
+  <!-- Isolated shell styles -->
+  <link rel="stylesheet" href="../css/chat-first-workspace.css?v=20260518-1">
+  <!-- Material Symbols -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+</head>
+<body class="cfw-body">
+  <div class="cfw-screen">
+
+    <!-- ─── Minimal Header ─────────────────────────────── -->
+    <header class="cfw-header">
+      <div class="cfw-header-logo">
+        <span class="cfw-header-logo-icon">🌳</span>
+        LoveTree
+        <span class="cfw-header-badge">prototype</span>
+      </div>
+      <nav class="cfw-header-nav">
+        <a href="my-trees" class="cfw-header-back-btn">← 내 러브트리</a>
+      </nav>
+    </header>
+
+    <!-- ─── Entry State ─────────────────────────────────── -->
+    <section class="cfw-entry" id="cfwEntry">
+      <div class="cfw-entry-card cfw-fade-in">
+        <span class="cfw-entry-icon">🌱</span>
+        <h1 class="cfw-entry-title">무엇부터 시작할까요?</h1>
+        <p class="cfw-entry-desc">
+          러브트리에 기록할 순간을 이야기해보세요.<br>
+          대화를 시작하면 트리와 순간들이 펼쳐집니다.
+        </p>
+
+        <div class="cfw-entry-input-wrap">
+          <input
+            type="text"
+            class="cfw-entry-input"
+            id="cfwEntryInput"
+            placeholder="예: 오늘 있었던 따뜻한 순간을 기록하고 싶어"
+            aria-label="대화 입력"
+            autofocus
+          />
+          <button class="cfw-entry-submit" id="cfwEntrySubmit" aria-label="전송">
+            <span class="material-symbols-outlined" style="font-size:22px;">arrow_forward</span>
+          </button>
+        </div>
+
+        <div class="cfw-entry-actions cfw-stagger" id="cfwEntryActions">
+          <button class="cfw-action-chip" data-action="새 러브트리를 시작하고 싶어">
+            <span class="cfw-action-chip-icon">🌿</span>
+            새 러브트리 시작
+          </button>
+          <button class="cfw-action-chip" data-action="예전 순간을 다시 보고 싶어">
+            <span class="cfw-action-chip-icon">🔍</span>
+            기존 순간 이어보기
+          </button>
+          <button class="cfw-action-chip" data-action="기억 속 특별한 순간을 찾아줘">
+            <span class="cfw-action-chip-icon">💭</span>
+            기억 속 순간 찾기
+          </button>
+          <button class="cfw-action-chip" data-action="관계 흐름을 분석해줘">
+            <span class="cfw-action-chip-icon">🔄</span>
+            관계 흐름 살펴보기
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── Workspace State ─────────────────────────────── -->
+    <div class="cfw-workspace" id="cfwWorkspace">
+
+      <!-- Main (left ~80%) -->
+      <div class="cfw-workspace-main">
+        <!-- Top bar with search -->
+        <div class="cfw-workspace-topbar">
+          <div class="cfw-search-box">
+            <span class="cfw-search-icon material-symbols-outlined">search</span>
+            <input type="text" class="cfw-search-input" placeholder="트리와 순간 검색..." aria-label="검색" disabled>
+          </div>
+          <button class="cfw-header-back-btn" id="cfwBackToEntry">← 처음으로</button>
+        </div>
+
+        <!-- Content grid -->
+        <div class="cfw-content-grid cfw-fade-in">
+          <!-- Tree Summary -->
+          <div class="cfw-card cfw-tree-summary">
+            <div class="cfw-card-header">
+              <span class="cfw-card-title">현재 트리</span>
+            </div>
+            <div class="cfw-tree-name" id="cfwTreeName"></div>
+            <div class="cfw-tree-meta" id="cfwTreeMeta"></div>
+            <div class="cfw-tree-stats">
+              <div class="cfw-stat">
+                <span class="cfw-stat-value cfw-stat-moments" id="cfwStatMoments">0</span>
+                <span class="cfw-stat-label">순간</span>
+              </div>
+              <div class="cfw-stat">
+                <span class="cfw-stat-value cfw-stat-branches" id="cfwStatBranches">0</span>
+                <span class="cfw-stat-label">브랜치</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Mini Tree Viz -->
+          <div class="cfw-card cfw-tree-viz">
+            <div class="cfw-card-header">
+              <span class="cfw-card-title">트리 시각화</span>
+            </div>
+            <div class="cfw-tree-viz-canvas">
+              <div class="cfw-viz-node core"></div>
+              <div class="cfw-viz-edge"></div>
+              <div class="cfw-viz-node"></div>
+              <div class="cfw-viz-edge"></div>
+              <div class="cfw-viz-node branch"></div>
+              <div class="cfw-viz-edge"></div>
+              <div class="cfw-viz-node"></div>
+              <div class="cfw-viz-edge"></div>
+              <div class="cfw-viz-node"></div>
+              <div class="cfw-viz-edge"></div>
+              <div class="cfw-viz-node branch"></div>
+            </div>
+          </div>
+
+          <!-- Moment Browser -->
+          <div class="cfw-card cfw-moment-browser">
+            <div class="cfw-card-header">
+              <span class="cfw-card-title">순간 브라우저</span>
+              <span style="font-size:11px;color:var(--on-surface-note);">5개의 순간</span>
+            </div>
+            <div class="cfw-moment-list" id="cfwMomentList"></div>
+          </div>
+
+          <!-- Selected Moment Card -->
+          <div class="cfw-card cfw-moment-card">
+            <div class="cfw-selected-moment">
+              <div class="cfw-selected-moment-header" id="cfwSelectedMomentHeader"></div>
+              <div class="cfw-selected-moment-body" id="cfwSelectedMomentBody"></div>
+              <div class="cfw-selected-moment-tags" id="cfwSelectedMomentTags"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Chat Panel (right ~20%) -->
+      <div class="cfw-workspace-panel">
+        <div class="cfw-chat-header">
+          <span class="material-symbols-outlined" style="font-size:18px;color:var(--primary);">forum</span>
+          대화
+        </div>
+        <div class="cfw-chat-messages" id="cfwChatMessages"></div>
+        <div class="cfw-chat-suggestions" id="cfwChatSuggestions">
+          <button class="cfw-chat-suggestion">이 순간을 기록해줘</button>
+          <button class="cfw-chat-suggestion">비슷한 순간 찾아줘</button>
+          <button class="cfw-chat-suggestion">관계 흐름 알려줘</button>
+          <button class="cfw-chat-suggestion">새 브랜치 제안해줘</button>
+        </div>
+        <div class="cfw-chat-input-bar">
+          <input type="text" class="cfw-chat-input" id="cfwChatInput" placeholder="메시지 입력..." aria-label="채팅 입력">
+          <button class="cfw-chat-send" id="cfwChatSend" aria-label="전송">
+            <span class="material-symbols-outlined" style="font-size:18px;">send</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- ─── Mobile Elements ──────────────────────────────── -->
+
+      <!-- Mobile Tab Bar -->
+      <div class="cfw-mobile-tabs" id="cfwMobileTabs">
+        <button class="cfw-mobile-tab active" data-tab="chat">
+          <span class="material-symbols-outlined" style="font-size:18px;display:block;margin:0 auto 2px;">forum</span>
+          대화
+        </button>
+        <button class="cfw-mobile-tab" data-tab="tree">
+          <span class="material-symbols-outlined" style="font-size:18px;display:block;margin:0 auto 2px;">account_tree</span>
+          트리
+        </button>
+        <button class="cfw-mobile-tab" data-tab="moments">
+          <span class="material-symbols-outlined" style="font-size:18px;display:block;margin:0 auto 2px;">auto_stories</span>
+          순간
+        </button>
+      </div>
+
+      <!-- Mobile Moment Strip (default state) -->
+      <div class="cfw-moment-strip" id="cfwMomentStrip">
+        <div class="cfw-moment-strip-dot"></div>
+        <span class="cfw-moment-strip-name" id="cfwMomentStripName">—</span>
+        <button class="cfw-moment-strip-expand" id="cfwMomentStripExpand">
+          펼쳐보기 <span style="font-size:10px;">▲</span>
+        </button>
+      </div>
+
+      <!-- Mobile panels -->
+      <div class="cfw-mobile-panel active" data-panel="chat">
+        <!-- Chat is shown inline on mobile -->
+      </div>
+      <div class="cfw-mobile-panel" data-panel="tree">
+        <div class="cfw-content-grid" style="padding:12px 16px;grid-template-columns:1fr;gap:12px;">
+          <div class="cfw-card"><div class="cfw-card-title" style="margin-bottom:8px;">현재 트리</div><div class="cfw-tree-name" style="margin-bottom:4px;"></div><div class="cfw-tree-viz-canvas" style="padding:8px 0;">트리 시각화 영역</div></div>
+        </div>
+      </div>
+      <div class="cfw-mobile-panel" data-panel="moments">
+        <div class="cfw-content-grid" style="padding:12px 16px;grid-template-columns:1fr;gap:12px;">
+          <div class="cfw-card"><div class="cfw-card-title" style="margin-bottom:8px;">순간 목록</div><div class="cfw-moment-list" id="cfwMomentListMobile"></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── Bottom Sheet (mobile expanded state) ────────── -->
+    <div class="cfw-bottom-sheet-overlay" id="cfwBottomSheetOverlay"></div>
+    <div class="cfw-bottom-sheet" id="cfwBottomSheet">
+      <div class="cfw-bottom-sheet-handle"></div>
+      <div class="cfw-bottom-sheet-content" id="cfwBottomSheetContent">
+        <!-- filled by JS -->
+      </div>
+    </div>
+  </div>
+
+  <!-- Script (deferred for performance) -->
+  <script src="../js/chat-first-workspace.js?v=20260518-1"></script>
+</body>
+</html>


### PR DESCRIPTION
Refs #1321

기준 문서: `docs/product/CHAT_FIRST_TREE_WORKSPACE_CONTRACT.md`
이미지 참고: `docs/image-gpt/`

Issue #1321의 chat-first tree workspace isolated UI shell을 구현합니다.

## 구현 범위

- **Desktop Entry State**: 중앙 대화 카드, 안내 문구, 입력창, 추천 액션 4개
- **Desktop Workspace State**: 80/20 split — 왼쪽 workspace (트리 요약, 순간 브라우저, 미니 트리 시각화, 선택된 순간 카드) + 오른쪽 chat panel
- **Mobile**: 탭 기반 (대화/트리/순간), 바텀시트 확장, 하단 모먼트 스트립
- **Mock data**: 하드코딩 트리/순간/대화 데이터
- **Mock chat**: 시뮬레이션된 LoveBud 응답

## 제한 사항

- Mock data only — no real DB/API/AI/LLM
- No editor replacement — 기존 editor/runtime 미변경
- No production route change — `pages/chat-first-workspace.html` isolated path
- No save/edit/delete functionality
- Search input은 disabled (static mock)
- 기존 shared-header/page-shell 미사용 (isolated self-contained)

## 변경 파일

| 파일 | 설명 |
|------|------|
| `pages/chat-first-workspace.html` | Isolated prototype HTML page |
| `css/chat-first-workspace.css` | All styles (design system tokens 재사용) |
| `js/chat-first-workspace.js` | All logic + mock data |

## Smoke Test 결과

- Desktop entry → workspace 전환: ✅
- Chat 메시지 송수신: ✅
- 순간 선택/변경: ✅
- 처음으로 돌아가기: ✅
- Mobile 탭 전환 (대화/트리/순간): ✅
- 바텀시트 열기/닫기 (Escape): ✅
- Console error: **0개**