### PR TITLE
refactor(editor): extract floating toolbar event target binding

### DIFF
--- a/js/editor/editor-floating-toolbar-events.js
+++ b/js/editor/editor-floating-toolbar-events.js
@@ -82,8 +82,29 @@
     }
   }
 
+  /**
+   * Bind editor floating toolbar events using the standard editor DOM targets.
+   *
+   * @param {Object} ctx
+   * @param {Function} ctx.updateToolbar
+   * @param {Function} ctx.scheduleUpdate
+   */
+  function bindEditorTargets(ctx) {
+    if (!ctx) return;
+
+    bind({
+      canvas: document.getElementById('canvasArea'),
+      updateToolbar: ctx.updateToolbar,
+      scheduleUpdate: ctx.scheduleUpdate,
+      compactToggleBtn: document.getElementById('compactModeToggleBtn'),
+      layoutToggleBtn: document.getElementById('layoutModeToggleBtn'),
+      editModeContainer: document.getElementById('detailEditMode')
+    });
+  }
+
   // Expose on global namespace
   window.LoveBudFloatingToolbarEvents = {
-    bind: bind
+    bind: bind,
+    bindEditorTargets: bindEditorTargets
   };
 })();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -213,14 +213,10 @@
     };
 
     // Delegate event wiring to helper
-    if (window.LoveBudFloatingToolbarEvents && window.LoveBudFloatingToolbarEvents.bind) {
-      window.LoveBudFloatingToolbarEvents.bind({
-        canvas: document.getElementById('canvasArea'),
+    if (window.LoveBudFloatingToolbarEvents && window.LoveBudFloatingToolbarEvents.bindEditorTargets) {
+      window.LoveBudFloatingToolbarEvents.bindEditorTargets({
         updateToolbar: updateToolbar,
-        scheduleUpdate: scheduleUpdate,
-        compactToggleBtn: document.getElementById('compactModeToggleBtn'),
-        layoutToggleBtn: document.getElementById('layoutModeToggleBtn'),
-        editModeContainer: document.getElementById('detailEditMode')
+        scheduleUpdate: scheduleUpdate
       });
     }
 


### PR DESCRIPTION
Summary:

  * Move floating toolbar event target lookup and binding assembly into the events helper.
  * Keep event wiring, lifecycle, visibility, positioning, tooltip, dropdown, affordance, and keyboard behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-events.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS or marked NOT TESTED with reason

Refs #1275