### PR TITLE
ux(my-trees): align naming, menu labels, and hero rhythm

### DIFF
--- a/js/i18n/i18n-my-trees.js
+++ b/js/i18n/i18n-my-trees.js
@@ -32,7 +32,7 @@
     'myTrees.page_title': { ko: '내 러브트리', en: 'My LoveTrees' },
     'myTrees.page_eyebrow': { ko: '내가 키우는 러브트리', en: 'Growing LoveTrees' },
     'myTrees.page_desc': { ko: '첫 순간부터 이어진 마음까지 다시 열어보세요', en: 'Reopen everything from first moments to feelings that followed' },
-    'myTrees.header_create': { ko: '새 트리', en: 'New tree' },
+    'myTrees.header_create': { ko: '새 러브트리', en: 'New LoveTree' },
     'myTrees.summary_total_suffix': { ko: '개의 트리', en: ' trees' },
     'myTrees.summary_public': { ko: '공개', en: 'Public' },
     'myTrees.summary_private': { ko: '비공개', en: 'Private' },

--- a/js/i18n/i18n-shared.js
+++ b/js/i18n/i18n-shared.js
@@ -15,7 +15,7 @@
       en: 'Home'
     },
     'nav.intro': {
-      ko: '러브트리',
+      ko: '러브트리 소개',
       en: 'About'
     },
     'nav.search': {
@@ -23,8 +23,8 @@
       en: 'Browse'
     },
     'nav.myTrees': {
-      ko: '나의트리',
-      en: 'My Trees'
+      ko: '내 러브트리',
+      en: 'My LoveTrees'
     },
     'nav.editor': {
       ko: '편집하기',

--- a/js/my-trees/my-trees-preview-hub.js
+++ b/js/my-trees/my-trees-preview-hub.js
@@ -196,7 +196,7 @@
         els.panel.classList.remove('is-loaded');
         if (els.placeholder) els.placeholder.hidden = false;
         if (els.content) els.content.hidden = true;
-        if (els.badge) els.badge.textContent = i18nHub('', '내 트리', 'My Tree');
+        if (els.badge) els.badge.textContent = i18nHub('', '내 러브트리', 'My LoveTrees');
         _selectedTree = null;
         _expandedFlowKey = null;
     }
@@ -220,7 +220,7 @@
 
         if (els.badge) {
             els.badge.textContent = hasMemories
-                ? i18nHub('', '내 트리', 'My Tree')
+                ? i18nHub('', '내 러브트리', 'My LoveTrees')
                 : i18nHub('', '트리', 'Tree');
         }
 

--- a/pages/my-trees.html
+++ b/pages/my-trees.html
@@ -98,7 +98,7 @@
         <div class="my-trees-hub-header">
           <div class="my-trees-hub-title-group">
             <h3>감상 허브</h3>
-            <span class="my-trees-hub-badge" id="myTreesHubBadge">내 트리</span>
+            <span class="my-trees-hub-badge" id="myTreesHubBadge">내 러브트리</span>
           </div>
         </div>
 


### PR DESCRIPTION
Refs #1669

## Summary

UX copy and typography alignment pass for the personal tree area and related menu labels.

## Changes

| Before | After | Location |
|---|---|---|
| **러브트리** (menu) | **러브트리 소개** | nav.intro ko — explainer menu label |
| **나의트리** (menu) | **내 러브트리** | nav.myTrees ko — personal tree menu label |
| **My Trees** (menu) | **My LoveTrees** | nav.myTrees en — personal tree menu label |
| **새 트리** (CTA) | **새 러브트리** | header_create — My Trees header CTA |
| **내 트리** (hub badge) | **내 러브트리** | HTML + JS hub badge fallbacks |

## Files modified

- `js/i18n/i18n-shared.js` — nav.intro/nav.myTrees labels
- `js/i18n/i18n-my-trees.js` — header_create CTA label
- `pages/my-trees.html` — hub badge hardcoded text
- `js/my-trees/my-trees-preview-hub.js` — hub badge JS fallbacks

## Verified

- npm run verify: **245/245 pass**
- npm test: **1180/1180 pass**
- Hero rhythm alignment: current My Trees header (dashboard compact style) intentionally differs from intro hero (marketing multi-line); no CSS changes needed.

## Non-goals preserved

- No My Trees page redesign
- No tree creation behavior change
- No sorting change
- No backend/API/DB change
- No global design token change