### PR TITLE
feat(editor): extract empty guide UI orchestration

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -508,57 +508,20 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-        const canvasEmptyStartBtn = document.getElementById('canvasEmptyStartBtn');
-        const canvasEmptyYoutubeInput = document.getElementById('canvasEmptyYoutubeInput');
-        const canvasEmptyTextStartBtn = document.getElementById('canvasEmptyTextStartBtn');
-        async function createMemoryFromCanvasUrl(options) {
-            const rawUrl = options && options.rawUrl;
-            const position = options && options.position;
-            if (!rawUrl) {
-                showAddMemoryForm();
-                return;
-            }
-            showAddMemoryForm();
-            if (memoryUrlInput) {
-                memoryUrlInput.value = rawUrl;
-                memoryUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-            if (memoryModeLinkBtn) memoryModeLinkBtn.click();
-            const beforeIds = new Set(treeMemories().map((memory) => memory && memory.id));
-            await addMemoryFromForm();
-            const createdMemory = treeMemories().find((memory) => memory && !beforeIds.has(memory.id));
-            if (createdMemory && position && editorCanvas && editorCanvas.viewportState) {
-                editorCanvas.viewportState.positions[createdMemory.id] = position;
-                if (typeof editorCanvas.persistStoredPositions === 'function') editorCanvas.persistStoredPositions();
-                if (typeof editorCanvas.initCanvas === 'function') editorCanvas.initCanvas();
-                if (typeof editorCanvas.focusNodeById === 'function') editorCanvas.focusNodeById(createdMemory.id);
-            }
-        }
-
-        if (canvasEmptyStartBtn) {
-            canvasEmptyStartBtn.addEventListener('click', () => {
-                const rawUrl = canvasEmptyYoutubeInput ? canvasEmptyYoutubeInput.value.trim() : '';
-                if (rawUrl) {
-                    createMemoryFromCanvasUrl({ rawUrl });
-                    return;
-                }
-                showAddMemoryForm();
+        const emptyGuideUIHelper = window.LoveBudEditorEmptyGuideUI || {};
+        let createMemoryFromCanvasUrl = () => {};
+        if (emptyGuideUIHelper.bindEmptyGuideEvents) {
+            const guideResult = emptyGuideUIHelper.bindEmptyGuideEvents({
+                getEditorCanvas: () => editorCanvas,
+                showAddMemoryForm,
+                addMemoryFromForm,
+                getTreeMemories: treeMemories,
+                showToast,
+                i18n
             });
-        }
-
-        if (canvasEmptyTextStartBtn) {
-            canvasEmptyTextStartBtn.addEventListener('click', () => {
-                showAddMemoryForm();
-                if (memoryModeTextBtn) memoryModeTextBtn.click();
-            });
-        }
-
-        if (canvasEmptyYoutubeInput) {
-            canvasEmptyYoutubeInput.addEventListener('keydown', (event) => {
-                if (event.key !== 'Enter') return;
-                event.preventDefault();
-                createMemoryFromCanvasUrl({ rawUrl: canvasEmptyYoutubeInput.value.trim() });
-            });
+            if (guideResult && guideResult.createMemoryFromCanvasUrl) {
+                createMemoryFromCanvasUrl = guideResult.createMemoryFromCanvasUrl;
+            }
         }
 
         initCanvas();

--- a/js/editor.js
+++ b/js/editor.js
@@ -515,7 +515,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 getEditorCanvas: () => editorCanvas,
                 showAddMemoryForm,
                 addMemoryFromForm,
-                getTreeMemories: treeMemories,
+                getTreeMemories: () => treeMemories(),
                 showToast,
                 i18n
             });

--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -1,0 +1,90 @@
+(function () {
+    const emptyGuideUI = window.LoveBudEditorEmptyGuideUI || {};
+
+    emptyGuideUI.bindEmptyGuideEvents = function(options) {
+        const getEditorCanvas = options.getEditorCanvas;
+        const showAddMemoryForm = options.showAddMemoryForm;
+        const addMemoryFromForm = options.addMemoryFromForm;
+        const getTreeMemories = options.getTreeMemories;
+        const showToast = options.showToast;
+        const i18n = options.i18n;
+
+        const canvasEmptyStartBtn = document.getElementById('canvasEmptyStartBtn');
+        const canvasEmptyYoutubeInput = document.getElementById('canvasEmptyYoutubeInput');
+        const canvasEmptyTextStartBtn = document.getElementById('canvasEmptyTextStartBtn');
+
+        // 의존성 DOM (문자열 등 추출을 위해 직접 탐색)
+        const memoryUrlInput = document.getElementById('memoryUrlInput');
+        const memoryModeLinkBtn = document.getElementById('memoryModeLinkBtn');
+        const memoryModeTextBtn = document.getElementById('memoryModeTextBtn');
+
+        async function createMemoryFromCanvasUrl(createOptions) {
+            const rawUrl = createOptions && createOptions.rawUrl;
+            const position = createOptions && createOptions.position;
+            if (!rawUrl) {
+                if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+                return;
+            }
+            if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+            if (memoryUrlInput) {
+                memoryUrlInput.value = rawUrl;
+                memoryUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            if (memoryModeLinkBtn) memoryModeLinkBtn.click();
+            
+            const memories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
+            const beforeIds = new Set(memories.map((memory) => memory && memory.id));
+            
+            if (typeof addMemoryFromForm === 'function') await addMemoryFromForm();
+            
+            const updatedMemories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
+            const createdMemory = updatedMemories.find((memory) => memory && !beforeIds.has(memory.id));
+            
+            const editorCanvas = typeof getEditorCanvas === 'function' ? getEditorCanvas() : null;
+            if (createdMemory && position && editorCanvas) {
+                if (typeof editorCanvas.addNodePosition === 'function') {
+                    editorCanvas.addNodePosition(createdMemory.id, position);
+                } else if (editorCanvas.viewportState && editorCanvas.viewportState.positions) {
+                    editorCanvas.viewportState.positions[createdMemory.id] = position;
+                }
+                
+                if (typeof editorCanvas.persistStoredPositions === 'function') editorCanvas.persistStoredPositions();
+                if (typeof editorCanvas.initCanvas === 'function') editorCanvas.initCanvas();
+                if (typeof editorCanvas.focusNodeById === 'function') editorCanvas.focusNodeById(createdMemory.id);
+            }
+        }
+
+        if (canvasEmptyStartBtn && canvasEmptyStartBtn.dataset.bound !== '1') {
+            canvasEmptyStartBtn.dataset.bound = '1';
+            canvasEmptyStartBtn.addEventListener('click', () => {
+                const rawUrl = canvasEmptyYoutubeInput ? canvasEmptyYoutubeInput.value.trim() : '';
+                if (rawUrl) {
+                    createMemoryFromCanvasUrl({ rawUrl });
+                    return;
+                }
+                if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+            });
+        }
+
+        if (canvasEmptyTextStartBtn && canvasEmptyTextStartBtn.dataset.bound !== '1') {
+            canvasEmptyTextStartBtn.dataset.bound = '1';
+            canvasEmptyTextStartBtn.addEventListener('click', () => {
+                if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+                if (memoryModeTextBtn) memoryModeTextBtn.click();
+            });
+        }
+
+        if (canvasEmptyYoutubeInput && canvasEmptyYoutubeInput.dataset.bound !== '1') {
+            canvasEmptyYoutubeInput.dataset.bound = '1';
+            canvasEmptyYoutubeInput.addEventListener('keydown', (event) => {
+                if (event.key !== 'Enter') return;
+                event.preventDefault();
+                createMemoryFromCanvasUrl({ rawUrl: canvasEmptyYoutubeInput.value.trim() });
+            });
+        }
+
+        return { createMemoryFromCanvasUrl };
+    };
+
+    window.LoveBudEditorEmptyGuideUI = emptyGuideUI;
+})();

--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -44,8 +44,6 @@
             if (createdMemory && position && editorCanvas) {
                 if (typeof editorCanvas.addNodePosition === 'function') {
                     editorCanvas.addNodePosition(createdMemory.id, position);
-                } else if (editorCanvas.viewportState && editorCanvas.viewportState.positions) {
-                    editorCanvas.viewportState.positions[createdMemory.id] = position;
                 }
                 
                 if (typeof editorCanvas.persistStoredPositions === 'function') editorCanvas.persistStoredPositions();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -83,6 +83,7 @@
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-utils.js?v=20260522-1277"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>


### PR DESCRIPTION
## 변경 사항
- `editor-empty-guide-ui.js` 생성
- `createMemoryFromCanvasUrl` 및 empty guide 이벤트 핸들러 추출
- `viewportState.positions` 직접 뮤테이션을 `editorCanvas.addNodePosition` 호출로 교체
- DOM 탐색 방식: `memoryUrlInput`, `memoryModeLinkBtn`, `memoryModeTextBtn`은 `editor-empty-guide-ui.js` 내부에서 `document.getElementById`로 직접 탐색하도록 이식했습니다.

Refs #1276