### PR TITLE
fix(modal): add legacy schema fallback to browse snapshot queries (#1291)

### DIFF
--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -7,9 +7,11 @@ from modal_compute.db import (
     run_db_with_retry,
 )
 from modal_compute.validation import (
+    estimate_stage,
     normalize_row,
     normalize_memory_row,
     normalize_tree_row,
+    parse_tags,
 )
 
 
@@ -147,13 +149,15 @@ def _normalize_legacy_memory_row(node: dict[str, Any], tree_id: str, row: dict[s
 
 
 def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") -> list[dict[str, Any]]:
-    """Fetch the latest public tree snapshots using a robust join-lateral query."""
+    """Fetch the latest public tree snapshots using a robust join-lateral query.
+    Falls back to legacy trees.payload format if memories table is missing.
+    """
 
     order_clause = "t.created_at DESC"
     if sort == "popular":
         order_clause = "c.memory_count DESC, t.created_at DESC"
 
-    query = """
+    modern_query = """
         SELECT
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
@@ -190,18 +194,75 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
     def operation() -> list[dict[str, Any]]:
         with get_db_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(query, (limit,))
-                return cur.fetchall()
+                has_memories = _table_exists(cur, "memories")
+                has_title = _table_has_column(cur, "trees", "title")
 
-    rows = run_db_with_retry(operation)
+                if has_memories and has_title:
+                    cur.execute(modern_query, (limit,))
+                    return [normalize_row(row) for row in cur.fetchall()]
 
-    return [normalize_row(row) for row in rows]
+                # Fallback: legacy schema (name/is_public/payload)
+                has_name = _table_has_column(cur, "trees", "name")
+                has_is_public = _table_has_column(cur, "trees", "is_public")
+                if not has_name or not has_is_public:
+                    return []
+
+                cur.execute(
+                    """SELECT id, name, is_public, payload, created_at, updated_at
+                       FROM trees WHERE is_public = true
+                       ORDER BY created_at DESC LIMIT %s""",
+                    (limit * 2,),
+                )
+                raw_rows = cur.fetchall()
+
+                result: list[dict[str, Any]] = []
+                for row in raw_rows:
+                    payload = row.get("payload") or {}
+                    nodes = payload.get("nodes") or []
+                    public_nodes = [n for n in nodes if n.get("visibility", "public") == "public"]
+                    if len(public_nodes) < 3:
+                        continue  # Quality filter: 3+ public memories
+
+                    all_tags_collected: list[list[str]] = []
+                    rep_thumbnail = ""
+                    rep_source_url = ""
+                    for n in public_nodes:
+                        tags = n.get("emotion_tags") or n.get("emotionTags") or []
+                        if isinstance(tags, list):
+                            all_tags_collected.append(tags)
+                        if not rep_thumbnail and n.get("thumbnail"):
+                            rep_thumbnail = n.get("thumbnail", "")
+                        if not rep_source_url and (n.get("source_url") or n.get("sourceUrl")):
+                            rep_source_url = n.get("source_url") or n.get("sourceUrl") or ""
+
+                    mc = len(public_nodes)
+                    result.append({
+                        "id": str(row["id"]),
+                        "title": row.get("name") or "나의 Lovetree",
+                        "visibility": "public",
+                        "createdAt": _to_isoformat_dt(row.get("created_at")),
+                        "updatedAt": _to_isoformat_dt(row.get("updated_at")),
+                        "representativeThumbnail": rep_thumbnail or rep_source_url or "",
+                        "memoryCount": mc,
+                        "emotionTags": parse_tags(all_tags_collected),
+                        "stage": estimate_stage(mc),
+                        "theme": "LoveTree",
+                        "timeRange": "",
+                        "representativeMemorySourceUrl": rep_source_url or "",
+                    })
+                    if len(result) >= limit:
+                        break
+                return result
+
+    return run_db_with_retry(operation)
 
 
 def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
-    """Fetch growing public tree snapshots for trees with 1-2 public memories."""
+    """Fetch growing public tree snapshots for trees with 1-2 public memories.
+    Falls back to legacy trees.payload format if memories table is missing.
+    """
 
-    query = """
+    modern_query = """
         SELECT
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
@@ -236,12 +297,68 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
     def operation() -> list[dict[str, Any]]:
         with get_db_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(query, (limit,))
-                return cur.fetchall()
+                has_memories = _table_exists(cur, "memories")
+                has_title = _table_has_column(cur, "trees", "title")
 
-    rows = run_db_with_retry(operation)
+                if has_memories and has_title:
+                    cur.execute(modern_query, (limit,))
+                    return [normalize_row(row, stage_override="growing") for row in cur.fetchall()]
 
-    return [normalize_row(row, stage_override="growing") for row in rows]
+                # Fallback: legacy schema (name/is_public/payload)
+                has_name = _table_has_column(cur, "trees", "name")
+                has_is_public = _table_has_column(cur, "trees", "is_public")
+                if not has_name or not has_is_public:
+                    return []
+
+                cur.execute(
+                    """SELECT id, name, is_public, payload, created_at, updated_at
+                       FROM trees WHERE is_public = true
+                       ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+                       LIMIT %s""",
+                    (limit * 3,),
+                )
+                raw_rows = cur.fetchall()
+
+                result: list[dict[str, Any]] = []
+                for row in raw_rows:
+                    payload = row.get("payload") or {}
+                    nodes = payload.get("nodes") or []
+                    public_nodes = [n for n in nodes if n.get("visibility", "public") == "public"]
+                    mc = len(public_nodes)
+                    if mc < 1 or mc > 2:
+                        continue  # Growing filter: 1-2 public memories
+
+                    all_tags_collected: list[list[str]] = []
+                    rep_thumbnail = ""
+                    rep_source_url = ""
+                    for n in public_nodes:
+                        tags = n.get("emotion_tags") or n.get("emotionTags") or []
+                        if isinstance(tags, list):
+                            all_tags_collected.append(tags)
+                        if not rep_thumbnail and n.get("thumbnail"):
+                            rep_thumbnail = n.get("thumbnail", "")
+                        if not rep_source_url and (n.get("source_url") or n.get("sourceUrl")):
+                            rep_source_url = n.get("source_url") or n.get("sourceUrl") or ""
+
+                    result.append({
+                        "id": str(row["id"]),
+                        "title": row.get("name") or "나의 Lovetree",
+                        "visibility": "public",
+                        "createdAt": _to_isoformat_dt(row.get("created_at")),
+                        "updatedAt": _to_isoformat_dt(row.get("updated_at")),
+                        "representativeThumbnail": rep_thumbnail or rep_source_url or "",
+                        "memoryCount": mc,
+                        "emotionTags": parse_tags(all_tags_collected),
+                        "stage": "growing",
+                        "theme": "LoveTree",
+                        "timeRange": "",
+                        "representativeMemorySourceUrl": rep_source_url or "",
+                    })
+                    if len(result) >= limit:
+                        break
+                return result
+
+    return run_db_with_retry(operation)
 
 
 def fetch_public_memories(tree_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -217,9 +217,13 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
 
                 result: list[dict[str, Any]] = []
                 for row in raw_rows:
-                    payload = row.get("payload") or {}
+                    raw_payload = row.get("payload")
+                    payload = raw_payload if isinstance(raw_payload, dict) else {}
                     nodes = payload.get("nodes") or []
-                    public_nodes = [n for n in nodes if n.get("visibility", "public") == "public"]
+                    public_nodes = [
+                        n for n in nodes
+                        if isinstance(n, dict) and n.get("visibility", "public") == "public"
+                    ]
                     if len(public_nodes) < 3:
                         continue  # Quality filter: 3+ public memories
 
@@ -321,9 +325,13 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
 
                 result: list[dict[str, Any]] = []
                 for row in raw_rows:
-                    payload = row.get("payload") or {}
+                    raw_payload = row.get("payload")
+                    payload = raw_payload if isinstance(raw_payload, dict) else {}
                     nodes = payload.get("nodes") or []
-                    public_nodes = [n for n in nodes if n.get("visibility", "public") == "public"]
+                    public_nodes = [
+                        n for n in nodes
+                        if isinstance(n, dict) and n.get("visibility", "public") == "public"
+                    ]
                     mc = len(public_nodes)
                     if mc < 1 or mc > 2:
                         continue  # Growing filter: 1-2 public memories

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -170,7 +170,7 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
             SELECT
                 tree_id,
                 count(*) as memory_count,
-                ARRAY_AGG(emotion_tags) as all_tags
+                jsonb_agg(emotion_tags) as all_tags
             FROM memories
             WHERE visibility = 'public'
             GROUP BY tree_id
@@ -278,7 +278,7 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
             SELECT
                 tree_id,
                 count(*) as memory_count,
-                ARRAY_AGG(emotion_tags) as all_tags
+                jsonb_agg(emotion_tags) as all_tags
             FROM memories
             WHERE visibility = 'public'
             GROUP BY tree_id

--- a/tests/contracts/modal-public-read-routes-contract.test.js
+++ b/tests/contracts/modal-public-read-routes-contract.test.js
@@ -102,6 +102,8 @@ test('modal public read helpers preserve public visibility filters and normaliza
   assert.ok(hasString(latestHelper, 'HAVING count(*) >= 3'));
   assert.ok(hasString(latestHelper, 'has_memories'));
   assert.ok(hasString(latestHelper, '_table_exists(cur, "memories")'));
+  assert.ok(hasString(latestHelper, 'jsonb_agg(emotion_tags)'));
+  assert.ok(!hasString(latestHelper, 'ARRAY_AGG(emotion_tags)'));
 
   const growingHelper = extractPythonFunction(content, 'fetch_growing_public_tree_snapshots');
   assert.ok(hasString(growingHelper, "t.visibility = 'public'"));
@@ -110,6 +112,8 @@ test('modal public read helpers preserve public visibility filters and normaliza
   assert.ok(hasString(growingHelper, 'HAVING count(*) BETWEEN 1 AND 2'));
   assert.ok(hasString(growingHelper, 'has_memories'));
   assert.ok(hasString(growingHelper, '_table_exists'));
+  assert.ok(hasString(growingHelper, 'jsonb_agg(emotion_tags)'));
+  assert.ok(!hasString(growingHelper, 'ARRAY_AGG(emotion_tags)'));
 
   const memoriesHelper = extractPythonFunction(content, 'fetch_public_memories');
   assert.ok(hasString(memoriesHelper, "m.visibility = 'public'"));

--- a/tests/contracts/modal-public-read-routes-contract.test.js
+++ b/tests/contracts/modal-public-read-routes-contract.test.js
@@ -98,14 +98,18 @@ test('modal public read helpers preserve public visibility filters and normaliza
   const latestHelper = extractPythonFunction(content, 'fetch_latest_public_tree_snapshots');
   assert.ok(hasString(latestHelper, "t.visibility = 'public'"));
   assert.ok(hasString(latestHelper, "WHERE visibility = 'public'"));
+  assert.ok(hasString(latestHelper, 'normalize_row(row)'));
   assert.ok(hasString(latestHelper, 'HAVING count(*) >= 3'));
-  assert.ok(hasString(latestHelper, 'return [normalize_row(row) for row in rows]'));
+  assert.ok(hasString(latestHelper, 'has_memories'));
+  assert.ok(hasString(latestHelper, '_table_exists(cur, "memories")'));
 
   const growingHelper = extractPythonFunction(content, 'fetch_growing_public_tree_snapshots');
   assert.ok(hasString(growingHelper, "t.visibility = 'public'"));
   assert.ok(hasString(growingHelper, "WHERE visibility = 'public'"));
+  assert.ok(hasString(growingHelper, 'normalize_row(row, stage_override="growing")'));
   assert.ok(hasString(growingHelper, 'HAVING count(*) BETWEEN 1 AND 2'));
-  assert.ok(hasString(growingHelper, 'return [normalize_row(row, stage_override="growing") for row in rows]'));
+  assert.ok(hasString(growingHelper, 'has_memories'));
+  assert.ok(hasString(growingHelper, '_table_exists'));
 
   const memoriesHelper = extractPythonFunction(content, 'fetch_public_memories');
   assert.ok(hasString(memoriesHelper, "m.visibility = 'public'"));


### PR DESCRIPTION
## 문제
test5에서 `/api/community/trees`와 `/api/community/growing-trees`가 500 반환. Cloudflare→Modal proxy 정상 (`x-lovebud-upstream: modal`), Modal이 500을 반환 중.

## 원인
### 1차: Legacy schema fallback 부재
`fetch_latest_public_tree_snapshots`와 `fetch_growing_public_tree_snapshots`가 modern schema (`trees.title`/`trees.visibility` + `memories` table)만 가정하고 SQL 실행. test5와 같은 legacy schema 환경에서 PostgreSQL 오류 가능성 방어를 위해 schema detection + legacy fallback 추가.

다른 함수 (`fetch_public_tree`, `fetch_public_memories`)는 `_table_exists`/`_table_has_column` 검사 후 legacy fallback하는데, browse 함수들만 이 검사가 없었음.

### 2차: ARRAY_AGG JSONB empty array limitation (Modal stderr logs로 확인)
Modal deploy 후 traceback에서 실제 500 원인 확인:

`psycopg.errors.ArraySubscriptError: cannot accumulate empty arrays`

test5는 modern schema (`memories` table 존재, `trees.title`/`visibility` 존재)로 라우팅되고 있었고, `ARRAY_AGG(emotion_tags)`가 JSONB empty array `[]`를 집계하면서 PostgreSQL 14+에서 실패한 것. `emotion_tags` column은 `JSONB NOT NULL DEFAULT '[]'::jsonb`로 정의되어 있음.

## 수정
- SQL 실행 전 schema detection (`_table_exists("memories")`, `_table_has_column("trees", "title")`)
- Modern schema 있으면 기존 query 그대로 사용 (단, ARRAY_AGG → jsonb_agg로 수정)
- Legacy schema (trees.name/is_public/payload)면 payload.nodes에서 browse snapshot 구성
- 두 함수 모두 동일 패턴 적용
- `ARRAY_AGG(emotion_tags)` → `jsonb_agg(emotion_tags)` (JSONB empty array 호환)

## 변경 파일
- `modal_compute/public_reads.py`: schema detection + legacy fallback + ARRAY_AGG→jsonb_agg
- `tests/contracts/modal-public-read-routes-contract.test.js`: contract test assertion 업데이트

## 변경 제약
- 기존 modern path 100% 동작 유지 (jsonb_agg output은 parse_tags에서 정상 처리)
- API contract 변경 없음
- DB migration/auth 변경 없음
- `Refs #1291` — close keyword 사용 안 함

## 검증
- `python -m py_compile` 통과
- AST parse 정상
- legacy fallback output format: browse snapshot contract 준수
- Non-dict node / payload 방어 가드 유지

## smoke unblock 조건
- 이 PR이 test5에 배포되면 두 endpoint 500 해소
- #1053/#248 smoke 재시도 가능
- 단, legacy fallback은 payload.nodes 데이터에 의존하므로 실제 공개 tree 데이터가 있어야 smoke 의미 있음

Refs #1291