### PR TITLE
refactor(viewer): extract public viewer route helper

### DIFF
--- a/js/viewer/tree-viewer.js
+++ b/js/viewer/tree-viewer.js
@@ -19,6 +19,7 @@
 
     var RS = window.LoveBudViewerRenderState.create(SEL);
 
+    var Route = window.LoveBudViewerRoute;
     var DT = window.LoveBudViewerDataTransform;
     var ShellRender = window.LoveBudViewerShellRender;
 
@@ -34,8 +35,7 @@
     }
 
     async function initViewer() {
-        var params = new URLSearchParams(window.location.search);
-        var treeId = params.get('treeId');
+        var treeId = Route.getTreeId();
         if (!treeId) { RS.renderEmpty(); return; }
         currentTreeId = treeId;
         RS.showLoading();
@@ -195,6 +195,7 @@
     if (window.__LOVE_BUD_TREE_VIEWER_TEST_HOOKS__ && DT) {
         window.LoveBudTreeViewerTestHooks = {
             buildBranches: DT.buildBranches,
+            getTreeId: Route && Route.getTreeId,
             renderShell: ShellRender && ShellRender.renderShell
         };
     }

--- a/js/viewer/viewer-route.js
+++ b/js/viewer/viewer-route.js
@@ -1,0 +1,14 @@
+(function() {
+    'use strict';
+
+    function getTreeId(locationLike) {
+        var loc = locationLike || window.location || {};
+        var search = typeof loc.search === 'string' ? loc.search : '';
+        var params = new URLSearchParams(search);
+        return params.get('treeId');
+    }
+
+    window.LoveBudViewerRoute = {
+        getTreeId: getTreeId
+    };
+})();

--- a/pages/tree.html
+++ b/pages/tree.html
@@ -69,6 +69,7 @@
     <script src="../js/viewer/share-actions.js?v=20260509-957-1"></script>
     <script src="../js/viewer/viewer-share-export-actions.js?v=20260519-1282-1"></script>
     <script src="../js/viewer/viewer-state.js?v=20260519-1282-2"></script>
+    <script src="../js/viewer/viewer-route.js?v=20260520-1282-4"></script>
     <script src="../js/viewer/viewer-data-transform.js?v=20260520-1282-1"></script>
     <script src="../js/viewer/viewer-render-state.js?v=20260520-1282-2"></script>
     <script src="../js/viewer/viewer-shell-render.js?v=20260520-1282-3"></script>

--- a/tests/contracts/visitor-viewer-channel-display-contract.test.js
+++ b/tests/contracts/visitor-viewer-channel-display-contract.test.js
@@ -9,10 +9,12 @@ const ROOT = path.join(__dirname, '..', '..');
 function createTreeViewerContext() {
   const context = {
     URL,
+    URLSearchParams,
     console,
     window: {
       __LOVE_BUD_TREE_VIEWER_TEST_HOOKS__: true,
-      __LOVE_BUD_TREE_VIEWER_SKIP_INIT__: true
+      __LOVE_BUD_TREE_VIEWER_SKIP_INIT__: true,
+      location: { search: '?treeId=public-route-ref' }
     },
     document: {
       readyState: 'loading',
@@ -22,6 +24,7 @@ function createTreeViewerContext() {
     }
   };
   vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-route.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-data-transform.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-render-state.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/viewer-shell-render.js'), 'utf8'), context);

--- a/tests/routes/viewer-branch-grouping.test.js
+++ b/tests/routes/viewer-branch-grouping.test.js
@@ -11,10 +11,18 @@ function loadHooks() {
         __LOVE_BUD_TREE_VIEWER_SKIP_INIT__: true,
         i18nViewer: {},
         i18n: { currentLang: 'en' },
-        location: { href: 'https://example.test/pages/tree.html' }
+        location: { href: 'https://example.test/pages/tree.html', search: '?treeId=public-route-ref' }
     };
     window.window = window;
 
+    var routeScript = fs.readFileSync('js/viewer/viewer-route.js', 'utf8');
+    vm.runInNewContext(routeScript, {
+        URLSearchParams,
+        window,
+        console,
+        setTimeout,
+        clearTimeout
+    });
     vm.runInNewContext(dtScript, {
         window,
         console,
@@ -97,6 +105,12 @@ test('missing public parent relation falls back to one main branch', () => {
 
     assert.equal(viewerData.branches.length, 1);
     assert.equal(viewerData.branches[0].id, 'main');
+});
+
+test('viewer route helper is exposed for route tests', () => {
+    const hooks = loadHooks();
+    assert.equal(typeof hooks.getTreeId, 'function');
+    assert.equal(hooks.getTreeId({ search: '?treeId=public-route-ref' }), 'public-route-ref');
 });
 
 test('viewer shell render helper is exposed for route tests', () => {


### PR DESCRIPTION
## Summary

Extract the public viewer route/query parsing into a small `viewer-route.js` helper.

### Slice

- Chosen slice: public viewer route helper
- New helper: `window.LoveBudViewerRoute.getTreeId(locationLike)`
- `tree-viewer.js` now delegates treeId query parsing to the helper
- Existing #1356 data-transform path remains intact
- Existing #1357 render-state path remains intact
- Existing #1359 shell-render path remains intact

### Changed files

- `js/viewer/viewer-route.js` — new route helper
- `js/viewer/tree-viewer.js` — uses `Route.getTreeId()`
- `pages/tree.html` — loads route helper before `tree-viewer.js`
- `tests/routes/viewer-branch-grouping.test.js` — loads route helper in VM test context and verifies `getTreeId`
- `tests/contracts/visitor-viewer-channel-display-contract.test.js` — loads route helper in VM test context

### Safety

- Behavior-preserving refactor only
- No CSS changes
- No backend/API/Auth/DB/schema changes
- No forbidden paths touched
- No #1288 reactions/comments work
- No #958 print/export behavior changes
- No Browse flow changes

Refs #1282