### PR TITLE
fix(my-trees): reset scroll position on menu navigation

### DIFF
--- a/js/my-trees.js
+++ b/js/my-trees.js
@@ -167,7 +167,7 @@
 
     setTimeout(function() {
       if (typeof previewHub.getSelectedTree === 'function' && previewHub.getSelectedTree()) return;
-      previewHub.onCardClick(trees[0]);
+      previewHub.onCardClick(trees[0], { skipScroll: true });
     }, 0);
   }
 

--- a/js/my-trees/my-trees-preview-hub.js
+++ b/js/my-trees/my-trees-preview-hub.js
@@ -408,8 +408,9 @@
 
     /* ── Card selection handler ── */
 
-    function onCardClick(tree, event) {
+    function onCardClick(tree, options) {
         if (!tree) return;
+        options = options || {};
 
         // Update visual selection state
         var grid = document.getElementById('trees-grid');
@@ -432,19 +433,16 @@
         }
 
         // Show appreciation hub
-        var hasMemories = Array.isArray(tree.memories) && tree.memories.length > 0;
-        if (hasMemories) {
-            showContent(tree);
-        } else {
-            showContent(tree);
-        }
+        showContent(tree);
 
-        // Scroll to hub on mobile
-        var panel = document.getElementById('myTreesHubPanel');
-        if (panel && window.innerWidth <= 768) {
-            setTimeout(function () {
-                panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }, 100);
+        // Scroll to hub on mobile (skip for initial auto-select)
+        if (!options.skipScroll) {
+            var panel = document.getElementById('myTreesHubPanel');
+            if (panel && window.innerWidth <= 768) {
+                setTimeout(function () {
+                    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }, 100);
+            }
         }
     }
 

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>내 러브트리 | LoveTree</title>
+  <script>(function(){try{if('scrollRestoration' in history)history.scrollRestoration='manual'}catch(e){}try{window.scrollTo(0,0)}catch(e){}})()</script>
   <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">


### PR DESCRIPTION
Refs #1671

Root cause:
1. **Browser scroll restoration** (primary): Chrome/Safari restore previous scroll position when returning to a page URL. Mobile menu → My Trees navigation is a full page load, and the browser restores the old scroll position from the prior visit.
2. **autoSelectFirstTree → hub scrollIntoView** (secondary): After renderTrees, autoSelectFirstTree calls previewHub.onCardClick(), which on mobile (≤768px) calls `panel.scrollIntoView()`, scrolling the page down to the hub panel below the tree cards.

Fix:
- `pages/my-trees.html`: Inline `<script>` in `<head>` sets `history.scrollRestoration='manual'` + `scrollTo(0,0)` *before any CSS/JS loads* — prevents browser scroll restoration from kicking in.
- `my-trees-preview-hub.js`: `onCardClick` now accepts `{ skipScroll }` option. Removed redundant if/else (both branches called the same `showContent(tree)`).
- `my-trees.js`: `autoSelectFirstTree` passes `{ skipScroll: true }` so initial page-load auto-selection doesn't trigger mobile scrollIntoView.

Scope: 3 files, +14 −15. No global changes to page-transitions.js. User-initiated card clicks still scroll to hub as intended.