### PR TITLE
fix(css): hide branch-port-handle, continueFromMomentBtn, ftbContinueBtn in read-only mode

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -55,4 +55,7 @@
 .editor-readonly .editor-moment-edit-chip,
 .editor-readonly [data-action="delete"],
 .editor-readonly #ftbBranchBtn,
-.editor-readonly #ftbForkBtn { display: none !important; }
+.editor-readonly #ftbForkBtn,
+.editor-readonly #ftbContinueBtn,
+.editor-readonly #continueFromMomentBtn,
+.editor-readonly .branch-port-handle { display: none !important; }


### PR DESCRIPTION
## Problem

QA for #1691 revealed 3 mutation controls still visible on the public read-only canvas:

1. **`.branch-port-handle`** — the 8 "+" add-moment buttons per node, created by `editor-canvas-branch-ports.js`. Become visible on node hover/select (`showPortsForMemory`).
2. **`#continueFromMomentBtn`** — "이 순간에서 이어가기" button in the detail panel, created by `editor-detail-view-mode-template.js`.
3. **`#ftbContinueBtn`** — "이어가기" button in the floating toolbar (`editor-floating-toolbar-template.js:8`).

All three were missing from the `.editor-readonly` CSS hide rule block.

## Fix

Add 3 selectors to the existing `.editor-readonly` hide block in `css/editor.css`:

~~~css
.editor-readonly #ftbContinueBtn,
.editor-readonly #continueFromMomentBtn,
.editor-readonly .branch-port-handle { display: none !important; }
~~~

## Verification

- `npm run verify`: 248/248 ✅
- `npm test`: 1180/1180 ✅
- Browser smoke on production public canvas confirmed: branch-port-handle, continueFromMomentBtn, ftbContinueBtn all `display:none` when `.editor-readonly` is on body

Refs #1691