### PR TITLE
refactor(editor): extract floating toolbar dropdown helpers

### DIFF
--- a/js/editor/editor-floating-toolbar-dropdown.js
+++ b/js/editor/editor-floating-toolbar-dropdown.js
@@ -1,0 +1,163 @@
+/**
+ * LoveBud Editor — Floating Toolbar Dropdown Helpers
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Provides dropdown visibility, positioning, event binding,
+ * and secondary action dispatch for the floating toolbar's "..." menu.
+ *
+ * No behavior change.
+ */
+
+(function () {
+  'use strict';
+
+  var IS_VISIBLE_CLASS = 'is-visible';
+  var IS_HIDDEN_CLASS = 'is-hidden';
+
+  /**
+   * Position the dropdown below/right of the "..." button.
+   */
+  function positionDropdown(dropdown, moreBtn) {
+    if (!dropdown || !moreBtn) return;
+    var rect = moreBtn.getBoundingClientRect();
+    var ddW = dropdown.offsetWidth || 180;
+
+    // Align the dropdown's right edge with the more button's right edge
+    var x = rect.right - ddW;
+    var y = rect.bottom + 4;
+
+    // Keep within viewport
+    var maxX = window.innerWidth - ddW - 8;
+    x = Math.max(8, Math.min(x, maxX));
+
+    dropdown.style.left = Math.round(x) + 'px';
+    dropdown.style.top = Math.round(y) + 'px';
+  }
+
+  /**
+   * Show the secondary actions dropdown.
+   */
+  function showDropdown(dropdown, moreBtn) {
+    if (!dropdown || !moreBtn) return;
+    dropdown.classList.remove(IS_HIDDEN_CLASS);
+    dropdown.style.display = '';
+    void dropdown.offsetWidth;
+    dropdown.classList.add(IS_VISIBLE_CLASS);
+    moreBtn.setAttribute('aria-expanded', 'true');
+    positionDropdown(dropdown, moreBtn);
+  }
+
+  /**
+   * Hide the secondary actions dropdown.
+   */
+  function hideDropdown(dropdown, moreBtn) {
+    if (!dropdown) return;
+    dropdown.classList.remove(IS_VISIBLE_CLASS);
+    dropdown.classList.add(IS_HIDDEN_CLASS);
+    dropdown.style.display = 'none';
+    if (moreBtn) {
+      moreBtn.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  /**
+   * Toggle the secondary actions dropdown.
+   */
+  function toggleDropdown(dropdown, moreBtn, e) {
+    if (e) {
+      e.stopPropagation();
+    }
+    if (dropdown && dropdown.classList.contains(IS_VISIBLE_CLASS)) {
+      hideDropdown(dropdown, moreBtn);
+    } else {
+      showDropdown(dropdown, moreBtn);
+    }
+  }
+
+  /**
+   * Bind dropdown events: more button click, document click-outside,
+   * and secondary action dispatch (delete, share, focus).
+   */
+  function bindDropdownEvents(ctx) {
+    var dropdown = ctx.dropdown;
+    var moreBtn = ctx.moreBtn;
+    var deleteAction = ctx.deleteAction;
+    var shareAction = ctx.shareAction;
+    var focusAction = ctx.focusAction;
+
+    // More button: toggle dropdown
+    if (moreBtn) {
+      moreBtn.addEventListener('click', function (e) {
+        toggleDropdown(dropdown, moreBtn, e);
+      });
+    }
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function (e) {
+      if (!dropdown) return;
+      if (dropdown.classList.contains(IS_VISIBLE_CLASS) &&
+          !dropdown.contains(e.target) &&
+          moreBtn && !moreBtn.contains(e.target)) {
+        hideDropdown(dropdown, moreBtn);
+      }
+    });
+
+    // Secondary action: delete
+    if (deleteAction) {
+      deleteAction.addEventListener('click', function (e) {
+        e.stopPropagation();
+        hideDropdown(dropdown, moreBtn);
+        // Trigger delete confirmation via the existing delete button
+        var deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
+        if (deleteMemoryBtn) {
+          deleteMemoryBtn.click();
+          return;
+        }
+        // Fallback: find any delete trigger
+        var btn = document.querySelector('[data-action="delete-memory"]');
+        if (btn) btn.click();
+      });
+    }
+
+    // Secondary action: share / copy link
+    if (shareAction) {
+      shareAction.addEventListener('click', function (e) {
+        e.stopPropagation();
+        hideDropdown(dropdown, moreBtn);
+        var shareBtn = document.getElementById('shareMemoryBtn');
+        if (shareBtn) {
+          shareBtn.click();
+          return;
+        }
+        // Fallback: copy current URL
+        var url = window.location.href;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).catch(function () {});
+        }
+        if (window.LoveBudUI && window.LoveBudUI.showToast) {
+          window.LoveBudUI.showToast('링크가 복사되었습니다', 'success', 1800);
+        }
+      });
+    }
+
+    // Secondary action: focus on selected moment
+    if (focusAction) {
+      focusAction.addEventListener('click', function (e) {
+        e.stopPropagation();
+        hideDropdown(dropdown, moreBtn);
+        var focusBtn = document.getElementById('focusSelectedBtn');
+        if (focusBtn) {
+          focusBtn.click();
+        }
+      });
+    }
+  }
+
+  // Expose on global namespace
+  window.LoveBudFloatingToolbarDropdown = {
+    show: function (dropdown, moreBtn) { showDropdown(dropdown, moreBtn); },
+    hide: function (dropdown, moreBtn) { hideDropdown(dropdown, moreBtn); },
+    toggle: function (dropdown, moreBtn, e) { toggleDropdown(dropdown, moreBtn, e); },
+    bind: function (ctx) { bindDropdownEvents(ctx); }
+  };
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -263,26 +263,6 @@
     }
 
     /**
-     * Position the dropdown below/right of the "..." button.
-     */
-    function positionDropdown() {
-      if (!dropdown || !moreBtn) return;
-      var rect = moreBtn.getBoundingClientRect();
-      var ddW = dropdown.offsetWidth || 180;
-
-      // Align the dropdown's right edge with the more button's right edge
-      var x = rect.right - ddW;
-      var y = rect.bottom + 4;
-
-      // Keep within viewport
-      var maxX = window.innerWidth - ddW - 8;
-      x = Math.max(8, Math.min(x, maxX));
-
-      dropdown.style.left = Math.round(x) + 'px';
-      dropdown.style.top = Math.round(y) + 'px';
-    }
-
-    /**
      * Show the floating toolbar.
      */
     function showToolbar() {
@@ -319,7 +299,7 @@
       // Hide associated affordances
       hideQuickAdd();
       if (window.LoveBudFloatingToolbarTooltip) window.LoveBudFloatingToolbarTooltip.hide();
-      hideDropdown();
+      if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
     }
 
     /**
@@ -346,46 +326,6 @@
       quickAdd.classList.remove(IS_VISIBLE_CLASS);
       quickAdd.classList.add(IS_HIDDEN_CLASS);
       quickAdd.style.display = 'none';
-    }
-
-    /**
-     * Show the secondary actions dropdown.
-     */
-    function showDropdown() {
-      if (!dropdown || !moreBtn) return;
-      dropdown.classList.remove(IS_HIDDEN_CLASS);
-      dropdown.style.display = '';
-      void dropdown.offsetWidth;
-      dropdown.classList.add(IS_VISIBLE_CLASS);
-      moreBtn.setAttribute('aria-expanded', 'true');
-      positionDropdown();
-    }
-
-    /**
-     * Hide the secondary actions dropdown.
-     */
-    function hideDropdown() {
-      if (!dropdown) return;
-      dropdown.classList.remove(IS_VISIBLE_CLASS);
-      dropdown.classList.add(IS_HIDDEN_CLASS);
-      dropdown.style.display = 'none';
-      if (moreBtn) {
-        moreBtn.setAttribute('aria-expanded', 'false');
-      }
-    }
-
-    /**
-     * Toggle the secondary actions dropdown.
-     */
-    function toggleDropdown(e) {
-      if (e) {
-        e.stopPropagation();
-      }
-      if (dropdown && dropdown.classList.contains(IS_VISIBLE_CLASS)) {
-        hideDropdown();
-      } else {
-        showDropdown();
-      }
     }
 
     /**
@@ -569,67 +509,13 @@
 
     // ─── More button / dropdown ────────────────────────────
 
-    if (moreBtn) {
-      moreBtn.addEventListener('click', toggleDropdown);
-    }
-
-    // Close dropdown when clicking outside
-    document.addEventListener('click', function (e) {
-      if (!dropdown) return;
-      if (dropdown.classList.contains(IS_VISIBLE_CLASS) &&
-          !dropdown.contains(e.target) &&
-          moreBtn && !moreBtn.contains(e.target)) {
-        hideDropdown();
-      }
-    });
-
-    // Secondary action: delete
-    if (deleteAction) {
-      deleteAction.addEventListener('click', function (e) {
-        e.stopPropagation();
-        hideDropdown();
-        // Trigger delete confirmation via the existing delete button
-        var deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
-        if (deleteMemoryBtn) {
-          deleteMemoryBtn.click();
-          return;
-        }
-        // Fallback: find any delete trigger
-        var btn = document.querySelector('[data-action="delete-memory"]');
-        if (btn) btn.click();
-      });
-    }
-
-    // Secondary action: share / copy link
-    if (shareAction) {
-      shareAction.addEventListener('click', function (e) {
-        e.stopPropagation();
-        hideDropdown();
-        var shareBtn = document.getElementById('shareMemoryBtn');
-        if (shareBtn) {
-          shareBtn.click();
-          return;
-        }
-        // Fallback: copy current URL
-        var url = window.location.href;
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-          navigator.clipboard.writeText(url).catch(function () {});
-        }
-        if (window.LoveBudUI && window.LoveBudUI.showToast) {
-          window.LoveBudUI.showToast('링크가 복사되었습니다', 'success', 1800);
-        }
-      });
-    }
-
-    // Secondary action: focus on selected moment
-    if (focusAction) {
-      focusAction.addEventListener('click', function (e) {
-        e.stopPropagation();
-        hideDropdown();
-        var focusBtn = document.getElementById('focusSelectedBtn');
-        if (focusBtn) {
-          focusBtn.click();
-        }
+    if (window.LoveBudFloatingToolbarDropdown) {
+      window.LoveBudFloatingToolbarDropdown.bind({
+        dropdown: dropdown,
+        moreBtn: moreBtn,
+        deleteAction: deleteAction,
+        shareAction: shareAction,
+        focusAction: focusAction
       });
     }
 
@@ -669,7 +555,7 @@
     if (quickAdd) {
       quickAdd.addEventListener('click', function (e) {
         e.stopPropagation();
-        hideDropdown();
+        if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
         // Quick-add triggers continue from the selected moment
         var continueBtnDetail = document.getElementById('continueFromMomentBtn');
         if (continueBtnDetail) {
@@ -738,7 +624,7 @@
           }
         }
         // Also hide dropdown if open
-        hideDropdown();
+        if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
       }
 
       // Arrow keys: navigate between buttons

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -354,6 +354,7 @@
     <script src="../js/editor/editor-floating-toolbar-actions.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-keyboard.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-tooltip.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-dropdown.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
## Summary
- Refs #1275
- PR #1329, #1330, #1331 후속 runtime split slice
- 동작 변경 없음
- share fallback(clipboard + toast) 포함하여 verbatim 이동

## Extracted scope
- `showDropdown` / `hideDropdown` / `toggleDropdown` / `positionDropdown`
- more button click wiring
- document click-outside handling
- delete / share / focus secondary action dispatchers

## share fallback
share action은 단순 click-through가 아니라 clipboard API + `LoveBudUI.showToast` fallback을 포함합니다. 기존 로직을 verbatim에 가깝게 이동했으며, 동작 변경은 없습니다.

## 제외 범위
- visibility/show/hide
- core toolbar positioning
- quick-add/adaptive state
- MutationObserver
- keyboard/action/tooltip helper internals

## Changed files
- `js/editor/editor-floating-toolbar-dropdown.js` (신규)
- `js/editor/editor-floating-toolbar.js` (dropdown 로직 제거, helper 위임)
- `pages/editor.html` (script tag 추가)

## Script order
```
editor-floating-toolbar-actions.js
editor-floating-toolbar-keyboard.js
editor-floating-toolbar-tooltip.js
editor-floating-toolbar-dropdown.js  ← NEW
editor-floating-toolbar.js
```