### PR TITLE
feat(viewer): add public read-only canvas data bridge

### DIFF
--- a/js/viewer/public-canvas-bridge.js
+++ b/js/viewer/public-canvas-bridge.js
@@ -1,0 +1,106 @@
+(function() {
+    'use strict';
+
+    var MARKER = 'LoveBudPublicCanvasBridgeLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    /**
+     * LoveBud Public Canvas Bridge
+     * 
+     * Fetches public tree data via public API endpoints and normalizes
+     * the payload to the editor canvas shape.
+     * 
+     * Security: only uses publicRead=true fetch (no auth headers).
+     * Private trees are never returned by the public endpoint.
+     */
+    function loadPublicTreeData(treeId) {
+        if (!treeId) return Promise.reject(new Error('treeId required'));
+
+        var apiFetch = window.LoveTreeBaseApiFetch && window.LoveTreeBaseApiFetch.apiFetch;
+        if (typeof apiFetch !== 'function') {
+            return Promise.reject(new Error('LoveTreeBaseApiFetch.apiFetch not available'));
+        }
+
+        var communityApi = window.apiClient && (
+            window.apiClient.communityApi ||
+            (window.apiClient.getCachedCommunityMemories ? { getCachedCommunityMemories: window.apiClient.getCachedCommunityMemories } : null)
+        );
+
+        var getCommunityMemories = communityApi && (
+            typeof communityApi.getCachedCommunityMemories === 'function'
+                ? function() { return communityApi.getCachedCommunityMemories({ treeId: treeId, limit: 100 }); }
+                : null
+        );
+
+        return apiFetch('/trees/' + encodeURIComponent(treeId), { publicRead: true })
+            .then(function(tree) {
+                if (!tree || !tree.id) {
+                    throw new Error('Tree not found or not public');
+                }
+                return tree;
+            })
+            .then(function(tree) {
+                if (typeof getCommunityMemories !== 'function') {
+                    return { tree: tree, memories: [] };
+                }
+                return getCommunityMemories().then(function(memories) {
+                    return { tree: tree, memories: Array.isArray(memories) ? memories : [] };
+                });
+            });
+    }
+
+    /**
+     * Normalize public tree + memories to the editor canvas shape.
+     * Sets window.currentTreeData and window.currentTreeMemories.
+     */
+    function normalizeForCanvas(tree, rawMemories) {
+        var treeData = {
+            id: tree.id || tree.treeId || '',
+            title: tree.title || '',
+            visibility: 'public',
+            stage: tree.stage || '',
+            memoryCount: Array.isArray(rawMemories) ? rawMemories.length : 0
+        };
+
+        var normalize = function(mem) {
+            if (!mem) return null;
+            return {
+                id: mem.id,
+                treeId: mem.treeId || mem.tree_id || tree.id,
+                parentId: mem.parentId ?? mem.parent_id ?? null,
+                title: mem.title || '',
+                memo: mem.memo || mem.description || mem.emotionMemo || '',
+                quote: mem.quote || '',
+                timestamp: mem.timestamp || '',
+                thumbnail: mem.thumbnail || '',
+                visibility: 'public',
+                artist: mem.artist || '',
+                source: mem.source || '',
+                sourceUrl: mem.sourceUrl || mem.source_url || '',
+                sourceType: mem.sourceType || mem.source_type || 'youtube',
+                emotionTags: mem.emotionTags || mem.emotion_tags || [],
+                createdAt: mem.createdAt || mem.created_at || null,
+                updatedAt: mem.updatedAt || mem.updated_at || null
+            };
+        };
+
+        var normalizedMemories = (Array.isArray(rawMemories) ? rawMemories : [])
+            .map(normalize)
+            .filter(Boolean);
+
+        // Set window globals expected by createEditorCanvas
+        window.currentTreeData = treeData;
+        window.currentTreeMemories = normalizedMemories;
+
+        return {
+            treeData: treeData,
+            treeMemories: normalizedMemories
+        };
+    }
+
+    window.LoveBudPublicCanvasBridge = {
+        loadPublicTreeData: loadPublicTreeData,
+        normalizeForCanvas: normalizeForCanvas
+    };
+})();

--- a/js/viewer/public-canvas-test-init.js
+++ b/js/viewer/public-canvas-test-init.js
@@ -1,0 +1,249 @@
+(function() {
+    'use strict';
+
+    var MARKER = 'LoveBudPublicCanvasTestInitLoaded';
+    if (window[MARKER]) return;
+    window[MARKER] = true;
+
+    function escapeHtml(value) {
+        var sec = window.LoveBudSecurity;
+        if (sec && typeof sec.escapeHtml === 'function') return sec.escapeHtml(value);
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function initTestPage() {
+        var params = new URLSearchParams(window.location.search);
+        var treeId = params.get('treeId');
+        if (!treeId) {
+            var errEl = document.createElement('div');
+            errEl.style.cssText = 'padding:2rem;text-align:center;font-size:1.2rem;';
+            errEl.textContent = 'treeId parameter required. Usage: ?treeId=<id>';
+            document.body.appendChild(errEl);
+            return;
+        }
+
+        // Apply editor-readonly class for CSS hiding of mutation controls
+        document.body.classList.add('editor-readonly');
+        document.body.classList.remove('editor-preload');
+
+        var bridge = window.LoveBudPublicCanvasBridge;
+        if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {
+            console.error('[public-canvas-test] Bridge not loaded');
+            return;
+        }
+
+        bridge.loadPublicTreeData(treeId).then(function(result) {
+            var tree = result.tree;
+            var memories = result.memories;
+
+            // Normalize to canvas shape
+            var normalized = bridge.normalizeForCanvas(tree, memories);
+            console.log('[public-canvas-test] Loaded tree:', normalized.treeData.id, 'memories:', normalized.treeMemories.length);
+
+            // Wait for all required modules
+            var maxWait = 100;
+            var waitInterval = 50;
+
+            function waitForModules(attempt) {
+                if (attempt >= maxWait) {
+                    console.error('[public-canvas-test] Timeout waiting for editor modules');
+                    return;
+                }
+
+                var canvasReady = typeof window.createEditorCanvas === 'function';
+                var detailReady = typeof window.createEditorDetailUI === 'function';
+                var detailUIBuildersReady = typeof window.createEditorDetailUIBuilders === 'function';
+                var edgesReady = typeof window.createEditorCanvasEdges === 'function';
+
+                if (canvasReady && detailReady && detailUIBuildersReady) {
+                    startCanvas();
+                    return;
+                }
+                setTimeout(function() { waitForModules(attempt + 1); }, waitInterval);
+            }
+
+            function startCanvas() {
+                var canvas = document.getElementById('canvasArea');
+                var svg = document.getElementById('canvasSvg');
+                var detailPanel = document.getElementById('detailPanel');
+
+                if (!canvas || !svg) {
+                    console.error('[public-canvas-test] Canvas or SVG element not found');
+                    return;
+                }
+
+                // Set up empty guide UI
+                var emptyGuideHelper = window.LoveBudEditorEmptyGuideUI || {};
+                var updateCanvasEmptyGuide = function() {
+                    var guide = document.getElementById('canvasEmptyGuide');
+                    if (!guide) return;
+                    var hasMoments = normalized.treeMemories.length > 0;
+                    guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
+                };
+
+                // Resolve root helpers
+                var rootUtils = window.LoveBudEditorUtils || {};
+                var getCanonicalRootId = rootUtils.getCanonicalRootId || (function() {
+                    var mems = function() { return normalized.treeMemories; };
+                    return function() {
+                        var root = mems().filter(function(m) { return m.parentId === null || m.parentId === undefined; });
+                        if (root.length === 0) return 'root';
+                        return root.sort(function(a, b) {
+                            return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
+                        })[0].id;
+                    };
+                })();
+
+                var isRootMemory = rootUtils.isRootMemory || function(mem, rootId) {
+                    return !!(mem && rootId && mem.id === rootId);
+                };
+
+                var canonicalRootId = getCanonicalRootId();
+
+                // Create noop stubs for mutation functions
+                var noop = function() {};
+                var noopAsync = function() { return Promise.resolve(); };
+                var noopFalseAsync = function() { return Promise.resolve(false); };
+
+                // Initially select first non-root memory or first memory
+                var selectedNodeId = canonicalRootId;
+                var currentEditingMemory = null;
+
+                function findFirstSelectableMemory() {
+                    var nonRoot = normalized.treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });
+                    return nonRoot.length > 0 ? nonRoot[0] : normalized.treeMemories[0] || null;
+                }
+
+                // Initialize detail UI
+                var formatI18nText = function(key, fallback) { return fallback || key; };
+                var showToast = function(msg) { console.log('[public-canvas-toast]', msg); };
+
+                var detailUIBuilders = window.createEditorDetailUIBuilders({ formatI18nText: formatI18nText });
+                var treeMetaBoundary = window.createEditorDetailTreeMetaBoundary({
+                    i18n: function(k) { return k; },
+                    formatI18nText: formatI18nText,
+                    resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
+                    createInlineIcon: detailUIBuilders.createInlineIcon,
+                    showToast: showToast,
+                    openCurrentMomentDetail: function() {
+                        var mem = currentEditingMemory || findFirstSelectableMemory();
+                        if (mem && mem.id) {
+                            window.location.href = 'detail.html?id=' + encodeURIComponent(mem.id) + '&tree=' + encodeURIComponent(treeId) + '&from=public';
+                        }
+                    }
+                });
+
+                var detailUI = window.createEditorDetailUI({
+                    detailPanel: detailPanel,
+                    i18n: function(k) { return k; },
+                    resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
+                    resolveHintText: function() { return ''; },
+                    resolveInfoText: function() { return ''; },
+                    resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                    escapeHtml: escapeHtml,
+                    isRootMemory: isRootMemory,
+                    getCanonicalRootId: function() { return canonicalRootId; },
+                    getSelectedNodeId: function() { return selectedNodeId; },
+                    getTreeMemories: function() { return normalized.treeMemories; },
+                    getCurrentTreeData: function() { return window.currentTreeData || {}; },
+                    getLocalSaveMode: function() { return false; },
+                    showToast: showToast,
+                    updateTreeVisibility: noopAsync,
+                    openCurrentMomentDetail: noop,
+                    focusSelectedMoment: noop,
+                    updateSelectedMemoryFields: noopFalseAsync
+                });
+
+                var setDetailEmptyState = detailUI.setDetailEmptyState;
+                var updateFocusSelectedBtn = detailUI.updateFocusSelectedBtn;
+                var updateSidebarStatus = detailUI.updateSidebarStatus;
+                var updateDetailPanel = detailUI.updateDetailPanel;
+
+                // Select first memory
+                var firstSelectable = findFirstSelectableMemory();
+                if (firstSelectable) {
+                    selectedNodeId = firstSelectable.id;
+                    currentEditingMemory = firstSelectable;
+                }
+
+                // Create canvas instance
+                var editorCanvas = window.createEditorCanvas({
+                    canvas: canvas,
+                    svg: svg,
+                    getTreeMemories: function() { return normalized.treeMemories; },
+                    getCanonicalRootId: function() { return canonicalRootId; },
+                    isRootMemory: isRootMemory,
+                    resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                    updateDetailPanel: updateDetailPanel,
+                    setDetailEmptyState: setDetailEmptyState,
+                    updateFocusSelectedBtn: updateFocusSelectedBtn,
+                    createInitialMemory: function() {
+                        return { id: 'root', title: normalized.treeData.title || '러브트리', parentId: null };
+                    },
+                    onNodeClick: function(el, data) {
+                        if (!data) return;
+                        selectedNodeId = data.id;
+                        currentEditingMemory = data;
+                        document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
+                        if (el) el.classList.add('selected');
+                        updateDetailPanel(data);
+                        updateFocusSelectedBtn();
+                        setDetailEmptyState(false);
+                        if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
+                            editorCanvas.updateAffordance();
+                        }
+                    },
+                    openAddMoment: noop,
+                    canEdit: false
+                });
+
+                // Store instance
+                if (canvas) canvas.__editorCanvasInstance = editorCanvas;
+                window.LoveBudEditor = window.LoveBudEditor || {};
+                window.LoveBudEditor.canEdit = false;
+
+                // Initialize canvas
+                if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {
+                    editorCanvas.initCanvas();
+                }
+
+                updateCanvasEmptyGuide();
+                updateSidebarStatus();
+
+                // Select first memory in detail panel
+                if (currentEditingMemory) {
+                    updateDetailPanel(currentEditingMemory);
+                    setDetailEmptyState(false);
+                }
+
+                console.log('[public-canvas-test] Canvas initialized successfully');
+            }
+
+            waitForModules(0);
+        }).catch(function(error) {
+            console.error('[public-canvas-test] Load failed:', error);
+            var container = document.getElementById('canvasArea');
+            if (container) {
+                var errState = document.createElement('div');
+                errState.style.cssText = 'display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:2rem;text-align:center;';
+                errState.innerHTML =
+                    '<span class="material-symbols-outlined" style="font-size:48px;color:var(--error);margin-bottom:16px;">error_outline</span>' +
+                    '<h2 style="margin:0 0 8px;">' + escapeHtml('트리를 불러올 수 없어요') + '</h2>' +
+                    '<p style="margin:0;color:var(--on-surface-variant);">' + escapeHtml(error.message || 'Public endpoint returned an error') + '</p>';
+                container.textContent = '';
+                container.appendChild(errState);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTestPage);
+    } else {
+        initTestPage();
+    }
+})();

--- a/pages/public-canvas-test.html
+++ b/pages/public-canvas-test.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Public LoveTree Canvas Test | LoveBud</title>
+    <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.ico" sizes="32x32">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1006">
+    <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+    <style>
+        /* Test page: ensure canvas fills viewport */
+        body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
+        .editor-layout { flex: 1; }
+    </style>
+</head>
+<body class="editor-preload">
+    <div class="noise-overlay"></div>
+
+    <div id="shared-header"></div>
+
+    <div class="editor-layout page-transition-enter">
+        <main class="canvas-area reveal-scale reveal-up" id="canvasArea">
+            <div id="editorCanvasTopbarTemplateMount"></div>
+            <svg class="canvas-svg" id="canvasSvg"></svg>
+            <div id="editorFloatingToolbarTemplateMount"></div>
+            <div id="editorEmptyGuideTemplateMount"></div>
+        </main>
+        <div id="editorDetailPanelShellTemplateMount"></div>
+    </div>
+
+    <!-- Utility scripts -->
+    <script src="../js/cache-utils.js?v=20260418-1"></script>
+    <script src="../js/utils/normalize.js?v=20260422-1"></script>
+    <script src="../js/utils/path.js?v=20260418-1"></script>
+    <script src="../js/utils/ui.js?v=20260418-1"></script>
+    <script src="../js/utils/media.js?v=20260418-1"></script>
+
+    <!-- Editor templates (view-mode only, no edit/add forms) -->
+    <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-floating-toolbar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-panel-shell-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260525-1280"></script>
+
+    <!-- Canvas core modules -->
+    <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-scale.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-projection.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-targets.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-feedback.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-state.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-fit.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-initial.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-branches.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
+
+    <!-- Floating toolbar -->
+    <script src="../js/editor/editor-floating-toolbar-actions.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-keyboard.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-tooltip.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-dropdown.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-positioning.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-affordance.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-visibility.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-events.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-selection.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-elements.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
+
+    <!-- Canvas support -->
+    <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
+    <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
+    <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
+    <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
+
+    <!-- Detail panel -->
+    <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
+    <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
+
+    <!-- API scripts (no Firebase/ auth) -->
+    <script src="../js/api/auth-policy.js?v=20260420-1"></script>
+    <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
+    <script src="../js/postgres-client.js?v=20260422-1"></script>
+
+    <!-- i18n -->
+    <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
+    <script src="../js/i18n.js?v=20260419-2"></script>
+
+    <!-- Shared header (no auth scripts — lightweight) -->
+    <script src="../js/shared-header.js?v=20260421-2"></script>
+
+    <!-- Public canvas bridge -->
+    <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
+
+    <!-- Test page init -->
+    <script src="../js/viewer/public-canvas-test-init.js?v=20260525-1"></script>
+</body>
+</html>

--- a/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
+++ b/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
@@ -124,6 +124,10 @@ const FILE_ALLOWLIST = {
     count: 11, classification: 'safe',
     reason: 'All user content escaped via escapeHtml/sanitizeUrl; clear-container for list; static no-media divs'
   },
+  'js/viewer/public-canvas-test-init.js': {
+    count: 1, classification: 'safe',
+    reason: 'Dev test page. innerHTML on fresh element with escapeHtml for all user content; uses textContent for primary error'
+  },
   'js/viewer/viewer-init-flow.js': {
     count: 1, classification: 'safe',
     reason: 'Panels.renderPanel — approved template renderer with internal escaping'


### PR DESCRIPTION
## Summary

Stage 2 of #1673 — Public tree data bridge + route adapter for read-only canvas.

## Changes

### New: `js/viewer/public-canvas-bridge.js` (+106)
- `LoveBudPublicCanvasBridge` namespace
- `loadPublicTreeData(treeId)` — fetches tree via `BaseApiFetch.apiFetch('/trees/:id', { publicRead: true })` (no auth) + public memories via `communityApi.getCachedCommunityMemories()`
- `normalizeForCanvas(tree, memories)` — normalizes to `window.currentTreeData` + `window.currentTreeMemories` (editor canvas shape)

### New: `js/viewer/public-canvas-test-init.js` (+249)
- DOM init script for test page
- Reads `?treeId=X` from URL
- Loads public tree data via bridge
- Initializes `createEditorCanvas` with `canEdit=false`
- Sets up `createEditorDetailUI` with noop stubs for mutation functions
- Hooks up node selection → detail panel update
- Error display with `escapeHtml` for user content

### New: `pages/public-canvas-test.html` (+129)
- Manual/test page loaded as: `public-canvas-test.html?treeId=X`
- Loads only canvas modules (no auth/Firebase/mutation scripts)
- Uses global.css + editor.css + page-transitions.css
- Has same canvas/toolbar/detail-panel structure as editor.html
- **No auth guard, no Firebase, no mutation scripts**

### Updated: `dom-xss-renderer-guardrail-contract.test.cjs` (+4)
- Allowlist entry for `public-canvas-test-init.js` (1 safe innerHTML with escapeHtml)

## Security

| Principle | Status |
|---|---|
| URL query로 owner auth guard 우회 금지 | ✅ Public test page has NO auth guard at all (separate page) |
| Public endpoint만 사용 | ✅ `apiFetch('/trees/:id', { publicRead: true })` → no auth headers |
| Public endpoint는 public tree만 반환 | ✅ Cloudflare proxy ensures this |
| Private tree 노출 금지 | ✅ Public endpoint returns 404 for private trees |
| Owner mutation API 호출 금지 | ✅ No mutation modules loaded, canEdit=false |
| `canEdit=false` 강제 | ✅ In bridge + body class |
| Save/delete/rename/add/edit 실행 금지 | ✅ No mutation modules, no bindings |
| Private tree 404/403 정책 유지 | ✅ Unchanged |

## Non-Goals

| 금지 항목 | Status |
|---|---|
| Browse `트리 열기` CTA 전환 | ❌ Not touched |
| 감상허브 제거 | ❌ Not touched |
| Owner editor auth guard 우회 | ❌ Separate test page, no interference |
| Owner mutation API public 노출 | ❌ PublicRead-only fetch only |
| DB schema 변경 | ❌ Not touched |
| API 권한 완화 | ❌ Not touched |
| Public/private visibility 정책 변경 | ❌ Not touched |
| 대규모 editor canvas refactor | ❌ 3 new files, 1 test allowlist update |
| #1501 auth.js 작업과 섞임 | ❌ js/auth.js not touched |
| #1685 파일과 충돌 | ❌ js/auth.js not touched |

## Verification

- `npm run verify` — 248/248 pass ✅
- `npm test` — 1181/1181 pass ✅ (1 new test for allowlist entry)

## Smoke Test Plan

1. Public tree on test page: `public-canvas-test.html?treeId={publicTreeId}`
2. Private tree on test page: should show error (404 from public endpoint)
3. Owner editor page: unchanged (`editor.html?treeId=X`)
4. Mobile viewport: CSS responsive + canEdit controls hidden
