### PR TITLE
refactor(editor): extract floating toolbar affordance binding

### DIFF
--- a/js/editor/editor-floating-toolbar-affordance.js
+++ b/js/editor/editor-floating-toolbar-affordance.js
@@ -128,6 +128,17 @@
     }
   }
 
+  /**
+   * Bind all affordance-related click handlers for the floating toolbar.
+   *
+   * @param {Object} ctx
+   */
+  function bind(ctx) {
+    if (!ctx) return;
+    bindConnectionButtons(ctx);
+    bindQuickAdd(ctx);
+  }
+
   // Expose on global namespace
   window.LoveBudFloatingToolbarAffordance = {
     isConnectionMode: isConnectionMode,
@@ -135,6 +146,7 @@
     hideQuickAdd: hideQuickAdd,
     updateAdaptiveState: updateAdaptiveState,
     bindQuickAdd: bindQuickAdd,
-    bindConnectionButtons: bindConnectionButtons
+    bindConnectionButtons: bindConnectionButtons,
+    bind: bind
   };
 })();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -247,16 +247,10 @@
       });
     }
 
-    // ─── Branch / connection-mode buttons ──────────────────
+    // ─── Affordance bindings ───────────────────────────────
 
-    if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.bindConnectionButtons) {
-      window.LoveBudFloatingToolbarAffordance.bindConnectionButtons(posCtx);
-    }
-
-    // ─── Quick-add affordance ─────────────────────────────
-
-    if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.bindQuickAdd) {
-      window.LoveBudFloatingToolbarAffordance.bindQuickAdd(posCtx);
+    if (window.LoveBudFloatingToolbarAffordance && window.LoveBudFloatingToolbarAffordance.bind) {
+      window.LoveBudFloatingToolbarAffordance.bind(posCtx);
     }
 
     // ─── Tooltip on hover over toolbar buttons ─────────────


### PR DESCRIPTION
Summary:

  * Move floating toolbar affordance click binding calls into a single affordance helper wrapper.
  * Keep quick-add, branch/fork, lifecycle, visibility, positioning, tooltip, dropdown, and keyboard behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-affordance.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS or marked NOT TESTED with reason

Refs #1275