### PR TITLE
refactor(editor): completely delegate data loading and remove fallbacks

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -268,8 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
             apiClient: window.apiClient,
             showToast,
             i18n,
-            normalizeMemory,
-            cacheTtlMs: 2 * 60 * 1000
+            normalizeMemory
         });
         const treeMemories = () => (window.currentTreeMemories || []).map(normalizeMemory).filter(Boolean);
         const canonicalRootId = getCanonicalRootId(treeMemories());

--- a/js/editor.js
+++ b/js/editor.js
@@ -160,12 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const renderTreeLoadError = editorPageHelpers.renderTreeLoadError ||
         entryFallbacks.createInlineRenderTreeLoadErrorFallback({ getMyTreesHref });
-    const createInlineNormalizeMemoryFallback = dataLoaderFallbacks.createInlineNormalizeMemoryFallback || (() => (mem) => mem);
-    const createInlineLoadInitialTreeFallback = dataLoaderFallbacks.createInlineLoadInitialTreeFallback || (() => async () => ({}));
-    const createInlineLoadEditorMemoriesFallback = dataLoaderFallbacks.createInlineLoadEditorMemoriesFallback || (() => async () => ({}));
-    const createInlineCreateInitialMemoryFallback = dataLoaderFallbacks.createInlineCreateInitialMemoryFallback || ((options) => () => ({}));
     const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
-    const createInlineRefreshMemoriesFallback = dataLoaderFallbacks.createInlineRefreshMemoriesFallback || ((options) => async () => {});
     const createInlineFormatTimeAgoFallback = entryFallbacks.createInlineFormatTimeAgoFallback;
 
     const markEditorReady = () => document.body?.classList.remove('editor-preload');
@@ -208,7 +203,11 @@ document.addEventListener('DOMContentLoaded', () => {
         let MEMORIES_CACHE_KEY = 'memories_default';
         let isLocalSaveMode = false;
 
-        const loadInitialTree = editorDataLoader.loadInitialEditorTree || createInlineLoadInitialTreeFallback();
+        const loadInitialTree = editorDataLoader.loadInitialEditorTree;
+        if (typeof loadInitialTree !== 'function') {
+            console.error('[editor] LoveBudEditorDataLoader.loadInitialEditorTree is not loaded');
+            return;
+        }
         const treeLoadResult = await loadInitialTree({
             urlTreeId,
             apiClient: window.apiClient,
@@ -252,20 +251,26 @@ document.addEventListener('DOMContentLoaded', () => {
         const treeId = tree.id || null;
         MEMORIES_CACHE_KEY = 'memories_' + (treeId || 'default');
 
-        const normalizeMemory = editorDataLoader.createNormalizeMemory
-            ? editorDataLoader.createNormalizeMemory({ sharedNormalize: window.LoveBudNormalize?.normalizeMemory })
-            : (window.LoveBudNormalize?.normalizeMemory || createInlineNormalizeMemoryFallback());
+        if (typeof editorDataLoader.createNormalizeMemory !== 'function') {
+            console.error('[editor] LoveBudEditorDataLoader.createNormalizeMemory is not loaded');
+            return;
+        }
+        const normalizeMemory = editorDataLoader.createNormalizeMemory({ sharedNormalize: window.LoveBudNormalize?.normalizeMemory });
 
-        await (editorDataLoader.loadEditorMemories || createInlineLoadEditorMemoriesFallback())({
+        if (typeof editorDataLoader.loadEditorMemories !== 'function') {
+            console.error('[editor] LoveBudEditorDataLoader.loadEditorMemories is not loaded');
+            return;
+        }
+        await editorDataLoader.loadEditorMemories({
             treeId,
             cache,
             cacheKey: MEMORIES_CACHE_KEY,
             apiClient: window.apiClient,
             showToast,
             i18n,
-            normalizeMemory
+            normalizeMemory,
+            cacheTtlMs: 2 * 60 * 1000
         });
-
         const treeMemories = () => (window.currentTreeMemories || []).map(normalizeMemory).filter(Boolean);
         const canonicalRootId = getCanonicalRootId(treeMemories());
         let selectedNodeId = canonicalRootId;
@@ -281,9 +286,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return memoryActions.updateSelectedMemoryFields(...args);
         };
 
-        const createInitialMemory = editorTreeHelpers.createInitialMemory
-            ? () => editorTreeHelpers.createInitialMemory({ getTreeMemories: () => treeMemories(), findRootMemory, canonicalRootId, treeId, i18n })
-            : createInlineCreateInitialMemoryFallback({ treeMemories, findRootMemory, canonicalRootId, treeId, i18n });
+        if (typeof editorTreeHelpers.createInitialMemory !== 'function') {
+            console.error('[editor] LoveBudEditorTreeHelpers.createInitialMemory is not loaded');
+            return;
+        }
+        const createInitialMemory = () => editorTreeHelpers.createInitialMemory({ getTreeMemories: () => treeMemories(), findRootMemory, canonicalRootId, treeId, i18n });
 
         const nextMemoryId = editorTreeHelpers.nextMemoryIdFromMemories
             ? () => editorTreeHelpers.nextMemoryIdFromMemories(treeMemories())
@@ -413,9 +420,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         };
 
-        const refreshMemories = editorDataLoader.createRefreshMemories
-            ? editorDataLoader.createRefreshMemories({ treeId, apiClient: window.apiClient, normalizeMemory, onMemoriesUpdated: handleMemoriesUpdated })
-            : createInlineRefreshMemoriesFallback({ treeId, apiClient: window.apiClient, normalizeMemory, onMemoriesUpdated: handleMemoriesUpdated });
+        if (typeof editorDataLoader.createRefreshMemories !== 'function') {
+            console.error('[editor] LoveBudEditorDataLoader.createRefreshMemories is not loaded');
+            return;
+        }
+        const refreshMemories = editorDataLoader.createRefreshMemories({ treeId, apiClient: window.apiClient, normalizeMemory, onMemoriesUpdated: handleMemoriesUpdated });
         window.refreshMemories = refreshMemories;
 
         const formatTimeAgo = editorSaveStatus.formatTimeAgo || createInlineFormatTimeAgoFallback();


### PR DESCRIPTION
## 변경 사항
- `editor.js` 내의 데이터 로더 관련 폴백 팩토리 5개(`createInlineNormalizeMemoryFallback` 등) 선언 및 할당 완전 제거
- `loadInitialEditorTree`, `createNormalizeMemory`, `loadEditorMemories`, `createRefreshMemories` 호출부에서 삼항 연산자 폴백 제거
- 데이터 로더 모듈이 없을 경우, silent fallback 대신 명시적인 `console.error`를 남기고 `return`하도록 방어 코드 추가 (Fail-fast 패턴 적용)
- `createInitialMemory` 폴백 제거 후 명시적 의존 선언 적용

Refs #1276