### PR TITLE
feat(editor): add RAF debouncing to canvas render pipeline

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -648,6 +648,16 @@ function createEditorCanvas(deps) {
         return drawableMemories[0] || null;
     }
 
+    let _rafPending = false;
+    function scheduleRender() {
+        if (_rafPending) return;
+        _rafPending = true;
+        requestAnimationFrame(() => {
+            _rafPending = false;
+            initCanvas();
+        });
+    }
+
     /**
      * DOM RENDER ORCHESTRATION BOUNDARY
      * High-risk regression point:
@@ -749,7 +759,7 @@ function createEditorCanvas(deps) {
                 getWorldPosition,
                 getMetrics,
                 viewportState,
-                initCanvas,
+                initCanvas: scheduleRender,
                 reapplySelection
             });
             persistStoredPositions();
@@ -775,7 +785,7 @@ function createEditorCanvas(deps) {
             viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
         }
         
-        initCanvas();
+        scheduleRender();
         reapplySelection(nodeId);
         persistStoredPositions();
     }
@@ -789,7 +799,7 @@ function createEditorCanvas(deps) {
                 getWorldPosition,
                 getMetrics,
                 viewportState,
-                initCanvas
+                initCanvas: scheduleRender
             });
             persistStoredPositions();
             return;
@@ -800,7 +810,7 @@ function createEditorCanvas(deps) {
             viewportState.offsetX = 0;
             viewportState.offsetY = 0;
             viewportState.scale = 1;
-            initCanvas();
+            scheduleRender();
             persistStoredPositions();
             return;
         }
@@ -822,7 +832,7 @@ function createEditorCanvas(deps) {
             viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
         }
 
-        initCanvas();
+        scheduleRender();
         persistStoredPositions();
     }
 
@@ -1052,7 +1062,7 @@ function createEditorCanvas(deps) {
                 factor,
                 viewportState,
                 getMetrics,
-                initCanvas
+                initCanvas: scheduleRender
             });
             persistStoredPositions();
             return;
@@ -1070,7 +1080,7 @@ function createEditorCanvas(deps) {
             viewportState.scale = newScale;
         }
 
-        initCanvas();
+        scheduleRender();
         persistStoredPositions();
     }
 


### PR DESCRIPTION
## 변경 사항
- `scheduleRender()` 헬퍼 함수 추가 (`_rafPending` 플래그 기반)
- `zoomBy`, `recenterViewport`, `focusNodeById` 3곳 적용

## 금지 영역 보존 확인
- `onAuthStateChanged` 내 `initCanvas()` — 미변경
- `switchToFreeMode` / `switchToStructuredMode` 내 `initCanvas()` — 미변경  
- `bindResizeHandling` 내 `initCanvas()` — 미변경

## 테스트
- [ ] 줌 인/아웃 연속 클릭 시 렌더 과부하 없음
- [ ] 뷰포트 리센터링 정상 동작
- [ ] 노드 포커스 이동 정상 동작

Closes #1468