### PR TITLE
refactor(editor): extract floating toolbar tooltip binding

### DIFF
--- a/js/editor/editor-floating-toolbar-tooltip.js
+++ b/js/editor/editor-floating-toolbar-tooltip.js
@@ -124,9 +124,40 @@
     });
   }
 
+  /**
+   * Bind tooltip events for all floating toolbar tooltip targets.
+   *
+   * @param {Object} ctx
+   * @param {HTMLElement} ctx.tooltip
+   * @param {HTMLElement} ctx.toolbar
+   * @param {HTMLElement} ctx.editBtn
+   * @param {HTMLElement} ctx.continueBtn
+   * @param {HTMLElement} ctx.viewBtn
+   * @param {HTMLElement} [ctx.moreBtn]
+   * @param {HTMLElement} [ctx.branchBtn]
+   * @param {HTMLElement} [ctx.forkBtn]
+   * @param {Function} ctx.getTitle
+   */
+  function bind(ctx) {
+    if (!ctx || !ctx.tooltip || !ctx.toolbar || !ctx.getTitle) return;
+
+    var targets = [ctx.editBtn, ctx.continueBtn, ctx.viewBtn];
+    if (ctx.moreBtn) targets.push(ctx.moreBtn);
+    if (ctx.branchBtn) targets.push(ctx.branchBtn);
+    if (ctx.forkBtn) targets.push(ctx.forkBtn);
+
+    initTooltipEvents({
+      tooltip: ctx.tooltip,
+      toolbar: ctx.toolbar,
+      targets: targets,
+      getTitle: ctx.getTitle
+    });
+  }
+
   // Export to global namespace
   window.LoveBudFloatingToolbarTooltip = {
     init: initTooltipEvents,
+    bind: bind,
     hide: hideTooltip
   };
 

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -261,16 +261,16 @@
 
     // ─── Tooltip on hover over toolbar buttons ─────────────
 
-    var tooltipTargets = [editBtn, continueBtn, viewBtn];
-    if (moreBtn) tooltipTargets.push(moreBtn);
-    if (branchBtn) tooltipTargets.push(branchBtn);
-    if (forkBtn) tooltipTargets.push(forkBtn);
-
-    if (window.LoveBudFloatingToolbarTooltip && window.LoveBudFloatingToolbarTooltip.init) {
-      window.LoveBudFloatingToolbarTooltip.init({
+    if (window.LoveBudFloatingToolbarTooltip && window.LoveBudFloatingToolbarTooltip.bind) {
+      window.LoveBudFloatingToolbarTooltip.bind({
         tooltip: tooltip,
         toolbar: toolbar,
-        targets: tooltipTargets,
+        editBtn: editBtn,
+        continueBtn: continueBtn,
+        viewBtn: viewBtn,
+        moreBtn: moreBtn,
+        branchBtn: branchBtn,
+        forkBtn: forkBtn,
         getTitle: getSelectedMomentTitle
       });
     }


### PR DESCRIPTION
Summary:

  * Move floating toolbar tooltip target assembly and binding call into the tooltip helper.
  * Keep tooltip behavior, lifecycle, visibility, positioning, keyboard, dropdown, and affordance behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-tooltip.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS or marked NOT TESTED with reason

Refs #1275