### PR TITLE
feat(editor): extract getYouTubeInputErrorMessage to editor-utils

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -144,7 +144,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail || inlineMediaResolvers.resolveMemoryThumbnail;
 
-    const getYouTubeInputErrorMessage = editorHelpers.getYouTubeInputErrorMessage || ((rawUrl) => {
+    const getYouTubeInputErrorMessage = rootUtils.getYouTubeInputErrorMessage || ((i18n, rawUrl) => {
+        warnRootHelperFallback();
         const value = String(rawUrl || '').trim();
         if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
         const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);

--- a/js/editor/editor-utils.js
+++ b/js/editor/editor-utils.js
@@ -1,0 +1,18 @@
+(function () {
+    const utils = window.LoveBudEditorUtils || {};
+
+    utils.getYouTubeInputErrorMessage = function(i18n, rawUrl) {
+        const value = String(rawUrl || '').trim();
+        if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
+        const looksLikeUrl = /^(https?:\/\/|www\.)/i.test(value);
+        const hasYouTubeHint = /(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(value);
+        const idLikeMatch = value.match(/(?:v=|\/|youtu\.be\/|shorts\/)([0-9A-Za-z_-]+)/i);
+        const candidateId = idLikeMatch ? idLikeMatch[1] : '';
+        if (!looksLikeUrl) return i18n('invalid_youtube_format') || '전체 YouTube 링크를 붙여 넣어 주세요.';
+        if (!hasYouTubeHint) return i18n('invalid_youtube_unsupported') || 'YouTube 링크만 지원합니다. youtube.com 또는 youtu.be 링크를 사용해 주세요.';
+        if (candidateId && candidateId.length !== 11) return i18n('invalid_youtube_id_length') || '링크가 중간에 잘린 것 같아요. 전체 YouTube 링크를 다시 복사해 주세요.';
+        return i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.';
+    };
+
+    window.LoveBudEditorUtils = utils;
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -80,6 +80,7 @@
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-utils.js?v=20260522-1277"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>


### PR DESCRIPTION
## 변경 사항
- `js/editor/editor-utils.js` 신규 생성 (네임스페이스: `window.LoveBudEditorUtils`)
- `getYouTubeInputErrorMessage` 함수를 순수 헬퍼로 추출
- `js/editor.js` 내 인라인 로직을 위임 래퍼 및 폴백 패턴으로 교체
- `pages/editor.html` 스크립트 로드 순서 반영 (`editor-canvas.js` 이전)

Refs #1276