### PR TITLE
ux(menu): polish mobile panel labels and icon rhythm

### DIFF
--- a/css/global/global-header.css
+++ b/css/global/global-header.css
@@ -338,7 +338,6 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
         position: absolute;
         top: calc(100% + 10px);
         right: 16px;
-        left: 16px;
         flex-direction: column;
         align-items: stretch;
         gap: 14px;
@@ -348,7 +347,7 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
         border-radius: 20px;
         box-shadow: 0 16px 40px rgba(75, 64, 57, 0.12);
         backdrop-filter: blur(18px);
-        width: auto;
+        width: min(82vw, 320px);
     }
 
     .main-nav-panel.show {
@@ -391,10 +390,10 @@ html:not(.material-symbols-ready) .mobile-nav-toggle .material-symbols-outlined 
     }
 
     .main-nav-panel {
-        left: 12px;
         right: 12px;
         top: calc(100% + 8px);
         padding: 14px;
+        width: min(84vw, 300px);
     }
 
     .nav-actions {


### PR DESCRIPTION
Refs #1670

## Summary

Narrow the mobile hamburger menu panel from near-full-width to a compact right-aligned sheet, improving the visual rhythm and reducing unused whitespace.

## Changes

| CSS Location | Before | After |
|---|---|---|
| `@media (max-width: 768px)` | `left: 16px; right: 16px; width: auto` (→ near full-width) | `right: 16px; width: min(82vw, 320px)` (→ compact, right-aligned) |
| `@media (max-width: 480px)` | `left: 12px; right: 12px; width: auto` | `right: 12px; width: min(84vw, 300px)` (→ tighter on small screens) |

## What was NOT changed

- Menu labels: already updated in PR #1680 (Refs #1669)
- Menu destinations / routing
- Header structure or JS behavior
- Desktop navigation
- Authentication / profile behavior
- API / DB / backend

## Verified

- `npm run verify`: **245/245 pass**
- `npm test`: **1180/1180 pass**
- No i18n or JS changes needed — i18n-shared.js was NOT re-written