### PR TITLE
refactor(viewer): extract public viewer render state helper

### DIFF
--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -17,6 +17,8 @@
 
     var currentTreeId = null;
 
+    var RS = window.LoveBudViewerRenderState.create(SEL);
+
     var DT = window.LoveBudViewerDataTransform;
     function escapeHtml(v) {
         var sec = window.LoveBudSecurity;
@@ -25,24 +27,6 @@
             return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
         });
     }
-
-    function qs(sel) { return document.querySelector(sel); }
-    function show() {
-        for (var i = 0; i < arguments.length; i++) {
-            var el = qs(arguments[i]);
-            if (el) { el.style.display = ''; el.removeAttribute('hidden'); }
-        }
-    }
-    function hide() {
-        for (var i = 0; i < arguments.length; i++) {
-            var el = qs(arguments[i]);
-            if (el) el.style.display = 'none';
-        }
-    }
-
-    function showLoading() { hide(SEL.treeContainer, SEL.empty, SEL.error); show(SEL.loading); }
-    function renderEmpty() { hide(SEL.treeContainer, SEL.loading, SEL.error); show(SEL.empty); }
-    function renderError() { hide(SEL.treeContainer, SEL.loading, SEL.empty); show(SEL.error); }
 
     async function loadPublicData(treeId) {
         var getMemories = window.apiClient &&
@@ -58,13 +42,13 @@
     async function initViewer() {
         var params = new URLSearchParams(window.location.search);
         var treeId = params.get('treeId');
-        if (!treeId) { renderEmpty(); return; }
+        if (!treeId) { RS.renderEmpty(); return; }
         currentTreeId = treeId;
-        showLoading();
+        RS.showLoading();
 
         try {
             var memories = await loadPublicData(treeId);
-            if (!memories || memories.length === 0) { renderEmpty(); return; }
+            if (!memories || memories.length === 0) { RS.renderEmpty(); return; }
 
             var viewerData = DT.buildBranches(memories);
 
@@ -81,10 +65,10 @@
             // Render state
             var state = State.createInitialState();
 
-            show(SEL.treeContainer);
-            hide(SEL.loading, SEL.empty, SEL.error);
+            RS.show(SEL.treeContainer);
+            RS.hide(SEL.loading, SEL.empty, SEL.error);
 
-            var container = qs('#viewerTreeContainer');
+            var container = RS.qs('#viewerTreeContainer');
             if (!container) return;
 
             var treeTitle = viewerData.tree.title;
@@ -234,7 +218,7 @@
 
         } catch (error) {
             console.error('[tree-viewer] load failed:', error);
-            renderError();
+            RS.renderError();
         }
     }
 

--- a/js/viewer/viewer-render-state.js
+++ b/js/viewer/viewer-render-state.js
@@ -1,0 +1,49 @@
+(function() {
+    'use strict';
+
+    var MARKER = 'LoveBudViewerRenderStateLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    /**
+     * Create viewer render state helpers for a given SEL config.
+     *
+     * @param {Object} SEL - Selector map with keys:
+     *   shell, loading, empty, error, treeContainer, treeTitle, treeMeta
+     * @returns {Object} With qs, show, hide, showLoading, renderEmpty, renderError
+     */
+    function create(SEL) {
+        function qs(sel) { return document.querySelector(sel); }
+
+        function show() {
+            for (var i = 0; i < arguments.length; i++) {
+                var el = qs(arguments[i]);
+                if (el) { el.style.display = ''; el.removeAttribute('hidden'); }
+            }
+        }
+
+        function hide() {
+            for (var i = 0; i < arguments.length; i++) {
+                var el = qs(arguments[i]);
+                if (el) el.style.display = 'none';
+            }
+        }
+
+        function showLoading() { hide(SEL.treeContainer, SEL.empty, SEL.error); show(SEL.loading); }
+        function renderEmpty() { hide(SEL.treeContainer, SEL.loading, SEL.error); show(SEL.empty); }
+        function renderError() { hide(SEL.treeContainer, SEL.loading, SEL.empty); show(SEL.error); }
+
+        return {
+            qs: qs,
+            show: show,
+            hide: hide,
+            showLoading: showLoading,
+            renderEmpty: renderEmpty,
+            renderError: renderError
+        };
+    }
+
+    window.LoveBudViewerRenderState = {
+        create: create
+    };
+})();

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -70,6 +70,7 @@
     <script src="../js/viewer/viewer-share-export-actions.js?v=20260519-1282-1"></script>
     <script src="../js/viewer/viewer-state.js?v=20260519-1282-2"></script>
     <script src="../js/viewer/viewer-data-transform.js?v=20260520-1282-1"></script>
+    <script src="../js/viewer/viewer-render-state.js?v=20260520-1282-2"></script>
     <script src="../js/viewer/tree-viewer.js?v=20260519-1282-1"></script>
 </body>
 </html>

--- a/tests/contracts/visitor-viewer-channel-display-contract.test.js
+++ b/tests/contracts/visitor-viewer-channel-display-contract.test.js
@@ -23,6 +23,7 @@ function createTreeViewerContext() {
   };
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-data-transform.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-render-state.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/tree-viewer.js'), 'utf8'), context);
   return context;
 }

--- a/tests/routes/viewer-branch-grouping.test.js
+++ b/tests/routes/viewer-branch-grouping.test.js
@@ -21,6 +21,13 @@ function loadHooks() {
         setTimeout,
         clearTimeout
     });
+    var rsScript = fs.readFileSync('js/viewer/viewer-render-state.js', 'utf8');
+    vm.runInNewContext(rsScript, {
+        window,
+        console,
+        setTimeout,
+        clearTimeout
+    });
     vm.runInNewContext(script, {
         window,
         console,


### PR DESCRIPTION
## Chosen slice: Render state / status helper

Extract DOM utility and status rendering helpers from `tree-viewer.js` into a new focused module `viewer-render-state.js`.

### Why this slice

These are pure DOM utility functions with no state mutation or event coupling:
- `qs()` / `show()` / `hide()` — general-purpose DOM display helpers
- `showLoading()` / `renderEmpty()` / `renderError()` — status rendering helpers

All functions are encapsulated in a `create(SEL)` factory that accepts the orchestrator's selector map, following the same pattern as `viewer-share-export-actions.js`.

### Changed files (5)

| File | Change |
|---|---|
| `js/viewer/viewer-render-state.js` | **NEW** — `create(SEL)` factory returning `{qs, show, hide, showLoading, renderEmpty, renderError}` |
| `js/viewer/tree-viewer.js` | **MODIFIED** — removed extracted functions (~16 lines), uses `RS = window.LoveBudViewerRenderState.create(SEL)` |
| `pages/tree.html` | **MODIFIED** — added `viewer-render-state.js` script tag before `tree-viewer.js` |
| `tests/routes/viewer-branch-grouping.test.js` | **MODIFIED** — loads `viewer-render-state.js` in vm context |
| `tests/contracts/visitor-viewer-channel-display-contract.test.js` | **MODIFIED** — loads `viewer-render-state.js` in vm context |

### Behavior-preserving statement

- Same function signatures via factory pattern
- Same DOM behavior (identical show/hide/qs logic)
- Same loading/empty/error render behavior
- `SEL` config stays in orchestrator (tree-viewer.js)
- No CSS changes
- No HTML/DOM changes
- No event listener changes
- No script load order changes beyond adding the new module tag

### Test results

| Test | Result |
|---|---|
| `node --check` (all JS files) | ✅ PASS |
| viewer-branch-grouping (3 tests) | ✅ PASS |
| viewer-share-contract (58 tests) | ✅ PASS |
| visitor-viewer-channel-display (4 tests) | ✅ PASS |
| `git diff --check` | ✅ PASS |
| `npm run lint` (static lint) | ✅ PASS |

### Forbidden paths / constraints

- Forbidden paths (PR #7 / prototype / reference / demo / variant): **NOT TOUCHED** ✅
- Backend/API/Auth/DB/schema: **NOT CHANGED** ✅
- #1288 reactions/comments: **NOT TOUCHED** ✅
- #958 print/export behavior: **PRESERVED** ✅
- PR #1356 data transform path: **PRESERVED** ✅ (`DT` reference and `viewer-data-transform.js` loading intact)

Refs #1282