### PR TITLE
feat(editor): refine empty guide UI — visible section headings, emoji, refined copy

### DIFF
--- a/css/editor/editor-canvas.css
+++ b/css/editor/editor-canvas.css
@@ -199,6 +199,14 @@
     margin-top: 8px;
 }
 
+.editor-canvas-empty-guide__section-heading {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: .04em;
+    color: var(--on-surface-variant);
+    text-align: center;
+}
+
 .editor-canvas-empty-guide__structured .btn-round,
 .editor-canvas-empty-guide__structured-btn {
     flex: 1 1 0;

--- a/js/editor/templates/editor-empty-guide-template.js
+++ b/js/editor/templates/editor-empty-guide-template.js
@@ -6,17 +6,19 @@
                 <p class="editor-canvas-empty-guide__desc" id="canvasEmptyGuideDesc">소중한 영상이나 글로 시작해보세요.</p>
 
                 <div class="editor-canvas-empty-guide__structured" aria-label="체계적으로 입력하기">
-                    <button type="button" id="canvasEmptyVideoBtn" class="btn-round btn-primary editor-canvas-empty-guide__structured-btn">영상으로 첫 순간 심기</button>
-                    <button type="button" id="canvasEmptyTextBtn" class="btn-round btn-outline editor-canvas-empty-guide__structured-btn">텍스트로 첫 순간 심기</button>
+                    <div class="editor-canvas-empty-guide__section-heading">체계적으로 입력하기</div>
+                    <button type="button" id="canvasEmptyVideoBtn" class="btn-round btn-primary editor-canvas-empty-guide__structured-btn">🎬 영상으로 시작하기</button>
+                    <button type="button" id="canvasEmptyTextBtn" class="btn-round btn-outline editor-canvas-empty-guide__structured-btn">📝 텍스트로 시작하기</button>
                 </div>
 
                 <div class="editor-canvas-empty-guide__divider" aria-hidden="true">또는</div>
 
                 <div class="editor-canvas-empty-guide__quick" aria-label="빠르게 바로 시작하기">
                     <label class="sr-only" for="canvasEmptyQuickInput" id="canvasEmptyQuickLabel">YouTube 링크 붙여넣기</label>
-                    <input type="url" id="canvasEmptyQuickInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크를 붙여넣어 바로 시작하기" autocomplete="off" inputmode="url">
+                    <div class="editor-canvas-empty-guide__section-heading">빠르게 바로 시작하기</div>
+                    <input type="url" id="canvasEmptyQuickInput" class="editor-canvas-empty-guide__input" placeholder="YouTube 링크 붙여넣기" autocomplete="off" inputmode="url">
                 </div>
-                <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">붙이는 순간 바로 순간이 만들어져요.</p>
+                <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">붙여넣는 순간 바로 생성돼요.</p>
             </div>
     `;
     const mount = document.getElementById('editorEmptyGuideTemplateMount');

--- a/tests/contracts/editor-empty-guide-template-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-template-contract.test.cjs
@@ -14,12 +14,15 @@ test('Empty Guide template helper exists and contains updated structured quick-s
     assert.ok(helperCode.includes('이 트리의 첫 순간을 기록해볼까요?'), 'must include updated title copy');
     assert.ok(helperCode.includes('소중한 영상이나 글로 시작해보세요.'), 'must include updated description copy');
     assert.ok(helperCode.includes('id="canvasEmptyVideoBtn"'), 'must include structured video button');
-    assert.ok(helperCode.includes('영상으로 첫 순간 심기'), 'must include structured video button copy');
+    assert.ok(helperCode.includes('🎬 영상으로 시작하기'), 'must include structured video button copy with emoji');
     assert.ok(helperCode.includes('id="canvasEmptyTextBtn"'), 'must include structured text button');
-    assert.ok(helperCode.includes('텍스트로 첫 순간 심기'), 'must include structured text button copy');
+    assert.ok(helperCode.includes('📝 텍스트로 시작하기'), 'must include structured text button copy with emoji');
     assert.ok(helperCode.includes('id="canvasEmptyQuickInput"'), 'must include quick YouTube input');
-    assert.ok(helperCode.includes('YouTube 링크를 붙여넣어 바로 시작하기'), 'must include quick input placeholder');
-    assert.ok(helperCode.includes('붙이는 순간 바로 순간이 만들어져요.'), 'must explain quick paste behavior');
+    assert.ok(helperCode.includes('YouTube 링크 붙여넣기'), 'must include quick input placeholder');
+    assert.ok(helperCode.includes('붙여넣는 순간 바로 생성돼요.'), 'must explain quick paste behavior');
+    assert.ok(helperCode.includes('class="editor-canvas-empty-guide__section-heading"'), 'must include visible section heading element');
+    assert.ok(helperCode.includes('체계적으로 입력하기'), 'must include structured section visible heading text');
+    assert.ok(helperCode.includes('빠르게 바로 시작하기'), 'must include quick section visible heading text');
 });
 
 test('editor.html uses template mount and removes raw empty guide markup', () => {


### PR DESCRIPTION
**#1503 narrow slice — Empty Guide UI structure refresh**

### Changes
| File | Δ |
|---|---|
| `js/editor/templates/editor-empty-guide-template.js` | +12/-4 |
| `css/editor/editor-canvas.css` | +8/-0 |
| `tests/contracts/editor-empty-guide-template-contract.test.cjs` | +4/-3 |

### What changed
- **Visible section headings**: added `editor-canvas-empty-guide__section-heading` with "체계적으로 입력하기" and "빠르게 바로 시작하기" (was aria-label only)
- **Button copy**: "영상으로 첫 순간 심기" → "🎬 영상으로 시작하기", "텍스트로 첫 순간 심기" → "📝 텍스트로 시작하기"
- **Placeholder**: "YouTube 링크를 붙여넣어 바로 시작하기" → "YouTube 링크 붙여넣기"
- **Hint**: "붙이는 순간 바로 순간이 만들어져요." → "붙여넣는 순간 바로 생성돼요."
- **CSS**: `.editor-canvas-empty-guide__section-heading` (12px, 700 weight, `--on-surface-variant`)

### What did NOT change
- `js/editor/editor-empty-guide-ui.js` — untouched (no runtime logic)
- YouTube paste flow — untouched
- oEmbed logic — untouched
- Modal / data flow — untouched
- `global.css` — untouched
- New CSS files — none added

### Validation
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` — 1180/1180 ✅
- `npm run verify` — 245/245 ✅

Refs #1503