### PR TITLE
refactor(api): extract owner write guards to write_validation.py

### DIFF
--- a/modal_compute/owner_writes.py
+++ b/modal_compute/owner_writes.py
@@ -14,6 +14,12 @@ from modal_compute.owner_reads import (
     fetch_owner_tree,
 )
 from modal_compute.owner_users import ensure_owner_user_exists
+from modal_compute.write_validation import (
+    fetch_tree_for_owner_check,
+    require_tree_owner,
+    fetch_memory_for_owner_check,
+    require_memory_owner,
+)
 from modal_compute.validation import (
     _to_isoformat,
     estimate_stage,
@@ -107,55 +113,6 @@ def create_owner_memory(owner_id: str, payload: dict[str, Any]) -> dict[str, Any
     return normalize_memory_row(row)
 
 
-def fetch_tree_for_owner_check(tree_id: str) -> dict[str, Any] | None:
-    query = """
-        SELECT id, owner_id, title, visibility, created_at, updated_at
-        FROM trees
-        WHERE id = %s
-        LIMIT 1;
-    """
-
-    with get_db_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, (tree_id,))
-            return cur.fetchone()
-
-
-def require_tree_owner(tree_id: str, owner_id: str) -> dict[str, Any]:
-    tree = fetch_tree_for_owner_check(tree_id)
-    if not tree:
-        raise HTTPException(status_code=404, detail="Tree not found")
-    if str(tree.get("owner_id") or "") != owner_id:
-        raise HTTPException(status_code=403, detail="Access denied: not your tree")
-    return tree
-
-
-def fetch_memory_for_owner_check(memory_id: str) -> dict[str, Any] | None:
-    query = """
-        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
-               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
-               m.channel_id, m.channel_name, m.channel_url,
-               m.created_at, m.updated_at, t.owner_id AS tree_owner_id
-        FROM memories m
-        INNER JOIN trees t
-          ON t.id = m.tree_id
-        WHERE m.id = %s
-        LIMIT 1;
-    """
-
-    with get_db_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(query, (memory_id,))
-            return cur.fetchone()
-
-
-def require_memory_owner(memory_id: str, owner_id: str) -> dict[str, Any]:
-    memory = fetch_memory_for_owner_check(memory_id)
-    if not memory:
-        raise HTTPException(status_code=404, detail="Memory not found")
-    if str(memory.get("tree_owner_id") or "") != owner_id:
-        raise HTTPException(status_code=403, detail="Access denied: not your memory")
-    return memory
 
 
 def update_owner_tree(owner_id: str, tree_id: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/modal_compute/write_validation.py
+++ b/modal_compute/write_validation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import get_db_connection
+
+def fetch_tree_for_owner_check(tree_id: str) -> dict[str, Any] | None:
+    query = """
+        SELECT id, owner_id, title, visibility, created_at, updated_at
+        FROM trees
+        WHERE id = %s
+        LIMIT 1;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (tree_id,))
+            return cur.fetchone()
+
+def require_tree_owner(tree_id: str, owner_id: str) -> dict[str, Any]:
+    tree = fetch_tree_for_owner_check(tree_id)
+    if not tree:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    if str(tree.get("owner_id") or "") != owner_id:
+        raise HTTPException(status_code=403, detail="Access denied: not your tree")
+    return tree
+
+def fetch_memory_for_owner_check(memory_id: str) -> dict[str, Any] | None:
+    query = """
+        SELECT m.id, m.tree_id, m.parent_id, m.title, m.memo, m.artist, m.source, m.source_url,
+               m.source_type, m.thumbnail, m.emotion_tags, m.timestamp, m.visibility,
+               m.channel_id, m.channel_name, m.channel_url,
+               m.created_at, m.updated_at, t.owner_id AS tree_owner_id
+        FROM memories m
+        INNER JOIN trees t
+          ON t.id = m.tree_id
+        WHERE m.id = %s
+        LIMIT 1;
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (memory_id,))
+            return cur.fetchone()
+
+def require_memory_owner(memory_id: str, owner_id: str) -> dict[str, Any]:
+    memory = fetch_memory_for_owner_check(memory_id)
+    if not memory:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    if str(memory.get("tree_owner_id") or "") != owner_id:
+        raise HTTPException(status_code=403, detail="Access denied: not your memory")
+    return memory


### PR DESCRIPTION
## 변경 사항
- `modal_compute/write_validation.py` 신규 생성
- `owner_writes.py` 내에 있던 4개의 권한 체크 가드 함수(`fetch_tree_for_owner_check`, `require_tree_owner`, `fetch_memory_for_owner_check`, `require_memory_owner`)를 `write_validation.py`로 잘라내기 이동
- `owner_writes.py` 상단에 해당 함수들을 import 하도록 수정하여 기존 로직 100% 호환성 유지

Refs #1284