### PR TITLE
refactor(editor): move floating toolbar flash feedback helper

### DIFF
--- a/js/editor/editor-floating-toolbar-keyboard.js
+++ b/js/editor/editor-floating-toolbar-keyboard.js
@@ -14,10 +14,27 @@
 (function () {
   'use strict';
 
+  var flashTimer = null;
+
+  /**
+   * Flash a toolbar button for visual feedback after keyboard activation.
+   *
+   * @param {Element|null} btn - Toolbar button to flash
+   */
+  function flashButton(btn) {
+    if (!btn) return;
+    if (flashTimer) clearTimeout(flashTimer);
+    btn.classList.add('flash-feedback');
+    flashTimer = setTimeout(function () {
+      btn.classList.remove('flash-feedback');
+      flashTimer = null;
+    }, 160);
+  }
+
   /**
    * Handle global keyboard shortcuts for the floating toolbar.
    * Processes E, C, V, and Delete/Backspace keys when the toolbar is visible.
-   * 
+   *
    * @param {KeyboardEvent} e - The keydown event
    * @param {Object} context - Context containing state and element references
    * @returns {boolean} - True if the event was handled
@@ -37,7 +54,7 @@
       if (!e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (context.flashButton) context.flashButton(context.editBtn);
+        flashButton(context.editBtn);
         // Prefer using action helper if available
         if (actions && actions.edit) {
           actions.edit();
@@ -53,7 +70,7 @@
       if (!e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (context.flashButton) context.flashButton(context.continueBtn);
+        flashButton(context.continueBtn);
         if (actions && actions.continue) {
           actions.continue();
         } else if (context.continueBtn) {
@@ -68,7 +85,7 @@
       if (!e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (context.flashButton) context.flashButton(context.viewBtn);
+        flashButton(context.viewBtn);
         if (actions && actions.view) {
           actions.view();
         } else if (context.viewBtn) {
@@ -85,14 +102,14 @@
       // Trigger delete via the dropdown action button
       if (context.deleteAction) {
         // Flash the more button to indicate where to find the delete
-        if (context.moreBtn && context.flashButton) {
-          context.flashButton(context.moreBtn);
+        if (context.moreBtn) {
+          flashButton(context.moreBtn);
         }
         context.deleteAction.click();
       } else {
         var deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
         if (deleteMemoryBtn) {
-          if (context.flashButton) context.flashButton(context.deleteAction);
+          flashButton(context.deleteAction);
           deleteMemoryBtn.click();
         }
       }
@@ -173,7 +190,8 @@
   // Export to global namespace
   window.LoveBudFloatingToolbarKeyboard = {
     handleShortcut: handleShortcut,
-    bindToolbarNavigation: bindToolbarNavigation
+    bindToolbarNavigation: bindToolbarNavigation,
+    flashButton: flashButton
   };
 
   console.log('[toolbar-keyboard] Initialized (Refs #1275)');

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -78,9 +78,6 @@
     if (toolbar.dataset.ftbInitialized === '1') return;
     toolbar.dataset.ftbInitialized = '1';
 
-    // Track keyboard shortcut keyup timeout for visual flash feedback
-    var flashTimer = null;
-
     var activeMemoryId = null;
 
     // ─── Positioning context ─────────────────────────────
@@ -211,19 +208,6 @@
       return '';
     }
 
-    /**
-     * Flash a toolbar button for visual feedback after keyboard activation.
-     */
-    function flashButton(btn) {
-      if (!btn) return;
-      if (flashTimer) clearTimeout(flashTimer);
-      btn.classList.add('flash-feedback');
-      flashTimer = setTimeout(function () {
-        btn.classList.remove('flash-feedback');
-        flashTimer = null;
-      }, 160);
-    }
-
     // ─── Event wiring ─────────────────────────────────────
 
     // Respond to viewport changes (pan/zoom/resize)
@@ -307,8 +291,7 @@
           continueBtn: continueBtn,
           viewBtn: viewBtn,
           moreBtn: moreBtn,
-          deleteAction: deleteAction,
-          flashButton: flashButton
+          deleteAction: deleteAction
         };
         window.LoveBudFloatingToolbarKeyboard.handleShortcut(e, context);
       }


### PR DESCRIPTION
Summary:

- Move flash feedback timer/helper from editor-floating-toolbar.js into editor-floating-toolbar-keyboard.js.
- Keep shortcut behavior unchanged while removing one utility from the core toolbar runtime.
- No lifecycle, visibility, positioning, action, CSS, backend, API, Auth, DB, or schema changes.

Verification:

- [x] git diff --check
- [x] static lint PASS
- [x] node --check both files PASS
- [x] changed files exactly 2 JS files
- [x] forbidden paths unchanged
- [x] backend/API/Auth/DB/schema unchanged
- [x] no close keyword

Refs #1275