### PR TITLE
test(editor): cover viewport target filtering contracts (Stage 27)

### DIFF
--- a/tests/contracts/editor-viewport-math-contracts.test.cjs
+++ b/tests/contracts/editor-viewport-math-contracts.test.cjs
@@ -449,3 +449,60 @@ test('getReadableViewportOffset — uses visible non-root nodes before canonical
   assert.equal(result.offsetX, 200);
   assert.equal(result.offsetY, 102);
 });
+
+// ---------------------------------------------------------------------------
+// getViewportTargets
+// ---------------------------------------------------------------------------
+test('getViewportTargets — empty memories returns empty array', () => {
+  const vp = createViewport();
+
+  const result = vp.getViewportTargets({
+    getTreeMemories: () => [],
+    getCanonicalRootId: () => 'root',
+    isRootMemory: () => true,
+  });
+
+  assert.equal(result.length, 0);
+});
+
+test('getViewportTargets — missing root helpers returns all memories', () => {
+  const vp = createViewport();
+  const memories = [{ id: 'root' }, { id: 'child' }];
+
+  const result = vp.getViewportTargets({
+    getTreeMemories: () => memories,
+    getCanonicalRootId: undefined,
+    isRootMemory: undefined,
+  });
+
+  assert.equal(result, memories);
+});
+
+test('getViewportTargets — returns visible non-root nodes before canonical root', () => {
+  const vp = createViewport();
+  const memories = [{ id: 'root' }, { id: 'child-1' }, { id: 'child-2' }];
+
+  const result = vp.getViewportTargets({
+    getTreeMemories: () => memories,
+    getCanonicalRootId: () => 'root',
+    isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
+  });
+
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, 'child-1');
+  assert.equal(result[1].id, 'child-2');
+});
+
+test('getViewportTargets — falls back to canonical root when no visible nodes exist', () => {
+  const vp = createViewport();
+  const memories = [{ id: 'root' }];
+
+  const result = vp.getViewportTargets({
+    getTreeMemories: () => memories,
+    getCanonicalRootId: () => 'root',
+    isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
+  });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 'root');
+});

--- a/tests/contracts/editor-viewport-math-contracts.test.cjs
+++ b/tests/contracts/editor-viewport-math-contracts.test.cjs
@@ -462,7 +462,7 @@ test('getViewportTargets — empty memories returns empty array', () => {
     isRootMemory: () => true,
   });
 
-  assert.equal(result.length, 0);
+  assert.deepEqual(result, []);
 });
 
 test('getViewportTargets — missing root helpers returns all memories', () => {
@@ -475,7 +475,7 @@ test('getViewportTargets — missing root helpers returns all memories', () => {
     isRootMemory: undefined,
   });
 
-  assert.equal(result, memories);
+  assert.deepEqual(result, memories);
 });
 
 test('getViewportTargets — returns visible non-root nodes before canonical root', () => {
@@ -488,9 +488,7 @@ test('getViewportTargets — returns visible non-root nodes before canonical roo
     isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
   });
 
-  assert.equal(result.length, 2);
-  assert.equal(result[0].id, 'child-1');
-  assert.equal(result[1].id, 'child-2');
+  assert.deepEqual(result, [{ id: 'child-1' }, { id: 'child-2' }]);
 });
 
 test('getViewportTargets — falls back to canonical root when no visible nodes exist', () => {
@@ -503,6 +501,5 @@ test('getViewportTargets — falls back to canonical root when no visible nodes 
     isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
   });
 
-  assert.equal(result.length, 1);
-  assert.equal(result[0].id, 'root');
+  assert.deepEqual(result, [{ id: 'root' }]);
 });

--- a/tests/contracts/editor-viewport-math-contracts.test.cjs
+++ b/tests/contracts/editor-viewport-math-contracts.test.cjs
@@ -462,7 +462,7 @@ test('getViewportTargets — empty memories returns empty array', () => {
     isRootMemory: () => true,
   });
 
-  assert.deepEqual(result, []);
+  assert.deepEqual(Array.from(result), []);
 });
 
 test('getViewportTargets — missing root helpers returns all memories', () => {
@@ -475,7 +475,7 @@ test('getViewportTargets — missing root helpers returns all memories', () => {
     isRootMemory: undefined,
   });
 
-  assert.deepEqual(result, memories);
+  assert.deepEqual(Array.from(result), memories);
 });
 
 test('getViewportTargets — returns visible non-root nodes before canonical root', () => {
@@ -488,7 +488,7 @@ test('getViewportTargets — returns visible non-root nodes before canonical roo
     isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
   });
 
-  assert.deepEqual(result, [{ id: 'child-1' }, { id: 'child-2' }]);
+  assert.deepEqual(Array.from(result), [{ id: 'child-1' }, { id: 'child-2' }]);
 });
 
 test('getViewportTargets — falls back to canonical root when no visible nodes exist', () => {
@@ -501,5 +501,5 @@ test('getViewportTargets — falls back to canonical root when no visible nodes 
     isRootMemory: (memory, canonicalRootId) => memory.id === canonicalRootId,
   });
 
-  assert.deepEqual(result, [{ id: 'root' }]);
+  assert.deepEqual(Array.from(result), [{ id: 'root' }]);
 });


### PR DESCRIPTION
Refs #1505