### PR TITLE
refactor(search): move page shell bootstrap out of inline script

### DIFF
--- a/js/search/search-page-shell-init.js
+++ b/js/search/search-page-shell-init.js
@@ -1,0 +1,6 @@
+(function initSearchPageShell() {
+  window.LoveTreePageShell.initSharedPage({
+    renderHeader: true,
+    applyI18n: true,
+  });
+})();

--- a/pages/search.html
+++ b/pages/search.html
@@ -177,9 +177,6 @@
      <script src="../js/auth/auth-ui-templates.js?v=20260522-1283"></script>
      <script src="../js/auth.js?v=20260422-3"></script>
      <script src="../js/page-transitions.js?v=20260430-1"></script>
-    <script>LoveTreePageShell.initSharedPage({
-      renderHeader: true,
-      applyI18n: true
-    });</script>
+     <script src="../js/search/search-page-shell-init.js?v=20260525-1629"></script>
 </body>
 </html>


### PR DESCRIPTION
Refs #1629

## Summary

- Move the Search page `LoveTreePageShell.initSharedPage` bootstrap out of an inline `<script>` block.
- Add `js/search/search-page-shell-init.js` as the external bootstrap file.
- Load the new external file at the same end-of-page point after page shell/auth/i18n dependencies.

## Scope

- No CSP header/config changes.
- No Firebase/Auth allowlist changes.
- No Search API/data behavior changes.
- No CSS changes.

## Validation

- Static diff scoped to `pages/search.html` and `js/search/search-page-shell-init.js`.
- Browser smoke still required on Cloudflare Preview for `/search` before merge.