### PR TITLE
refactor(viewer): rename public-canvas from test to production naming (#1673)

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 
-    var MARKER = 'LoveBudPublicCanvasTestInitLoaded';
+    var MARKER = 'LoveBudPublicCanvasInitLoaded';
     if (window[MARKER]) return;
     window[MARKER] = true;
 
@@ -16,7 +16,7 @@
             .replace(/'/g, '&#39;');
     }
 
-    function initTestPage() {
+    function initPublicCanvas() {
         var params = new URLSearchParams(window.location.search);
         var treeId = params.get('treeId');
         if (!treeId) {
@@ -33,7 +33,7 @@
 
         var bridge = window.LoveBudPublicCanvasBridge;
         if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {
-            console.error('[public-canvas-test] Bridge not loaded');
+            console.error('[public-canvas] Bridge not loaded');
             return;
         }
 
@@ -43,7 +43,7 @@
 
             // Normalize to canvas shape
             var normalized = bridge.normalizeForCanvas(tree, memories);
-            console.log('[public-canvas-test] Loaded tree:', normalized.treeData.id, 'memories:', normalized.treeMemories.length);
+            console.log('[public-canvas] Loaded tree:', normalized.treeData.id, 'memories:', normalized.treeMemories.length);
 
             // Wait for all required modules
             var maxWait = 100;
@@ -51,7 +51,7 @@
 
             function waitForModules(attempt) {
                 if (attempt >= maxWait) {
-                    console.error('[public-canvas-test] Timeout waiting for editor modules');
+                    console.error('[public-canvas] Timeout waiting for editor modules');
                     return;
                 }
 
@@ -73,7 +73,7 @@
                 var detailPanel = document.getElementById('detailPanel');
 
                 if (!canvas || !svg) {
-                    console.error('[public-canvas-test] Canvas or SVG element not found');
+                    console.error('[public-canvas] Canvas or SVG element not found');
                     return;
                 }
 
@@ -121,7 +121,7 @@
 
                 // Initialize detail UI
                 var formatI18nText = function(key, fallback) { return fallback || key; };
-                var showToast = function(msg) { console.log('[public-canvas-toast]', msg); };
+                var showToast = function(msg) { console.log('[public-canvas]', msg); };
 
                 var detailUIBuilders = window.createEditorDetailUIBuilders({ formatI18nText: formatI18nText });
                 var treeMetaBoundary = window.createEditorDetailTreeMetaBoundary({
@@ -221,12 +221,12 @@
                     setDetailEmptyState(false);
                 }
 
-                console.log('[public-canvas-test] Canvas initialized successfully');
+                console.log('[public-canvas] Canvas initialized successfully');
             }
 
             waitForModules(0);
         }).catch(function(error) {
-            console.error('[public-canvas-test] Load failed:', error);
+            console.error('[public-canvas] Load failed:', error);
             var container = document.getElementById('canvasArea');
             if (container) {
                 var errState = document.createElement('div');
@@ -242,8 +242,8 @@
     }
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initTestPage);
+        document.addEventListener('DOMContentLoaded', initPublicCanvas);
     } else {
-        initTestPage();
+        initPublicCanvas();
     }
 })();

--- a/pages/public-canvas.html
+++ b/pages/public-canvas.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Public LoveTree Canvas Test | LoveBud</title>
+    <title>Public LoveTree Canvas | LoveBud</title>
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
     <style>
-        /* Test page: ensure canvas fills viewport */
+        /* Public canvas: ensure canvas fills viewport */
         body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
         .editor-layout { flex: 1; }
     </style>
@@ -123,7 +123,7 @@
     <!-- Public canvas bridge -->
     <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
 
-    <!-- Test page init -->
-    <script src="../js/viewer/public-canvas-test-init.js?v=20260525-1"></script>
+    <!-- Public canvas init -->
+    <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
 </body>
 </html>

--- a/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
+++ b/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
@@ -17,7 +17,7 @@
  * per file, which is more stable than line-level matching across
  * code changes.
  *
- * v20260525-1
+ * v20260525-2
  */
 
 const test = require('node:test');
@@ -124,9 +124,9 @@ const FILE_ALLOWLIST = {
     count: 11, classification: 'safe',
     reason: 'All user content escaped via escapeHtml/sanitizeUrl; clear-container for list; static no-media divs'
   },
-  'js/viewer/public-canvas-test-init.js': {
+  'js/viewer/public-canvas-init.js': {
     count: 1, classification: 'safe',
-    reason: 'Dev test page. innerHTML on fresh element with escapeHtml for all user content; uses textContent for primary error'
+    reason: 'Public read-only canvas route. innerHTML on fresh error element with escapeHtml for user-visible error message; uses textContent for primary error'
   },
   'js/viewer/viewer-init-flow.js': {
     count: 1, classification: 'safe',


### PR DESCRIPTION
### Cleanup PR for #1686 — rename from test to production naming

PR #1686이 이미 **squash merged**된 상태여서, 해당 cleanup 요청을 별도 PR로 진행합니다.

### 요청 반영 목록

| # | 요청 | 처리 |
|---|---|---|
| 1 | `pages/public-canvas-test.html` → `pages/public-canvas.html` | ✅ `git mv` |
| 2 | `js/viewer/public-canvas-test-init.js` → `js/viewer/public-canvas-init.js` | ✅ `git mv` |
| 3 | HTML script 경로 업데이트 | ✅ `public-canvas-init.js` |
| 4 | JS log prefix `[public-canvas-test]` → `[public-canvas]` | ✅ |
| 5 | DOM XSS allowlist path + reason: `'Dev test page'` → `'Public read-only canvas route'` | ✅ |
| 6 | PR 본문 "test page" → "manual public read-only canvas route" | ✅ (본 PR 본문) |
| 7 | URL 예시: `/pages/public-canvas.html?treeId={TREE_ID}` | ✅ |

### 하지 않은 것 (의도적으로 보존)
- ❌ Browse `트리 열기` CTA 변경 금지
- ❌ 감상허브 건드리지 않음
- ❌ auth guard, API/DB/backend 변경 없음
- ❌ public/private visibility 정책 변경 없음
- ❌ #1501 / #1685와 섞지 않음

### 검증
- `npm run verify`: **248/248** ✅
- `npm test`: **1180/1180** ✅
- Preview smoke 필요 시 CI 배포 후 진행

### Head SHA
`fcb2886d`

Merge 판단 부탁드립니다.