### PR TITLE
feat(search): open public trees in read-only canvas (#1673 Stage 3)

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -111,7 +111,7 @@
 
     function getTreeViewerHref(tree) {
         if (!tree?.id) return '';
-        return `${getBasePath()}tree?treeId=${encodeURIComponent(tree.id)}`;
+        return `${getBasePath()}public-canvas.html?treeId=${encodeURIComponent(tree.id)}`;
     }
 
     function getTreePreviewTone(tree) {

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -133,7 +133,7 @@
      */
     function renderOpenTreeButton(tree) {
         if (!tree?.id) return '';
-        const href = `${getBasePath()}tree?treeId=${encodeURIComponent(tree.id)}`;
+        const href = `${getBasePath()}public-canvas.html?treeId=${encodeURIComponent(tree.id)}`;
         const label = getSearchCopy(
             'search.previewOpenTreeCta',
             '트리 열기',

--- a/tests/routes/search-runtime-modules.test.cjs
+++ b/tests/routes/search-runtime-modules.test.cjs
@@ -197,7 +197,7 @@ test('browse cards expose a truthful public tree viewer bridge', () => {
   const cardRenderer = read('js/search/search-card-renderer.js');
 
   assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
-  assert.match(cardRenderer, /tree\?treeId=/);
+  assert.match(cardRenderer, /public-canvas\.html\?treeId=/);
   assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
   assert.match(cardRenderer, /tree-card-open-link/);
   assert.match(cardRenderer, /트리 열기/);
@@ -234,7 +234,7 @@ test('browse selected hub primary tree CTA and secondary viewing CTA keep truthf
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
-  assert.match(actionHelper, /tree\?treeId=/);
+  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
   assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
@@ -270,7 +270,7 @@ test('browse selected hub exposes focus-stage shell without changing route helpe
   assert.match(previewCss, /Issue #907: focus-stage selected hub shell/);
   assert.match(previewCss, /preview-sidebar\.preview-state-media \.video-container|preview-sidebar\.preview-state-media[\s\S]*?\.video-container/);
   assert.match(previewCss, /preview-sidebar \.preview-primary-action/);
-  assert.match(actionHelper, /tree\?treeId=/);
+  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
   assert.match(actionHelper, /data-share-tree-link/);
 });
 

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -197,7 +197,7 @@ test('browse cards expose a truthful public tree viewer bridge', () => {
   const cardRenderer = read('js/search/search-card-renderer.js');
 
   assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
-  assert.match(cardRenderer, /tree\?treeId=/);
+  assert.match(cardRenderer, /public-canvas\.html\?treeId=/);
   assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
   assert.match(cardRenderer, /tree-card-open-link/);
   assert.match(cardRenderer, /트리 열기/);
@@ -234,7 +234,7 @@ test('browse selected hub primary tree CTA and secondary viewing CTA keep truthf
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
-  assert.match(actionHelper, /tree\?treeId=/);
+  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
   assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
@@ -270,7 +270,7 @@ test('browse selected hub exposes focus-stage shell without changing route helpe
   assert.match(previewCss, /Issue #907: focus-stage selected hub shell/);
   assert.match(previewCss, /preview-sidebar\.preview-state-media \.video-container|preview-sidebar\.preview-state-media[\s\S]*?\.video-container/);
   assert.match(previewCss, /preview-sidebar \.preview-primary-action/);
-  assert.match(actionHelper, /tree\?treeId=/);
+  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
   assert.match(actionHelper, /data-share-tree-link/);
 });
 

--- a/tests/routes/viewer-route-contract.test.cjs
+++ b/tests/routes/viewer-route-contract.test.cjs
@@ -180,19 +180,17 @@ test('tree viewer route does not reference Editor/Builder page', () => {
     assert.ok(noEditorPage, 'tree.html must not load any Editor module');
 });
 
-test('Browse tree-open CTA targets extensionless tree route with treeId param', () => {
+test('Browse tree-open CTA targets public-canvas read-only route with treeId param', () => {
     const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
-    const hasTreeUrl = helper.includes('tree?treeId=');
-    assert.ok(hasTreeUrl, 'search-preview-action-helper.js must use tree?treeId= for tree-open CTA');
-    assert.ok(!helper.includes('tree.html?treeId='), 'search-preview-action-helper.js must not use .html tree route for tree-open CTA');
+    const hasCanvasUrl = helper.includes('public-canvas.html?treeId=');
+    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use public-canvas.html?treeId= for tree-open CTA');
     const noDetailUrl = !helper.includes('detail.html?tree=');
     assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
 });
 
-test('Browse card renderer targets extensionless tree route with treeId param', () => {
+test('Browse card renderer targets public-canvas read-only route with treeId param', () => {
     const renderer = fs.readFileSync('js/search/search-card-renderer.js', 'utf8');
-    assert.ok(renderer.includes('tree?treeId='), 'search-card-renderer.js must use tree?treeId= for card tree-open link');
-    assert.ok(!renderer.includes('tree.html?treeId='), 'search-card-renderer.js must not use .html tree route for card tree-open link');
+    assert.ok(renderer.includes('public-canvas.html?treeId='), 'search-card-renderer.js must use public-canvas.html?treeId= for card tree-open link');
 });
 
 test('My Trees owner routes target extensionless editor route with treeId param', () => {

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -180,19 +180,17 @@ test('tree viewer route does not reference Editor/Builder page', () => {
     assert.ok(noEditorPage, 'tree.html must not load any Editor module');
 });
 
-test('Browse tree-open CTA targets extensionless tree route with treeId param', () => {
+test('Browse tree-open CTA targets public-canvas read-only route with treeId param', () => {
     const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
-    const hasTreeUrl = helper.includes('tree?treeId=');
-    assert.ok(hasTreeUrl, 'search-preview-action-helper.js must use tree?treeId= for tree-open CTA');
-    assert.ok(!helper.includes('tree.html?treeId='), 'search-preview-action-helper.js must not use .html tree route for tree-open CTA');
+    const hasCanvasUrl = helper.includes('public-canvas.html?treeId=');
+    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use public-canvas.html?treeId= for tree-open CTA');
     const noDetailUrl = !helper.includes('detail.html?tree=');
     assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
 });
 
-test('Browse card renderer targets extensionless tree route with treeId param', () => {
+test('Browse card renderer targets public-canvas read-only route with treeId param', () => {
     const renderer = fs.readFileSync('js/search/search-card-renderer.js', 'utf8');
-    assert.ok(renderer.includes('tree?treeId='), 'search-card-renderer.js must use tree?treeId= for card tree-open link');
-    assert.ok(!renderer.includes('tree.html?treeId='), 'search-card-renderer.js must not use .html tree route for card tree-open link');
+    assert.ok(renderer.includes('public-canvas.html?treeId='), 'search-card-renderer.js must use public-canvas.html?treeId= for card tree-open link');
 });
 
 test('My Trees owner routes target extensionless editor route with treeId param', () => {


### PR DESCRIPTION
### Stage 3 of #1673 — Browse CTA → public read-only canvas route

**핵심 변경:** Browse `트리 열기` CTA가 이제 `public-canvas.html?treeId=X` (read-only SVG canvas)로 연결됩니다. 기존 `tree.html` (감상허브/공유 페이지)는 **보조 경로로 유지**됩니다.

### 변경 파일 (6 files, +18 -22)

| File | Change |
|---|---|
| `js/search/search-card-renderer.js` | `getTreeViewerHref()`: `tree?treeId=` → `public-canvas.html?treeId=` |
| `js/search/search-preview-action-helper.js` | `renderOpenTreeButton()`: `tree?treeId=` → `public-canvas.html?treeId=` |
| `tests/routes/search-runtime-modules.test.cjs` | Update asserts |
| `tests/routes/search-runtime-modules.test.js` | Same |
| `tests/routes/viewer-route-contract.test.cjs` | Update asserts + test descriptions |
| `tests/routes/viewer-route-contract.test.js` | Same |

### 변경하지 않은 것
- ❌ 감상허브 (`tree.html`) — secondary/auxiliary path 유지
- ❌ 공유 링크 (`tree.html` 내 share module) — `tree?treeId=` 그대로
- ❌ Auth guard / API / DB / backend
- ❌ Owner editor
- ❌ `#1501` / `#1685` (auth delegation scope)

### 검증
- `npm run verify`: **248/248** ✅
- `npm test`: **1180/1180** ✅
- CF Pages Preview smoke: CI 배포 후 진행

### Route 판단
- `/pages/public-canvas.html?treeId={id}` → 당장 canonical public read-only route로 사용
- 향후 더 깔끔한 URL은 별도 PR로 가능

### Smoke 필요
1. logged-out 상태에서 Browse → `트리 열기` → canvas render
2. node selection / pan/zoom
3. no edit/delete controls
4. private tree 직접 접근 → 404 boundary
5. owner editor 유지
6. 감상허브 동선 유지
7. mobile 375/390/430px

`#1673`은 **close하지 않습니다** (OPEN 유지).