### PR TITLE
refactor(editor): extract floating toolbar selection helper

### DIFF
--- a/js/editor/editor-floating-toolbar-selection.js
+++ b/js/editor/editor-floating-toolbar-selection.js
@@ -1,0 +1,87 @@
+/**
+ * LoveBud Editor — Floating Toolbar Selection Resolvers
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Provides utility functions to resolve the currently selected
+ * memory node, its associated memory object, and its display title.
+ *
+ * No behavior change. No side effects (no DOM mutation, no show/hide).
+ */
+(function () {
+  'use strict';
+
+  var DEFAULT_NODE_SELECTOR = '.memory-node';
+  var DEFAULT_SELECTED_CLASS = 'selected';
+
+  /**
+   * Find the currently selected memory node element on the canvas.
+   *
+   * @param {Object} [ctx]
+   * @param {string} [ctx.nodeSelector]  - CSS selector for memory nodes (default: '.memory-node')
+   * @param {string} [ctx.selectedClass] - Class for selected state (default: 'selected')
+   * @returns {Element|null}
+   */
+  function getSelectedNode(ctx) {
+    var sel = (ctx && ctx.nodeSelector) || DEFAULT_NODE_SELECTOR;
+    var cls = (ctx && ctx.selectedClass) || DEFAULT_SELECTED_CLASS;
+    return document.querySelector(sel + '.' + cls);
+  }
+
+  /**
+   * Resolve the memory object by the selected node element.
+   * Falls back to reading the node's data-memory-id and looking up in global state.
+   *
+   * @param {Object} [ctx]
+   * @param {string} [ctx.nodeSelector]  - CSS selector for memory nodes
+   * @param {string} [ctx.selectedClass] - Class for selected state
+   * @returns {Object|null}
+   */
+  function getSelectedMemory(ctx) {
+    var selectedEl = getSelectedNode(ctx);
+    if (!selectedEl) return null;
+
+    var memoryId = selectedEl.dataset.memoryId;
+    if (!memoryId) return null;
+
+    // Try global editor state
+    if (window.currentTreeMemories && Array.isArray(window.currentTreeMemories)) {
+      return window.currentTreeMemories.find(function (m) {
+        return m.id === memoryId;
+      }) || null;
+    }
+
+    // Fallback: return minimal info from the node element
+    return {
+      id: memoryId,
+      title: selectedEl.querySelector('.node-title')?.textContent || selectedEl.getAttribute('aria-label') || ''
+    };
+  }
+
+  /**
+   * Get the moment title for the selected node (for tooltip display).
+   *
+   * @param {Object} [ctx]
+   * @param {string} [ctx.nodeSelector]  - CSS selector for memory nodes
+   * @param {string} [ctx.selectedClass] - Class for selected state
+   * @returns {string}
+   */
+  function getSelectedMomentTitle(ctx) {
+    var mem = getSelectedMemory(ctx);
+    if (mem && mem.title) return mem.title;
+
+    // Fallback: extract title from the node element
+    var selectedEl = getSelectedNode(ctx);
+    if (!selectedEl) return '';
+
+    var titleEl = selectedEl.querySelector('.node-title');
+    if (titleEl && titleEl.textContent) return titleEl.textContent.trim();
+    return '';
+  }
+
+  // Expose on global namespace
+  window.LoveBudFloatingToolbarSelection = {
+    getSelectedNode: getSelectedNode,
+    getSelectedMemory: getSelectedMemory,
+    getSelectedMomentTitle: getSelectedMomentTitle
+  };
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -38,33 +38,17 @@
 
   /**
    * Find the currently selected memory node element on the canvas.
-   * Kept in outer scope because tooltip helpers run outside initFloatingToolbar's
-   * lexical scope and also need to resolve the selected node.
+   * Delegates to LoveBudFloatingToolbarSelection helper.
+   * Kept in IIFE scope because other helpers reference it.
    */
   function getSelectedNodeEl() {
-    return document.querySelector(NODE_SELECTOR + '.' + SELECTED_CLASS);
-  }
-
-/**
-   * Resolves the memory object by the selected node element.
-   * Falls back to reading the node's data-memory-id and looking up in global state.
-   */
-  function getSelectedMemory() {
-    var selectedEl = getSelectedNodeEl();
-    if (!selectedEl) return null;
-    var memoryId = selectedEl.dataset.memoryId;
-    if (!memoryId) return null;
-    // Try global editor state
-    if (window.currentTreeMemories && Array.isArray(window.currentTreeMemories)) {
-      return window.currentTreeMemories.find(function (m) {
-        return m.id === memoryId;
-      }) || null;
+    if (window.LoveBudFloatingToolbarSelection && window.LoveBudFloatingToolbarSelection.getSelectedNode) {
+      return window.LoveBudFloatingToolbarSelection.getSelectedNode({
+        nodeSelector: NODE_SELECTOR,
+        selectedClass: SELECTED_CLASS
+      });
     }
-    // Fallback: return minimal info from the node element
-    return {
-      id: memoryId,
-      title: selectedEl.querySelector('.node-title')?.textContent || selectedEl.getAttribute('aria-label') || ''
-    };
+    return document.querySelector(NODE_SELECTOR + '.' + SELECTED_CLASS);
   }
 
   /**
@@ -215,15 +199,15 @@
 
     /**
      * Get the moment title for the selected node (for tooltip display).
+     * Delegates to LoveBudFloatingToolbarSelection helper.
      */
     function getSelectedMomentTitle() {
-      var mem = getSelectedMemory();
-      if (mem && mem.title) return mem.title;
-      // Fallback: extract title from the node element
-      var selectedEl = getSelectedNodeEl();
-      if (!selectedEl) return '';
-      var titleEl = selectedEl.querySelector('.node-title');
-      if (titleEl && titleEl.textContent) return titleEl.textContent.trim();
+      if (window.LoveBudFloatingToolbarSelection && window.LoveBudFloatingToolbarSelection.getSelectedMomentTitle) {
+        return window.LoveBudFloatingToolbarSelection.getSelectedMomentTitle({
+          nodeSelector: NODE_SELECTOR,
+          selectedClass: SELECTED_CLASS
+        });
+      }
       return '';
     }
 

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -359,6 +359,7 @@
     <script src="../js/editor/editor-floating-toolbar-affordance.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-visibility.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-events.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-selection.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
Refs #1275

## Changed files
| file | type |
|---|---|
| `js/editor/editor-floating-toolbar-selection.js` | new (+87) |
| `js/editor/editor-floating-toolbar.js` | modified (−31/+16) |
| `pages/editor.html` | modified (+1) |

## Extracted scope
- `getSelectedNode(ctx)` — find selected `.memory-node.selected` element
- `getSelectedMemory(ctx)` — resolve memory object via `data-memory-id` + `window.currentTreeMemories` lookup, with title fallback
- `getSelectedMomentTitle(ctx)` — get display title with fallback chain (`mem.title` → `.node-title` textContent → `aria-label` → `''`)
- New namespace: `window.LoveBudFloatingToolbarSelection`

## Excluded scope
- `getSelectedNodeEl()` kept as delegate wrapper (referenced by posCtx, visibility, keyboard nav)
- showToolbar/hideToolbar/updateToolbar remains
- event wiring, keyboard shortcuts, action wiring unchanged
- `.memory-node.selected` selector unchanged
- `window.currentTreeMemories` lookup pattern preserved
- title fallback order preserved

## Verification
- ✅ `npm run verify` — 177/179 (pre-existing failures only)
- ✅ `node --check` passed for all 3 files
- ✅ 3 files changed (1 new + 2 modified)
- ✅ No CSS changes
- ✅ No backend/API/Auth/DB/schema changes
- ✅ No forbidden path changes
- ✅ No close keywords
- ✅ Existing 9 other helpers untouched (0 diff)
- ✅ Helper has no side effects (no DOM mutation, no show/hide)
- ✅ Fallback to direct `document.querySelector` if helper absent

## Smoke status
- 🔲 Editor load
- 🔲 Console fatal error
- 🔲 selection namespace exists
- 🔲 getSelectedNode/getSelectedMemory/getSelectedMomentTitle APIs exist
- 🔲 Selected node lookup works
- 🔲 Memory id lookup works
- 🔲 Title fallback works
- 🔲 All regression scenarios