### PR TITLE
feat(editor): add addNodePosition setter to canvas

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -1084,6 +1084,11 @@ function createEditorCanvas(deps) {
         persistStoredPositions();
     }
 
+    function addNodePosition(memoryId, pos) {
+        if (!memoryId || !pos) return;
+        viewportState.positions[memoryId] = pos;
+    }
+
     requestAnimationFrame(() => {
         if (viewportState.layoutMode === 'structured') {
             document.body.classList.add('layout-structured');
@@ -1094,6 +1099,7 @@ function createEditorCanvas(deps) {
     });
 
     return {
+        addNodePosition,
         calcPosition,
         drawBranch,
         drawNode,


### PR DESCRIPTION
## 변경 사항
- `editor-canvas.js`에 `addNodePosition(memoryId, pos)` 추가
- 4순위 추출 과제(`editor-empty-guide-ui.js`)를 위한 선행 작업
- `viewportState.positions` 직접 뮤테이션을 방지하고 캡슐화 유지

Refs #1276