### PR TITLE
refactor(viewer): extract public viewer shell render helper

### DIFF
--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -20,13 +20,7 @@
     var RS = window.LoveBudViewerRenderState.create(SEL);
 
     var DT = window.LoveBudViewerDataTransform;
-    function escapeHtml(v) {
-        var sec = window.LoveBudSecurity;
-        if (sec) return sec.escapeHtml(v);
-        return String(v == null ? '' : v).replace(/[&<>"']/g, function(c) {
-            return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
-        });
-    }
+    var ShellRender = window.LoveBudViewerShellRender;
 
     async function loadPublicData(treeId) {
         var getMemories = window.apiClient &&
@@ -61,6 +55,7 @@
             // State helper (extracted to viewer-state.js)
             var State = window.LoveBudViewerState;
             if (!State) throw new Error('Viewer state helper unavailable');
+            if (!ShellRender || typeof ShellRender.renderShell !== 'function') throw new Error('Viewer shell render helper unavailable');
 
             // Render state
             var state = State.createInitialState();
@@ -71,37 +66,7 @@
             var container = RS.qs('#viewerTreeContainer');
             if (!container) return;
 
-            var treeTitle = viewerData.tree.title;
-            var treeMetaText = viewerData.tree.meta;
-
-            container.innerHTML =
-                '<header class="vv-header">' +
-                '  <div><p class="vv-eyebrow">Public LoveTree Viewer</p>' +
-                '  <h1 class="vv-title">' + escapeHtml(treeTitle) + '</h1>' +
-                '  <div class="vv-meta-row"><span>' + escapeHtml(viewerData.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(treeMetaText) + '</span></div></div>' +
-                '  <div class="vv-header-actions">' +
-                '    <button type="button" class="vv-layout-toggle" data-action="toggle-layout" aria-label="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;" title="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;">' +
-                '      <span class="vv-layout-toggle-label" id="vvLayoutToggleLabel">&#xAD6C;&#xC870; &#xBCF4;&#xAE30;</span>' +
-                '    </button>' +
-                '  </div>' +
-                '</header>' +
-                '<div class="vv-action-dock">' +
-                '  <div class="vv-action-group">' +
-                '    <button type="button" class="vv-action-btn" data-action="toggle-like" aria-label="트리 좋아요"><span class="vv-action-icon">' +
-                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon vv-icon-heart"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
-                '    좋아요</button>' +
-                '    <button type="button" class="vv-action-btn" data-action="open-tree-comments" aria-label="트리 댓글 보기"><span class="vv-action-icon">' +
-                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
-                '    댓글</button>' +
-                '    <button type="button" class="vv-action-btn" data-action="open-share" aria-label="트리 공유하기"><span class="vv-action-icon">' +
-                '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M8.1 12.7 15.9 17M15.9 7 8.1 11.3M6.4 14.6a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm10.9-5a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm0 10a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg></span>' +
-                '    공유</button>' +
-                '  </div>' +
-                '</div>' +
-                '<div class="vv-viewer-layout">' +
-                '  <div class="vv-tree-container"></div>' +
-                '  <div class="vv-panel-host"></div>' +
-                '</div>';
+            ShellRender.renderShell(container, viewerData);
 
             var allMoments = State.getAllMoments(viewerData);
 
@@ -229,7 +194,8 @@
 
     if (window.__LOVE_BUD_TREE_VIEWER_TEST_HOOKS__ && DT) {
         window.LoveBudTreeViewerTestHooks = {
-            buildBranches: DT.buildBranches
+            buildBranches: DT.buildBranches,
+            renderShell: ShellRender && ShellRender.renderShell
         };
     }
 

--- a/js/viewer/viewer-shell-render.js
+++ b/js/viewer/viewer-shell-render.js
@@ -1,0 +1,52 @@
+(function() {
+    'use strict';
+
+    function escapeHtml(v) {
+        var sec = window.LoveBudSecurity;
+        if (sec) return sec.escapeHtml(v);
+        return String(v == null ? '' : v).replace(/[&<>"']/g, function(c) {
+            return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+        });
+    }
+
+    function renderShell(container, viewerData) {
+        if (!container || !viewerData || !viewerData.tree) return;
+
+        var treeTitle = viewerData.tree.title;
+        var treeMetaText = viewerData.tree.meta;
+
+        container.innerHTML =
+            '<header class="vv-header">' +
+            '  <div><p class="vv-eyebrow">Public LoveTree Viewer</p>' +
+            '  <h1 class="vv-title">' + escapeHtml(treeTitle) + '</h1>' +
+            '  <div class="vv-meta-row"><span>' + escapeHtml(viewerData.tree.creator) + '</span><span class="vv-dot">·</span><span>' + escapeHtml(treeMetaText) + '</span></div></div>' +
+            '  <div class="vv-header-actions">' +
+            '    <button type="button" class="vv-layout-toggle" data-action="toggle-layout" aria-label="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;" title="&#xB808;&#xC774;&#xC544;&#xC6B0;&#xCDE8; &#xC804;&#xD658;">' +
+            '      <span class="vv-layout-toggle-label" id="vvLayoutToggleLabel">&#xAD6C;&#xC870; &#xBCF4;&#xAE30;</span>' +
+            '    </button>' +
+            '  </div>' +
+            '</header>' +
+            '<div class="vv-action-dock">' +
+            '  <div class="vv-action-group">' +
+            '    <button type="button" class="vv-action-btn" data-action="toggle-like" aria-label="트리 좋아요"><span class="vv-action-icon">' +
+            '<svg viewBox="0 0 24 24" fill="none" class="vv-icon vv-icon-heart"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
+            '    좋아요</button>' +
+            '    <button type="button" class="vv-action-btn" data-action="open-tree-comments" aria-label="트리 댓글 보기"><span class="vv-action-icon">' +
+            '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10z" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></span>' +
+            '    댓글</button>' +
+            '    <button type="button" class="vv-action-btn" data-action="open-share" aria-label="트리 공유하기"><span class="vv-action-icon">' +
+            '<svg viewBox="0 0 24 24" fill="none" class="vv-icon"><path d="M8.1 12.7 15.9 17M15.9 7 8.1 11.3M6.4 14.6a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm10.9-5a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Zm0 10a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2Z" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg></span>' +
+            '    공유</button>' +
+            '  </div>' +
+            '</div>' +
+            '<div class="vv-viewer-layout">' +
+            '  <div class="vv-tree-container"></div>' +
+            '  <div class="vv-panel-host"></div>' +
+            '</div>';
+    }
+
+    window.LoveBudViewerShellRender = {
+        renderShell: renderShell,
+        escapeHtml: escapeHtml
+    };
+})();

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -71,6 +71,7 @@
     <script src="../js/viewer/viewer-state.js?v=20260519-1282-2"></script>
     <script src="../js/viewer/viewer-data-transform.js?v=20260520-1282-1"></script>
     <script src="../js/viewer/viewer-render-state.js?v=20260520-1282-2"></script>
+    <script src="../js/viewer/viewer-shell-render.js?v=20260520-1282-3"></script>
     <script src="../js/viewer/tree-viewer.js?v=20260519-1282-1"></script>
 </body>
 </html>

--- a/tests/contracts/visitor-viewer-channel-display-contract.test.js
+++ b/tests/contracts/visitor-viewer-channel-display-contract.test.js
@@ -24,6 +24,7 @@ function createTreeViewerContext() {
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-data-transform.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-render-state.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-shell-render.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/tree-viewer.js'), 'utf8'), context);
   return context;
 }

--- a/tests/routes/viewer-branch-grouping.test.js
+++ b/tests/routes/viewer-branch-grouping.test.js
@@ -28,6 +28,13 @@ function loadHooks() {
         setTimeout,
         clearTimeout
     });
+    var shellScript = fs.readFileSync('js/viewer/viewer-shell-render.js', 'utf8');
+    vm.runInNewContext(shellScript, {
+        window,
+        console,
+        setTimeout,
+        clearTimeout
+    });
     vm.runInNewContext(script, {
         window,
         console,
@@ -90,4 +97,9 @@ test('missing public parent relation falls back to one main branch', () => {
 
     assert.equal(viewerData.branches.length, 1);
     assert.equal(viewerData.branches[0].id, 'main');
+});
+
+test('viewer shell render helper is exposed for route tests', () => {
+    const hooks = loadHooks();
+    assert.equal(typeof hooks.renderShell, 'function');
 });


### PR DESCRIPTION
## Summary

Extract the public viewer shell/header/action dock HTML rendering from `tree-viewer.js` into a small `viewer-shell-render.js` helper.

### Slice

- Chosen slice: public viewer shell render helper
- New helper: `window.LoveBudViewerShellRender.renderShell(container, viewerData)`
- Existing #1356 data-transform path remains intact
- Existing #1357 render-state path remains intact

### Changed files

- `js/viewer/viewer-shell-render.js` — new shell render helper
- `js/viewer/tree-viewer.js` — delegates shell HTML rendering to helper
- `pages/tree.html` — loads shell helper before `tree-viewer.js`
- `tests/routes/viewer-branch-grouping.test.js` — loads shell helper in VM test context
- `tests/contracts/visitor-viewer-channel-display-contract.test.js` — loads shell helper in VM test context

### Safety

- Behavior-preserving refactor only
- No CSS changes
- No backend/API/Auth/DB/schema changes
- No forbidden paths touched
- No #1288 reactions/comments work
- No #958 print/export behavior changes
- No Browse flow changes

Refs #1282