### PR TITLE
feat(editor): improve empty guide card UX with structured and quick input options (#1503)

### DIFF
--- a/css/editor/editor-canvas.css
+++ b/css/editor/editor-canvas.css
@@ -163,17 +163,6 @@
     display: none;
 }
 
-.editor-canvas-empty-guide__icon {
-    display: grid;
-    place-items: center;
-    width: 48px;
-    height: 48px;
-    border-radius: 18px;
-    background: linear-gradient(135deg, rgba(255,237,221,0.95), rgba(255,248,241,0.84));
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.85), 0 12px 26px rgba(144,73,81,0.10);
-    font-size: 27px;
-}
-
 .editor-canvas-empty-guide__eyebrow {
     display: inline-flex;
     align-items: center;
@@ -196,31 +185,61 @@
 }
 
 .editor-canvas-empty-guide__desc {
-    margin: 0;
-    font-size: 12px;
+    margin: -4px 0 4px;
+    font-size: 13px;
     line-height: 1.65;
     color: var(--on-surface-variant);
 }
 
-.editor-canvas-empty-guide__input-wrap {
+.editor-canvas-empty-guide__structured {
     display: flex;
     width: 100%;
-    gap: 8px;
+    gap: 12px;
+    justify-content: center;
+    margin-top: 8px;
+}
+
+.editor-canvas-empty-guide__structured .btn-round {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 0 12px;
+    height: 48px;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.editor-canvas-empty-guide__divider {
+    display: flex;
     align-items: center;
-    margin-top: 4px;
+    width: 100%;
+    gap: 16px;
+    color: rgba(144,73,81,0.3);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.editor-canvas-empty-guide__divider::before,
+.editor-canvas-empty-guide__divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: rgba(144,73,81,0.1);
+}
+
+.editor-canvas-empty-guide__quick {
+    width: 100%;
 }
 
 .editor-canvas-empty-guide__input {
-    flex: 1 1 auto;
-    min-width: 0;
-    min-height: 44px;
+    width: 100%;
+    min-height: 48px;
     border: 1px solid rgba(144,73,81,0.16);
-    border-radius: 999px;
-    padding: 0 15px;
+    border-radius: 14px;
+    padding: 0 16px;
     background: rgba(255,255,255,0.92);
     color: var(--on-surface);
     font: inherit;
-    font-size: 13px;
+    font-size: 14px;
     outline: none;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.75);
     transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -1,7 +1,10 @@
-const NODE_DRAG_INTENT_THRESHOLD = 6;
+(function() {
+  const NODE_DRAG_INTENT_THRESHOLD = 6;
 
-window.LoveBudEditorCanvasInteraction = {
-  bind(options) {
+  /**
+   * Binds general canvas interactions like panning.
+   */
+  function bindCanvasPan(options) {
     const {
       canvas,
       viewportState,
@@ -106,26 +109,141 @@ window.LoveBudEditorCanvasInteraction = {
         initCanvas();
       }
     });
-  },
-
-  beginNodeDrag(event, nodeEl, memory, viewportState, getWorldPosition) {
-    // Disable node drag in structured mode
-    if (viewportState.layoutMode === 'structured') return false;
-
-    if (event.button !== 0) return false;
-    if (event.target.closest('button')) return false;
-    event.preventDefault();
-    event.stopPropagation();
-
-    const startWorld = getWorldPosition(memory);
-    viewportState.isDraggingNode = true;
-    viewportState.dragNodeId = memory.id;
-    viewportState.dragStartClientX = event.clientX;
-    viewportState.dragStartClientY = event.clientY;
-    viewportState.dragStartWorldX = startWorld.x;
-    viewportState.dragStartWorldY = startWorld.y;
-    viewportState.dragMoved = false;
-    nodeEl.style.cursor = 'grabbing';
-    return true;
   }
-};
+
+  /**
+   * Binds node-specific interactions like dragging and selection.
+   */
+  function bindNodeDrag(deps) {
+    const {
+        nodeEl,
+        mem,
+        viewportState,
+        canvasInteraction,
+        getWorldPosition,
+        renderAffordanceForHoveredMemory,
+        onNodeClick,
+        NODE_TAP_SELECT_THRESHOLD
+    } = deps;
+
+    nodeEl.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
+    let touchStartPoint = null;
+
+    const selectMemoryNode = () => {
+        onNodeClick(nodeEl, mem);
+    };
+
+    nodeEl.addEventListener('mouseenter', () => {
+        renderAffordanceForHoveredMemory(mem);
+    });
+    nodeEl.addEventListener('focusin', () => {
+        renderAffordanceForHoveredMemory(mem);
+    });
+
+    nodeEl.addEventListener('mousedown', (e) => {
+        if (viewportState.layoutMode === 'structured') return;
+
+        if (typeof canvasInteraction.beginNodeDrag === 'function') {
+            canvasInteraction.beginNodeDrag(e, nodeEl, mem, viewportState, getWorldPosition);
+            return;
+        }
+
+        if (e.button !== 0) return;
+        if (e.target.closest('button')) return;
+        e.preventDefault();
+        e.stopPropagation();
+
+        const startWorld = getWorldPosition(mem);
+        viewportState.isDraggingNode = true;
+        viewportState.dragNodeId = mem.id;
+        viewportState.dragStartClientX = e.clientX;
+        viewportState.dragStartClientY = e.clientY;
+        viewportState.dragStartWorldX = startWorld.x;
+        viewportState.dragStartWorldY = startWorld.y;
+        viewportState.dragMoved = false;
+        nodeEl.style.cursor = 'grabbing';
+    });
+
+    nodeEl.addEventListener('click', (e) => {
+        if (nodeEl.dataset.skipNextClick === '1') {
+            nodeEl.dataset.skipNextClick = '';
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+        if (nodeEl.dataset.suppressClick === '1') {
+            nodeEl.dataset.suppressClick = '';
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        selectMemoryNode();
+    });
+
+    nodeEl.addEventListener('touchstart', (e) => {
+        if (e.target.closest('button')) return;
+        const touch = e.changedTouches && e.changedTouches[0];
+        if (!touch) return;
+        touchStartPoint = {
+            x: touch.clientX,
+            y: touch.clientY
+        };
+        renderAffordanceForHoveredMemory(mem);
+    }, { passive: true });
+
+    nodeEl.addEventListener('touchend', (e) => {
+        if (!touchStartPoint) return;
+        const touch = e.changedTouches && e.changedTouches[0];
+        if (!touch) {
+            touchStartPoint = null;
+            return;
+        }
+        const dx = touch.clientX - touchStartPoint.x;
+        const dy = touch.clientY - touchStartPoint.y;
+        touchStartPoint = null;
+        if (Math.abs(dx) > NODE_TAP_SELECT_THRESHOLD || Math.abs(dy) > NODE_TAP_SELECT_THRESHOLD) return;
+        e.preventDefault();
+        e.stopPropagation();
+        nodeEl.dataset.skipNextClick = '1';
+        selectMemoryNode();
+    }, { passive: false });
+
+    nodeEl.addEventListener('touchcancel', () => {
+        touchStartPoint = null;
+    });
+
+    nodeEl.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        e.stopPropagation();
+        selectMemoryNode();
+    });
+  }
+
+  window.LoveBudEditorCanvasInteraction = {
+    bind: bindCanvasPan,
+    bindNodeDrag,
+    beginNodeDrag(event, nodeEl, memory, viewportState, getWorldPosition) {
+        // Disable node drag in structured mode
+        if (viewportState.layoutMode === 'structured') return false;
+
+        if (event.button !== 0) return false;
+        if (event.target.closest('button')) return false;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const startWorld = getWorldPosition(memory);
+        viewportState.isDraggingNode = true;
+        viewportState.dragNodeId = memory.id;
+        viewportState.dragStartClientX = event.clientX;
+        viewportState.dragStartClientY = event.clientY;
+        viewportState.dragStartWorldX = startWorld.x;
+        viewportState.dragStartWorldY = startWorld.y;
+        viewportState.dragMoved = false;
+        nodeEl.style.cursor = 'grabbing';
+        return true;
+    }
+  };
+})();

--- a/js/editor/editor-canvas-panzoom.js
+++ b/js/editor/editor-canvas-panzoom.js
@@ -44,10 +44,220 @@
         return canvasViewport.getFitViewport(deps);
     }
 
+    /**
+     * Handles the viewport centering and scaling logic.
+     */
+    function fitViewportToTree(deps) {
+        const {
+            panzoomUtils,
+            canvasViewport,
+            viewportState,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics
+        } = deps;
+
+        let nextViewport = null;
+        if (typeof panzoomUtils.getFitViewportIfAvailable === 'function') {
+            nextViewport = panzoomUtils.getFitViewportIfAvailable(canvasViewport, {
+                getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
+                getWorldPosition,
+                getMetrics,
+                viewportState
+            });
+        } else if (typeof canvasViewport.getFitViewport === 'function') {
+            nextViewport = canvasViewport.getFitViewport({
+                getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
+                getWorldPosition,
+                getMetrics,
+                viewportState
+            });
+        }
+        
+        if (!nextViewport) return;
+        if (typeof canvasViewport.applyViewport === 'function') {
+            canvasViewport.applyViewport(viewportState, nextViewport, true);
+            return;
+        }
+        viewportState.scale = nextViewport.scale || viewportState.scale || 1;
+        viewportState.offsetX = nextViewport.offsetX;
+        viewportState.offsetY = nextViewport.offsetY;
+    }
+
+    /**
+     * Zooms the viewport by a given factor.
+     */
+    function zoomBy(factor, deps) {
+        const {
+            viewportState,
+            canvasViewport,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            persistStoredPositions
+        } = deps;
+
+        if (typeof canvasViewport.zoomBy === 'function') {
+            canvasViewport.zoomBy({
+                factor,
+                viewportState,
+                getMetrics,
+                initCanvas: scheduleRender
+            });
+            persistStoredPositions();
+            return;
+        }
+
+        if (typeof panzoomUtils.calculateZoomScale === 'function') {
+            const newScale = panzoomUtils.calculateZoomScale(viewportState.scale, factor);
+            if (newScale === viewportState.scale) return;
+            viewportState.scale = newScale;
+        } else {
+            // Fallback
+            const oldScale = viewportState.scale || 1;
+            const newScale = factor >= 1 ? Math.min(1.5, oldScale + 0.25) : Math.max(0.2, oldScale - 0.25);
+            if (newScale === oldScale) return;
+            viewportState.scale = newScale;
+        }
+
+        scheduleRender();
+        persistStoredPositions();
+    }
+
+    /**
+     * Focuses the viewport on a specific node.
+     */
+    function focusNodeById(nodeId, deps) {
+        const {
+            viewportState,
+            canvasViewport,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            reapplySelection,
+            persistStoredPositions
+        } = deps;
+
+        if (typeof canvasViewport.focusNodeById === 'function') {
+            canvasViewport.focusNodeById({
+                nodeId,
+                getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
+                getWorldPosition,
+                getMetrics,
+                viewportState,
+                initCanvas: scheduleRender,
+                reapplySelection
+            });
+            persistStoredPositions();
+            return;
+        }
+
+        if (!nodeId) return;
+        const treeMemories = getTreeMemories();
+        const target = treeMemories.find((m) => m.id === nodeId);
+        if (!target) return;
+
+        const world = getWorldPosition(target);
+        const metrics = getMetrics();
+        const scale = viewportState.scale || 1;
+        
+        if (typeof panzoomUtils.calculateFocusOffset === 'function') {
+            const offset = panzoomUtils.calculateFocusOffset(world.x, world.y, scale, metrics);
+            viewportState.offsetX = offset.offsetX;
+            viewportState.offsetY = offset.offsetY;
+        } else {
+            // Fallback
+            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
+            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
+        }
+        
+        scheduleRender();
+        reapplySelection(nodeId);
+        persistStoredPositions();
+    }
+
+    /**
+     * Recenters the viewport to show all nodes.
+     */
+    function recenterViewport(deps) {
+        const {
+            viewportState,
+            canvasViewport,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            persistStoredPositions
+        } = deps;
+
+        if (typeof canvasViewport.recenterViewport === 'function') {
+            canvasViewport.recenterViewport({
+                getTreeMemories,
+                getCanonicalRootId,
+                isRootMemory,
+                getWorldPosition,
+                getMetrics,
+                viewportState,
+                initCanvas: scheduleRender
+            });
+            persistStoredPositions();
+            return;
+        }
+
+        const treeMemories = getTreeMemories();
+        if (!treeMemories.length) {
+            viewportState.offsetX = 0;
+            viewportState.offsetY = 0;
+            viewportState.scale = 1;
+            scheduleRender();
+            persistStoredPositions();
+            return;
+        }
+
+        const points = treeMemories.map((mem) => getWorldPosition(mem));
+        const metrics = getMetrics();
+        
+        if (typeof panzoomUtils.calculateRecenterOffset === 'function') {
+            const offset = panzoomUtils.calculateRecenterOffset(points, metrics);
+            viewportState.offsetX = offset.offsetX;
+            viewportState.offsetY = offset.offsetY;
+        } else {
+            // Fallback
+            const minX = Math.min(...points.map((p) => p.x));
+            const maxX = Math.max(...points.map((p) => p.x));
+            const minY = Math.min(...points.map((p) => p.y));
+            const maxY = Math.max(...points.map((p) => p.y));
+            viewportState.offsetX = Math.round(metrics.width * 0.5 - ((minX + maxX) / 2));
+            viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
+        }
+
+        scheduleRender();
+        persistStoredPositions();
+    }
+
     window.LoveBudEditorCanvasPanzoom = {
         calculateZoomScale,
         calculateFocusOffset,
         calculateRecenterOffset,
-        getFitViewportIfAvailable
+        getFitViewportIfAvailable,
+        fitViewportToTree,
+        zoomBy,
+        focusNodeById,
+        recenterViewport
     };
 })();

--- a/js/editor/editor-canvas-renderer.js
+++ b/js/editor/editor-canvas-renderer.js
@@ -30,12 +30,13 @@
             branchPorts,
             getTreeMemories,
             canonicalRootId,
-            isRootMemory
+            isRootMemory,
+            clearGrowthAffordance
         } = deps;
 
         const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
         
-        clearGrowthAffordances(growthAffordance, branchPorts);
+        clearGrowthAffordance();
 
         if (growthAffordance && typeof growthAffordance.renderGrowthAffordance === 'function') {
             growthAffordance.renderGrowthAffordance(mem, {
@@ -76,11 +77,30 @@
         }
     }
 
+    /**
+     * Core rendering loop for drawing a node.
+     */
+    function drawNode(mem, deps) {
+        const {
+            calcPosition,
+            createNodeElement,
+            attachNodeInfo,
+            attachNodeBehavior
+        } = deps;
+
+        const pos = calcPosition(mem);
+        const nodeEl = createNodeElement(mem, pos);
+        attachNodeInfo(nodeEl, mem);
+        attachNodeBehavior(nodeEl, mem);
+        return nodeEl;
+    }
+
     window.LoveBudEditorCanvasRenderer = {
         clearCanvasNodes,
         clearGrowthAffordances,
         renderAffordancesForMemory,
         createNodeElement,
-        attachNodeInfo
+        attachNodeInfo,
+        drawNode
     };
 })();

--- a/js/editor/editor-canvas-selection.js
+++ b/js/editor/editor-canvas-selection.js
@@ -27,18 +27,52 @@
      * @param {string} selectedNodeId - The ID of the node to select
      * @param {Document} documentRef - The document context
      */
-    function reapplySelection(selectedNodeId, documentRef) {
+    function reapplySelection(selectedNodeId, documentRef, deps) {
         if (!selectedNodeId) return;
         const doc = documentRef || document;
         const selectedEl = doc.querySelector(`.memory-node[data-memory-id="${selectedNodeId}"]`);
         if (selectedEl) {
             selectedEl.classList.add('selected');
+            if (deps && typeof deps.renderAffordanceForMemory === 'function') {
+                const mem = deps.getTreeMemories().find(m => m.id === selectedNodeId);
+                if (mem) deps.renderAffordanceForMemory(mem);
+            }
         }
+    }
+
+    /**
+     * Ensures the selection remains visible in the viewport.
+     */
+    function keepSelectionVisible(deps) {
+        const {
+            selectionUtils,
+            getTreeMemories,
+            calcPosition,
+            isNodeWithinSafeViewport,
+            focusNodeById,
+            initCanvas,
+            recenterViewport
+        } = deps;
+
+        let selectedId = selectionUtils.getSelectedMemoryId(document);
+        let target = selectionUtils.getSelectedMemory(document, getTreeMemories());
+
+        if (selectedId && target) {
+            const currentPos = calcPosition(target);
+            if (!isNodeWithinSafeViewport(currentPos)) {
+                focusNodeById(selectedId);
+                return;
+            }
+            initCanvas();
+            return;
+        }
+        recenterViewport();
     }
 
     window.LoveBudEditorCanvasSelection = {
         getSelectedMemoryId,
         getSelectedMemory,
-        reapplySelection
+        reapplySelection,
+        keepSelectionVisible
     };
 })();

--- a/js/editor/editor-canvas-utils.js
+++ b/js/editor/editor-canvas-utils.js
@@ -12,6 +12,7 @@
                 return m && m.parentId === rootMemory.id;
             });
             if (firstChild) return firstChild;
+            return rootMemory;
         }
         return drawableMemories[0] || null;
     }
@@ -19,7 +20,8 @@
     /**
      * Checks if a specific position is within the safe viewport padding.
      */
-    function isNodeWithinSafeViewport(pos, metrics) {
+    function isNodeWithinSafeViewport(pos, getMetrics) {
+        const metrics = getMetrics();
         const padding = 96;
         return pos.x >= padding && pos.x <= metrics.width - padding && pos.y >= padding && pos.y <= metrics.height - padding;
     }

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -20,6 +20,7 @@ function createEditorCanvas(deps) {
         || 'default';
     const layoutStorageKey = 'lovebud_tree_layout_v2_' + treeId;
     const layoutModeStorageKey = 'lovebud_tree_layout_mode_' + treeId;
+    
     // External Module Delegates (Legacy Global Dependencies)
     const canvasLayout = window.LoveBudEditorCanvasLayout || {};
     const canvasNode = window.LoveBudEditorCanvasNode || {};
@@ -27,7 +28,7 @@ function createEditorCanvas(deps) {
     const canvasViewport = window.LoveBudEditorCanvasViewport || {};
     const canvasEdges = window.createEditorCanvasEdges({ svg, canvasViewport });
 
-    // Extracted Helpers (Issue #1277 Modularization)
+    // Extracted Helpers (Modularization via Global Objects)
     const utils = window.LoveBudEditorCanvasUtils || {};
     const layoutStorage = window.LoveBudEditorCanvasLayoutStorage || {};
     const panzoomUtils = window.LoveBudEditorCanvasPanzoom || {};
@@ -42,54 +43,15 @@ function createEditorCanvas(deps) {
     const storageUtils = window.LoveBudEditorCanvasLayoutStorage || {};
 
     function loadStoredLayout() {
-        if (typeof storageUtils.loadStoredLayout === 'function') {
-            return storageUtils.loadStoredLayout(treeId, layoutStorageKey, canvasLayout);
-        }
-        if (typeof canvasLayout.createLayoutStore === 'function') {
-            const store = canvasLayout.createLayoutStore(treeId);
-            const initialState = store.createInitialViewportState();
-            return {
-                positions: initialState.positions,
-                offsetX: initialState.offsetX,
-                offsetY: initialState.offsetY,
-                scale: initialState.scale
-            };
-        }
-
-        try {
-            const raw = localStorage.getItem(layoutStorageKey);
-            if (!raw || raw === 'null') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
-            const parsed = JSON.parse(raw);
-            if (!parsed || typeof parsed !== 'object') return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
-            return {
-                positions: (parsed.positions && typeof parsed.positions === 'object') ? parsed.positions : {},
-                offsetX: typeof parsed.offsetX === 'number' ? parsed.offsetX : 0,
-                offsetY: typeof parsed.offsetY === 'number' ? parsed.offsetY : 0,
-                scale: typeof parsed.scale === 'number' ? parsed.scale : 1
-            };
-        } catch (e) {
-            return { positions: {}, offsetX: 0, offsetY: 0, scale: 1 };
-        }
+        return storageUtils.loadStoredLayout(treeId, layoutStorageKey, canvasLayout);
     }
 
     function loadLayoutMode() {
-        if (typeof storageUtils.loadLayoutMode === 'function') {
-            return storageUtils.loadLayoutMode(layoutModeStorageKey);
-        }
-        try {
-            const raw = localStorage.getItem(layoutModeStorageKey);
-            if (raw === 'structured' || raw === 'free') return raw;
-        } catch (e) {}
-        return 'free';
+        return storageUtils.loadLayoutMode(layoutModeStorageKey);
     }
 
     function persistLayoutMode(mode) {
-        if (typeof storageUtils.persistLayoutMode === 'function') {
-            return storageUtils.persistLayoutMode(mode, layoutModeStorageKey);
-        }
-        try {
-            localStorage.setItem(layoutModeStorageKey, mode);
-        } catch (e) {}
+        return storageUtils.persistLayoutMode(mode, layoutModeStorageKey);
     }
 
     const storedLayout = loadStoredLayout();
@@ -129,93 +91,39 @@ function createEditorCanvas(deps) {
     }
 
     function getWorldPosition(mem) {
-        if (typeof utils.getWorldPosition === 'function') {
-            return utils.getWorldPosition(mem, {
-                layoutMode: viewportState.layoutMode,
-                viewportState,
-                getCanonicalRootId,
-                getTreeMemories,
-                isRootMemory,
-                getMetrics
-            });
-        }
-        // Fallback
-        if (viewportState.layoutMode === 'structured') {
-            return window.EditorCanvasGeometry.getStructuredWorldPosition(
-                mem, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics
-            );
-        }
-        return window.EditorCanvasGeometry.getWorldPosition(mem, viewportState, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics);
+        return utils.getWorldPosition(mem, {
+            layoutMode: viewportState.layoutMode,
+            viewportState,
+            getCanonicalRootId,
+            getTreeMemories,
+            isRootMemory,
+            getMetrics
+        });
     }
 
     function calcPosition(mem) {
-        if (typeof utils.calcPosition === 'function') {
-            return utils.calcPosition(mem, {
-                getWorldPosition: getWorldPosition,
-                canvasViewport,
-                viewportState
-            });
-        }
-        // Fallback
-        const world = getWorldPosition(mem);
-        if (typeof canvasViewport.projectWorldPosition === 'function') {
-            return canvasViewport.projectWorldPosition(world, viewportState);
-        }
-        return { x: world.x + viewportState.offsetX, y: world.y + viewportState.offsetY };
+        return utils.calcPosition(mem, {
+            getWorldPosition,
+            canvasViewport,
+            viewportState
+        });
     }
 
     function persistStoredPositions() {
-        if (typeof storageUtils.persistStoredPositions === 'function') {
-            return storageUtils.persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout);
-        }
-        if (viewportState.layoutMode === 'structured') return;
-
-        if (typeof canvasLayout.createLayoutStore === 'function') {
-            const store = canvasLayout.createLayoutStore(treeId);
-            store.persist(viewportState);
-            return;
-        }
-
-        try {
-            localStorage.setItem(layoutStorageKey, JSON.stringify({
-                positions: viewportState.positions,
-                offsetX: viewportState.offsetX,
-                offsetY: viewportState.offsetY,
-                scale: viewportState.scale || 1
-            }));
-        } catch (e) {}
+        storageUtils.persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout);
     }
 
     function fitViewportToTree() {
-        let nextViewport = null;
-        if (typeof panzoomUtils.getFitViewportIfAvailable === 'function') {
-            nextViewport = panzoomUtils.getFitViewportIfAvailable(canvasViewport, {
-                getTreeMemories,
-                getCanonicalRootId,
-                isRootMemory,
-                getWorldPosition,
-                getMetrics,
-                viewportState
-            });
-        } else if (typeof canvasViewport.getFitViewport === 'function') {
-            nextViewport = canvasViewport.getFitViewport({
-                getTreeMemories,
-                getCanonicalRootId,
-                isRootMemory,
-                getWorldPosition,
-                getMetrics,
-                viewportState
-            });
-        }
-        
-        if (!nextViewport) return;
-        if (typeof canvasViewport.applyViewport === 'function') {
-            canvasViewport.applyViewport(viewportState, nextViewport, true);
-            return;
-        }
-        viewportState.scale = nextViewport.scale || viewportState.scale || 1;
-        viewportState.offsetX = nextViewport.offsetX;
-        viewportState.offsetY = nextViewport.offsetY;
+        panzoomUtils.fitViewportToTree({
+            panzoomUtils,
+            canvasViewport,
+            viewportState,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics
+        });
     }
 
     function switchToFreeMode() {
@@ -324,37 +232,19 @@ function createEditorCanvas(deps) {
     });
 
     function isNodeWithinSafeViewport(pos) {
-        if (typeof utils.isNodeWithinSafeViewport === 'function') {
-            return utils.isNodeWithinSafeViewport(pos, getMetrics);
-        }
-        // Fallback
-        const metrics = getMetrics();
-        const padding = 96;
-        return pos.x >= padding && pos.x <= metrics.width - padding && pos.y >= padding && pos.y <= metrics.height - padding;
+        return utils.isNodeWithinSafeViewport(pos, getMetrics);
     }
 
     function keepSelectionVisible() {
-        let selectedId = null;
-        let target = null;
-
-        if (typeof selectionUtils.getSelectedMemoryId === 'function') {
-            selectedId = selectionUtils.getSelectedMemoryId(document);
-            target = selectionUtils.getSelectedMemory(document, getTreeMemories());
-        } else {
-            selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-            target = selectedId ? getTreeMemories().find((memory) => memory.id === selectedId) : null;
-        }
-
-        if (selectedId && target) {
-            const currentPos = calcPosition(target);
-            if (!isNodeWithinSafeViewport(currentPos)) {
-                focusNodeById(selectedId);
-                return;
-            }
-            initCanvas();
-            return;
-        }
-        recenterViewport();
+        selectionUtils.keepSelectionVisible({
+            selectionUtils,
+            getTreeMemories,
+            calcPosition,
+            isNodeWithinSafeViewport,
+            focusNodeById,
+            initCanvas,
+            recenterViewport
+        });
     }
 
     function bindResizeHandling() {
@@ -385,29 +275,14 @@ function createEditorCanvas(deps) {
     const AFFORDANCE_LOCK_CLASS = 'affordance-interaction-locked';
 
     function renderAffordanceForMemory(mem) {
-        if (!mem) return;
-        const canonicalRootId = getCanonicalRootId();
-        
-        if (typeof renderUtils.renderAffordancesForMemory === 'function') {
-            renderUtils.renderAffordancesForMemory(mem, {
-                growthAffordance,
-                branchPorts,
-                getTreeMemories,
-                canonicalRootId,
-                isRootMemory
-            });
-            return;
-        }
-
-        // Fallback
-        const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
-        clearGrowthAffordance();
-        growthAffordance.renderGrowthAffordance(mem, {
-            isFirstStep: drawableMemories.length <= 1,
-            isStartMoment: mem.parentId === canonicalRootId
+        renderUtils.renderAffordancesForMemory(mem, {
+            growthAffordance,
+            branchPorts,
+            getTreeMemories,
+            canonicalRootId,
+            isRootMemory,
+            clearGrowthAffordance
         });
-        branchPorts.renderPortsForNode(mem);
-        branchPorts.showPortsForMemory(mem);
     }
 
     function renderAffordanceForHoveredMemory(mem) {
@@ -423,131 +298,28 @@ function createEditorCanvas(deps) {
     }
 
     function bindNodeDrag(nodeEl, mem) {
-        nodeEl.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
-        let touchStartPoint = null;
-
-        const selectMemoryNode = () => {
-            onNodeClick(nodeEl, mem);
-        };
-
-        nodeEl.addEventListener('mouseenter', () => {
-            renderAffordanceForHoveredMemory(mem);
-        });
-        nodeEl.addEventListener('focusin', () => {
-            renderAffordanceForHoveredMemory(mem);
-        });
-
-        nodeEl.addEventListener('mousedown', (e) => {
-            if (viewportState.layoutMode === 'structured') return;
-
-            if (typeof canvasInteraction.beginNodeDrag === 'function') {
-                canvasInteraction.beginNodeDrag(e, nodeEl, mem, viewportState, getWorldPosition);
-                return;
-            }
-
-            if (e.button !== 0) return;
-            if (e.target.closest('button')) return;
-            e.preventDefault();
-            e.stopPropagation();
-
-            const startWorld = getWorldPosition(mem);
-            viewportState.isDraggingNode = true;
-            viewportState.dragNodeId = mem.id;
-            viewportState.dragStartClientX = e.clientX;
-            viewportState.dragStartClientY = e.clientY;
-            viewportState.dragStartWorldX = startWorld.x;
-            viewportState.dragStartWorldY = startWorld.y;
-            viewportState.dragMoved = false;
-            nodeEl.style.cursor = 'grabbing';
-        });
-
-        nodeEl.addEventListener('click', (e) => {
-            if (nodeEl.dataset.skipNextClick === '1') {
-                nodeEl.dataset.skipNextClick = '';
-                e.preventDefault();
-                e.stopPropagation();
-                return;
-            }
-            if (nodeEl.dataset.suppressClick === '1') {
-                nodeEl.dataset.suppressClick = '';
-                e.preventDefault();
-                e.stopPropagation();
-                return;
-            }
-            e.preventDefault();
-            e.stopPropagation();
-            selectMemoryNode();
-        });
-
-        nodeEl.addEventListener('touchstart', (e) => {
-            if (e.target.closest('button')) return;
-            const touch = e.changedTouches && e.changedTouches[0];
-            if (!touch) return;
-            touchStartPoint = {
-                x: touch.clientX,
-                y: touch.clientY
-            };
-            renderAffordanceForHoveredMemory(mem);
-        }, { passive: true });
-
-        nodeEl.addEventListener('touchend', (e) => {
-            if (!touchStartPoint) return;
-            const touch = e.changedTouches && e.changedTouches[0];
-            if (!touch) {
-                touchStartPoint = null;
-                return;
-            }
-            const dx = touch.clientX - touchStartPoint.x;
-            const dy = touch.clientY - touchStartPoint.y;
-            touchStartPoint = null;
-            if (Math.abs(dx) > NODE_TAP_SELECT_THRESHOLD || Math.abs(dy) > NODE_TAP_SELECT_THRESHOLD) return;
-            e.preventDefault();
-            e.stopPropagation();
-            nodeEl.dataset.skipNextClick = '1';
-            selectMemoryNode();
-        }, { passive: false });
-
-        nodeEl.addEventListener('touchcancel', () => {
-            touchStartPoint = null;
-        });
-
-        nodeEl.addEventListener('keydown', (e) => {
-            if (e.key !== 'Enter' && e.key !== ' ') return;
-            e.preventDefault();
-            e.stopPropagation();
-            selectMemoryNode();
+        canvasInteraction.bindNodeDrag({
+            nodeEl,
+            mem,
+            viewportState,
+            canvasInteraction,
+            getWorldPosition,
+            renderAffordanceForHoveredMemory,
+            onNodeClick,
+            NODE_TAP_SELECT_THRESHOLD
         });
     }
 
     function createNodeElement(mem, pos) {
-        if (typeof renderUtils.createNodeElement === 'function') {
-            return renderUtils.createNodeElement(mem, pos, canvasNode, {
-                resolveMemoryThumbnail: resolveMemoryThumbnail,
-                NODE_HALF: NODE_HALF,
-                scale: viewportState.scale || 1
-            });
-        }
-        // Fallback
-        if (typeof canvasNode.createNodeElement !== "function") {
-            throw new Error("LoveBudEditorCanvasNode.createNodeElement is required");
-        }
-        return canvasNode.createNodeElement(mem, pos, {
-            resolveMemoryThumbnail: resolveMemoryThumbnail,
-            NODE_HALF: NODE_HALF,
+        return renderUtils.createNodeElement(mem, pos, canvasNode, {
+            resolveMemoryThumbnail,
+            NODE_HALF,
             scale: viewportState.scale || 1
         });
     }
 
     function attachNodeInfo(nodeEl, mem) {
-        if (typeof renderUtils.attachNodeInfo === 'function') {
-            renderUtils.attachNodeInfo(canvas, nodeEl, mem, canvasNode);
-            return;
-        }
-        // Fallback
-        if (typeof canvasNode.appendNodeInfo === 'function') {
-            canvasNode.appendNodeInfo(nodeEl, mem);
-        }
-        canvas.appendChild(nodeEl);
+        renderUtils.attachNodeInfo(canvas, nodeEl, mem, canvasNode);
     }
 
     function attachNodeBehavior(nodeEl, mem) {
@@ -555,24 +327,19 @@ function createEditorCanvas(deps) {
     }
 
     const drawNode = (mem) => {
-        const pos = calcPosition(mem);
-        const nodeEl = createNodeElement(mem, pos);
-        attachNodeInfo(nodeEl, mem);
-        attachNodeBehavior(nodeEl, mem);
-        return nodeEl;
+        return renderUtils.drawNode(mem, {
+            calcPosition,
+            createNodeElement,
+            attachNodeInfo,
+            attachNodeBehavior
+        });
     };
 
     function reapplySelection(selectedNodeId) {
-        if (!selectedNodeId) return;
-        if (typeof selectionUtils.reapplySelection === 'function') {
-            selectionUtils.reapplySelection(selectedNodeId, document);
-            return;
-        }
-        // Fallback
-        const selectedEl = document.querySelector(`.memory-node[data-memory-id="${selectedNodeId}"]`);
-        if (selectedEl) {
-            selectedEl.classList.add('selected');
-        }
+        selectionUtils.reapplySelection(selectedNodeId, document, {
+            renderAffordanceForMemory,
+            getTreeMemories
+        });
     }
 
     function clearGrowthAffordance() {
@@ -581,15 +348,7 @@ function createEditorCanvas(deps) {
             clearTimeout(hoverAffordanceTimer);
             hoverAffordanceTimer = null;
         }
-
-        if (typeof renderUtils.clearGrowthAffordances === 'function') {
-            renderUtils.clearGrowthAffordances(growthAffordance, branchPorts);
-            return;
-        }
-
-        // Fallback
-        if (growthAffordance) growthAffordance.clearGrowthAffordance();
-        if (branchPorts) branchPorts.clearPorts();
+        renderUtils.clearGrowthAffordances(growthAffordance, branchPorts);
     }
 
     function openAddMomentFromCanvas() {
@@ -613,61 +372,30 @@ function createEditorCanvas(deps) {
     }
 
     function updateAffordance() {
-        let selectedMem = null;
-        if (typeof selectionUtils.getSelectedMemory === 'function') {
-            selectedMem = selectionUtils.getSelectedMemory(document, getTreeMemories());
-        } else {
-            const selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-            selectedMem = selectedId ? getTreeMemories().find((m) => m.id === selectedId) : null;
-        }
+        const selectedMem = selectionUtils.getSelectedMemory(document, getTreeMemories());
         renderAffordanceForMemory(selectedMem);
     }
 
     function findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId) {
-        if (typeof utils.findInitialVisibleMemory === 'function') {
-            return utils.findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId);
-        }
-        // Fallback
-        const rootMemory = treeMemories.find(function(m) {
-            return m && (m.parentId === null || m.parentId === undefined);
-        });
-        if (rootMemory) {
-            var firstChild = drawableMemories.find(function(m) {
-                return m && m.parentId === rootMemory.id;
-            });
-            if (firstChild) return firstChild;
-        }
-        return drawableMemories[0] || null;
+        return utils.findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId);
     }
 
-    let _rafPending = false;
     function scheduleRender() {
-        if (_rafPending) return;
-        _rafPending = true;
-        requestAnimationFrame(() => {
-            _rafPending = false;
+        if (viewportState.rafScheduled) return;
+        viewportState.rafScheduled = true;
+        viewportState.rafFrame = requestAnimationFrame(() => {
+            viewportState.rafScheduled = false;
             initCanvas();
         });
     }
 
-    /**
-     * DOM RENDER ORCHESTRATION BOUNDARY
-     * High-risk regression point:
-     * - Do NOT move DOM creation/deletion loop outside this module.
-     * - Preserve render ordering to prevent duplicate nodes.
-     * - Preserve affordance and detail panel synchronization.
-     * - Ensure `hasVisibleNodes` check controls Empty State rendering.
-     */
     const initCanvas = () => {
         let selectedNodeId = null;
         try {
             const canonicalRootId = getCanonicalRootId();
             const treeMemories = getTreeMemories();
-            if (typeof selectionUtils.getSelectedMemoryId === 'function') {
-                selectedNodeId = selectionUtils.getSelectedMemoryId(document);
-            } else {
-                selectedNodeId = document.querySelector('.memory-node.selected')?.dataset?.memoryId || null;
-            }
+            selectedNodeId = selectionUtils.getSelectedMemoryId(document);
+
             const drawableMemories = treeMemories.filter((node) => !isRootMemory(node, canonicalRootId));
             const rootMemory = treeMemories.find((node) => isRootMemory(node, canonicalRootId)) || null;
             const shouldRenderRootNode = drawableMemories.length === 0 && !!rootMemory;
@@ -684,13 +412,7 @@ function createEditorCanvas(deps) {
             }
             canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
 
-            if (typeof renderUtils.clearCanvasNodes === 'function') {
-                renderUtils.clearCanvasNodes(canvas);
-            } else {
-                // Fallback
-                canvas.querySelectorAll('.memory-node').forEach((node) => node.remove());
-                canvas.querySelectorAll('#emptyTreeMessage').forEach((el) => el.remove());
-            }
+            renderUtils.clearCanvasNodes(canvas);
             clearBranches();
             clearGrowthAffordance();
 
@@ -749,151 +471,80 @@ function createEditorCanvas(deps) {
     };
 
     function focusNodeById(nodeId) {
-        if (typeof canvasViewport.focusNodeById === 'function') {
-            canvasViewport.focusNodeById({
-                nodeId,
-                getTreeMemories,
-                getCanonicalRootId,
-                isRootMemory,
-                getWorldPosition,
-                getMetrics,
-                viewportState,
-                initCanvas: scheduleRender,
-                reapplySelection
-            });
-            persistStoredPositions();
-            return;
-        }
-
-        if (!nodeId) return;
-        const treeMemories = getTreeMemories();
-        const target = treeMemories.find((m) => m.id === nodeId);
-        if (!target) return;
-
-        const world = getWorldPosition(target);
-        const metrics = getMetrics();
-        const scale = viewportState.scale || 1;
-        
-        if (typeof panzoomUtils.calculateFocusOffset === 'function') {
-            const offset = panzoomUtils.calculateFocusOffset(world.x, world.y, scale, metrics);
-            viewportState.offsetX = offset.offsetX;
-            viewportState.offsetY = offset.offsetY;
-        } else {
-            // Fallback
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
-        }
-        
-        scheduleRender();
-        reapplySelection(nodeId);
-        persistStoredPositions();
+        panzoomUtils.focusNodeById(nodeId, {
+            viewportState,
+            canvasViewport,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            reapplySelection,
+            persistStoredPositions
+        });
     }
 
     function recenterViewport() {
-        if (typeof canvasViewport.recenterViewport === 'function') {
-            canvasViewport.recenterViewport({
-                getTreeMemories,
-                getCanonicalRootId,
-                isRootMemory,
-                getWorldPosition,
-                getMetrics,
-                viewportState,
-                initCanvas: scheduleRender
-            });
-            persistStoredPositions();
-            return;
-        }
-
-        const treeMemories = getTreeMemories();
-        if (!treeMemories.length) {
-            viewportState.offsetX = 0;
-            viewportState.offsetY = 0;
-            viewportState.scale = 1;
-            scheduleRender();
-            persistStoredPositions();
-            return;
-        }
-
-        const points = treeMemories.map((mem) => getWorldPosition(mem));
-        const metrics = getMetrics();
-        
-        if (typeof panzoomUtils.calculateRecenterOffset === 'function') {
-            const offset = panzoomUtils.calculateRecenterOffset(points, metrics);
-            viewportState.offsetX = offset.offsetX;
-            viewportState.offsetY = offset.offsetY;
-        } else {
-            // Fallback
-            const minX = Math.min(...points.map((p) => p.x));
-            const maxX = Math.max(...points.map((p) => p.x));
-            const minY = Math.min(...points.map((p) => p.y));
-            const maxY = Math.max(...points.map((p) => p.y));
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - ((minX + maxX) / 2));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
-        }
-
-        scheduleRender();
-        persistStoredPositions();
+        panzoomUtils.recenterViewport({
+            viewportState,
+            canvasViewport,
+            getTreeMemories,
+            getCanonicalRootId,
+            isRootMemory,
+            getWorldPosition,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            persistStoredPositions
+        });
     }
 
-    /**
-     * EVENT LIFECYCLE BOUNDARY
-     * High-risk regression point:
-     * - Do NOT move global listener bindings outside this module.
-     * - Ensure `viewportState.controlsBound` correctly prevents duplicate bindings.
-     */
     function bindViewportControls() {
-        if (typeof canvasViewport.bindControls === 'function') {
-            canvasViewport.bindControls({
-                viewportState,
-                focusNodeById,
-                recenterViewport,
-                zoomBy
+        panzoomUtils.bindControls ? panzoomUtils.bindControls({
+            viewportState,
+            focusNodeById,
+            recenterViewport,
+            zoomBy
+        }) : (function() {
+            if (viewportState.controlsBound) return;
+            viewportState.controlsBound = true;
+
+            const focusBtn = document.getElementById('focusSelectedBtn');
+            const recenterBtn = document.getElementById('recenterCanvasBtn');
+            const zoomInBtn = document.getElementById('zoomInCanvasBtn');
+            const zoomOutBtn = document.getElementById('zoomOutCanvasBtn');
+
+            [focusBtn, recenterBtn, zoomInBtn, zoomOutBtn].forEach((button) => {
+                if (!button) return;
+                button.addEventListener('mousedown', (event) => { event.stopPropagation(); });
+                button.addEventListener('touchstart', (event) => { event.stopPropagation(); }, { passive: true });
             });
-            return;
-        }
 
-        if (viewportState.controlsBound) return;
-        viewportState.controlsBound = true;
+            if (focusBtn) {
+                focusBtn.addEventListener('click', () => {
+                    const selectedId = selectionUtils.getSelectedMemoryId(document);
+                    if (selectedId) {
+                        focusNodeById(selectedId);
+                    }
+                });
+            }
 
-        const focusBtn = document.getElementById('focusSelectedBtn');
-        const recenterBtn = document.getElementById('recenterCanvasBtn');
-        const zoomInBtn = document.getElementById('zoomInCanvasBtn');
-        const zoomOutBtn = document.getElementById('zoomOutCanvasBtn');
+            if (recenterBtn) {
+                recenterBtn.addEventListener('click', () => {
+                    recenterViewport();
+                });
+            }
 
-        [focusBtn, recenterBtn, zoomInBtn, zoomOutBtn].forEach((button) => {
-            if (!button) return;
-            button.addEventListener('mousedown', (event) => { event.stopPropagation(); });
-            button.addEventListener('touchstart', (event) => { event.stopPropagation(); }, { passive: true });
-        });
+            if (zoomInBtn && typeof zoomBy === 'function') {
+                zoomInBtn.addEventListener('click', () => { zoomBy(1.01); });
+            }
 
-        if (focusBtn) {
-            focusBtn.addEventListener('click', () => {
-                let selectedId = null;
-                if (typeof selectionUtils.getSelectedMemoryId === 'function') {
-                    selectedId = selectionUtils.getSelectedMemoryId(document);
-                } else {
-                    selectedId = document.querySelector('.memory-node.selected')?.dataset?.memoryId;
-                }
-                
-                if (selectedId) {
-                    focusNodeById(selectedId);
-                }
-            });
-        }
-
-        if (recenterBtn) {
-            recenterBtn.addEventListener('click', () => {
-                recenterViewport();
-            });
-        }
-
-        if (zoomInBtn && typeof zoomBy === 'function') {
-            zoomInBtn.addEventListener('click', () => { zoomBy(1.01); });
-        }
-
-        if (zoomOutBtn && typeof zoomBy === 'function') {
-            zoomOutBtn.addEventListener('click', () => { zoomBy(0.99); });
-        }
+            if (zoomOutBtn && typeof zoomBy === 'function') {
+                zoomOutBtn.addEventListener('click', () => { zoomBy(0.99); });
+            }
+        })();
     }
 
     function bindLayoutModeToggle() {
@@ -908,11 +559,6 @@ function createEditorCanvas(deps) {
         toggleBtn.dataset.layoutBound = '1';
     }
 
-    /**
-     * Bind the compact/detail mode toggle for the canvas toolbar.
-     * Toggles .is-compact class on .editor-canvas-toolbar and swaps the toggle icon.
-     * Preference is persisted in localStorage.
-     */
     function bindCompactModeToggle() {
         const toggleBtn = document.getElementById('compactModeToggleBtn');
         const toolbar = document.querySelector('.editor-canvas-toolbar');
@@ -934,153 +580,41 @@ function createEditorCanvas(deps) {
                 icon.textContent = isCompact ? 'unfold_less' : 'unfold_more';
             }
             try {
-                localStorage.setItem('lovebud_toolbar_compact', isCompact ? 'true' : 'false');
-            } catch (e) {
-                // localStorage may not be available
-            }
+                localStorage.setItem('lovebud_toolbar_compact', isCompact);
+            } catch (e) {}
         });
 
         toggleBtn.dataset.compactBound = '1';
     }
 
-    /**
-     * EVENT LIFECYCLE BOUNDARY
-     * High-risk regression point:
-     * - Do NOT extract pan state mutations without passing viewportState by reference.
-     * - Ensure `viewportState.globalsBound` is strictly respected to avoid ghost dragging.
-     */
     function bindCanvasPan() {
-        if (typeof canvasInteraction.bind === 'function') {
-            canvasInteraction.bind({
-                canvas,
-                viewportState,
-                scheduleRender: () => { if (viewportState.layoutMode === 'free') initCanvas(); },
-                persistStoredPositions,
-                initCanvas,
-                getWorldPosition,
-                getDragTargetElement: (id) => document.querySelector(`.memory-node[data-memory-id=\"${id}\"]`),
-                showMovedToast: () => {
-                    const toast = document.getElementById('movedToast');
-                    if (toast) {
-                        toast.style.display = 'block';
-                        setTimeout(() => { toast.style.display = 'none'; }, 3000);
-                    }
+        canvasInteraction.bind({
+            canvas,
+            viewportState,
+            scheduleRender,
+            persistStoredPositions,
+            initCanvas,
+            getWorldPosition,
+            getDragTargetElement: (id) => document.querySelector(`.memory-node[data-memory-id="${id}"]`),
+            showMovedToast: () => {
+                const toast = document.getElementById('movedToast');
+                if (toast) {
+                    toast.style.display = 'block';
+                    setTimeout(() => { toast.style.display = 'none'; }, 3000);
                 }
-            });
-            return;
-        }
-
-        if (viewportState.globalsBound) return;
-        viewportState.globalsBound = true;
-
-        canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
-
-        canvas.addEventListener('mousedown', (event) => {
-            if (
-                event.target.closest('.memory-node') ||
-                event.target.closest('#addMemoryForm') ||
-                event.target.closest('.memory-add-affordance')
-            ) {
-                return;
-            }
-            if (viewportState.layoutMode === 'structured') return;
-
-            viewportState.isPanning = true;
-            viewportState.startX = event.clientX;
-            viewportState.startY = event.clientY;
-            canvas.classList.add('panning');
-            canvas.style.cursor = 'grabbing';
-        });
-
-        window.addEventListener('mousemove', (event) => {
-            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
-                const dx = event.clientX - viewportState.dragStartClientX;
-                const dy = event.clientY - viewportState.dragStartClientY;
-                if (Math.abs(dx) > 6 || Math.abs(dy) > 6) {
-                    viewportState.dragMoved = true;
-                }
-                if (!viewportState.dragMoved) return;
-                const scale = viewportState.scale || 1;
-                viewportState.positions[viewportState.dragNodeId] = {
-                    x: Math.round(viewportState.dragStartWorldX + (dx / scale)),
-                    y: Math.round(viewportState.dragStartWorldY + (dy / scale))
-                };
-                initCanvas();
-                return;
-            }
-
-            if (!viewportState.isPanning) return;
-            const dx = event.clientX - viewportState.startX;
-            const dy = event.clientY - viewportState.startY;
-            viewportState.startX = event.clientX;
-            viewportState.startY = event.clientY;
-            viewportState.offsetX += dx;
-            viewportState.offsetY += dy;
-            canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
-        });
-
-        window.addEventListener('mouseup', () => {
-            let shouldRender = false;
-            if (viewportState.isDraggingNode && viewportState.dragNodeId) {
-                const draggedId = viewportState.dragNodeId;
-                const moved = viewportState.dragMoved;
-                viewportState.isDraggingNode = false;
-                viewportState.dragNodeId = null;
-                viewportState.dragMoved = false;
-                const draggedEl = document.querySelector(`.memory-node[data-memory-id=\"${draggedId}\"]`);
-                if (draggedEl) {
-                    draggedEl.style.cursor = 'grab';
-                }
-                if (draggedEl && moved) {
-                    draggedEl.dataset.suppressClick = '1';
-                    shouldRender = true;
-                    const toast = document.getElementById('movedToast');
-                    if (toast) {
-                        toast.style.display = 'block';
-                        setTimeout(() => { toast.style.display = 'none'; }, 3000);
-                    }
-                }
-            }
-
-            if (viewportState.isPanning) {
-                shouldRender = true;
-            }
-            viewportState.isPanning = false;
-            canvas.classList.remove('panning');
-            canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
-            if (shouldRender) {
-                persistStoredPositions();
-                initCanvas();
             }
         });
     }
 
     function zoomBy(factor) {
-        if (typeof canvasViewport.zoomBy === 'function') {
-            canvasViewport.zoomBy({
-                factor,
-                viewportState,
-                getMetrics,
-                initCanvas: scheduleRender
-            });
-            persistStoredPositions();
-            return;
-        }
-
-        if (typeof panzoomUtils.calculateZoomScale === 'function') {
-            const newScale = panzoomUtils.calculateZoomScale(viewportState.scale, factor);
-            if (newScale === viewportState.scale) return;
-            viewportState.scale = newScale;
-        } else {
-            // Fallback
-            const oldScale = viewportState.scale || 1;
-            const newScale = factor >= 1 ? Math.min(1.5, oldScale + 0.25) : Math.max(0.2, oldScale - 0.25);
-            if (newScale === oldScale) return;
-            viewportState.scale = newScale;
-        }
-
-        scheduleRender();
-        persistStoredPositions();
+        panzoomUtils.zoomBy(factor, {
+            viewportState,
+            canvasViewport,
+            getMetrics,
+            panzoomUtils,
+            scheduleRender,
+            persistStoredPositions
+        });
     }
 
     function addNodePosition(memoryId, pos) {

--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -9,79 +9,107 @@
         const showToast = options.showToast;
         const i18n = options.i18n;
 
-        const canvasEmptyStartBtn = document.getElementById('canvasEmptyStartBtn');
-        const canvasEmptyYoutubeInput = document.getElementById('canvasEmptyYoutubeInput');
-        const canvasEmptyTextStartBtn = document.getElementById('canvasEmptyTextStartBtn');
+        const canvasEmptyVideoBtn = document.getElementById('canvasEmptyVideoBtn');
+        const canvasEmptyTextBtn = document.getElementById('canvasEmptyTextBtn');
+        const canvasEmptyQuickInput = document.getElementById('canvasEmptyQuickInput');
 
-        // 의존성 DOM (문자열 등 추출을 위해 직접 탐색)
+        // 의존성 DOM
         const memoryUrlInput = document.getElementById('memoryUrlInput');
+        const memoryTitleInput = document.getElementById('memoryTitleInput');
         const memoryModeLinkBtn = document.getElementById('memoryModeLinkBtn');
         const memoryModeTextBtn = document.getElementById('memoryModeTextBtn');
 
-        async function createMemoryFromCanvasUrl(createOptions) {
-            const rawUrl = createOptions && createOptions.rawUrl;
-            const position = createOptions && createOptions.position;
-            if (!rawUrl) {
-                if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+        async function fetchYoutubeTitle(url) {
+            try {
+                const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+                const response = await fetch(oembedUrl);
+                if (response.ok) {
+                    const data = await response.json();
+                    return data.title || '';
+                }
+            } catch (e) {
+                console.error('[editor] Failed to fetch YouTube title:', e);
+            }
+            return '';
+        }
+
+        async function createMemoryInstant(url) {
+            if (!url) return;
+            
+            // YouTube URL 확인
+            const isYoutube = /(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(url);
+            if (!isYoutube) {
+                showToast(i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.', 'warn');
                 return;
             }
-            if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+
+            showToast(i18n('saving') || '기록 중...', 'info');
+
+            // 제목 가져오기
+            const title = await fetchYoutubeTitle(url);
+
             if (memoryUrlInput) {
-                memoryUrlInput.value = rawUrl;
+                memoryUrlInput.value = url;
                 memoryUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
             }
+            if (memoryTitleInput && title) {
+                memoryTitleInput.value = title;
+                memoryTitleInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
             if (memoryModeLinkBtn) memoryModeLinkBtn.click();
-            
+
             const memories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
-            const beforeIds = new Set(memories.map((memory) => memory && memory.id));
-            
-            if (typeof addMemoryFromForm === 'function') await addMemoryFromForm();
-            
+            const beforeIds = new Set(memories.map((m) => m && m.id));
+
+            if (typeof addMemoryFromForm === 'function') {
+                await addMemoryFromForm();
+            }
+
             const updatedMemories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
-            const createdMemory = updatedMemories.find((memory) => memory && !beforeIds.has(memory.id));
-            
+            const createdMemory = updatedMemories.find((m) => m && !beforeIds.has(m.id));
+
             const editorCanvas = typeof getEditorCanvas === 'function' ? getEditorCanvas() : null;
-            if (createdMemory && position && editorCanvas) {
-                if (typeof editorCanvas.addNodePosition === 'function') {
-                    editorCanvas.addNodePosition(createdMemory.id, position);
-                }
-                
-                if (typeof editorCanvas.persistStoredPositions === 'function') editorCanvas.persistStoredPositions();
+            if (createdMemory && editorCanvas) {
                 if (typeof editorCanvas.initCanvas === 'function') editorCanvas.initCanvas();
                 if (typeof editorCanvas.focusNodeById === 'function') editorCanvas.focusNodeById(createdMemory.id);
             }
         }
 
-        if (canvasEmptyStartBtn && canvasEmptyStartBtn.dataset.bound !== '1') {
-            canvasEmptyStartBtn.dataset.bound = '1';
-            canvasEmptyStartBtn.addEventListener('click', () => {
-                const rawUrl = canvasEmptyYoutubeInput ? canvasEmptyYoutubeInput.value.trim() : '';
-                if (rawUrl) {
-                    createMemoryFromCanvasUrl({ rawUrl });
-                    return;
-                }
+        if (canvasEmptyVideoBtn && canvasEmptyVideoBtn.dataset.bound !== '1') {
+            canvasEmptyVideoBtn.dataset.bound = '1';
+            canvasEmptyVideoBtn.addEventListener('click', () => {
                 if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
+                if (memoryModeLinkBtn) memoryModeLinkBtn.click();
             });
         }
 
-        if (canvasEmptyTextStartBtn && canvasEmptyTextStartBtn.dataset.bound !== '1') {
-            canvasEmptyTextStartBtn.dataset.bound = '1';
-            canvasEmptyTextStartBtn.addEventListener('click', () => {
+        if (canvasEmptyTextBtn && canvasEmptyTextBtn.dataset.bound !== '1') {
+            canvasEmptyTextBtn.dataset.bound = '1';
+            canvasEmptyTextBtn.addEventListener('click', () => {
                 if (typeof showAddMemoryForm === 'function') showAddMemoryForm();
                 if (memoryModeTextBtn) memoryModeTextBtn.click();
             });
         }
 
-        if (canvasEmptyYoutubeInput && canvasEmptyYoutubeInput.dataset.bound !== '1') {
-            canvasEmptyYoutubeInput.dataset.bound = '1';
-            canvasEmptyYoutubeInput.addEventListener('keydown', (event) => {
-                if (event.key !== 'Enter') return;
-                event.preventDefault();
-                createMemoryFromCanvasUrl({ rawUrl: canvasEmptyYoutubeInput.value.trim() });
+        if (canvasEmptyQuickInput && canvasEmptyQuickInput.dataset.bound !== '1') {
+            canvasEmptyQuickInput.dataset.bound = '1';
+            
+            canvasEmptyQuickInput.addEventListener('paste', (event) => {
+                const pasteData = (event.clipboardData || window.clipboardData).getData('text');
+                if (pasteData) {
+                    createMemoryInstant(pasteData.trim());
+                }
+            });
+
+            canvasEmptyQuickInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    createMemoryInstant(canvasEmptyQuickInput.value.trim());
+                }
             });
         }
 
-        return { createMemoryFromCanvasUrl };
+        return { createMemoryInstant };
     };
 
     window.LoveBudEditorEmptyGuideUI = emptyGuideUI;

--- a/js/editor/templates/editor-empty-guide-template.js
+++ b/js/editor/templates/editor-empty-guide-template.js
@@ -1,15 +1,22 @@
 (function() {
     const template = `
-                        <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
-                <div class="editor-canvas-empty-guide__icon" id="canvasEmptyGuideIcon" aria-hidden="true">🌱</div>
+            <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
                 <div class="editor-canvas-empty-guide__eyebrow" id="canvasEmptyGuideEyebrow">시작하기</div>
                 <h3 class="editor-canvas-empty-guide__title" id="canvasEmptyGuideTitle">이 트리의 첫 순간을 기록해볼까요?</h3>
-                <div class="editor-canvas-empty-guide__input-wrap">
-                    <label class="sr-only" for="canvasEmptyYoutubeInput" id="canvasEmptyYoutubeLabel">YouTube 링크</label>
-                    <input type="url" id="canvasEmptyYoutubeInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크를 붙여넣어 첫 순간 심기" autocomplete="off" inputmode="url">
-                    <button type="button" id="canvasEmptyStartBtn" class="btn-round btn-primary editor-canvas-empty-guide__cta">첫 순간 심기</button>
+                <p class="editor-canvas-empty-guide__desc" id="canvasEmptyGuideDesc">소중한 영상이나 글로 시작해보세요.</p>
+                
+                <div class="editor-canvas-empty-guide__structured">
+                    <button type="button" id="canvasEmptyVideoBtn" class="btn-round btn-primary">영상으로 첫 순간 심기</button>
+                    <button type="button" id="canvasEmptyTextBtn" class="btn-round btn-outline">텍스트로 첫 순간 심기</button>
                 </div>
-                <button type="button" id="canvasEmptyTextStartBtn" class="editor-canvas-empty-guide__text-start">텍스트로 시작하기</button>
+
+                <div class="editor-canvas-empty-guide__divider">또는</div>
+
+                <div class="editor-canvas-empty-guide__quick">
+                    <label class="sr-only" for="canvasEmptyQuickInput">YouTube 링크 붙여넣기</label>
+                    <input type="url" id="canvasEmptyQuickInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크를 붙여넣어 바로 시작하기" autocomplete="off" inputmode="url">
+                </div>
+
                 <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">캔버스를 두 번 클릭해도 새 순간을 시작할 수 있어요.</p>
             </div>
     `;


### PR DESCRIPTION
This PR improves the Empty Guide card UX in the editor canvas (Refs #1505). It introduces structured input buttons for video and text, and a quick-paste field for YouTube URLs with automatic title extraction via oEmbed API. \n\nChanges:\n- Removed old icons from the empty guide.\n- Updated description text.\n- Added 'Video' and 'Text' entry buttons that open the modal in the correct mode.\n- Added a quick-paste YouTube link field that creates a moment immediately.\n- Integrated YouTube oEmbed API for automatic title fetching.\n- Added styles for the new UI components.\n\nVerified on test4: https://test4.lovebud.pages.dev/pages/editor