### PR TITLE
refactor(editor): split video segment grid CSS

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -18,6 +18,7 @@
 @import url("./editor/editor-memory-form.css");
 @import url("./editor/editor-memory-form-animations.css");
 @import url("./editor/editor-memory-node.css");
+@import url("./editor/editor-memory-video-segments.css");
 @import url("./editor/editor-detail-panel.css?v=20260504-627");
 @import url("./editor/editor-detail-content.css?v=20260519-1");
 @import url("./editor/editor-detail-actions.css?v=20260518-1");

--- a/css/editor/editor-memory-form.css
+++ b/css/editor/editor-memory-form.css
@@ -185,69 +185,6 @@
     line-height: 1.25;
 }
 
-.editor-video-segment-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-areas:
-        "startLabel endLabel"
-        "startInput endInput"
-        "help help";
-    column-gap: 10px;
-    row-gap: 7px;
-    align-items: start;
-    padding: 10px;
-    border: 1px solid rgba(144,73,81,0.08);
-    border-radius: 16px;
-    background: rgba(255, 250, 247, 0.52);
-}
-
-.editor-video-segment-field {
-    display: contents !important;
-}
-
-.editor-video-segment-field-start .editor-form-label {
-    grid-area: startLabel;
-}
-
-.editor-video-segment-field-start .editor-form-input {
-    grid-area: startInput;
-}
-
-.editor-video-segment-field-end .editor-form-label {
-    grid-area: endLabel;
-}
-
-.editor-video-segment-field-end .editor-form-input {
-    grid-area: endInput;
-}
-
-.editor-video-segment-field .editor-form-label {
-    align-self: end;
-    justify-self: start;
-    margin: 0;
-}
-
-.editor-video-segment-field .editor-form-input {
-    width: 100%;
-    height: 42px;
-    min-height: 42px;
-    max-height: 42px;
-    margin: 0;
-    box-sizing: border-box;
-}
-
-.editor-video-segment-help {
-    grid-area: help;
-    margin: 0;
-    padding: 6px 8px;
-    border-radius: 12px;
-    background: rgba(255,255,255,0.42);
-    color: rgba(75, 64, 57, 0.52);
-    font-weight: 600;
-    text-align: center;
-    line-height: 1.3;
-}
-
 .editor-memory-form-modal .memory-link-preview.is-enhanced {
     max-height: 54px;
     margin-top: 0 !important;
@@ -276,17 +213,6 @@
 
     .editor-memory-form-body {
         padding: 16px 14px 9px;
-    }
-
-    .editor-video-segment-grid {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            "startLabel"
-            "startInput"
-            "endLabel"
-            "endInput"
-            "help";
-        padding: 9px;
     }
 
     .editor-memory-form-modal .editor-form-actions {

--- a/css/editor/editor-memory-video-segments.css
+++ b/css/editor/editor-memory-video-segments.css
@@ -1,0 +1,82 @@
+/*
+ * Editor video segment grid styles.
+ *
+ * Extracted from editor-memory-form.css. Covers the YouTube video
+ * segment start/end time grid layout and its mobile responsive override.
+ */
+
+.editor-video-segment-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+        "startLabel endLabel"
+        "startInput endInput"
+        "help help";
+    column-gap: 10px;
+    row-gap: 7px;
+    align-items: start;
+    padding: 10px;
+    border: 1px solid rgba(144,73,81,0.08);
+    border-radius: 16px;
+    background: rgba(255, 250, 247, 0.52);
+}
+
+.editor-video-segment-field {
+    display: contents !important;
+}
+
+.editor-video-segment-field-start .editor-form-label {
+    grid-area: startLabel;
+}
+
+.editor-video-segment-field-start .editor-form-input {
+    grid-area: startInput;
+}
+
+.editor-video-segment-field-end .editor-form-label {
+    grid-area: endLabel;
+}
+
+.editor-video-segment-field-end .editor-form-input {
+    grid-area: endInput;
+}
+
+.editor-video-segment-field .editor-form-label {
+    align-self: end;
+    justify-self: start;
+    margin: 0;
+}
+
+.editor-video-segment-field .editor-form-input {
+    width: 100%;
+    height: 42px;
+    min-height: 42px;
+    max-height: 42px;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+.editor-video-segment-help {
+    grid-area: help;
+    margin: 0;
+    padding: 6px 8px;
+    border-radius: 12px;
+    background: rgba(255,255,255,0.42);
+    color: rgba(75, 64, 57, 0.52);
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.3;
+}
+
+@media (max-width: 560px) {
+    .editor-video-segment-grid {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "startLabel"
+            "startInput"
+            "endLabel"
+            "endInput"
+            "help";
+        padding: 9px;
+    }
+}


### PR DESCRIPTION
## Summary

- Split video segment grid styles from `css/editor/editor-memory-form.css` into dedicated `css/editor/editor-memory-video-segments.css`
- Preserve existing selectors, class names, grid layout, and style values
- Include mobile responsive `@media (max-width: 560px)` override in the new file
- Add import in `css/editor.css` after `editor-memory-node.css` to preserve cascade order
- Keep #1604 open for remaining memory form split planning

## Validation

- npm run lint: PASS
- npm run build: PASS
- npm test: 1079 pass, 0 fail
- npm run verify: 242/242 pass

## Scope

- CSS-only narrow split (video segment grid extraction)
- 3 files changed: editor-memory-form.css (segment selectors removed), editor-memory-video-segments.css (new), editor.css (import added)
- No JS runtime changes
- No pages/editor.html changes
- No backend/API/Auth/DB/schema changes
- No selector, class name, style value, or animation name changes

## Changed Files

| File | Change |
|------|--------|
| `css/editor/editor-memory-form.css` | Removed video segment grid selectors and mobile override (~63 lines) |
| `css/editor/editor-memory-video-segments.css` | New file with extracted video segment grid styles (~83 lines) |
| `css/editor.css` | Added import for `editor-memory-video-segments.css` after `editor-memory-node.css` |

## Selectors Extracted

- `.editor-video-segment-grid` — grid container
- `.editor-video-segment-field` — display: contents wrapper
- `.editor-video-segment-field-start .editor-form-label` — start label grid area
- `.editor-video-segment-field-start .editor-form-input` — start input grid area
- `.editor-video-segment-field-end .editor-form-label` — end label grid area
- `.editor-video-segment-field-end .editor-form-input` — end input grid area
- `.editor-video-segment-field .editor-form-label` — shared label styles
- `.editor-video-segment-field .editor-form-input` — shared input styles
- `.editor-video-segment-help` — help text
- `@media (max-width: 560px) .editor-video-segment-grid` — mobile 1-column override

## Cascade Order

Import sequence in `css/editor.css`:
1. `editor-memory-form.css` — modal/form/sidebar/canvas
2. `editor-memory-form-animations.css` — animation keyframes
3. `editor-memory-node.css` — memory node styles
4. `editor-memory-video-segments.css` — video segment grid (this PR)
5. `editor-detail-panel.css` — detail panel

## Reference

Refs #1604