### PR TITLE
feat(detail): add moment reactions UI to public viewer

### DIFF
--- a/js/detail/detail-loader.js
+++ b/js/detail/detail-loader.js
@@ -229,7 +229,73 @@
             });
 
             configureBackButton(sourceContext, canonicalTreeId);
+            loadDetailReactions(memoryId);
         };
+
+        function loadDetailReactions(memoryId) {
+            const bar = document.getElementById('detailReactionsBar');
+            const likeBtn = document.getElementById('detailLikeBtn');
+            const likeCount = document.getElementById('detailLikeCount');
+            const commentCount = document.getElementById('detailCommentCount');
+            if (!bar || !likeBtn || !likeCount || !commentCount) return;
+
+            // 1. 인증 여부 확인
+            const isAuthed = window.LoveTreeAuthPolicy?.hasConfirmedAuthSession?.() ?? false;
+
+            // 2. 리액션 요약 로드
+            if (!window.apiClient?.fetchReactionSummary) return;
+            window.apiClient.fetchReactionSummary(memoryId)
+                .then(summary => {
+                    if (!summary) return;
+                    likeCount.textContent = summary.like_count ?? summary.likeCount ?? 0;
+                    commentCount.textContent = summary.comment_count ?? summary.commentCount ?? 0;
+
+                    const userReacted = summary.user_reacted ?? summary.userReacted ?? false;
+                    likeBtn.dataset.reacted = userReacted ? 'true' : 'false';
+                    likeBtn.querySelector('.detail-reaction-like-icon').textContent = userReacted ? '❤️' : '🤍';
+
+                    // 3. 인증된 사용자만 좋아요 버튼 활성화
+                    if (isAuthed) {
+                        likeBtn.disabled = false;
+                        likeBtn.onclick = async () => {
+                            const wasReacted = likeBtn.dataset.reacted === 'true';
+                            const prevCount = parseInt(likeCount.textContent) || 0;
+                            const nextReacted = !wasReacted;
+                            const nextCount = nextReacted ? prevCount + 1 : Math.max(0, prevCount - 1);
+
+                            // 낙관적 업데이트
+                            likeBtn.dataset.reacted = nextReacted ? 'true' : 'false';
+                            likeBtn.querySelector('.detail-reaction-like-icon').textContent = nextReacted ? '❤️' : '🤍';
+                            likeCount.textContent = nextCount;
+
+                            try {
+                                const result = await window.apiClient.toggleReaction(memoryId, 'like');
+                                if (result) {
+                                    likeCount.textContent = result.like_count ?? result.likeCount ?? nextCount;
+                                    const serverReacted = result.user_reacted ?? result.userReacted ?? nextReacted;
+                                    likeBtn.dataset.reacted = serverReacted ? 'true' : 'false';
+                                    likeBtn.querySelector('.detail-reaction-like-icon').textContent = serverReacted ? '❤️' : '🤍';
+                                }
+                            } catch (e) {
+                                // 롤백
+                                likeBtn.dataset.reacted = wasReacted ? 'true' : 'false';
+                                likeBtn.querySelector('.detail-reaction-like-icon').textContent = wasReacted ? '❤️' : '🤍';
+                                likeCount.textContent = prevCount;
+                            }
+                        };
+                    } else {
+                        // 비인증 — 카운트만 표시, 버튼 비활성
+                        likeBtn.disabled = true;
+                        likeBtn.title = '로그인 후 좋아요를 남길 수 있어요';
+                    }
+
+                    // 4. 데이터 준비 완료 후 표시
+                    bar.style.display = '';
+                })
+                .catch(() => {
+                    // 리액션 로드 실패 — bar 숨김 유지, 조용히 처리
+                });
+        }
 
         return {
             configureBackButton,

--- a/pages/detail.html
+++ b/pages/detail.html
@@ -76,6 +76,23 @@
             </section>
 
             <aside class="detail-secondary-stack">
+                <div class="detail-reactions-bar" id="detailReactionsBar" style="display:none;">
+                  <button
+                    class="detail-reaction-like-btn"
+                    id="detailLikeBtn"
+                    aria-label="좋아요"
+                    data-reacted="false"
+                    disabled
+                  >
+                    <span class="detail-reaction-like-icon">🤍</span>
+                    <span class="detail-reaction-like-count" id="detailLikeCount">0</span>
+                  </button>
+                  <div class="detail-reaction-comment-count-wrap">
+                    <span class="detail-reaction-comment-icon">💬</span>
+                    <span id="detailCommentCount">0</span>
+                  </div>
+                </div>
+
                 <div class="connected-section">
                     <div class="connected-heading">
                         <span id="connectedKicker" class="connected-kicker">&nbsp;</span>


### PR DESCRIPTION
## 변경 사항
- `pages/detail.html`: connected-section 바로 위에 리액션 바 마크업 삽입 (`display:none` 초기 상태)
- `js/detail/detail-loader.js`: 메모리 로드 직후 리액션 데이터 비동기 로드(fire-and-forget) 기능 추가
- `window.LoveTreeAuthPolicy.hasConfirmedAuthSession()`을 활용하여 비인증 사용자일 경우 좋아요 버튼 클릭 비활성화 및 안내 툴팁 제공
- 코멘트는 이번 페이즈에서 카운트 표시까지만 지원

Refs #1288