### PR TITLE
refactor(editor): extract floating toolbar primary action binding

### DIFF
--- a/js/editor/editor-floating-toolbar-actions.js
+++ b/js/editor/editor-floating-toolbar-actions.js
@@ -96,12 +96,23 @@
     }
   }
 
+  /**
+   * Bind all action-related handlers for the floating toolbar.
+   *
+   * @param {Object} ctx
+   */
+  function bind(ctx) {
+    if (!ctx) return;
+    bindPrimaryActions(ctx);
+  }
+
   // Export to global namespace for use by editor-floating-toolbar.js
   window.LoveBudFloatingToolbarActions = {
     edit: toolbarEditAction,
     continue: toolbarContinueAction,
     view: toolbarViewAction,
-    bindPrimaryActions: bindPrimaryActions
+    bindPrimaryActions: bindPrimaryActions,
+    bind: bind
   };
 
   console.log('[toolbar-actions] Initialized (Refs #1275)');

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -222,9 +222,8 @@
 
 // ─── Button actions ───────────────────────────────────
 
-    // Delegate primary action button wiring to helper
-    if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.bindPrimaryActions) {
-      window.LoveBudFloatingToolbarActions.bindPrimaryActions({
+    if (window.LoveBudFloatingToolbarActions && window.LoveBudFloatingToolbarActions.bind) {
+      window.LoveBudFloatingToolbarActions.bind({
         editBtn: editBtn,
         continueBtn: continueBtn,
         viewBtn: viewBtn


### PR DESCRIPTION
Summary:

  * Move floating toolbar primary action binding call into a single actions helper wrapper.
  * Keep edit, continue, view, lifecycle, visibility, positioning, tooltip, dropdown, affordance, and keyboard behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-actions.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS or marked NOT TESTED with reason

Refs #1275