### PR TITLE
docs(css): document variant CSS reference policy

### DIFF
--- a/assets/css/kimi-v2/README.md
+++ b/assets/css/kimi-v2/README.md
@@ -1,0 +1,36 @@
+# assets/css/kimi-v2 — Design Reference Archive
+
+> ⚠️ **This directory is a design reference / variant archive. It is NOT an active runtime CSS entrypoint.**
+
+## Status
+
+| Property | Value |
+|---|---|
+| Type | Design Reference Archive |
+| Active Runtime? | ❌ No |
+| Cleanup target? | ❌ No |
+| Import chain? | Not imported by production pages |
+
+## Purpose
+
+This directory contains CSS from the **Kimi v2 design iteration** of LoveBud. It is retained as a historical design reference to:
+
+- Document the visual design language explored during the Kimi v2 iteration
+- Serve as a reference for the Kimi-inspired design aesthetic
+- Preserve variant styles that may inform future product decisions
+
+## What This Means for Contributors and Agents
+
+- **Do not delete** files in this directory
+- **Do not merge** these styles into active stylesheets
+- **Do not rewrite** tokens or normalize variables here
+- **Do not treat** this directory as dead code or a cleanup candidate
+- **Do not include** these files in CSS audit scope unless a specific promotion decision has been made
+
+Zero-byte files in this directory are intentional archive markers and must not be removed.
+
+## Policy Reference
+
+See [`docs/design/CSS_VARIANT_REFERENCE_POLICY.md`](../../docs/design/CSS_VARIANT_REFERENCE_POLICY.md) for the full policy.
+
+Refs: #1499

--- a/css/gemini-v2/README.md
+++ b/css/gemini-v2/README.md
@@ -1,0 +1,36 @@
+# css/gemini-v2 — Design Reference Archive
+
+> ⚠️ **This directory is a design reference / variant archive. It is NOT an active runtime CSS entrypoint.**
+
+## Status
+
+| Property | Value |
+|---|---|
+| Type | Design Reference Archive |
+| Active Runtime? | ❌ No |
+| Cleanup target? | ❌ No |
+| Import chain? | Not imported by production pages |
+
+## Purpose
+
+This directory contains CSS from the **Gemini v2 design iteration** of LoveBud. It is retained as a historical design reference to:
+
+- Document the visual design language explored during the Gemini v2 iteration
+- Serve as a reference baseline for future Gemini-inspired design work
+- Preserve variant styles that may inform future product decisions
+
+## What This Means for Contributors and Agents
+
+- **Do not delete** files in this directory
+- **Do not merge** these styles into active stylesheets
+- **Do not rewrite** tokens or normalize variables here
+- **Do not treat** this directory as dead code or a cleanup candidate
+- **Do not include** these files in CSS audit scope unless a specific promotion decision has been made
+
+Zero-byte files in this directory are intentional archive markers and must not be removed.
+
+## Policy Reference
+
+See [`docs/design/CSS_VARIANT_REFERENCE_POLICY.md`](../../docs/design/CSS_VARIANT_REFERENCE_POLICY.md) for the full policy.
+
+Refs: #1499

--- a/css/gemini-v3/README.md
+++ b/css/gemini-v3/README.md
@@ -1,0 +1,36 @@
+# css/gemini-v3 — Design Reference Archive
+
+> ⚠️ **This directory is a design reference / variant archive. It is NOT an active runtime CSS entrypoint.**
+
+## Status
+
+| Property | Value |
+|---|---|
+| Type | Design Reference Archive |
+| Active Runtime? | ❌ No |
+| Cleanup target? | ❌ No |
+| Import chain? | Not imported by production pages |
+
+## Purpose
+
+This directory contains CSS from the **Gemini v3 design iteration** of LoveBud. It is retained as a historical design reference to:
+
+- Document the visual design language explored during the Gemini v3 iteration
+- Serve as an evolved reference from Gemini v2, capturing further design progression
+- Preserve variant styles that may inform future product decisions
+
+## What This Means for Contributors and Agents
+
+- **Do not delete** files in this directory
+- **Do not merge** these styles into active stylesheets
+- **Do not rewrite** tokens or normalize variables here
+- **Do not treat** this directory as dead code or a cleanup candidate
+- **Do not include** these files in CSS audit scope unless a specific promotion decision has been made
+
+Zero-byte files in this directory are intentional archive markers and must not be removed.
+
+## Policy Reference
+
+See [`docs/design/CSS_VARIANT_REFERENCE_POLICY.md`](../../docs/design/CSS_VARIANT_REFERENCE_POLICY.md) for the full policy.
+
+Refs: #1499

--- a/css/v2/README.md
+++ b/css/v2/README.md
@@ -1,0 +1,36 @@
+# css/v2 — Design Reference Archive
+
+> ⚠️ **This directory is a design reference / variant archive. It is NOT an active runtime CSS entrypoint.**
+
+## Status
+
+| Property | Value |
+|---|---|
+| Type | Design Reference Archive |
+| Active Runtime? | ❌ No |
+| Cleanup target? | ❌ No |
+| Import chain? | Not imported by production pages |
+
+## Purpose
+
+This directory contains CSS from the **v2 design iteration** of LoveBud. It is retained as a historical design reference to:
+
+- Document design decisions made during the v2 iteration
+- Serve as a reference baseline for future design work
+- Preserve visual variants that may inform future product decisions
+
+## What This Means for Contributors and Agents
+
+- **Do not delete** files in this directory
+- **Do not merge** these styles into active stylesheets
+- **Do not rewrite** tokens or normalize variables here
+- **Do not treat** this directory as dead code or a cleanup candidate
+- **Do not include** these files in CSS audit scope unless a specific promotion decision has been made
+
+Zero-byte files in this directory are intentional archive markers and must not be removed.
+
+## Policy Reference
+
+See [`docs/design/CSS_VARIANT_REFERENCE_POLICY.md`](../../docs/design/CSS_VARIANT_REFERENCE_POLICY.md) for the full policy.
+
+Refs: #1499

--- a/docs/design/CSS_VARIANT_REFERENCE_POLICY.md
+++ b/docs/design/CSS_VARIANT_REFERENCE_POLICY.md
@@ -1,0 +1,90 @@
+# CSS Variant Reference Policy
+
+> **Refs:** #1499  
+> **Status:** Active policy — do not remove or supersede without a product/design decision.
+
+---
+
+## Overview
+
+This repository contains two distinct categories of CSS:
+
+| Category | Description | Examples |
+|---|---|---|
+| **Active Runtime CSS** | Imported by production pages; subject to cleanup, tokenization, and normalization | `css/global.css`, `css/index.css`, `css/editor.css`, etc. |
+| **Design Reference / Variant Archive** | Historical design variants preserved for reference; **not** imported by production pages | `css/v2/`, `css/gemini-v2/`, `css/gemini-v3/`, `assets/css/kimi-v2/` |
+
+---
+
+## Variant Archive Directories
+
+The following directories are **design reference archives** and must be treated as such:
+
+- `css/v2/`
+- `css/gemini-v2/`
+- `css/gemini-v3/`
+- `assets/css/kimi-v2/`
+
+These directories were **intentionally retained** as design reference / variant archives. They are **not** accidental duplicates, dead code, or cleanup candidates.
+
+---
+
+## Rules for Future Audits and Cleanup Tasks
+
+### ✅ Allowed — Active Runtime CSS only
+
+The following operations apply **only** to CSS files that are actively imported by production pages:
+
+- CSS cleanup and dead code removal
+- Design token extraction and substitution
+- Variable normalization
+- Import chain restructuring
+
+### ❌ Prohibited — Variant Archive CSS
+
+The following operations are **prohibited** on variant archive directories without an explicit product/design promotion decision:
+
+- Deletion of files or directories
+- Merging into active stylesheets
+- Token rewriting or normalization
+- Consolidation with other variant directories
+- Modification of the active stylesheet import chain based on archive content
+
+### 🔍 Audit Classification Step (Required)
+
+Before any CSS audit or cleanup task, auditors **must** first classify each CSS file as either:
+
+1. **Active / Imported** — verify the file is referenced in an import chain from a production HTML page
+2. **Reference / Archive** — file exists in a known variant archive directory (see list above)
+
+Only Active/Imported CSS is in scope for cleanup.
+
+---
+
+## Zero-Byte and Placeholder Files
+
+Zero-byte (empty) CSS files within variant archive directories may serve as:
+
+- **Archive markers** — intentionally retained to document the existence of a design iteration
+- **Directory retention stubs** — preventing the directory from being removed by Git
+
+Such files **must not** be deleted solely because they are empty or unreferenced. Their presence is intentional.
+
+---
+
+## Promotion of a Variant to Active Runtime
+
+If a future product or design decision determines that a variant should become the active stylesheet, the following process applies:
+
+1. Open a dedicated PR with a clear product/design rationale
+2. Update the import chain in the relevant HTML pages
+3. Remove or update the README in the promoted directory to reflect its new active status
+4. Update this policy document accordingly
+
+This is the **only** acceptable path for modifying variant archive CSS.
+
+---
+
+## Background
+
+This policy was introduced in response to Issue #1499, where variant CSS directories were mistakenly identified as cleanup candidates. The v2, gemini-v2, gemini-v3, and kimi-v2 CSS directories are **intentional design reference archives**, not accidental duplicates or leftover dead code.


### PR DESCRIPTION
Refs #1499

## Summary

This is a **docs-only PR**. No CSS code, imports, or any runtime files were modified.

Adds documentation to clearly distinguish **design reference / variant archive** CSS directories from **active runtime CSS** entrypoints, so that future contributors and automated agents do not mistakenly treat these directories as cleanup candidates.

## Files Added

| File | Purpose |
|---|---|
| `docs/design/CSS_VARIANT_REFERENCE_POLICY.md` | Top-level policy document defining the two CSS categories and the rules for each |
| `css/v2/README.md` | Marks `css/v2/` as a design reference archive |
| `css/gemini-v2/README.md` | Marks `css/gemini-v2/` as a design reference archive |
| `css/gemini-v3/README.md` | Marks `css/gemini-v3/` as a design reference archive |
| `assets/css/kimi-v2/README.md` | Marks `assets/css/kimi-v2/` as a design reference archive |

## Key Policy Points

- `css/v2/`, `css/gemini-v2/`, `css/gemini-v3/`, `assets/css/kimi-v2/` are **intentional design reference archives**, not dead code or accidental duplicates.
- The cleanup / tokenization scope of #1499 is limited to **active runtime CSS** (files actually imported by production pages).
- Reference CSS must not be deleted, merged, token-rewritten, normalized, or consolidated.
- Zero-byte placeholder files in these directories are intentional archive markers.
- A variant may only be promoted to active runtime via a dedicated product/design decision and a separate PR.
- Future CSS audits must classify files as Active/Imported vs. Reference/Archive **before** taking any action.

## Checklist

- [x] No CSS code changes
- [x] No file deletions
- [x] No token substitutions
- [x] No variant directory consolidation
- [x] No active stylesheet import chain changes
- [x] No UI/design changes
