### PR TITLE
refactor(editor): split memory form animations CSS

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -16,6 +16,7 @@
 @import url("./editor/editor-floating-toolbar.css?v=20260518-1");
 @import url("./editor/editor-mobile-action-bar.css?v=20260518-1");
 @import url("./editor/editor-memory-form.css");
+@import url("./editor/editor-memory-form-animations.css");
 @import url("./editor/editor-detail-panel.css?v=20260504-627");
 @import url("./editor/editor-detail-content.css?v=20260519-1");
 @import url("./editor/editor-detail-actions.css?v=20260518-1");

--- a/css/editor/editor-memory-form-animations.css
+++ b/css/editor/editor-memory-form-animations.css
@@ -1,0 +1,19 @@
+/*
+ * Editor memory form animation keyframes.
+ *
+ * Extracted from editor-memory-form.css to keep animation definitions
+ * in a dedicated file. Selector-level animation properties remain in
+ * editor-memory-form.css.
+ *
+ * Keyframe names: skeleton-shimmer, newNodePulse
+ */
+
+@keyframes skeleton-shimmer {
+    0% { background-position: 100% 100%; }
+    100% { background-position: 0% 0%; }
+}
+
+@keyframes newNodePulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.15); }
+}

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -418,11 +418,6 @@
     opacity: 0.3;
 }
 
-@keyframes skeleton-shimmer {
-    0% { background-position: 100% 100%; }
-    100% { background-position: 0% 0%; }
-}
-
 .memory-node:hover .node-card,
 .memory-node.selected .node-card {
     transform: scale(1.03);
@@ -436,7 +431,3 @@
     box-shadow: 0 0 0 4px rgba(144, 73, 81, 0.3), 0 25px 50px rgba(144, 73, 81, 0.2) !important;
 }
 
-@keyframes newNodePulse {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(1.15); }
-}


### PR DESCRIPTION
## Summary

- Split `@keyframes skeleton-shimmer` and `@keyframes newNodePulse` from `css/editor/editor-memory-form.css` into dedicated `css/editor/editor-memory-form-animations.css`
- Preserve existing animation names (`skeleton-shimmer`, `newNodePulse`) and all selectors/style values
- Add import immediately after `editor-memory-form.css` in `css/editor.css` to preserve cascade order
- Keep #1604 open for remaining memory form split planning

## Validation

- npm run lint: PASS
- npm run build: PASS
- npm test: 1078 pass, 0 fail
- npm run verify: 242/242 pass

## Scope

- CSS-only narrow split (animation keyframes extraction)
- 3 files changed: editor-memory-form.css (keyframes removed), editor-memory-form-animations.css (new), editor.css (import added)
- No JS runtime changes
- No pages/editor.html changes
- No backend/API/Auth/DB/schema changes
- No selector or style value changes

## Changed Files

| File | Change |
|------|--------|
| `css/editor/editor-memory-form.css` | Removed `@keyframes skeleton-shimmer` (L421-424) and `@keyframes newNodePulse` (L439-442) |
| `css/editor/editor-memory-form-animations.css` | New file with extracted keyframes |
| `css/editor.css` | Added import for `editor-memory-form-animations.css` after `editor-memory-form.css` |

## Animation Names Preserved

- `skeleton-shimmer` — used by `.node-skeleton` selector (animation property remains in editor-memory-form.css)
- `newNodePulse` — used by `.new-node-highlight .node-card` selector (animation property remains in editor-memory-form.css)

## Keyframes Extracted

```css
@keyframes skeleton-shimmer {
    0% { background-position: 100% 100%; }
    100% { background-position: 0% 0%; }
}

@keyframes newNodePulse {
    0%, 100% { transform: scale(1); }
    50% { transform: scale(1.15); }
}
```

## Reference

Refs #1604