### PR TITLE
refactor(editor): extract floating toolbar document keyboard binding

### DIFF
--- a/js/editor/editor-floating-toolbar-keyboard.js
+++ b/js/editor/editor-floating-toolbar-keyboard.js
@@ -187,9 +187,39 @@
     });
   }
 
+  /**
+   * Bind document-level keyboard shortcuts for the floating toolbar.
+   *
+   * @param {Object} ctx
+   * @param {Element} ctx.toolbar
+   * @param {string} ctx.visibleClass
+   * @param {Element} ctx.editBtn
+   * @param {Element} ctx.continueBtn
+   * @param {Element} ctx.viewBtn
+   * @param {Element} [ctx.moreBtn]
+   * @param {Element} [ctx.deleteAction]
+   */
+  function bindDocumentShortcuts(ctx) {
+    if (!ctx || !ctx.toolbar) return;
+
+    document.addEventListener('keydown', function (e) {
+      var context = {
+        isVisible: ctx.toolbar && ctx.toolbar.classList.contains(ctx.visibleClass || 'is-visible'),
+        editBtn: ctx.editBtn,
+        continueBtn: ctx.continueBtn,
+        viewBtn: ctx.viewBtn,
+        moreBtn: ctx.moreBtn,
+        deleteAction: ctx.deleteAction
+      };
+
+      handleShortcut(e, context);
+    });
+  }
+
   // Export to global namespace
   window.LoveBudFloatingToolbarKeyboard = {
     handleShortcut: handleShortcut,
+    bindDocumentShortcuts: bindDocumentShortcuts,
     bindToolbarNavigation: bindToolbarNavigation,
     flashButton: flashButton
   };

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -262,19 +262,17 @@
     // ─── Keyboard shortcuts ──────────────────────────────────
 
     // Keyboard shortcuts via document-level keydown listener
-    document.addEventListener('keydown', function (e) {
-      if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.handleShortcut) {
-        var context = {
-          isVisible: toolbar && toolbar.classList.contains(IS_VISIBLE_CLASS),
-          editBtn: editBtn,
-          continueBtn: continueBtn,
-          viewBtn: viewBtn,
-          moreBtn: moreBtn,
-          deleteAction: deleteAction
-        };
-        window.LoveBudFloatingToolbarKeyboard.handleShortcut(e, context);
-      }
-    });
+    if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.bindDocumentShortcuts) {
+      window.LoveBudFloatingToolbarKeyboard.bindDocumentShortcuts({
+        toolbar: toolbar,
+        visibleClass: IS_VISIBLE_CLASS,
+        editBtn: editBtn,
+        continueBtn: continueBtn,
+        viewBtn: viewBtn,
+        moreBtn: moreBtn,
+        deleteAction: deleteAction
+      });
+    }
 
     // ─── Toolbar keyboard navigation ─────────────────────
 


### PR DESCRIPTION
Summary:

- Move document-level floating toolbar shortcut binding from editor-floating-toolbar.js into editor-floating-toolbar-keyboard.js.
- Keep handleShortcut, toolbar navigation, lifecycle, visibility, positioning, tooltip, dropdown, and affordance behavior unchanged.
- No CSS, backend, API, Auth, DB, or schema changes.

Verification:

- [x] git diff --check
- [x] node --check js/editor/editor-floating-toolbar.js
- [x] node --check js/editor/editor-floating-toolbar-keyboard.js
- [x] static lint PASS
- [x] changed files exactly 2 JS files
- [x] forbidden paths unchanged
- [x] backend/API/Auth/DB/schema unchanged
- [x] CSS unchanged
- [x] no close keyword

Refs #1275