### PR TITLE
feat(editor): improve empty guide card UX with structured and quick input options (#1503)

### DIFF
--- a/css/editor/editor-canvas.css
+++ b/css/editor/editor-canvas.css
@@ -163,17 +163,6 @@
     display: none;
 }
 
-.editor-canvas-empty-guide__icon {
-    display: grid;
-    place-items: center;
-    width: 48px;
-    height: 48px;
-    border-radius: 18px;
-    background: linear-gradient(135deg, rgba(255,237,221,0.95), rgba(255,248,241,0.84));
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.85), 0 12px 26px rgba(144,73,81,0.10);
-    font-size: 27px;
-}
-
 .editor-canvas-empty-guide__eyebrow {
     display: inline-flex;
     align-items: center;
@@ -196,31 +185,63 @@
 }
 
 .editor-canvas-empty-guide__desc {
-    margin: 0;
-    font-size: 12px;
+    margin: -4px 0 4px;
+    font-size: 13px;
     line-height: 1.65;
     color: var(--on-surface-variant);
 }
 
-.editor-canvas-empty-guide__input-wrap {
+.editor-canvas-empty-guide__structured {
     display: flex;
     width: 100%;
-    gap: 8px;
+    gap: 12px;
+    justify-content: center;
+    margin-top: 8px;
+}
+
+.editor-canvas-empty-guide__structured .btn-round,
+.editor-canvas-empty-guide__structured-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 48px;
+    padding: 0 12px;
+    font-size: 14px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.editor-canvas-empty-guide__divider {
+    display: flex;
     align-items: center;
-    margin-top: 4px;
+    width: 100%;
+    gap: 16px;
+    color: rgba(144,73,81,0.38);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.editor-canvas-empty-guide__divider::before,
+.editor-canvas-empty-guide__divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: rgba(144,73,81,0.12);
+}
+
+.editor-canvas-empty-guide__quick {
+    width: 100%;
 }
 
 .editor-canvas-empty-guide__input {
-    flex: 1 1 auto;
-    min-width: 0;
-    min-height: 44px;
+    width: 100%;
+    min-height: 48px;
     border: 1px solid rgba(144,73,81,0.16);
-    border-radius: 999px;
-    padding: 0 15px;
+    border-radius: 14px;
+    padding: 0 16px;
     background: rgba(255,255,255,0.92);
     color: var(--on-surface);
     font: inherit;
-    font-size: 13px;
+    font-size: 14px;
     outline: none;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.75);
     transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
@@ -234,31 +255,6 @@
     border-color: rgba(144,73,81,0.46);
     background: #fff;
     box-shadow: 0 0 0 4px rgba(144,73,81,0.10);
-}
-
-.editor-canvas-empty-guide__cta {
-    flex: 0 0 auto;
-    min-width: 118px;
-    min-height: 44px;
-    white-space: nowrap;
-}
-
-.editor-canvas-empty-guide__text-start {
-    border: 0;
-    background: transparent;
-    color: var(--primary);
-    font: inherit;
-    font-size: 13px;
-    font-weight: 800;
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    cursor: pointer;
-}
-
-.editor-canvas-empty-guide__text-start:focus-visible {
-    outline: 2px solid rgba(144,73,81,0.38);
-    outline-offset: 4px;
-    border-radius: 999px;
 }
 
 .editor-canvas-empty-guide__hint {
@@ -292,12 +288,12 @@
         padding: 24px 18px 22px;
     }
 
-    .editor-canvas-empty-guide__input-wrap {
+    .editor-canvas-empty-guide__structured {
         flex-direction: column;
     }
 
     .editor-canvas-empty-guide__input,
-    .editor-canvas-empty-guide__cta {
+    .editor-canvas-empty-guide__structured-btn {
         width: 100%;
     }
 }

--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -9,79 +9,107 @@
         const showToast = options.showToast;
         const i18n = options.i18n;
 
-        const canvasEmptyStartBtn = document.getElementById('canvasEmptyStartBtn');
-        const canvasEmptyYoutubeInput = document.getElementById('canvasEmptyYoutubeInput');
-        const canvasEmptyTextStartBtn = document.getElementById('canvasEmptyTextStartBtn');
+        const canvasEmptyVideoBtn = document.getElementById('canvasEmptyVideoBtn');
+        const canvasEmptyTextBtn = document.getElementById('canvasEmptyTextBtn');
+        const canvasEmptyQuickInput = document.getElementById('canvasEmptyQuickInput');
 
-        // 의존성 DOM (문자열 등 추출을 위해 직접 탐색)
         const memoryUrlInput = document.getElementById('memoryUrlInput');
+        const memoryTitleInput = document.getElementById('memoryTitleInput');
         const memoryModeLinkBtn = document.getElementById('memoryModeLinkBtn');
         const memoryModeTextBtn = document.getElementById('memoryModeTextBtn');
 
-        async function createMemoryFromCanvasUrl(createOptions) {
-            const rawUrl = createOptions && createOptions.rawUrl;
-            const position = createOptions && createOptions.position;
-            if (!rawUrl) {
-                if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+        function isYoutubeUrl(url) {
+            return /(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(url || '');
+        }
+
+        async function fetchYoutubeTitle(url) {
+            try {
+                const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+                const response = await fetch(oembedUrl);
+                if (!response.ok) return '';
+                const data = await response.json();
+                return data && data.title ? data.title : '';
+            } catch (error) {
+                console.warn('[editor] YouTube oEmbed title lookup failed', error);
+                return '';
+            }
+        }
+
+        async function createMemoryFromQuickYoutube(rawUrl) {
+            const url = (rawUrl || '').trim();
+            if (!url) return;
+            if (!isYoutubeUrl(url)) {
+                if (typeof showToast === 'function') {
+                    showToast(i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.', 'warn');
+                }
                 return;
             }
-            if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+
+            if (typeof showToast === 'function') {
+                showToast(i18n('saving') || '기록 중...', 'info');
+            }
+
+            const title = await fetchYoutubeTitle(url);
+            if (memoryModeLinkBtn) memoryModeLinkBtn.click();
             if (memoryUrlInput) {
-                memoryUrlInput.value = rawUrl;
+                memoryUrlInput.value = url;
                 memoryUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
             }
-            if (memoryModeLinkBtn) memoryModeLinkBtn.click();
-            
+            if (memoryTitleInput && title) {
+                memoryTitleInput.value = title;
+                memoryTitleInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+
             const memories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
             const beforeIds = new Set(memories.map((memory) => memory && memory.id));
-            
+
             if (typeof addMemoryFromForm === 'function') await addMemoryFromForm();
-            
+
             const updatedMemories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
             const createdMemory = updatedMemories.find((memory) => memory && !beforeIds.has(memory.id));
-            
             const editorCanvas = typeof getEditorCanvas === 'function' ? getEditorCanvas() : null;
-            if (createdMemory && position && editorCanvas) {
-                if (typeof editorCanvas.addNodePosition === 'function') {
-                    editorCanvas.addNodePosition(createdMemory.id, position);
-                }
-                
-                if (typeof editorCanvas.persistStoredPositions === 'function') editorCanvas.persistStoredPositions();
+            if (createdMemory && editorCanvas) {
                 if (typeof editorCanvas.initCanvas === 'function') editorCanvas.initCanvas();
                 if (typeof editorCanvas.focusNodeById === 'function') editorCanvas.focusNodeById(createdMemory.id);
             }
+
+            if (canvasEmptyQuickInput) canvasEmptyQuickInput.value = '';
         }
 
-        if (canvasEmptyStartBtn && canvasEmptyStartBtn.dataset.bound !== '1') {
-            canvasEmptyStartBtn.dataset.bound = '1';
-            canvasEmptyStartBtn.addEventListener('click', () => {
-                const rawUrl = canvasEmptyYoutubeInput ? canvasEmptyYoutubeInput.value.trim() : '';
-                if (rawUrl) {
-                    createMemoryFromCanvasUrl({ rawUrl });
-                    return;
-                }
+        if (canvasEmptyVideoBtn && canvasEmptyVideoBtn.dataset.bound !== '1') {
+            canvasEmptyVideoBtn.dataset.bound = '1';
+            canvasEmptyVideoBtn.addEventListener('click', () => {
                 if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+                if (memoryModeLinkBtn) memoryModeLinkBtn.click();
             });
         }
 
-        if (canvasEmptyTextStartBtn && canvasEmptyTextStartBtn.dataset.bound !== '1') {
-            canvasEmptyTextStartBtn.dataset.bound = '1';
-            canvasEmptyTextStartBtn.addEventListener('click', () => {
+        if (canvasEmptyTextBtn && canvasEmptyTextBtn.dataset.bound !== '1') {
+            canvasEmptyTextBtn.dataset.bound = '1';
+            canvasEmptyTextBtn.addEventListener('click', () => {
                 if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
                 if (memoryModeTextBtn) memoryModeTextBtn.click();
             });
         }
 
-        if (canvasEmptyYoutubeInput && canvasEmptyYoutubeInput.dataset.bound !== '1') {
-            canvasEmptyYoutubeInput.dataset.bound = '1';
-            canvasEmptyYoutubeInput.addEventListener('keydown', (event) => {
+        if (canvasEmptyQuickInput && canvasEmptyQuickInput.dataset.bound !== '1') {
+            canvasEmptyQuickInput.dataset.bound = '1';
+            canvasEmptyQuickInput.addEventListener('paste', (event) => {
+                const clipboard = event.clipboardData || window.clipboardData;
+                const pastedText = clipboard ? clipboard.getData('text') : '';
+                if (!pastedText) return;
+                event.preventDefault();
+                canvasEmptyQuickInput.value = pastedText.trim();
+                createMemoryFromQuickYoutube(pastedText);
+            });
+            canvasEmptyQuickInput.addEventListener('keydown', (event) => {
                 if (event.key !== 'Enter') return;
                 event.preventDefault();
-                createMemoryFromCanvasUrl({ rawUrl: canvasEmptyYoutubeInput.value.trim() });
+                createMemoryFromQuickYoutube(canvasEmptyQuickInput.value);
             });
         }
 
-        return { createMemoryFromCanvasUrl };
+        return { createMemoryFromQuickYoutube, fetchYoutubeTitle };
     };
 
     window.LoveBudEditorEmptyGuideUI = emptyGuideUI;

--- a/js/editor/templates/editor-empty-guide-template.js
+++ b/js/editor/templates/editor-empty-guide-template.js
@@ -1,16 +1,22 @@
 (function() {
     const template = `
                         <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
-                <div class="editor-canvas-empty-guide__icon" id="canvasEmptyGuideIcon" aria-hidden="true">🌱</div>
                 <div class="editor-canvas-empty-guide__eyebrow" id="canvasEmptyGuideEyebrow">시작하기</div>
                 <h3 class="editor-canvas-empty-guide__title" id="canvasEmptyGuideTitle">이 트리의 첫 순간을 기록해볼까요?</h3>
-                <div class="editor-canvas-empty-guide__input-wrap">
-                    <label class="sr-only" for="canvasEmptyYoutubeInput" id="canvasEmptyYoutubeLabel">YouTube 링크</label>
-                    <input type="url" id="canvasEmptyYoutubeInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크를 붙여넣어 첫 순간 심기" autocomplete="off" inputmode="url">
-                    <button type="button" id="canvasEmptyStartBtn" class="btn-round btn-primary editor-canvas-empty-guide__cta">첫 순간 심기</button>
+                <p class="editor-canvas-empty-guide__desc" id="canvasEmptyGuideDesc">소중한 영상이나 글로 시작해보세요.</p>
+
+                <div class="editor-canvas-empty-guide__structured" aria-label="체계적으로 입력하기">
+                    <button type="button" id="canvasEmptyVideoBtn" class="btn-round btn-primary editor-canvas-empty-guide__structured-btn">영상으로 첫 순간 심기</button>
+                    <button type="button" id="canvasEmptyTextBtn" class="btn-round btn-outline editor-canvas-empty-guide__structured-btn">텍스트로 첫 순간 심기</button>
                 </div>
-                <button type="button" id="canvasEmptyTextStartBtn" class="editor-canvas-empty-guide__text-start">텍스트로 시작하기</button>
-                <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">캔버스를 두 번 클릭해도 새 순간을 시작할 수 있어요.</p>
+
+                <div class="editor-canvas-empty-guide__divider" aria-hidden="true">또는</div>
+
+                <div class="editor-canvas-empty-guide__quick" aria-label="빠르게 바로 시작하기">
+                    <label class="sr-only" for="canvasEmptyQuickInput" id="canvasEmptyQuickLabel">YouTube 링크 붙여넣기</label>
+                    <input type="url" id="canvasEmptyQuickInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크를 붙여넣어 바로 시작하기" autocomplete="off" inputmode="url">
+                </div>
+                <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">붙이는 순간 바로 순간이 만들어져요.</p>
             </div>
     `;
     const mount = document.getElementById('editorEmptyGuideTemplateMount');

--- a/tests/contracts/editor-empty-guide-template-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-template-contract.test.cjs
@@ -2,28 +2,33 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 
-test('Empty Guide template helper exists and contains markup', () => {
+test('Empty Guide template helper exists and contains updated structured quick-start markup', () => {
     const helperPath = 'js/editor/templates/editor-empty-guide-template.js';
     assert.ok(fs.existsSync(helperPath), 'template helper file must exist');
 
     const helperCode = fs.readFileSync(helperPath, 'utf8');
     assert.ok(helperCode.includes('id="canvasEmptyGuide"'), 'must include empty guide root id');
     assert.ok(helperCode.includes('class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden"'), 'must include root classes');
-    assert.ok(helperCode.includes('id="canvasEmptyGuideIcon"'), 'must preserve icon');
-    assert.ok(helperCode.includes('id="canvasEmptyGuideTitle"'), 'must preserve title');
-    assert.ok(helperCode.includes('id="canvasEmptyYoutubeInput"'), 'must preserve youtube input');
-    assert.ok(helperCode.includes('id="canvasEmptyStartBtn"'), 'must preserve start button');
-    assert.ok(helperCode.includes('id="canvasEmptyTextStartBtn"'), 'must preserve text start button');
+    assert.ok(!helperCode.includes('id="canvasEmptyGuideIcon"'), 'must remove the decorative sprout icon');
+    assert.ok(helperCode.includes('id="canvasEmptyGuideTitle"'), 'must preserve title id');
+    assert.ok(helperCode.includes('이 트리의 첫 순간을 기록해볼까요?'), 'must include updated title copy');
+    assert.ok(helperCode.includes('소중한 영상이나 글로 시작해보세요.'), 'must include updated description copy');
+    assert.ok(helperCode.includes('id="canvasEmptyVideoBtn"'), 'must include structured video button');
+    assert.ok(helperCode.includes('영상으로 첫 순간 심기'), 'must include structured video button copy');
+    assert.ok(helperCode.includes('id="canvasEmptyTextBtn"'), 'must include structured text button');
+    assert.ok(helperCode.includes('텍스트로 첫 순간 심기'), 'must include structured text button copy');
+    assert.ok(helperCode.includes('id="canvasEmptyQuickInput"'), 'must include quick YouTube input');
+    assert.ok(helperCode.includes('YouTube 링크를 붙여넣어 바로 시작하기'), 'must include quick input placeholder');
+    assert.ok(helperCode.includes('붙이는 순간 바로 순간이 만들어져요.'), 'must explain quick paste behavior');
 });
 
 test('editor.html uses template mount and removes raw empty guide markup', () => {
     const html = fs.readFileSync('pages/editor.html', 'utf8');
 
-    // Should have the mount anchor
     assert.ok(html.includes('id="editorEmptyGuideTemplateMount"'), 'must have mount anchor');
-
-    // Should not have the inner contents like canvasEmptyTextStartBtn in the raw HTML anymore
-    assert.ok(!html.includes('id="canvasEmptyTextStartBtn"'), 'raw HTML should not contain empty guide inner contents');
+    assert.ok(!html.includes('id="canvasEmptyVideoBtn"'), 'raw HTML should not contain empty guide inner contents');
+    assert.ok(!html.includes('id="canvasEmptyTextBtn"'), 'raw HTML should not contain empty guide inner contents');
+    assert.ok(!html.includes('id="canvasEmptyQuickInput"'), 'raw HTML should not contain empty guide inner contents');
 });
 
 test('editor.html loads template helper before editor runtime in correct order', () => {
@@ -39,7 +44,7 @@ test('editor.html loads template helper before editor runtime in correct order',
     assert.notEqual(addMemoryHelperIndex, -1, 'editor.html must still load the add memory form helper');
     assert.notEqual(sidebarHelperIndex, -1, 'editor.html must still load the sidebar helper script');
     assert.notEqual(topbarHelperIndex, -1, 'editor.html must still load the canvas topbar helper script');
-    assert.notEqual(emptyGuideHelperIndex, -1, 'editor.html must load the new empty guide helper script');
+    assert.notEqual(emptyGuideHelperIndex, -1, 'editor.html must load the empty guide helper script');
 
     assert.ok(emptyGuideHelperIndex < domSelectorsIndex, 'empty guide helper must load before dom selectors');
     assert.ok(emptyGuideHelperIndex < editorJsIndex, 'empty guide helper must load before js/editor.js');


### PR DESCRIPTION
This PR improves the Empty Guide card UX in the editor canvas by introducing structured input buttons for video and text, and a quick-paste field for YouTube URLs with automatic title extraction via oEmbed API.