### PR TITLE
refactor(search): adopt scroll-load helper

### DIFF
--- a/js/search/search-ui.js
+++ b/js/search/search-ui.js
@@ -15,6 +15,7 @@
         const { PreviewRenderer } = renderers;
         const treeDataMap = new WeakMap();
         const boundContainers = new WeakSet();
+        const ScrollLoad = window.LoveBudSearchScrollLoad || {};
 
         // overlay element reference + saved scroll position for lock/restore
         let sheetOverlay = null;
@@ -242,6 +243,12 @@
         }
 
         function canLoadMorePublicTrees() {
+            if (typeof ScrollLoad.canLoadMorePublicTrees === 'function') {
+                return ScrollLoad.canLoadMorePublicTrees(state, callbacks, {
+                    isQueued: isScrollLoadQueued
+                });
+            }
+
             return Boolean(
                 callbacks.loadMorePublicTrees
                 && state.apiTreesLoaded
@@ -253,6 +260,11 @@
         }
 
         function syncScrollLoadSentinel() {
+            if (typeof ScrollLoad.syncScrollLoadSentinel === 'function') {
+                ScrollLoad.syncScrollLoadSentinel(scrollLoadSentinel, state);
+                return;
+            }
+
             if (!scrollLoadSentinel) return;
 
             const isDone = !state.apiTreesLoaded || state.currentLimit >= 60 || !state.hasMoreTrees;
@@ -274,6 +286,10 @@
         }
 
         function isSentinelNearViewport() {
+            if (typeof ScrollLoad.isSentinelNearViewport === 'function') {
+                return ScrollLoad.isSentinelNearViewport(scrollLoadSentinel, window);
+            }
+
             if (!scrollLoadSentinel || scrollLoadSentinel.hidden) return false;
             const rect = scrollLoadSentinel.getBoundingClientRect();
             return rect.top <= window.innerHeight + 720 && rect.bottom >= -240;
@@ -309,8 +325,11 @@
         }
 
         function handleScrollLoadKeydown(event) {
-            const scrollingKeys = [' ', 'PageDown', 'End', 'ArrowDown'];
-            if (scrollingKeys.includes(event.key)) {
+            const isIntentKey = typeof ScrollLoad.isScrollIntentKey === 'function'
+                ? ScrollLoad.isScrollIntentKey(event)
+                : [' ', 'PageDown', 'End', 'ArrowDown'].includes(event.key);
+
+            if (isIntentKey) {
                 markScrollLoadIntent();
             }
         }
@@ -330,13 +349,17 @@
         function ensureScrollLoadSentinel() {
             if (!resultsList || scrollLoadSentinel) return;
 
-            scrollLoadSentinel = document.createElement('div');
-            scrollLoadSentinel.id = 'browseScrollLoadSentinel';
-            scrollLoadSentinel.className = 'browse-scroll-load-sentinel';
-            scrollLoadSentinel.innerHTML = `
+            if (typeof ScrollLoad.createScrollLoadSentinel === 'function') {
+                scrollLoadSentinel = ScrollLoad.createScrollLoadSentinel(document);
+            } else {
+                scrollLoadSentinel = document.createElement('div');
+                scrollLoadSentinel.id = 'browseScrollLoadSentinel';
+                scrollLoadSentinel.className = 'browse-scroll-load-sentinel';
+                scrollLoadSentinel.innerHTML = `
                 <span class="material-symbols-outlined" aria-hidden="true">progress_activity</span>
                 <span data-scroll-load-label></span>
             `;
+            }
 
             resultsList.insertAdjacentElement('afterend', scrollLoadSentinel);
             syncScrollLoadSentinel();

--- a/pages/search.html
+++ b/pages/search.html
@@ -143,7 +143,7 @@
     <script src="../js/search/search-preview-cache.js?v=20260427-1"></script>
     <script src="../js/search/search-copy.js?v=20260520-1281-1"></script>
     <script src="../js/search/search-ui-copy.js?v=20260520-1281-2"></script>
-    <script src="../js/search/search-ui.js?v=20260508-618-rev1"></script>
+    <script src="../js/search/search-ui.js?v=20260520-1281-7"></script>
     <script src="../js/search/search-card-events.js?v=20260520-1281-3"></script>
     <script src="../js/search/search-preview-state.js?v=20260520-1281-4"></script>
     <script src="../js/search/search-mobile-preview-sheet.js?v=20260520-1281-5"></script>


### PR DESCRIPTION
Refs #1281

Summary:
- Route Browse search scroll-load checks through the existing helper.
- Keep fallback logic in search-ui.js.
- Refresh the search-ui.js cache key in pages/search.html.

Validation:
- Syntax check completed on the updated search-ui.js file.
- Browser smoke required before Ready or merge.