### PR TITLE
feat(editor): add moment reactions and comments UI to detail panel

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -407,6 +407,79 @@ function createEditorDetailUI(deps) {
             }
         }
 
+        // --- 1288 Phase B: Reactions & Comments ---
+        const reactionsCard = document.getElementById('momentReactionsCard');
+        if (reactionsCard) {
+            if (isRootMemory(data, canonicalRootId)) {
+                reactionsCard.style.display = 'none';
+            } else {
+                reactionsCard.style.display = '';
+
+                const likeBtn = document.getElementById('momentLikeBtn');
+                const likeCount = document.getElementById('momentLikeCount');
+                const commentCount = document.getElementById('momentCommentCount');
+                
+                if (likeBtn && likeCount && commentCount) {
+                    likeBtn.dataset.reacted = 'false';
+                    likeBtn.querySelector('.editor-reaction-like-icon').textContent = '🤍';
+                    likeCount.textContent = '0';
+                    commentCount.textContent = '0';
+
+                    if (window.apiClient?.fetchReactionSummary) {
+                        window.apiClient.fetchReactionSummary(data.id)
+                            .then(summary => {
+                                if (!summary) return;
+                                likeCount.textContent = summary.like_count ?? summary.likeCount ?? 0;
+                                commentCount.textContent = summary.comment_count ?? summary.commentCount ?? 0;
+                                const userReacted = summary.user_reacted ?? summary.userReacted ?? false;
+                                likeBtn.dataset.reacted = userReacted ? 'true' : 'false';
+                                likeBtn.querySelector('.editor-reaction-like-icon').textContent = userReacted ? '❤️' : '🤍';
+                            })
+                            .catch(() => {});
+                    }
+
+                    likeBtn.onclick = async () => {
+                        const wasReacted = likeBtn.dataset.reacted === 'true';
+                        const prevCount = parseInt(likeCount.textContent) || 0;
+
+                        const nextReacted = !wasReacted;
+                        const nextCount = nextReacted ? prevCount + 1 : Math.max(0, prevCount - 1);
+                        likeBtn.dataset.reacted = nextReacted ? 'true' : 'false';
+                        likeBtn.querySelector('.editor-reaction-like-icon').textContent = nextReacted ? '❤️' : '🤍';
+                        likeCount.textContent = nextCount;
+
+                        try {
+                            const result = await window.apiClient.toggleReaction(data.id, 'like');
+                            if (result) {
+                                likeCount.textContent = result.like_count ?? result.likeCount ?? nextCount;
+                                const serverReacted = result.user_reacted ?? result.userReacted ?? nextReacted;
+                                likeBtn.dataset.reacted = serverReacted ? 'true' : 'false';
+                                likeBtn.querySelector('.editor-reaction-like-icon').textContent = serverReacted ? '❤️' : '🤍';
+                            }
+                        } catch (e) {
+                            likeBtn.dataset.reacted = wasReacted ? 'true' : 'false';
+                            likeBtn.querySelector('.editor-reaction-like-icon').textContent = wasReacted ? '❤️' : '🤍';
+                            likeCount.textContent = prevCount;
+                            showToast(i18n('reaction_failed') || '반응을 저장하지 못했어요.', 'error');
+                        }
+                    };
+
+                    const commentBtn = document.getElementById('momentCommentBtn');
+                    if (commentBtn) {
+                        commentBtn.onclick = () => {
+                            if (!data.id || !treeId) return;
+                            const basePath = typeof window.getEditorBasePath === 'function' ? window.getEditorBasePath() : '../pages/';
+                            window.location.href = basePath
+                                + 'detail.html?id=' + encodeURIComponent(data.id)
+                                + '&tree=' + encodeURIComponent(treeId)
+                                + '&from=editor';
+                        };
+                    }
+                }
+            }
+        }
+        // --- End Reactions ---
+
         if (memoryActions) {
             memoryActions.style.display = isEmptyState ? 'none' : 'flex';
             memoryActions.style.marginTop = '4px';

--- a/js/editor/templates/editor-detail-view-mode-template.js
+++ b/js/editor/templates/editor-detail-view-mode-template.js
@@ -56,6 +56,26 @@
                         </div>
                     </div>
 
+                    <div class="editor-moment-reactions-card" id="momentReactionsCard">
+                        <button
+                            class="editor-reaction-like-btn"
+                            id="momentLikeBtn"
+                            aria-label="좋아요"
+                            data-reacted="false"
+                        >
+                            <span class="editor-reaction-like-icon">🤍</span>
+                            <span class="editor-reaction-like-count" id="momentLikeCount">0</span>
+                        </button>
+                        <button
+                            class="editor-reaction-comment-btn"
+                            id="momentCommentBtn"
+                            aria-label="코멘트 보기"
+                        >
+                            <span class="editor-reaction-comment-icon">💬</span>
+                            <span class="editor-reaction-comment-count" id="momentCommentCount">0</span>
+                        </button>
+                    </div>
+
                     <div class="editor-save-status-card">
                         <div id="saveStatusIndicator" class="save-status-indicator save-status editor-save-status-wrap" aria-live="polite">
                             <span id="saveStatusIcon" class="editor-save-status-icon-hidden"></span>


### PR DESCRIPTION
## 변경 사항
- `editor-detail-view-mode-template.js`: 뷰 모드 템플릿에 리액션 카드 마크업 추가
- `editor-detail-ui.js`: 리액션 카드 이벤트 바인딩 (좋아요 낙관적 업데이트 및 코멘트 진입점)
- 루트 노드 시 리액션 섹션 숨김 처리

Refs #1288