### PR TITLE
refactor(editor): extract floating toolbar keyboard binding

### DIFF
--- a/js/editor/editor-floating-toolbar-keyboard.js
+++ b/js/editor/editor-floating-toolbar-keyboard.js
@@ -216,11 +216,23 @@
     });
   }
 
+  /**
+   * Bind all keyboard-related handlers for the floating toolbar.
+   *
+   * @param {Object} ctx
+   */
+  function bind(ctx) {
+    if (!ctx) return;
+    bindDocumentShortcuts(ctx);
+    bindToolbarNavigation(ctx);
+  }
+
   // Export to global namespace
   window.LoveBudFloatingToolbarKeyboard = {
     handleShortcut: handleShortcut,
     bindDocumentShortcuts: bindDocumentShortcuts,
     bindToolbarNavigation: bindToolbarNavigation,
+    bind: bind,
     flashButton: flashButton
   };
 

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -265,30 +265,20 @@
       });
     }
 
-    // ─── Keyboard shortcuts ──────────────────────────────────
+    // ─── Keyboard bindings ─────────────────────────────────
 
-    // Keyboard shortcuts via document-level keydown listener
-    if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.bindDocumentShortcuts) {
-      window.LoveBudFloatingToolbarKeyboard.bindDocumentShortcuts({
+    if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.bind) {
+      window.LoveBudFloatingToolbarKeyboard.bind({
         toolbar: toolbar,
         visibleClass: IS_VISIBLE_CLASS,
         editBtn: editBtn,
         continueBtn: continueBtn,
         viewBtn: viewBtn,
         moreBtn: moreBtn,
-        deleteAction: deleteAction
-      });
-    }
-
-    // ─── Toolbar keyboard navigation ─────────────────────
-
-    if (window.LoveBudFloatingToolbarKeyboard && window.LoveBudFloatingToolbarKeyboard.bindToolbarNavigation) {
-      window.LoveBudFloatingToolbarKeyboard.bindToolbarNavigation({
-        toolbar: toolbar,
+        deleteAction: deleteAction,
         getSelectedNode: getSelectedNodeEl,
         hideToolbar: hideToolbar,
         dropdown: dropdown,
-        moreBtn: moreBtn,
         selectedClass: SELECTED_CLASS
       });
     }


### PR DESCRIPTION
Summary:

  * Move floating toolbar keyboard binding calls into a single keyboard helper wrapper.
  * Keep document shortcuts, toolbar navigation, lifecycle, visibility, positioning, tooltip, dropdown, and affordance behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-keyboard.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS or marked NOT TESTED with reason

Refs #1275