### PR TITLE
ux(viewer): add canonical public read-only canvas route

### DIFF
--- a/js/search/search-card-renderer.js
+++ b/js/search/search-card-renderer.js
@@ -111,7 +111,7 @@
 
     function getTreeViewerHref(tree) {
         if (!tree?.id) return '';
-        return `${getBasePath()}public-canvas.html?treeId=${encodeURIComponent(tree.id)}`;
+        return `${getBasePath()}view.html?treeId=${encodeURIComponent(tree.id)}`;
     }
 
     function getTreePreviewTone(tree) {

--- a/js/search/search-preview-action-helper.js
+++ b/js/search/search-preview-action-helper.js
@@ -133,7 +133,7 @@
      */
     function renderOpenTreeButton(tree) {
         if (!tree?.id) return '';
-        const href = `${getBasePath()}public-canvas.html?treeId=${encodeURIComponent(tree.id)}`;
+        const href = `${getBasePath()}view.html?treeId=${encodeURIComponent(tree.id)}`;
         const label = getSearchCopy(
             'search.previewOpenTreeCta',
             '트리 열기',

--- a/pages/view.html
+++ b/pages/view.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LoveTree | LoveBud</title>
+    <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.ico" sizes="32x32">
+    <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
+    <link rel="stylesheet" href="../css/editor.css?v=20260510-1006">
+    <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+    <style>
+        /* Public canvas: ensure canvas fills viewport */
+        body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
+        .editor-layout { flex: 1; }
+    </style>
+</head>
+<body class="editor-preload">
+    <div class="noise-overlay"></div>
+
+    <div id="shared-header"></div>
+
+    <div class="editor-layout page-transition-enter">
+        <main class="canvas-area reveal-scale reveal-up" id="canvasArea">
+            <div id="editorCanvasTopbarTemplateMount"></div>
+            <svg class="canvas-svg" id="canvasSvg"></svg>
+            <div id="editorFloatingToolbarTemplateMount"></div>
+            <div id="editorEmptyGuideTemplateMount"></div>
+        </main>
+        <div id="editorDetailPanelShellTemplateMount"></div>
+    </div>
+
+    <!-- Utility scripts -->
+    <script src="../js/cache-utils.js?v=20260418-1"></script>
+    <script src="../js/utils/normalize.js?v=20260422-1"></script>
+    <script src="../js/utils/path.js?v=20260418-1"></script>
+    <script src="../js/utils/ui.js?v=20260418-1"></script>
+    <script src="../js/utils/media.js?v=20260418-1"></script>
+
+    <!-- Editor templates (view-mode only, no edit/add forms) -->
+    <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-floating-toolbar-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-panel-shell-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>
+    <script src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260525-1280"></script>
+
+    <!-- Canvas core modules -->
+    <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-scale.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-projection.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-targets.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-feedback.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-state.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-fit.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-initial.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-branches.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
+
+    <!-- Floating toolbar -->
+    <script src="../js/editor/editor-floating-toolbar-actions.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-keyboard.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-tooltip.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-dropdown.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-positioning.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-affordance.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-visibility.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-events.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-selection.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar-elements.js?v=20260519-1275"></script>
+    <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
+
+    <!-- Canvas support -->
+    <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>
+    <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
+    <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
+    <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
+    <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
+
+    <!-- Detail panel -->
+    <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
+    <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
+
+    <!-- API scripts (no Firebase/ auth) -->
+    <script src="../js/api/auth-policy.js?v=20260420-1"></script>
+    <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
+    <script src="../js/postgres-client.js?v=20260422-1"></script>
+
+    <!-- i18n -->
+    <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
+    <script src="../js/i18n.js?v=20260419-2"></script>
+
+    <!-- Shared header (no auth scripts — lightweight) -->
+    <script src="../js/shared-header.js?v=20260421-2"></script>
+
+    <!-- Public canvas bridge -->
+    <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
+
+    <!-- Public canvas init -->
+    <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
+</body>
+</html>

--- a/tests/routes/search-runtime-modules.test.cjs
+++ b/tests/routes/search-runtime-modules.test.cjs
@@ -197,7 +197,7 @@ test('browse cards expose a truthful public tree viewer bridge', () => {
   const cardRenderer = read('js/search/search-card-renderer.js');
 
   assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
-  assert.match(cardRenderer, /public-canvas\.html\?treeId=/);
+  assert.match(cardRenderer, /view\.html\?treeId=/);
   assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
   assert.match(cardRenderer, /tree-card-open-link/);
   assert.match(cardRenderer, /트리 열기/);
@@ -234,7 +234,7 @@ test('browse selected hub primary tree CTA and secondary viewing CTA keep truthf
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
-  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
+  assert.match(actionHelper, /view\.html\?treeId=/);
   assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
@@ -270,7 +270,7 @@ test('browse selected hub exposes focus-stage shell without changing route helpe
   assert.match(previewCss, /Issue #907: focus-stage selected hub shell/);
   assert.match(previewCss, /preview-sidebar\.preview-state-media \.video-container|preview-sidebar\.preview-state-media[\s\S]*?\.video-container/);
   assert.match(previewCss, /preview-sidebar \.preview-primary-action/);
-  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
+  assert.match(actionHelper, /view\.html\?treeId=/);
   assert.match(actionHelper, /data-share-tree-link/);
 });
 

--- a/tests/routes/search-runtime-modules.test.js
+++ b/tests/routes/search-runtime-modules.test.js
@@ -197,7 +197,7 @@ test('browse cards expose a truthful public tree viewer bridge', () => {
   const cardRenderer = read('js/search/search-card-renderer.js');
 
   assert.match(cardRenderer, /function getTreeViewerHref\(tree\)/);
-  assert.match(cardRenderer, /public-canvas\.html\?treeId=/);
+  assert.match(cardRenderer, /view\.html\?treeId=/);
   assert.match(cardRenderer, /encodeURIComponent\(tree\.id\)/);
   assert.match(cardRenderer, /tree-card-open-link/);
   assert.match(cardRenderer, /트리 열기/);
@@ -234,7 +234,7 @@ test('browse selected hub primary tree CTA and secondary viewing CTA keep truthf
   assert.match(i18nSearch, /'search\.previewOpenViewingCta'/);
   assert.match(i18nSearch, /ko:\s*'감상 열기'/);
   assert.match(actionHelper, /renderOpenTreeButton/);
-  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
+  assert.match(actionHelper, /view\.html\?treeId=/);
   assert.match(actionHelper, /preview-primary-action/);
   assert.match(actionHelper, /search\.previewOpenTreeCta/);
   assert.match(previewRenderer, /renderOpenTreeButton/);
@@ -270,7 +270,7 @@ test('browse selected hub exposes focus-stage shell without changing route helpe
   assert.match(previewCss, /Issue #907: focus-stage selected hub shell/);
   assert.match(previewCss, /preview-sidebar\.preview-state-media \.video-container|preview-sidebar\.preview-state-media[\s\S]*?\.video-container/);
   assert.match(previewCss, /preview-sidebar \.preview-primary-action/);
-  assert.match(actionHelper, /public-canvas\.html\?treeId=/);
+  assert.match(actionHelper, /view\.html\?treeId=/);
   assert.match(actionHelper, /data-share-tree-link/);
 });
 

--- a/tests/routes/viewer-route-contract.test.cjs
+++ b/tests/routes/viewer-route-contract.test.cjs
@@ -182,15 +182,15 @@ test('tree viewer route does not reference Editor/Builder page', () => {
 
 test('Browse tree-open CTA targets public-canvas read-only route with treeId param', () => {
     const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
-    const hasCanvasUrl = helper.includes('public-canvas.html?treeId=');
-    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use public-canvas.html?treeId= for tree-open CTA');
+    const hasCanvasUrl = helper.includes('view.html?treeId=');
+    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use view.html?treeId= for tree-open CTA');
     const noDetailUrl = !helper.includes('detail.html?tree=');
     assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
 });
 
 test('Browse card renderer targets public-canvas read-only route with treeId param', () => {
     const renderer = fs.readFileSync('js/search/search-card-renderer.js', 'utf8');
-    assert.ok(renderer.includes('public-canvas.html?treeId='), 'search-card-renderer.js must use public-canvas.html?treeId= for card tree-open link');
+    assert.ok(renderer.includes('view.html?treeId='), 'search-card-renderer.js must use view.html?treeId= for card tree-open link');
 });
 
 test('My Trees owner routes target extensionless editor route with treeId param', () => {

--- a/tests/routes/viewer-route-contract.test.js
+++ b/tests/routes/viewer-route-contract.test.js
@@ -182,15 +182,15 @@ test('tree viewer route does not reference Editor/Builder page', () => {
 
 test('Browse tree-open CTA targets public-canvas read-only route with treeId param', () => {
     const helper = fs.readFileSync('js/search/search-preview-action-helper.js', 'utf8');
-    const hasCanvasUrl = helper.includes('public-canvas.html?treeId=');
-    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use public-canvas.html?treeId= for tree-open CTA');
+    const hasCanvasUrl = helper.includes('view.html?treeId=');
+    assert.ok(hasCanvasUrl, 'search-preview-action-helper.js must use view.html?treeId= for tree-open CTA');
     const noDetailUrl = !helper.includes('detail.html?tree=');
     assert.ok(noDetailUrl, 'search-preview-action-helper.js must not use detail.html?tree= for tree-open CTA');
 });
 
 test('Browse card renderer targets public-canvas read-only route with treeId param', () => {
     const renderer = fs.readFileSync('js/search/search-card-renderer.js', 'utf8');
-    assert.ok(renderer.includes('public-canvas.html?treeId='), 'search-card-renderer.js must use public-canvas.html?treeId= for card tree-open link');
+    assert.ok(renderer.includes('view.html?treeId='), 'search-card-renderer.js must use view.html?treeId= for card tree-open link');
 });
 
 test('My Trees owner routes target extensionless editor route with treeId param', () => {


### PR DESCRIPTION
Refs #1689

## Summary
Add `/pages/view.html` as the canonical public read-only canvas URL.
The internal `/pages/public-canvas.html` remains functional for backward compatibility.

## Changes
| File | Change |
|---|---|
| pages/view.html | **New** — canonical public read-only canvas page |
| search-card-renderer.js | getTreeViewerHref: public-canvas.html → view.html |
| search-preview-action-helper.js | renderOpenTreeButton: public-canvas.html → view.html |
| tests/routes/search-runtime-modules.test.{cjs,js} | 3 assertions updated → view.html |
| tests/routes/viewer-route-contract.test.{cjs,js} | 2 assertions updated → view.html |

## Verification
- npm run verify: **249/249** ✅
- npm test: **1180/1180** ✅
- No auth/API/DB/backend changes
- No public/private visibility policy changes
- 감상허브 tree.html unchanged

## Non-goals
- No new public viewer created
- No editor canvas refactoring
- No 감상허브 removal
- No `tree.html` route changes