### PR TITLE
refactor(editor): extract floating toolbar DOM element lookup

### DIFF
--- a/js/editor/editor-floating-toolbar-elements.js
+++ b/js/editor/editor-floating-toolbar-elements.js
@@ -1,0 +1,52 @@
+/**
+ * LoveBud Editor — Floating Toolbar DOM Element Helpers
+ * Issue #1275 — Extracted from editor-floating-toolbar.js
+ *
+ * Provides DOM element lookup for the floating toolbar runtime.
+ * No behavior change. No event binding. No DOM mutation.
+ */
+
+(function () {
+  'use strict';
+
+  function byId(id) {
+    return document.getElementById(id);
+  }
+
+  /**
+   * Resolve all floating toolbar DOM elements.
+   *
+   * @param {Object} ids
+   * @returns {Object|null}
+   */
+  function getElements(ids) {
+    if (!ids) return null;
+
+    var toolbar = byId(ids.toolbar);
+    if (!toolbar) return null;
+
+    var elements = {
+      toolbar: toolbar,
+      editBtn: byId(ids.editBtn),
+      continueBtn: byId(ids.continueBtn),
+      viewBtn: byId(ids.viewBtn),
+      moreBtn: byId(ids.moreBtn),
+      quickAdd: byId(ids.quickAdd),
+      tooltip: byId(ids.tooltip),
+      dropdown: byId(ids.dropdown),
+      branchBtn: byId(ids.branchBtn),
+      forkBtn: byId(ids.forkBtn),
+      deleteAction: byId(ids.deleteAction),
+      shareAction: byId(ids.shareAction),
+      focusAction: byId(ids.focusAction)
+    };
+
+    if (!elements.editBtn || !elements.continueBtn || !elements.viewBtn) return null;
+
+    return elements;
+  }
+
+  window.LoveBudFloatingToolbarElements = {
+    getElements: getElements
+  };
+})();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -56,23 +56,39 @@
    * Self-contained: monitors DOM for selection changes and positions itself.
    */
   function initFloatingToolbar() {
-    var toolbar = document.getElementById(FLOATING_TOOLBAR_ID);
-    if (!toolbar) return;
+    var elements = window.LoveBudFloatingToolbarElements && window.LoveBudFloatingToolbarElements.getElements
+      ? window.LoveBudFloatingToolbarElements.getElements({
+        toolbar: FLOATING_TOOLBAR_ID,
+        editBtn: EDIT_BTN_ID,
+        continueBtn: CONTINUE_BTN_ID,
+        viewBtn: VIEW_BTN_ID,
+        moreBtn: MORE_BTN_ID,
+        quickAdd: QUICK_ADD_ID,
+        tooltip: TOOLTIP_ID,
+        dropdown: DROPDOWN_ID,
+        branchBtn: BRANCH_BTN_ID,
+        forkBtn: FORK_BTN_ID,
+        deleteAction: DELETE_ACTION_ID,
+        shareAction: SHARE_ACTION_ID,
+        focusAction: FOCUS_ACTION_ID
+      })
+      : null;
 
-    var editBtn = document.getElementById(EDIT_BTN_ID);
-    var continueBtn = document.getElementById(CONTINUE_BTN_ID);
-    var viewBtn = document.getElementById(VIEW_BTN_ID);
-    var moreBtn = document.getElementById(MORE_BTN_ID);
-    var quickAdd = document.getElementById(QUICK_ADD_ID);
-    var tooltip = document.getElementById(TOOLTIP_ID);
-    var dropdown = document.getElementById(DROPDOWN_ID);
-    var branchBtn = document.getElementById(BRANCH_BTN_ID);
-    var forkBtn = document.getElementById(FORK_BTN_ID);
-    var deleteAction = document.getElementById(DELETE_ACTION_ID);
-    var shareAction = document.getElementById(SHARE_ACTION_ID);
-    var focusAction = document.getElementById(FOCUS_ACTION_ID);
+    if (!elements) return;
 
-    if (!editBtn || !continueBtn || !viewBtn) return;
+    var toolbar = elements.toolbar;
+    var editBtn = elements.editBtn;
+    var continueBtn = elements.continueBtn;
+    var viewBtn = elements.viewBtn;
+    var moreBtn = elements.moreBtn;
+    var quickAdd = elements.quickAdd;
+    var tooltip = elements.tooltip;
+    var dropdown = elements.dropdown;
+    var branchBtn = elements.branchBtn;
+    var forkBtn = elements.forkBtn;
+    var deleteAction = elements.deleteAction;
+    var shareAction = elements.shareAction;
+    var focusAction = elements.focusAction;
 
     // Prevent double-init
     if (toolbar.dataset.ftbInitialized === '1') return;

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -360,6 +360,7 @@
     <script src="../js/editor/editor-floating-toolbar-visibility.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-events.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-selection.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-elements.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>


### PR DESCRIPTION
Summary:

- Move floating toolbar DOM element lookup and required button guard into a focused elements helper.
- Keep lifecycle, visibility, positioning, keyboard, tooltip, dropdown, and affordance behavior unchanged.
- No CSS, backend, API, Auth, DB, or schema changes.

Verification:

- [x] git diff --check
- [x] node --check js/editor/editor-floating-toolbar.js
- [x] node --check js/editor/editor-floating-toolbar-elements.js
- [x] static lint PASS
- [x] changed files exactly 3 files
- [x] script order verified (elements.js before toolbar.js)
- [x] forbidden paths unchanged
- [x] backend/API/Auth/DB/schema unchanged
- [x] CSS unchanged
- [x] no close keyword

Refs #1275