### PR TITLE
fix(viewer): auto-enable compact toolbar on mobile public canvas

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -222,6 +222,16 @@
                 }
 
                 console.log('[public-canvas] Canvas initialized successfully');
+
+                // Auto-enable compact mode on narrow viewports (toolbar labels would overflow)
+                var compactMql = window.matchMedia('(max-width: 480px)');
+                function updateToolbarCompact(e) {
+                    var tb = document.querySelector('.editor-canvas-toolbar');
+                    if (!tb) return;
+                    tb.classList.toggle('is-compact', e.matches);
+                }
+                updateToolbarCompact(compactMql);
+                compactMql.addEventListener('change', updateToolbarCompact);
             }
 
             waitForModules(0);


### PR DESCRIPTION
Refs #1690

## Summary
Auto-enable compact toolbar mode on viewports ≤ 480px for the public read-only canvas (view.html + public-canvas.html views).

## Problem
At 375-430px viewport widths, the canvas toolbar (zoom controls, tree view controls, layout mode, compact toggle) requires ~460px but only ~351px is available. The toolbar has `overflow-x: auto`, requiring horizontal scrolling on every load.

## Fix
Add a matchMedia listener at 480px breakpoint in public-canvas-init.js. When active:
- .is-compact class is auto-applied to .editor-canvas-toolbar
- Labels hidden, zoom indicator hidden, wide buttons shrink to 34px icon-only
- Toolbar reduces from ~460px to ~236px — fits 375/390/430px viewports
- Works on both view.html and public-canvas.html (shared init script)
- Non-intrusive: user can still manually toggle compact mode via the toggle button

## What does NOT change
- No CSS changes
- No auth/API/DB/backend changes
- No public/private boundary changes
- No Browse route changes
- No 감상허브 (tree.html) changes
- Owner editor is unaffected (separate init flow)
- Desktop viewport (> 480px) unaffected

## Verification
- npm run verify: **249/249** ✅
- npm test: **1180/1180** ✅
- XSS guardrail: unchanged (no new innerHTML sinks)
- Backward compatibility confirmed