### PR TITLE
refactor(editor): extract floating toolbar affordance helper

### DIFF
--- a/js/editor/editor-floating-toolbar-affordance.js
+++ b/js/editor/editor-floating-toolbar-affordance.js
@@ -1,0 +1,140 @@
+/**
+ * LoveBud Editor — Floating Toolbar Quick-Add / Adaptive Affordance
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Manages quick-add affordance visibility and adaptive toolbar state
+ * (normal vs connection mode) for the floating toolbar.
+ *
+ * No behavior change.
+ */
+(function () {
+  'use strict';
+
+  var IS_VISIBLE_CLASS = 'is-visible';
+  var IS_HIDDEN_CLASS = 'is-hidden';
+  var IS_CONNECTING_CLASS = 'is-connecting';
+  var AFFORDANCE_SELECTOR = '.memory-add-affordance';
+
+  /**
+   * Check if connection mode is active (user is in a "continue" or "branch" flow).
+   * Detected by presence of growth affordance elements on the canvas.
+   */
+  function isConnectionMode(ctx) {
+    var canvas = document.getElementById('canvasArea');
+    if (!canvas) return false;
+    // Connection mode is active when the growth affordance tip or branch lines exist
+    var affordance = canvas.querySelector(AFFORDANCE_SELECTOR);
+    return !!affordance;
+  }
+
+  /**
+   * Show the quick-add affordance near the selected node.
+   */
+  function showQuickAdd(ctx) {
+    if (!ctx || !ctx.quickAdd) return;
+    if (ctx.quickAdd.classList.contains(IS_VISIBLE_CLASS)) return;
+    if (isConnectionMode(ctx)) return; // Don't show during connection mode
+
+    ctx.quickAdd.classList.remove(IS_HIDDEN_CLASS);
+    ctx.quickAdd.style.display = '';
+    void ctx.quickAdd.offsetWidth;
+    ctx.quickAdd.classList.add(IS_VISIBLE_CLASS);
+    if (window.LoveBudFloatingToolbarPositioning && window.LoveBudFloatingToolbarPositioning.positionQuickAdd) {
+      window.LoveBudFloatingToolbarPositioning.positionQuickAdd(ctx);
+    }
+  }
+
+  /**
+   * Hide the quick-add affordance.
+   */
+  function hideQuickAdd(ctx) {
+    if (!ctx || !ctx.quickAdd) return;
+    if (!ctx.quickAdd.classList.contains(IS_VISIBLE_CLASS)) return;
+    ctx.quickAdd.classList.remove(IS_VISIBLE_CLASS);
+    ctx.quickAdd.classList.add(IS_HIDDEN_CLASS);
+    ctx.quickAdd.style.display = 'none';
+  }
+
+  /**
+   * Update the toolbar's adaptive state based on current mode.
+   * Switches between normal mode (edit/continue/view) and connection mode (branch/fork).
+   */
+  function updateAdaptiveState(ctx) {
+    if (!ctx || !ctx.toolbar) return;
+    var connecting = isConnectionMode(ctx);
+    ctx.toolbar.classList.toggle(IS_CONNECTING_CLASS, connecting);
+
+    // Hide quick add in connection mode
+    if (connecting) {
+      hideQuickAdd(ctx);
+    } else if (ctx.toolbar.classList.contains(IS_VISIBLE_CLASS)) {
+      showQuickAdd(ctx);
+    }
+  }
+
+  /**
+   * Wire up the quick-add affordance click handler.
+   * Quick-add triggers continue from the selected moment.
+   */
+  function bindQuickAdd(ctx) {
+    if (!ctx || !ctx.quickAdd) return;
+    ctx.quickAdd.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(ctx.dropdown, ctx.moreBtn);
+      // Quick-add triggers continue from the selected moment
+      var continueBtnDetail = document.getElementById('continueFromMomentBtn');
+      if (continueBtnDetail) {
+        continueBtnDetail.click();
+        return;
+      }
+      var addMemoryBtn = document.getElementById('addMemoryBtn');
+      if (addMemoryBtn) {
+        addMemoryBtn.click();
+      }
+    });
+  }
+
+  /**
+   * Wire up the branch and fork connection-mode buttons.
+   */
+  function bindConnectionButtons(ctx) {
+    if (ctx.branchBtn) {
+      ctx.branchBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        // Trigger branch via existing branch button in detail panel
+        var createBranchBtn = document.getElementById('createBranchBtn');
+        if (createBranchBtn) {
+          createBranchBtn.click();
+          return;
+        }
+        // Fallback: assume continue flow
+        var continueBtnDetail = document.getElementById('continueFromMomentBtn');
+        if (continueBtnDetail) {
+          continueBtnDetail.click();
+        }
+      });
+    }
+
+    if (ctx.forkBtn) {
+      ctx.forkBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        // Fork: similar to branch but might trigger a different flow
+        var createBranchBtn = document.getElementById('createBranchBtn');
+        if (createBranchBtn) {
+          createBranchBtn.click();
+          return;
+        }
+      });
+    }
+  }
+
+  // Expose on global namespace
+  window.LoveBudFloatingToolbarAffordance = {
+    isConnectionMode: isConnectionMode,
+    showQuickAdd: showQuickAdd,
+    hideQuickAdd: hideQuickAdd,
+    updateAdaptiveState: updateAdaptiveState,
+    bindQuickAdd: bindQuickAdd,
+    bindConnectionButtons: bindConnectionButtons
+  };
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -34,10 +34,9 @@
   const NODE_SELECTOR = '.memory-node';
   const IS_VISIBLE_CLASS = 'is-visible';
   const IS_HIDDEN_CLASS = 'is-hidden';
-  const IS_CONNECTING_CLASS = 'is-connecting';
   const COMPACT_CLASS = 'is-compact';
   const MOBILE_BREAKPOINT = 480;
-  const AFFORDANCE_SELECTOR = '.memory-add-affordance';
+
 
   /**
    * Find the currently selected memory node element on the canvas.
@@ -48,19 +47,7 @@
     return document.querySelector(NODE_SELECTOR + '.' + SELECTED_CLASS);
   }
 
-  /**
-   * Check if connection mode is active (user is in a "continue" or "branch" flow).
-   * Detected by presence of growth affordance elements on the canvas.
-   */
-  function isConnectionMode() {
-    var canvas = document.getElementById('canvasArea');
-    if (!canvas) return false;
-    // Connection mode is active when the growth affordance tip or branch lines exist
-    var affordance = canvas.querySelector(AFFORDANCE_SELECTOR);
-    return !!affordance;
-  }
-
-  /**
+/**
    * Resolves the memory object by the selected node element.
    * Falls back to reading the node's data-memory-id and looking up in global state.
    */
@@ -119,6 +106,10 @@
       getSelectedNode: getSelectedNodeEl,
       toolbar: toolbar,
       quickAdd: quickAdd,
+      dropdown: dropdown,
+      moreBtn: moreBtn,
+      branchBtn: branchBtn,
+      forkBtn: forkBtn,
       lastX: -1,
       lastY: -1,
       positionTimer: null,
@@ -164,7 +155,9 @@
       if (toolbar.classList.contains(IS_VISIBLE_CLASS)) return;
 
       // Update adaptive state before showing
-      updateAdaptiveState();
+      if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.updateAdaptiveState) {
+        window.LoveBudFloatingToolbarAffordance.updateAdaptiveState(posCtx);
+      }
 
       toolbar.classList.remove(IS_HIDDEN_CLASS);
       toolbar.style.display = '';
@@ -175,7 +168,9 @@
       if (window.LoveBudFloatingToolbarPositioning && window.LoveBudFloatingToolbarPositioning.positionToolbar) {
         window.LoveBudFloatingToolbarPositioning.positionToolbar(posCtx);
       }
-      showQuickAdd();
+      if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.showQuickAdd) {
+        window.LoveBudFloatingToolbarAffordance.showQuickAdd(posCtx);
+      }
     }
 
     /**
@@ -193,54 +188,11 @@
       posCtx.lastY = -1;
 
       // Hide associated affordances
-      hideQuickAdd();
+      if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.hideQuickAdd) {
+        window.LoveBudFloatingToolbarAffordance.hideQuickAdd(posCtx);
+      }
       if (window.LoveBudFloatingToolbarTooltip) window.LoveBudFloatingToolbarTooltip.hide();
       if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
-    }
-
-    /**
-     * Show the quick-add affordance near the selected node.
-     */
-    function showQuickAdd() {
-      if (!quickAdd) return;
-      if (quickAdd.classList.contains(IS_VISIBLE_CLASS)) return;
-      if (isConnectionMode()) return; // Don't show during connection mode
-
-      quickAdd.classList.remove(IS_HIDDEN_CLASS);
-      quickAdd.style.display = '';
-      void quickAdd.offsetWidth;
-      quickAdd.classList.add(IS_VISIBLE_CLASS);
-      if (window.LoveBudFloatingToolbarPositioning && window.LoveBudFloatingToolbarPositioning.positionQuickAdd) {
-        window.LoveBudFloatingToolbarPositioning.positionQuickAdd(posCtx);
-      }
-    }
-
-    /**
-     * Hide the quick-add affordance.
-     */
-    function hideQuickAdd() {
-      if (!quickAdd) return;
-      if (!quickAdd.classList.contains(IS_VISIBLE_CLASS)) return;
-      quickAdd.classList.remove(IS_VISIBLE_CLASS);
-      quickAdd.classList.add(IS_HIDDEN_CLASS);
-      quickAdd.style.display = 'none';
-    }
-
-    /**
-     * Update the toolbar's adaptive state based on current mode.
-     * Switches between normal mode (edit/continue/view) and connection mode (branch/fork).
-     */
-    function updateAdaptiveState() {
-      if (!toolbar) return;
-      var connecting = isConnectionMode();
-      toolbar.classList.toggle(IS_CONNECTING_CLASS, connecting);
-
-      // Hide quick add in connection mode
-      if (connecting) {
-        hideQuickAdd();
-      } else if (toolbar.classList.contains(IS_VISIBLE_CLASS)) {
-        showQuickAdd();
-      }
     }
 
     /**
@@ -407,52 +359,14 @@
 
     // ─── Branch / connection-mode buttons ──────────────────
 
-    if (branchBtn) {
-      branchBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        // Trigger branch via existing branch button in detail panel
-        var createBranchBtn = document.getElementById('createBranchBtn');
-        if (createBranchBtn) {
-          createBranchBtn.click();
-          return;
-        }
-        // Fallback: assume continue flow
-        var continueBtnDetail = document.getElementById('continueFromMomentBtn');
-        if (continueBtnDetail) {
-          continueBtnDetail.click();
-        }
-      });
-    }
-
-    if (forkBtn) {
-      forkBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        // Fork: similar to branch but might trigger a different flow
-        var createBranchBtn = document.getElementById('createBranchBtn');
-        if (createBranchBtn) {
-          createBranchBtn.click();
-          return;
-        }
-      });
+    if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.bindConnectionButtons) {
+      window.LoveBudFloatingToolbarAffordance.bindConnectionButtons(posCtx);
     }
 
     // ─── Quick-add affordance ─────────────────────────────
 
-    if (quickAdd) {
-      quickAdd.addEventListener('click', function (e) {
-        e.stopPropagation();
-        if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
-        // Quick-add triggers continue from the selected moment
-        var continueBtnDetail = document.getElementById('continueFromMomentBtn');
-        if (continueBtnDetail) {
-          continueBtnDetail.click();
-          return;
-        }
-        var addMemoryBtn = document.getElementById('addMemoryBtn');
-        if (addMemoryBtn) {
-          addMemoryBtn.click();
-        }
-      });
+    if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.bindQuickAdd) {
+      window.LoveBudFloatingToolbarAffordance.bindQuickAdd(posCtx);
     }
 
     // ─── Tooltip on hover over toolbar buttons ─────────────

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -356,6 +356,7 @@
     <script src="../js/editor/editor-floating-toolbar-tooltip.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-dropdown.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-positioning.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-affordance.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
Refs #1275

## Changed files
- `js/editor/editor-floating-toolbar-affordance.js` (new, +146)
- `js/editor/editor-floating-toolbar.js` (modified, −105/+19)
- `pages/editor.html` (modified, +1)

## Extracted scope
- `isConnectionMode` — detection via canvas `.memory-add-affordance` selector
- `showQuickAdd` / `hideQuickAdd` — quick-add visibility and position
- `updateAdaptiveState` — toggles `is-connecting` class, manages quickAdd in connection mode
- `bindQuickAdd` — click wiring (`continueFromMomentBtn` → fallback `addMemoryBtn`)
- `bindConnectionButtons` — branch/fork button click delegation

## Excluded scope
- Positioning logic (already in positioning helper)
- Visibility / show/hide orchestration (stays in main orchestrator)
- Keyboard shortcuts (already in keyboard helper)
- Dropdown/tooltip (already in respective helpers)

## Verification
- `npm run verify` — PASS (174/176, only pre-existing firebase-admin/pg failures)
- JS syntax check — PASS for all 71 editor files
- Script order: actions → keyboard → tooltip → dropdown → positioning → **affordance** → main
- Existing helpers (action/keyboard/tooltip/dropdown/positioning) — 0 diff
- Backend/API/Auth/DB/schema — untouched
- CSS — untouched
- Forbidden paths — untouched
- Close keyword — absent (Refs #1275 only)

## Smoke status
Pending — authenticated runtime smoke required before Ready transition