### PR TITLE
refactor(editor): remove unused floating toolbar selection state

### DIFF
--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -78,8 +78,6 @@
     if (toolbar.dataset.ftbInitialized === '1') return;
     toolbar.dataset.ftbInitialized = '1';
 
-    var activeMemoryId = null;
-
     // ─── Positioning context ─────────────────────────────
     var posCtx = {
       getSelectedNode: getSelectedNodeEl,
@@ -171,27 +169,8 @@
           window.LoveBudFloatingToolbarPositioning.positionToolbar(posCtx);
         }
       } else {
-        if (activeMemoryId !== null) {
-          activeMemoryId = null;
-        }
         hideToolbar();
       }
-    }
-
-    /**
-     * Handle node selection: show toolbar.
-     */
-    function handleNodeSelection(memoryId) {
-      activeMemoryId = memoryId || null;
-      updateToolbar();
-    }
-
-    /**
-     * Clear selection: hide toolbar.
-     */
-    function handleSelectionCleared() {
-      activeMemoryId = null;
-      hideToolbar();
     }
 
     /**


### PR DESCRIPTION
Summary:

- Remove unused activeMemoryId state and uncalled selection wrapper functions from editor-floating-toolbar.js.
- Keep toolbar lifecycle, visibility, positioning, keyboard, tooltip, dropdown, and affordance behavior unchanged.
- No CSS, backend, API, Auth, DB, or schema changes.

Verification:

- [x] grep confirmed no external callers for handleNodeSelection / handleSelectionCleared / activeMemoryId
- [x] git diff --check
- [x] node --check js/editor/editor-floating-toolbar.js
- [x] static lint PASS
- [x] changed files exactly 1 JS file
- [x] forbidden paths unchanged
- [x] backend/API/Auth/DB/schema unchanged
- [x] CSS unchanged
- [x] no close keyword

Refs #1275