### PR TITLE
refactor(editor): extract floating toolbar primary action wiring

### DIFF
--- a/js/editor/editor-floating-toolbar-actions.js
+++ b/js/editor/editor-floating-toolbar-actions.js
@@ -55,11 +55,53 @@
     }
   }
 
+  /**
+   * Bind click event wiring for primary action buttons.
+   * Extracted from editor-floating-toolbar.js (Issue #1275).
+   * Each ctx member is optional — missing elements skip their wiring.
+   *
+   * @param {Object}   ctx
+   * @param {Element}  [ctx.editBtn]     - Edit button element
+   * @param {Element}  [ctx.continueBtn] - Continue button element
+   * @param {Element}  [ctx.viewBtn]     - View button element
+   */
+  function bindPrimaryActions(ctx) {
+    if (!ctx) return;
+
+    if (ctx.editBtn) {
+      ctx.editBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.edit) {
+          window.LoveBudFloatingToolbarActions.edit();
+        }
+      });
+    }
+
+    if (ctx.continueBtn) {
+      ctx.continueBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.continue) {
+          window.LoveBudFloatingToolbarActions.continue();
+        }
+      });
+    }
+
+    if (ctx.viewBtn) {
+      ctx.viewBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.view) {
+          window.LoveBudFloatingToolbarActions.view();
+        }
+      });
+    }
+  }
+
   // Export to global namespace for use by editor-floating-toolbar.js
   window.LoveBudFloatingToolbarActions = {
     edit: toolbarEditAction,
     continue: toolbarContinueAction,
-    view: toolbarViewAction
+    view: toolbarViewAction,
+    bindPrimaryActions: bindPrimaryActions
   };
 
   console.log('[toolbar-actions] Initialized (Refs #1275)');

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -263,29 +263,14 @@
 
 // ─── Button actions ───────────────────────────────────
 
-    // Edit: trigger detail panel edit mode
-    editBtn.addEventListener('click', function (e) {
-      e.stopPropagation();
-      if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.edit) {
-        window.LoveBudFloatingToolbarActions.edit();
-      }
-    });
-
-    // Continue: trigger "continue from moment" growth affordance behavior
-    continueBtn.addEventListener('click', function (e) {
-      e.stopPropagation();
-      if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.continue) {
-        window.LoveBudFloatingToolbarActions.continue();
-      }
-    });
-
-    // View: trigger moment detail view
-    viewBtn.addEventListener('click', function (e) {
-      e.stopPropagation();
-      if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.view) {
-        window.LoveBudFloatingToolbarActions.view();
-      }
-    });
+    // Delegate primary action button wiring to helper
+    if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.bindPrimaryActions) {
+      window.LoveBudFloatingToolbarActions.bindPrimaryActions({
+        editBtn: editBtn,
+        continueBtn: continueBtn,
+        viewBtn: viewBtn
+      });
+    }
 
     // ─── More button / dropdown ────────────────────────────
 


### PR DESCRIPTION
Refs #1275

## Changed files
| file | type |
|---|---|
| `js/editor/editor-floating-toolbar-actions.js` | modified (+44) |
| `js/editor/editor-floating-toolbar.js` | modified (−24) |

## Extracted scope
- Edit button click wiring (`e.stopPropagation()` + action dispatch)
- Continue button click wiring (`e.stopPropagation()` + action dispatch)
- View button click wiring (`e.stopPropagation()` + action dispatch)
- New API: `LoveBudFloatingToolbarActions.bindPrimaryActions(ctx)`

## Excluded scope
- `edit`/`continue`/`view` action functions unchanged
- showToolbar/hideToolbar/updateToolbar remains
- keyboard navigation / Escape handler remains
- event wiring remains
- No new file, no script order change (editor.html unchanged)

## Verification
- ✅ `npm run verify` — 176/178 (pre-existing failures only)
- ✅ `node --check` passed for both files
- ✅ Only 2 files changed
- ✅ No CSS changes
- ✅ No backend/API/Auth/DB/schema changes
- ✅ No forbidden path changes
- ✅ No close keywords
- ✅ Existing 7 other helpers untouched (0 diff)
- ✅ `e.stopPropagation()` preserved
- ✅ action dispatch pattern preserved (checks helper namespace before call)

## Smoke status
- 🔲 Editor load
- 🔲 Console fatal error
- 🔲 bindPrimaryActions API exists
- 🔲 Toolbar shows on moment selection
- 🔲 Edit click flow works
- 🔲 Continue click flow works
- 🔲 View click flow works
- 🔲 Keyboard shortcuts unaffected
- 🔲 Keyboard navigation/Escape unaffected
- 🔲 All regression scenarios (positioning, affordance, visibility, dropdown, tooltip, event)