### PR TITLE
refactor(editor-detail-ui): delegate createEditorDetailUIBuilders to window helper

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -31,51 +31,7 @@ function createEditorDetailUI(deps) {
         return text;
     };
 
-    const createEditorDetailUIBuilders = window.createEditorDetailUIBuilders || function({ formatI18nText }) {
-        const createInlineIcon = (name, size = '12px') => {
-            const icon = document.createElement('span');
-            icon.className = 'material-symbols-outlined';
-            icon.style.fontSize = size;
-            icon.textContent = name;
-            return icon;
-        };
-
-        const getDisplayEmotionTags = (data, options = {}) => {
-            const opts = options || {};
-            const isRootSelected = !!opts.isRootSelected;
-            const isEmptyState = !!opts.isEmptyState;
-            const rawTags = Array.isArray(data?.emotionTags) ? data.emotionTags.filter(Boolean) : [];
-            const normalizedTags = rawTags.map((tag) => {
-                const trimmed = String(tag || '').trim();
-                if (!trimmed) return '';
-                if (trimmed === '기록') {
-                    return formatI18nText('editor_root_emotion_tag', '첫 마음');
-                }
-                return trimmed;
-            }).filter(Boolean);
-
-            if (normalizedTags.length > 0) return normalizedTags;
-            if (!isEmptyState && isRootSelected) return [formatI18nText('editor_root_emotion_tag', '첫 마음')];
-            return [];
-        };
-
-        const getMemoFallbackText = (options = {}) => {
-            const opts = options || {};
-            if (opts.isEmptyState) {
-                return formatI18nText('empty_tree_memo', '아직 비어 있는 자리예요. 첫 순간을 심으면 이 트리가 당신의 흐름으로 자라나기 시작해요.');
-            }
-            if (opts.isRootSelected) {
-                return formatI18nText('editor_root_memo_fallback', '이 장면이 왜 시작이 되었는지 남겨두면, 다음 순간들이 더 자연스럽게 이어져요.');
-            }
-            return formatI18nText('editor_selected_memo_fallback', '이 순간의 마음을 한 줄 남겨두면, 이어진 흐름을 다시 떠올리기 쉬워져요.');
-        };
-
-        return {
-            createInlineIcon,
-            getDisplayEmotionTags,
-            getMemoFallbackText
-        };
-    };
+    const createEditorDetailUIBuilders = window.createEditorDetailUIBuilders;
     const {
         createInlineIcon,
         getDisplayEmotionTags,


### PR DESCRIPTION
## Summary

Delegate the local `createEditorDetailUIBuilders` fallback in `editor-detail-ui.js` to the pre-loaded `window.createEditorDetailUIBuilders` helper.

### Change

- **Remove**: 45-line local fallback body (L34-L78) that duplicated `editor-detail-ui-builders.js` verbatim.
- **Add**: single-line delegation — `const createEditorDetailUIBuilders = window.createEditorDetailUIBuilders;`

### Line count

| File | Before | After | Δ |
|---|---|---|---|
| `js/editor/editor-detail-ui.js` | 530 | 485 | −45 |

### Contract compliance

- `editor-detail-ui-builders.js` is guaranteed to load before `editor-detail-ui.js` by the script-order contract (`tests/contracts/editor-script-order-contract.test.cjs`).
- `window.createEditorDetailUIBuilders` is always present when this file executes; no runtime risk introduced.

### Verification

- `npm test`: 242/242 PASS
- `npm run verify`: 242/242 PASS
- `npm run lint` + `npm run build`: PASS
- Changed file: `js/editor/editor-detail-ui.js` only
- No HTML / CSS / API / auth / schema changes

Refs #1501