### PR TITLE
refactor(editor): extract floating toolbar keyboard navigation

### DIFF
--- a/js/editor/editor-floating-toolbar-keyboard.js
+++ b/js/editor/editor-floating-toolbar-keyboard.js
@@ -102,9 +102,78 @@
     return false;
   }
 
+  /**
+   * Bind toolbar-level keyboard navigation (Escape + arrow keys).
+   * Extracted from editor-floating-toolbar.js (Issue #1275).
+   *
+   * @param {Object}   ctx
+   * @param {Element}  ctx.toolbar        - Floating toolbar element
+   * @param {Function} ctx.getSelectedNode- Returns selected node element or null
+   * @param {Function} ctx.hideToolbar    - Hides the floating toolbar
+   * @param {Element}  [ctx.dropdown]     - Dropdown element
+   * @param {Element}  [ctx.moreBtn]      - More/overflow button element
+   * @param {string}   [ctx.selectedClass]- Selected node CSS class (default: 'selected')
+   */
+  function bindToolbarNavigation(ctx) {
+    if (!ctx || !ctx.toolbar) return;
+
+    var selectedClass = ctx.selectedClass || 'selected';
+    var btnSelector = '.editor-floating-toolbar-btn, .editor-ftb-more-btn';
+
+    ctx.toolbar.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        // Deselect the current node
+        var selectedEl = ctx.getSelectedNode ? ctx.getSelectedNode() : null;
+        if (selectedEl) {
+          selectedEl.classList.remove(selectedClass);
+          selectedEl.blur();
+        }
+        if (ctx.hideToolbar) ctx.hideToolbar();
+
+        // Also clear detail panel selection by clicking on empty canvas
+        var canvasArea = document.getElementById('canvasArea');
+        if (canvasArea) {
+          var emptySpot = canvasArea.querySelector('.canvas-svg');
+          if (emptySpot) {
+            emptySpot.click();
+          }
+        }
+        // Also hide dropdown if open
+        if (window.LoveBudFloatingToolbarDropdown) {
+          window.LoveBudFloatingToolbarDropdown.hide(ctx.dropdown, ctx.moreBtn);
+        }
+      }
+
+      // Arrow keys: navigate between buttons
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        var next = e.target.nextElementSibling;
+        if (next && (next.classList.contains('editor-floating-toolbar-btn') || next.classList.contains('editor-ftb-more-btn'))) {
+          next.focus();
+        } else {
+          // Wrap to first
+          var first = ctx.toolbar.querySelector(btnSelector);
+          if (first) first.focus();
+        }
+      }
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        var prev = e.target.previousElementSibling;
+        if (prev && (prev.classList.contains('editor-floating-toolbar-btn') || prev.classList.contains('editor-ftb-more-btn'))) {
+          prev.focus();
+        } else {
+          // Wrap to last
+          var buttons = ctx.toolbar.querySelectorAll(btnSelector);
+          if (buttons.length) buttons[buttons.length - 1].focus();
+        }
+      }
+    });
+  }
+
   // Export to global namespace
   window.LoveBudFloatingToolbarKeyboard = {
-    handleShortcut: handleShortcut
+    handleShortcut: handleShortcut,
+    bindToolbarNavigation: bindToolbarNavigation
   };
 
   console.log('[toolbar-keyboard] Initialized (Refs #1275)');

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -330,54 +330,18 @@
       }
     });
 
-    // ─── Toolbar keyboard navigation (existing) ────────────
+    // ─── Toolbar keyboard navigation ─────────────────────
 
-    toolbar.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape') {
-        // Deselect the current node
-        var selectedEl = getSelectedNodeEl();
-        if (selectedEl) {
-          selectedEl.classList.remove(SELECTED_CLASS);
-          selectedEl.blur();
-        }
-        hideToolbar();
-
-        // Also clear detail panel selection by clicking on empty canvas
-        var canvasArea = document.getElementById('canvasArea');
-        if (canvasArea) {
-          var emptySpot = canvasArea.querySelector('.canvas-svg');
-          if (emptySpot) {
-            emptySpot.click();
-          }
-        }
-        // Also hide dropdown if open
-        if (window.LoveBudFloatingToolbarDropdown) window.LoveBudFloatingToolbarDropdown.hide(dropdown, moreBtn);
-      }
-
-      // Arrow keys: navigate between buttons
-      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-        e.preventDefault();
-        var next = e.target.nextElementSibling;
-        if (next && (next.classList.contains('editor-floating-toolbar-btn') || next.classList.contains('editor-ftb-more-btn'))) {
-          next.focus();
-        } else {
-          // Wrap to first
-          var first = toolbar.querySelector('.editor-floating-toolbar-btn, .editor-ftb-more-btn');
-          if (first) first.focus();
-        }
-      }
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-        e.preventDefault();
-        var prev = e.target.previousElementSibling;
-        if (prev && (prev.classList.contains('editor-floating-toolbar-btn') || prev.classList.contains('editor-ftb-more-btn'))) {
-          prev.focus();
-        } else {
-          // Wrap to last
-          var buttons = toolbar.querySelectorAll('.editor-floating-toolbar-btn, .editor-ftb-more-btn');
-          if (buttons.length) buttons[buttons.length - 1].focus();
-        }
-      }
-    });
+    if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.bindToolbarNavigation) {
+      window.LoveBudFloatingToolbarKeyboard.bindToolbarNavigation({
+        toolbar: toolbar,
+        getSelectedNode: getSelectedNodeEl,
+        hideToolbar: hideToolbar,
+        dropdown: dropdown,
+        moreBtn: moreBtn,
+        selectedClass: SELECTED_CLASS
+      });
+    }
 
     // ─── Initial state ────────────────────────────────────
     hideToolbar();


### PR DESCRIPTION
Refs #1275

## Changed files
| file | type |
|---|---|
| `js/editor/editor-floating-toolbar-keyboard.js` | modified (+77) |
| `js/editor/editor-floating-toolbar.js` | modified (−58) |

## Extracted scope
- Escape handler: deselect node, hide toolbar, canvas empty-spot click, dropdown hide
- ArrowRight/ArrowDown: next button focus with wrap-to-first
- ArrowLeft/ArrowUp: prev button focus with wrap-to-last
- New API: `LoveBudFloatingToolbarKeyboard.bindToolbarNavigation(ctx)`

## Excluded scope
- document-level `handleShortcut` (E/C/V/Delete) remains in main
- `handleShortcut` API preserved unchanged
- showToolbar/hideToolbar/updateToolbar remains
- primary action wiring unchanged
- event wiring unchanged
- No new file, no script order change (editor.html unchanged)

## Verification
- ✅ `npm run verify` — 176/178 (pre-existing failures only)
- ✅ `node --check` passed for both files
- ✅ Only 2 files changed
- ✅ No CSS changes
- ✅ No backend/API/Auth/DB/schema changes
- ✅ No forbidden path changes
- ✅ No close keywords
- ✅ Existing 8 other helpers untouched (0 diff)
- ✅ document-level keyboard shortcut wiring unchanged (2 handleShortcut refs in main)
- ✅ selectedClass configurable via ctx (default: 'selected')
- ✅ all callback null-safety (getSelectedNode, hideToolbar, dropdown, moreBtn)

## Smoke status
- 🔲 Editor load
- 🔲 Console fatal error
- 🔲 bindToolbarNavigation API exists
- 🔲 handleShortcut API preserved
- 🔲 ArrowRight/ArrowDown focus next
- 🔲 ArrowLeft/ArrowUp focus previous
- 🔲 Wrap navigation works
- 🔲 Escape clears selected node and hides toolbar
- 🔲 Escape hides dropdown if open
- 🔲 Document shortcuts E/C/V/Delete unaffected
- 🔲 All regression scenarios