### PR TITLE
refactor(search): extract browse copy helper

### DIFF
--- a/js/search/search-copy.js
+++ b/js/search/search-copy.js
@@ -1,0 +1,22 @@
+(function () {
+    'use strict';
+
+    function getCurrentLocale() {
+        const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
+        return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    function getSearchCopy(key, fallbackKo, fallbackEn) {
+        const locale = getCurrentLocale();
+        const dict = window.i18nSearch?.[key];
+        if (dict && typeof dict === 'object') {
+            return dict[locale] || dict.ko || dict.en || fallbackKo;
+        }
+        return locale === 'en' ? fallbackEn : fallbackKo;
+    }
+
+    window.LoveBudSearchCopy = {
+        getCurrentLocale,
+        getSearchCopy
+    };
+})();

--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -27,6 +27,10 @@
         let scrollLoadIntentBound = false;
 
         function getCurrentLocale() {
+            var SearchCopy = window.LoveBudSearchCopy;
+            if (SearchCopy && typeof SearchCopy.getCurrentLocale === 'function') {
+                return SearchCopy.getCurrentLocale();
+            }
             const locale = window.i18n?.currentLang || window.getCurrentLang?.() || document.documentElement?.lang || 'ko';
             return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
         }
@@ -121,6 +125,10 @@
         }
 
         function getSearchCopy(key, fallbackKo, fallbackEn) {
+            var SearchCopy = window.LoveBudSearchCopy;
+            if (SearchCopy && typeof SearchCopy.getSearchCopy === 'function') {
+                return SearchCopy.getSearchCopy(key, fallbackKo, fallbackEn);
+            }
             const locale = getCurrentLocale();
             const dict = window.i18nSearch?.[key];
             if (dict && typeof dict === 'object') {

--- a/pages/search.html
+++ b/pages/search.html
@@ -141,6 +141,7 @@
     <script src="../js/search/search-preview-playable-hub-patch.js?v=20260512-1058-3"></script>
     <script src="../js/search/search-preview-hub-dom-patch.js?v=20260512-1058-1"></script>
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
+    <script src="../js/search/search-copy.js?v=20260520-1281-1"></script>
     <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
      <script src="../js/search/search-url-state.js?v=20260429-1"></script>
      <script src="../js/search/search-controls.js?v=20260429-1"></script>

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -24,6 +24,7 @@ test('search runtime submodules load after existing search helpers and before se
   const searchEntrypointIndex = indexOf('../js/search/index.js');
   const expectedModules = [
     '../js/search/search-preview-cache.js',
+    '../js/search/search-copy.js',
     '../js/search/search-ui.js',
     '../js/search/search-url-state.js',
   ];
@@ -58,6 +59,18 @@ test('search UI module preserves orchestrator contract methods', () => {
   for (const method of requiredMethods) {
     assert.match(uiModule, new RegExp(`\\b${method}\\b`));
   }
+});
+
+test('search copy helper exposes namespace contract', () => {
+  const copyModule = read('js/search/search-copy.js');
+  assert.match(copyModule, /window\.LoveBudSearchCopy/);
+  assert.match(copyModule, /getCurrentLocale/);
+  assert.match(copyModule, /getSearchCopy/);
+});
+
+test('search UI module references LoveBudSearchCopy helper', () => {
+  const uiModule = read('js/search/search-ui.js');
+  assert.match(uiModule, /window\.LoveBudSearchCopy/);
 });
 
 test('browse feed controls do not expose batch strategy as product UI', () => {

--- a/tests/routes/search-script-order-contract.test.js
+++ b/tests/routes/search-script-order-contract.test.js
@@ -51,6 +51,7 @@ test('search page keeps Search helper and renderer modules before the Search ent
     '../js/search/search-card-renderer.js',
     '../js/search/search-preview-renderer.js',
     '../js/search/search-preview-cache.js',
+    '../js/search/search-copy.js',
     '../js/search/search-ui.js',
     '../js/search/search-url-state.js',
     '../js/search/search-controls.js',


### PR DESCRIPTION
## Summary

Extract Browse/Search locale and copy lookup helpers into `search-copy.js`.

### Slice

- Chosen slice: Browse/Search copy helper
- New helper: `window.LoveBudSearchCopy`
- `search-ui.js` keeps the same public methods and uses the helper with inline fallback
- No card click/tap behavior changes
- No mobile direct-open behavior changes
- No preview behavior changes

### Changed files

- `js/search/search-copy.js`
- `js/search/search-ui.js`
- `pages/search.html`
- `tests/routes/search-script-order-contract.test.js`
- `tests/routes/search-runtime-modules.test.js`

### Safety

- Behavior-preserving refactor only
- No CSS changes
- No backend/API/Auth/DB/schema changes
- No forbidden paths touched
- No #1288 reactions/comments work
- No #1282 public viewer changes
- No #958 print/export behavior changes
- No Browse mobile direct-open implementation

Refs #1281