### PR TITLE
fix(search): render browse subtitle HTML break

### DIFF
--- a/pages/search.html
+++ b/pages/search.html
@@ -23,7 +23,7 @@
                 <div class="search-panel-header">
                     <div class="search-panel-eyebrow"><span data-i18n="search.eyebrow">러브트리 둘러보기</span></div>
                     <h1 class="headline" data-i18n="search.title" data-i18n-html><span class="title-line">다른 사람의</span><span class="title-line title-accent">러브트리를</span><span class="title-line">둘러보세요</span></h1>
-                    <p data-i18n="search.subtitle">첫 순간과 이어진 마음,<br class="pc-only">깊어진 감정의 흐름을 가볍게 살펴보세요.</p>
+                    <p data-i18n="search.subtitle" data-i18n-html>첫 순간과 이어진 마음,<br class="pc-only">깊어진 감정의 흐름을 가볍게 살펴보세요.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
Mobile Browse showed the literal `<br class="pc-only">` text in the hero subtitle because the subtitle i18n target was rendered as text.

This marks the subtitle node as HTML-enabled to match the existing `search.title` rendering pattern.

Scope:
- `pages/search.html` only
- no CSS changes
- no API/backend/schema changes