### PR TITLE
refactor(editor): extract floating toolbar visibility helper

### DIFF
--- a/js/editor/editor-floating-toolbar-visibility.js
+++ b/js/editor/editor-floating-toolbar-visibility.js
@@ -1,0 +1,54 @@
+/**
+ * LoveBud Editor — Floating Toolbar Visibility Rules
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Determines whether the floating toolbar should be visible based on
+ * the current editor state (layout, mode, viewport, selection).
+ *
+ * No behavior change.
+ */
+(function () {
+  'use strict';
+
+  var DEFAULT_MOBILE_BREAKPOINT = 480;
+  var DEFAULT_COMPACT_CLASS = 'is-compact';
+
+  /**
+   * Check if the floating toolbar should be visible based on contract §4.
+   */
+  function shouldShow(ctx) {
+    if (!ctx) return false;
+
+    // Mobile <breakpoint: never show
+    var breakpoint = ctx.mobileBreakpoint || DEFAULT_MOBILE_BREAKPOINT;
+    if (window.innerWidth < breakpoint) return false;
+
+    // Selected node guard
+    var selectedEl = ctx.getSelectedNode ? ctx.getSelectedNode() : null;
+    if (!selectedEl) return false;
+
+    // Check if detail panel edit mode is active
+    var editMode = document.getElementById('detailEditMode');
+    if (editMode && editMode.style.display !== 'none' && editMode.style.display !== '') return false;
+
+    // Check if compact mode is active on the canvas toolbar
+    var compactCls = ctx.compactClass || DEFAULT_COMPACT_CLASS;
+    var canvasToolbar = document.querySelector('.editor-canvas-toolbar');
+    if (canvasToolbar && canvasToolbar.classList.contains(compactCls)) return false;
+
+    // Check if we're in structured layout mode
+    var bodyClass = document.body.className;
+    if (bodyClass.indexOf('layout-structured') !== -1) return false;
+
+    // Check tree owner / auth context
+    var canvasEmptyGuide = document.getElementById('canvasEmptyGuide');
+    if (canvasEmptyGuide && !canvasEmptyGuide.classList.contains('editor-canvas-empty-guide-hidden')) return false;
+
+    return true;
+  }
+
+  // Expose on global namespace
+  window.LoveBudFloatingToolbarVisibility = {
+    shouldShow: shouldShow
+  };
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -34,8 +34,6 @@
   const NODE_SELECTOR = '.memory-node';
   const IS_VISIBLE_CLASS = 'is-visible';
   const IS_HIDDEN_CLASS = 'is-hidden';
-  const COMPACT_CLASS = 'is-compact';
-  const MOBILE_BREAKPOINT = 480;
 
 
   /**
@@ -120,31 +118,16 @@
 
     /**
      * Check if the floating toolbar should be visible based on contract §4.
+     * Delegates to LoveBudFloatingToolbarVisibility helper.
      */
     function shouldShowToolbar() {
-      // Mobile <480px: never show
-      if (window.innerWidth < MOBILE_BREAKPOINT) return false;
-
-      var selectedEl = getSelectedNodeEl();
-      if (!selectedEl) return false;
-
-      // Check if detail panel edit mode is active
-      var editMode = document.getElementById('detailEditMode');
-      if (editMode && editMode.style.display !== 'none' && editMode.style.display !== '') return false;
-
-      // Check if compact mode is active on the canvas toolbar
-      var canvasToolbar = document.querySelector('.editor-canvas-toolbar');
-      if (canvasToolbar && canvasToolbar.classList.contains(COMPACT_CLASS)) return false;
-
-      // Check if we're in structured layout mode
-      var bodyClass = document.body.className;
-      if (bodyClass.indexOf('layout-structured') !== -1) return false;
-
-      // Check tree owner / auth context
-      var canvasEmptyGuide = document.getElementById('canvasEmptyGuide');
-      if (canvasEmptyGuide && !canvasEmptyGuide.classList.contains('editor-canvas-empty-guide-hidden')) return false;
-
-      return true;
+      if (window.LoveBudFloatingToolbarVisibility && window.LoveBudFloatingToolbarVisibility.shouldShow) {
+        return window.LoveBudFloatingToolbarVisibility.shouldShow({
+          getSelectedNode: getSelectedNodeEl
+        });
+      }
+      // Fallback: safe default — do not show
+      return false;
     }
 
     /**

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -357,6 +357,7 @@
     <script src="../js/editor/editor-floating-toolbar-dropdown.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-positioning.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-affordance.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-visibility.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
Refs #1275

## Changed files
- `js/editor/editor-floating-toolbar-visibility.js` (new, +51)
- `js/editor/editor-floating-toolbar.js` (modified, -25/+9)
- `pages/editor.html` (modified, +1)

## Extracted scope
- `shouldShowToolbar()` → `LoveBudFloatingToolbarVisibility.shouldShow(ctx)`
- All 6 visibility guards extracted verbatim:
  1. Mobile width guard (`<480px`)
  2. Selected node guard
  3. Edit mode guard (`detailEditMode` display check)
  4. Compact mode guard (`is-compact` on canvas toolbar)
  5. Structured layout guard (`layout-structured`)
  6. Empty guide / auth context guard

## Excluded scope
- `showToolbar` / `hideToolbar` / `updateToolbar` — remain in main orchestrator
- MutationObserver — unchanged
- Event wiring (resize, compact, layout, edit observers) — unchanged
- All other helpers (action/keyboard/tooltip/dropdown/positioning/affordance) — untouched
- `getSelectedNodeEl` shared utility — remains in main file (also used by tooltip and escape handler)

## Constants moved
- `MOBILE_BREAKPOINT` (480) — moved to helper as `DEFAULT_MOBILE_BREAKPOINT`
- `COMPACT_CLASS` ('is-compact') — moved to helper as `DEFAULT_COMPACT_CLASS`
- Overridable via ctx (`mobileBreakpoint`, `compactClass`)

## Verification
- `npm run verify` — PASS (175/177, only pre-existing firebase-admin/pg failures)
- JS syntax — PASS for all files
- Script order: actions → keyboard → tooltip → dropdown → positioning → affordance → **visibility** → main
- Existing helpers (6 modules) — 0 diff
- Backend/API/Auth/DB/schema — untouched
- CSS — untouched
- Forbidden paths — untouched
- Close keyword — absent (Refs #1275 only)

## Smoke status
Pending — authenticated runtime smoke required before Ready transition