### PR TITLE
refactor(editor): extract floating toolbar keyboard shortcut helpers

### DIFF
--- a/js/editor/editor-floating-toolbar-keyboard.js
+++ b/js/editor/editor-floating-toolbar-keyboard.js
@@ -1,0 +1,111 @@
+/**
+ * LoveBud Editor — Floating Toolbar Keyboard Shortcut Helpers
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Provides keyboard shortcut dispatch for the floating toolbar.
+ * - E shortcut -> edit action
+ * - C shortcut -> continue action
+ * - V shortcut -> view action
+ * - Delete/Backspace -> delete confirmation
+ *
+ * No behavior change. No accessibility changes (roving focus, escape, etc.).
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * Handle global keyboard shortcuts for the floating toolbar.
+   * Processes E, C, V, and Delete/Backspace keys when the toolbar is visible.
+   * 
+   * @param {KeyboardEvent} e - The keydown event
+   * @param {Object} context - Context containing state and element references
+   * @returns {boolean} - True if the event was handled
+   */
+  function handleShortcut(e, context) {
+    if (!context || !context.isVisible) return false;
+
+    // Guard: Don't process if user is typing in an input field
+    var tag = e.target && e.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
+
+    var key = e.key;
+    var actions = window.LoveBudFloatingToolbarActions;
+
+    // E → Edit selected moment
+    if (key === 'e' || key === 'E') {
+      if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (context.flashButton) context.flashButton(context.editBtn);
+        // Prefer using action helper if available
+        if (actions && actions.edit) {
+          actions.edit();
+        } else if (context.editBtn) {
+          context.editBtn.click();
+        }
+        return true;
+      }
+    }
+
+    // C → Continue from selected moment
+    if (key === 'c' || key === 'C') {
+      if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (context.flashButton) context.flashButton(context.continueBtn);
+        if (actions && actions.continue) {
+          actions.continue();
+        } else if (context.continueBtn) {
+          context.continueBtn.click();
+        }
+        return true;
+      }
+    }
+
+    // V → View selected moment detail
+    if (key === 'v' || key === 'V') {
+      if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (context.flashButton) context.flashButton(context.viewBtn);
+        if (actions && actions.view) {
+          actions.view();
+        } else if (context.viewBtn) {
+          context.viewBtn.click();
+        }
+        return true;
+      }
+    }
+
+    // Delete/Backspace → Show delete confirmation
+    if (key === 'Delete' || key === 'Backspace') {
+      e.preventDefault();
+      e.stopPropagation();
+      // Trigger delete via the dropdown action button
+      if (context.deleteAction) {
+        // Flash the more button to indicate where to find the delete
+        if (context.moreBtn && context.flashButton) {
+          context.flashButton(context.moreBtn);
+        }
+        context.deleteAction.click();
+      } else {
+        var deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
+        if (deleteMemoryBtn) {
+          if (context.flashButton) context.flashButton(context.deleteAction);
+          deleteMemoryBtn.click();
+        }
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // Export to global namespace
+  window.LoveBudFloatingToolbarKeyboard = {
+    handleShortcut: handleShortcut
+  };
+
+  console.log('[toolbar-keyboard] Initialized (Refs #1275)');
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -781,65 +781,17 @@
 
     // Keyboard shortcuts via document-level keydown listener
     document.addEventListener('keydown', function (e) {
-      // Only process when toolbar is visible
-      if (!toolbar || !toolbar.classList.contains(IS_VISIBLE_CLASS)) return;
-
-      // Don't process if user is typing in an input field
-      var tag = e.target && e.target.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-
-      var key = e.key;
-
-      // E → Edit selected moment
-      if (key === 'e' || key === 'E') {
-        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-          e.preventDefault();
-          e.stopPropagation();
-          flashButton(editBtn);
-          editBtn.click();
-          return;
-        }
-      }
-
-      // C → Continue from selected moment
-      if (key === 'c' || key === 'C') {
-        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-          e.preventDefault();
-          e.stopPropagation();
-          flashButton(continueBtn);
-          continueBtn.click();
-          return;
-        }
-      }
-
-      // V → View selected moment detail
-      if (key === 'v' || key === 'V') {
-        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-          e.preventDefault();
-          e.stopPropagation();
-          flashButton(viewBtn);
-          viewBtn.click();
-          return;
-        }
-      }
-
-      // Delete/Backspace → Show delete confirmation
-      if (key === 'Delete' || key === 'Backspace') {
-        e.preventDefault();
-        e.stopPropagation();
-        // Trigger delete via the dropdown action button (which triggers the existing flow)
-        if (deleteAction) {
-          // Flash the more button to indicate where to find the delete
-          if (moreBtn) flashButton(moreBtn);
-          deleteAction.click();
-        } else {
-          var deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
-          if (deleteMemoryBtn) {
-            flashButton(deleteAction);
-            deleteMemoryBtn.click();
-          }
-        }
-        return;
+      if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.handleShortcut) {
+        var context = {
+          isVisible: toolbar && toolbar.classList.contains(IS_VISIBLE_CLASS),
+          editBtn: editBtn,
+          continueBtn: continueBtn,
+          viewBtn: viewBtn,
+          moreBtn: moreBtn,
+          deleteAction: deleteAction,
+          flashButton: flashButton
+        };
+        window.LoveBudFloatingToolbarKeyboard.handleShortcut(e, context);
       }
     });
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -352,6 +352,7 @@
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
     <script src="../js/editor/editor-floating-toolbar-actions.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-keyboard.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
- Refs #1275
- PR #1329 후속 runtime split slice입니다.

**추출 범위:**
- E shortcut edit
- C shortcut continue
- V shortcut view
- Delete/Backspace existing behavior dispatch

**제외 범위:**
- roving focus
- arrow navigation
- Escape
- focus restore
- aria changes
- visibility/show/hide
- positioning
- selection state
- MutationObserver
- tooltip/dropdown

**참고:**
- `contenteditable` guard는 기존에도 없었고 이번 PR에서도 behavior change 방지를 위해 추가하지 않았습니다.
- GitHub Actions는 PR 생성 후 확인 예정입니다.
