### PR TITLE
fix(editor): add pointer event support for mobile canvas pan and node drag

### DIFF
--- a/js/editor/editor-canvas-interaction-helpers.js
+++ b/js/editor/editor-canvas-interaction-helpers.js
@@ -15,7 +15,7 @@ window.LoveBudEditorCanvasInteractionHelpers = {
     canvas.style.cursor = 'grab';
     canvas.style.touchAction = 'none';
 
-    canvas.addEventListener('mousedown', (event) => {
+    canvas.addEventListener('pointerdown', (event) => {
       if (
         event.target.closest('.memory-node') ||
         event.target.closest('#addMemoryForm') ||
@@ -30,7 +30,7 @@ window.LoveBudEditorCanvasInteractionHelpers = {
       canvas.style.cursor = 'grabbing';
     });
 
-    window.addEventListener('mousemove', (event) => {
+    window.addEventListener('pointermove', (event) => {
       if (viewportState.isDraggingNode && viewportState.dragNodeId) {
         const dx = event.clientX - viewportState.dragStartClientX;
         const dy = event.clientY - viewportState.dragStartClientY;
@@ -58,7 +58,7 @@ window.LoveBudEditorCanvasInteractionHelpers = {
       scheduleInitCanvas();
     });
 
-    window.addEventListener('mouseup', () => {
+    window.addEventListener('pointerup', () => {
       const currentFrame = viewportState.rafFrame;
       if (currentFrame) {
         cancelAnimationFrame(currentFrame);

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -19,7 +19,7 @@ window.LoveBudEditorCanvasInteraction = {
     canvas.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
     canvas.style.touchAction = 'none';
 
-    canvas.addEventListener('mousedown', (event) => {
+    canvas.addEventListener('pointerdown', (event) => {
       if (
         event.target.closest('.memory-node') ||
         event.target.closest('#addMemoryForm') ||
@@ -38,7 +38,7 @@ window.LoveBudEditorCanvasInteraction = {
       canvas.style.cursor = 'grabbing';
     });
 
-    window.addEventListener('mousemove', (event) => {
+    window.addEventListener('pointermove', (event) => {
       if (viewportState.isDraggingNode && viewportState.dragNodeId) {
         const dx = event.clientX - viewportState.dragStartClientX;
         const dy = event.clientY - viewportState.dragStartClientY;
@@ -67,7 +67,7 @@ window.LoveBudEditorCanvasInteraction = {
       scheduleRender();
     });
 
-    window.addEventListener('mouseup', () => {
+    window.addEventListener('pointerup', () => {
       const currentFrame = viewportState.rafFrame;
       if (currentFrame) {
         cancelAnimationFrame(currentFrame);
@@ -112,7 +112,7 @@ window.LoveBudEditorCanvasInteraction = {
     // Disable node drag in structured mode
     if (viewportState.layoutMode === 'structured') return false;
 
-    if (event.button !== 0) return false;
+    if (event.pointerType === 'mouse' && event.button !== 0) return false;
     if (event.target.closest('button')) return false;
     event.preventDefault();
     event.stopPropagation();

--- a/js/editor/editor-canvas-ui-helpers.js
+++ b/js/editor/editor-canvas-ui-helpers.js
@@ -293,14 +293,17 @@ export function bindNodePointerSelection(nodeEl, options) {
 export function bindNodeDragStart(nodeEl, getLayoutMode, onDragStart) {
     if (!nodeEl) return;
 
-    nodeEl.addEventListener('mousedown', (e) => {
+    function handleDragStart(e) {
         const layoutMode = typeof getLayoutMode === 'function' ? getLayoutMode() : null;
         if (layoutMode === 'structured') return;
-        
+
         if (typeof onDragStart === 'function') {
             onDragStart(e);
         }
-    });
+    }
+
+    nodeEl.addEventListener('mousedown', handleDragStart);
+    nodeEl.addEventListener('pointerdown', handleDragStart);
 }
 
 /**


### PR DESCRIPTION
Refs #1672

## Problem

Canvas panning (drag to move the tree view) and node dragging were implemented exclusively with mouse events (`mousedown`/`mousemove`/`mouseup`). The canvas also sets `touchAction: 'none'`, which blocks browser default touch behaviors without providing alternative gesture handlers, making the canvas area effectively non-interactive on touch devices.

## Changes

| File | Before | After |
|---|---|---|
| `editor-canvas-interaction.js` | `mousedown`/`mousemove`/`mouseup` for pan | `pointerdown`/`pointermove`/`pointerup` |
| `editor-canvas-interaction-helpers.js` | Same (fallback module) | Same pointer event migration |
| `editor-canvas-ui-helpers.js` | `bindNodeDragStart`: `mousedown` only | + `pointerdown` listener via shared handler |
| `editor-canvas-interaction.js` `beginNodeDrag` | `event.button !== 0` rejects touch | `pointerType === 'mouse' && button !== 0` allows touch/pen |

## Why PointerEvent

`PointerEvent` API is supported in all modern browsers (Chrome 55+, Safari 13+, Firefox 59+, Edge 79+) and provides unified mouse + touch + pen handling. No 300ms touch delay. Desktop behavior is unchanged — `pointerdown` from a mouse is identical to `mousedown`.

## What still works

- Node selection via touch (`bindNodePointerSelection` in ui-helpers) ✅
- Zoom buttons via `click` ✅
- Control buttons via `touchstart` guard ✅
- Desktop mouse pan/drag ✅

## What was NOT changed

- No API, DB, or backend changes
- No CSS changes
- No editor layout changes
- No touchAction value changes (still 'none' — correct with pointer events)
- No public viewer changes

## Verification

- `npm run verify`: **245/245 pass**
- `npm test`: **1180/1180 pass**