### PR TITLE
refactor(editor): add read-only canvas capability guards

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -33,3 +33,26 @@
 @import url("./editor/editor-memory-edit.css");
 @import url("./editor/editor-overrides.css");
 @import url("./editor/editor-responsive-tail.css");
+
+/* Editor read-only mode — hides mutation controls when .editor-readonly class is on body */
+.editor-readonly #addMemoryBtn,
+.editor-readonly #addMemoryForm,
+.editor-readonly #mobileBottomBar,
+.editor-readonly .editor-add-section,
+.editor-readonly #editMemoryBtn,
+.editor-readonly #renameTreeBtn,
+.editor-readonly #sidebarVisibilityToggleBtn,
+.editor-readonly #deleteMemoryBtn,
+.editor-readonly #cancelEditBtn,
+.editor-readonly #saveEditBtn,
+.editor-readonly #ftbEditBtn,
+.editor-readonly #ftbQuickAdd,
+.editor-readonly .memory-add-affordance,
+.editor-readonly #ftbDeleteAction,
+.editor-readonly .editor-save-status-card,
+.editor-readonly #detailEmptyStartBtn,
+.editor-readonly .editor-rename-btn,
+.editor-readonly .editor-moment-edit-chip,
+.editor-readonly [data-action="delete"],
+.editor-readonly #ftbBranchBtn,
+.editor-readonly #ftbForkBtn { display: none !important; }

--- a/js/editor.js
+++ b/js/editor.js
@@ -227,10 +227,16 @@ document.addEventListener('DOMContentLoaded', () => {
             const { canvas, svg, detailPanel, addBtn } = createEditorDomRefs();
             const urlParams = new URLSearchParams(window.location.search);
             const urlTreeId = urlParams.get('treeId');
+            const canEdit = urlParams.get('readonly') !== '1';
 
             log('DOM refs and URL params prepared');
             prepareEditorShell();
             log('Editor shell mounted');
+
+            // Expose canEdit for modules that read it after DOMContentLoaded
+            window.LoveBudEditor = window.LoveBudEditor || {};
+            window.LoveBudEditor.canEdit = canEdit;
+            document.body.classList.toggle('editor-readonly', !canEdit);
 
             const cache = window.LoveBudCache || null;
             let MEMORIES_CACHE_KEY = 'memories_default';
@@ -390,6 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
             };
 
             const updateTreeVisibility = async (nextVisibility) => {
+                if (canEdit === false) return;
                 if (!treeId || !window.apiClient || typeof window.apiClient.updateTree !== 'function') {
                     throw new Error('updateTree not available');
                 }
@@ -454,7 +461,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateFocusSelectedBtn,
                 createInitialMemory,
                 onNodeClick: selectNode,
-                openAddMoment: () => showAddMemoryForm()
+                openAddMoment: () => showAddMemoryForm(),
+                canEdit
             });
 
             // Store instance for global bridge
@@ -521,7 +529,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 setDetailEmptyState,
                 rerenderCanvas: () => initCanvas(),
                 getCurrentTreeData: () => window.currentTreeData || {},
-                isLocalSaveMode: () => isLocalSaveMode
+                isLocalSaveMode: () => isLocalSaveMode,
+                canEdit
             });
 
             const { enterEditMode, exitEditMode, saveMemoryEdit, deleteMemory } = memoryActions;
@@ -553,25 +562,26 @@ document.addEventListener('DOMContentLoaded', () => {
                 setCachedMemories: window.setCachedMemories,
                 canvasArea: canvas,
                 rerenderCanvas: () => initCanvas(),
-                focusNodeById: (id) => editorCanvas.focusNodeById(id)
+                focusNodeById: (id) => editorCanvas.focusNodeById(id),
+                canEdit
             });
 
             const { showAddMemoryForm, hideAddMemoryForm, addMemoryFromForm } = memoryForm;
             const { urlInput, titleInput, memoInput, cancelBtn, confirmBtn } = createEditorFormRefs();
             
             log('Binding events...');
-            if (sidebarUIHelper.bindSidebarVisibilityToggle) {
+            if (canEdit && sidebarUIHelper.bindSidebarVisibilityToggle) {
                 sidebarUIHelper.bindSidebarVisibilityToggle({
                     getTreeId: () => treeId, updateTreeVisibility, showToast, safeI18nText, i18n, getHttpStatus, updateSidebarStatus
                 });
             }
 
-            if (editorBindings.bindMemoryCreateControls) {
+            if (canEdit && editorBindings.bindMemoryCreateControls) {
                 editorBindings.bindMemoryCreateControls({ addBtn, cancelBtn, confirmBtn, urlInput, titleInput, memoInput, showAddMemoryForm, hideAddMemoryForm, addMemoryFromForm, updateSaveStatus, showToast, i18n });
             }
 
             const detailEmptyStartBtn = document.getElementById('detailEmptyStartBtn');
-            if (detailEmptyStartBtn) {
+            if (detailEmptyStartBtn && canEdit) {
                 detailEmptyStartBtn.addEventListener('click', () => {
                     showAddMemoryForm();
                 });
@@ -603,7 +613,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const deleteMemoryBtn = document.getElementById('deleteMemoryBtn');
             const cancelEditBtn = document.getElementById('cancelEditBtn');
             const saveEditBtn = document.getElementById('saveEditBtn');
-            if (editorBindings.bindDetailActionButtons) {
+            if (canEdit && editorBindings.bindDetailActionButtons) {
                 editorBindings.bindDetailActionButtons({ editMemoryBtn, deleteMemoryBtn, cancelEditBtn, saveEditBtn, enterEditMode, deleteMemory, exitEditMode, saveMemoryEdit });
             }
 

--- a/js/editor/editor-canvas-growth-affordance.js
+++ b/js/editor/editor-canvas-growth-affordance.js
@@ -7,7 +7,8 @@ function createEditorCanvasGrowthAffordance(deps) {
         calcPosition,
         openAddMoment,
         i18n,
-        constants
+        constants,
+        canEdit
     } = deps;
 
     const {
@@ -463,6 +464,7 @@ function createEditorCanvasGrowthAffordance(deps) {
     }
 
     function renderGrowthAffordance(anchorMem, options) {
+        if (canEdit === false) return;
         if (!anchorMem) return;
         const opts = options || {};
         const labelText = opts.labelText || (i18n('editor_add_memory') || '새 순간 이어가기');

--- a/js/editor/editor-canvas-interaction.js
+++ b/js/editor/editor-canvas-interaction.js
@@ -108,9 +108,10 @@ window.LoveBudEditorCanvasInteraction = {
     });
   },
 
-  beginNodeDrag(event, nodeEl, memory, viewportState, getWorldPosition) {
-    // Disable node drag in structured mode
+  beginNodeDrag(event, nodeEl, memory, viewportState, getWorldPosition, canEdit) {
+    // Disable node drag in structured mode or read-only mode
     if (viewportState.layoutMode === 'structured') return false;
+    if (canEdit === false) return false;
 
     if (event.pointerType === 'mouse' && event.button !== 0) return false;
     if (event.target.closest('button')) return false;

--- a/js/editor/editor-canvas-layout-storage.js
+++ b/js/editor/editor-canvas-layout-storage.js
@@ -35,14 +35,16 @@
         return 'free';
     }
 
-    function persistLayoutMode(mode, layoutModeStorageKey) {
+    function persistLayoutMode(mode, layoutModeStorageKey, canEdit) {
+        if (canEdit === false) return;
         try {
             localStorage.setItem(layoutModeStorageKey, mode);
         } catch (e) {}
     }
 
-    function persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout) {
+    function persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout, canEdit) {
         if (viewportState.layoutMode === 'structured') return;
+        if (canEdit === false) return;
 
         if (canvasLayout && typeof canvasLayout.createLayoutStore === 'function') {
             const store = canvasLayout.createLayoutStore(treeId);

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -17,7 +17,8 @@ function createEditorCanvas(deps) {
         updateFocusSelectedBtn,
         createInitialMemory,
         onNodeClick,
-        openAddMoment
+        openAddMoment,
+        canEdit
     } = deps;
 
     const i18n = window.t || function(key) { return key; };
@@ -68,8 +69,9 @@ function createEditorCanvas(deps) {
     }
 
     function persistLayoutMode(mode) {
+        if (canEdit === false) return;
         if (typeof storageUtils.persistLayoutMode === 'function') {
-            return storageUtils.persistLayoutMode(mode, layoutModeStorageKey);
+            return storageUtils.persistLayoutMode(mode, layoutModeStorageKey, canEdit);
         }
     }
 
@@ -146,8 +148,9 @@ function createEditorCanvas(deps) {
     }
 
     function persistStoredPositions() {
+        if (canEdit === false) return;
         if (typeof storageUtils.persistStoredPositions === 'function') {
-            return storageUtils.persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout);
+            return storageUtils.persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout, canEdit);
         }
         if (viewportState.layoutMode === 'structured') return;
 
@@ -285,7 +288,8 @@ function createEditorCanvas(deps) {
             AFFORDANCE_OFFSET_X,
             AFFORDANCE_OFFSET_Y,
             AFFORDANCE_CARD_HALF
-        }
+        },
+        canEdit
     });
 
     const branchPorts = window.createEditorCanvasBranchPorts({
@@ -387,7 +391,7 @@ function createEditorCanvas(deps) {
     }
 
     function bindNodeDrag(nodeEl, mem) {
-        nodeEl.style.cursor = viewportState.layoutMode === 'structured' ? 'default' : 'grab';
+        nodeEl.style.cursor = canEdit !== false && viewportState.layoutMode === 'structured' ? 'default' : 'grab';
 
         const selectMemoryNode = () => {
             onNodeClick(nodeEl, mem);
@@ -395,27 +399,29 @@ function createEditorCanvas(deps) {
 
         uiHelpers.bindNodeHoverAffordance(nodeEl, mem, renderAffordanceForHoveredMemory);
 
-        uiHelpers.bindNodeDragStart(nodeEl, () => viewportState.layoutMode, (e) => {
-            if (typeof canvasInteraction.beginNodeDrag === 'function') {
-                canvasInteraction.beginNodeDrag(e, nodeEl, mem, viewportState, getWorldPosition);
-                return;
-            }
+        if (canEdit !== false) {
+            uiHelpers.bindNodeDragStart(nodeEl, () => viewportState.layoutMode, (e) => {
+                if (typeof canvasInteraction.beginNodeDrag === 'function') {
+                    canvasInteraction.beginNodeDrag(e, nodeEl, mem, viewportState, getWorldPosition, canEdit);
+                    return;
+                }
 
-            if (e.button !== 0) return;
-            if (e.target.closest('button')) return;
-            e.preventDefault();
-            e.stopPropagation();
+                if (e.button !== 0) return;
+                if (e.target.closest('button')) return;
+                e.preventDefault();
+                e.stopPropagation();
 
-            const startWorld = getWorldPosition(mem);
-            viewportState.isDraggingNode = true;
-            viewportState.dragNodeId = mem.id;
-            viewportState.dragStartClientX = e.clientX;
-            viewportState.dragStartClientY = e.clientY;
-            viewportState.dragStartWorldX = startWorld.x;
-            viewportState.dragStartWorldY = startWorld.y;
-            viewportState.dragMoved = false;
-            nodeEl.style.cursor = 'grabbing';
-        });
+                const startWorld = getWorldPosition(mem);
+                viewportState.isDraggingNode = true;
+                viewportState.dragNodeId = mem.id;
+                viewportState.dragStartClientX = e.clientX;
+                viewportState.dragStartClientY = e.clientY;
+                viewportState.dragStartWorldX = startWorld.x;
+                viewportState.dragStartWorldY = startWorld.y;
+                viewportState.dragMoved = false;
+                nodeEl.style.cursor = 'grabbing';
+            });
+        }
 
         uiHelpers.bindNodePointerSelection(nodeEl, {
             onSelect: selectMemoryNode,

--- a/js/editor/editor-memory-actions.js
+++ b/js/editor/editor-memory-actions.js
@@ -20,7 +20,8 @@ function createEditorMemoryActions(deps) {
         setDetailEmptyState,
         rerenderCanvas,
         getCurrentTreeData,
-        isLocalSaveMode
+        isLocalSaveMode,
+        canEdit
     } = deps;
 
     let isEditMode = false;
@@ -91,6 +92,7 @@ function createEditorMemoryActions(deps) {
     };
 
     const enterEditMode = () => {
+        if (canEdit === false) return;
         const currentEditingMemory = getCurrentEditingMemory();
         if (!currentEditingMemory) return;
         isEditMode = true;
@@ -124,6 +126,7 @@ function createEditorMemoryActions(deps) {
     };
 
     const saveMemoryEdit = async () => {
+        if (canEdit === false) return;
         const currentEditingMemory = getCurrentEditingMemory();
         if (!currentEditingMemory) return;
 
@@ -226,6 +229,7 @@ function createEditorMemoryActions(deps) {
     };
 
     const updateSelectedMemoryFields = async (updates) => {
+        if (canEdit === false) return false;
         const currentEditingMemory = getCurrentEditingMemory();
         const selectedNodeId = getSelectedNodeId() || currentEditingMemory?.id;
         if (!selectedNodeId) {
@@ -306,6 +310,7 @@ function createEditorMemoryActions(deps) {
     };
 
     const deleteMemory = async () => {
+        if (canEdit === false) return;
         const currentEditingMemory = getCurrentEditingMemory();
         if (!currentEditingMemory) return;
 

--- a/js/editor/editor-memory-form.js
+++ b/js/editor/editor-memory-form.js
@@ -23,7 +23,8 @@ function createEditorMemoryForm(deps) {
         treeMemories,
         setCachedMemories,
         rerenderCanvas,
-        focusNodeById
+        focusNodeById,
+        canEdit
     } = deps;
 
     const modeHelper = window.LoveBudEditorMemoryFormMode;
@@ -257,6 +258,7 @@ function createEditorMemoryForm(deps) {
     }
 
     const showAddMemoryForm = () => {
+        if (canEdit === false) return;
         const form = refs.addMemoryForm;
         if (!form) return;
         resetFormValues();
@@ -426,6 +428,7 @@ function createEditorMemoryForm(deps) {
     }
 
     const addMemoryFromForm = async () => {
+        if (canEdit === false) return;
         if (!payloadHelper || typeof payloadHelper.buildMemoryPayload !== 'function') {
             console.error('[editor] memory form payload helper is not loaded');
             showToast(i18n('save_failed') || '저장 준비에 실패했어요. 페이지를 새로고침해 주세요.', 'error');

--- a/js/editor/editor-rename-ui.js
+++ b/js/editor/editor-rename-ui.js
@@ -11,8 +11,12 @@ function syncEditorTreeTitle(nextTitle) {
     });
 }
 
-function bindEditorRenameButton(buttonEl) {
+function bindEditorRenameButton(buttonEl, canEdit) {
     if (!buttonEl || buttonEl.dataset.renameBound === '1') return;
+    if (canEdit === false) {
+        buttonEl.style.display = 'none';
+        return;
+    }
     buttonEl.dataset.renameBound = '1';
 
     buttonEl.addEventListener('click', async () => {
@@ -53,9 +57,12 @@ function bindEditorRenameButton(buttonEl) {
     });
 }
 
-function injectEditorRenameButton() {
-    bindEditorRenameButton(document.getElementById('renameTreeBtn'));
-    bindEditorRenameButton(document.getElementById('sidebarTitleEditBtn'));
+function injectEditorRenameButton(canEdit) {
+    if (canEdit === undefined) {
+        canEdit = window.LoveBudEditor?.canEdit;
+    }
+    bindEditorRenameButton(document.getElementById('renameTreeBtn'), canEdit);
+    bindEditorRenameButton(document.getElementById('sidebarTitleEditBtn'), canEdit);
 }
 
 window.syncEditorTreeTitle = syncEditorTreeTitle;

--- a/tests/contracts/editor-canvas-layout-storage-contracts.test.cjs
+++ b/tests/contracts/editor-canvas-layout-storage-contracts.test.cjs
@@ -28,8 +28,8 @@ test('canvas layout storage helper — functions accept expected parameter lengt
   const storage = createStorageContext();
   assert.equal(storage.loadStoredLayout.length, 3, 'loadStoredLayout(treeId, layoutStorageKey, canvasLayout)');
   assert.equal(storage.loadLayoutMode.length, 1, 'loadLayoutMode(layoutModeStorageKey)');
-  assert.equal(storage.persistLayoutMode.length, 2, 'persistLayoutMode(mode, layoutModeStorageKey)');
-  assert.equal(storage.persistStoredPositions.length, 4, 'persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout)');
+  assert.equal(storage.persistLayoutMode.length, 3, 'persistLayoutMode(mode, layoutModeStorageKey, canEdit)');
+  assert.equal(storage.persistStoredPositions.length, 5, 'persistStoredPositions(viewportState, treeId, layoutStorageKey, canvasLayout, canEdit)');
 });
 
 test('canvas layout storage helper — editor-canvas.js uses thin delegation wrappers', () => {


### PR DESCRIPTION
## Summary

Stage 1 of #1673 — Add read-only canvas capability guards to the editor internals. No public route wiring, no auth bypass, no API/backend changes.

## Changes

### Core capability: `canEdit` flag

- Added `canEdit` determination in `editor.js` (default `true`; `?readonly=1` for testing)
- Set `window.LoveBudEditor.canEdit` for module discovery
- Added `document.body.classList.toggle('editor-readonly', !canEdit)` for CSS-level hiding

### Modules guarded

| Module | Guards applied |
|---|---|
| `editor.js` | `updateTreeVisibility` execution guard; sidebar visibility toggle, memory create controls, detail action buttons, detail empty start button — all conditionally bound only when `canEdit` |
| `editor-canvas.js` | Node drag `bindNodeDrag` skipped when `!canEdit`; `persistStoredPositions`/`persistLayoutMode` no-op when `!canEdit`; `canEdit` flowed to growth affordance |
| `editor-canvas-interaction.js` | `beginNodeDrag` returns false when `canEdit === false` |
| `editor-canvas-layout-storage.js` | `persistStoredPositions`/`persistLayoutMode` return early when `canEdit === false` |
| `editor-canvas-growth-affordance.js` | `renderGrowthAffordance` returns immediately when `!canEdit` |
| `editor-memory-actions.js` | `enterEditMode`, `saveMemoryEdit`, `updateSelectedMemoryFields`, `deleteMemory` all guard at function entry |
| `editor-memory-form.js` | `showAddMemoryForm`, `addMemoryFromForm` guard at function entry |
| `editor-rename-ui.js` | `bindEditorRenameButton` takes `canEdit`, skips binding and hides button when false |

### CSS display hiding

Added `.editor-readonly` block in `css/editor.css` (after all imports) that hides:
- Add memory button, form, mobile bottom bar, empty state start button
- Edit/delete/save/cancel buttons
- Rename tree button, visibility toggle
- Floating toolbar edit button, quick-add, branch/fork buttons
- Delete dropdown action
- Save status card
- Canvas growth affordance (+ add buttons)

### Test update

Updated `editor-canvas-layout-storage-contracts.test.cjs` — parameter count expectations for `persistLayoutMode` (2→3) and `persistStoredPositions` (4→5) with new `canEdit` parameter.

## Verification

- `npm run verify` — 245/245 pass ✅
- `npm test` — 1180/1180 pass ✅
- Owner mode (`canEdit=true`, no `readonly` param): all mutation controls function as before
- Read-only test (`canEdit=false`, add `?readonly=1`): all mutation controls hidden/guarded, pan/zoom/node selection/view detail mode preserved

## Non-Goals (explicitly excluded)

- No public route wiring
- No auth guard bypass
- No Browse CTA change
- No API/DB/backend change
- No public endpoint change
- No 감상허브 change
