### PR TITLE
refactor(editor): extract floating toolbar dropdown binding

### DIFF
--- a/js/editor/editor-floating-toolbar-dropdown.js
+++ b/js/editor/editor-floating-toolbar-dropdown.js
@@ -153,11 +153,34 @@
     }
   }
 
+  /**
+   * Bind dropdown events for the floating toolbar using toolbar element context.
+   *
+   * @param {Object} ctx
+   * @param {HTMLElement} [ctx.dropdown]
+   * @param {HTMLElement} [ctx.moreBtn]
+   * @param {HTMLElement} [ctx.deleteAction]
+   * @param {HTMLElement} [ctx.shareAction]
+   * @param {HTMLElement} [ctx.focusAction]
+   */
+  function bindToolbarDropdown(ctx) {
+    if (!ctx) return;
+
+    bindDropdownEvents({
+      dropdown: ctx.dropdown,
+      moreBtn: ctx.moreBtn,
+      deleteAction: ctx.deleteAction,
+      shareAction: ctx.shareAction,
+      focusAction: ctx.focusAction
+    });
+  }
+
   // Expose on global namespace
   window.LoveBudFloatingToolbarDropdown = {
     show: function (dropdown, moreBtn) { showDropdown(dropdown, moreBtn); },
     hide: function (dropdown, moreBtn) { hideDropdown(dropdown, moreBtn); },
     toggle: function (dropdown, moreBtn, e) { toggleDropdown(dropdown, moreBtn, e); },
-    bind: function (ctx) { bindDropdownEvents(ctx); }
+    bind: function (ctx) { bindDropdownEvents(ctx); },
+    bindToolbarDropdown: bindToolbarDropdown
   };
 })();

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -232,8 +232,8 @@
 
     // ─── More button / dropdown ────────────────────────────
 
-    if (window.LoveBudFloatingToolbarDropdown) {
-      window.LoveBudFloatingToolbarDropdown.bind({
+    if (window.LoveBudFloatingToolbarDropdown && window.LoveBudFloatingToolbarDropdown.bindToolbarDropdown) {
+      window.LoveBudFloatingToolbarDropdown.bindToolbarDropdown({
         dropdown: dropdown,
         moreBtn: moreBtn,
         deleteAction: deleteAction,


### PR DESCRIPTION
Summary:

  * Add an explicit dropdown binding wrapper and route floating toolbar dropdown binding through it.
  * Keep dropdown show, hide, toggle, secondary actions, lifecycle, visibility, positioning, tooltip, affordance, and keyboard behavior unchanged.
  * No CSS, backend, API, Auth, DB, or schema changes.

Verification:

  * [x] git diff --check
  * [x] node --check js/editor/editor-floating-toolbar.js
  * [x] node --check js/editor/editor-floating-toolbar-dropdown.js
  * [x] static verification PASS
  * [x] changed files exactly 2 JS files
  * [x] forbidden paths unchanged
  * [x] backend/API/Auth/DB/schema unchanged
  * [x] CSS unchanged
  * [x] pages/editor.html unchanged
  * [x] no close keyword
  * [x] runtime smoke PASS

Refs #1275