### PR TITLE
fix(header): contain mobile profile dropdown

### DIFF
--- a/css/global/global-header-language.css
+++ b/css/global/global-header-language.css
@@ -97,3 +97,40 @@
     background: rgba(144, 73, 81, 0.1);
     color: var(--primary);
 }
+
+/* Keep the account dropdown inside the mobile header panel. */
+@media (max-width: 768px) {
+    .nav-bar .main-nav-panel .nav-actions {
+        align-items: stretch;
+        flex-wrap: wrap;
+    }
+
+    .nav-bar .main-nav-panel #auth-nav,
+    .nav-bar .main-nav-panel #auth-nav-container {
+        width: 100%;
+        height: auto !important;
+        min-width: 0 !important;
+        align-items: stretch !important;
+        justify-content: flex-end !important;
+        overflow: visible;
+    }
+
+    .nav-bar .main-nav-panel .user-dropdown {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .nav-bar .main-nav-panel .user-dropdown-trigger-icon {
+        margin-left: auto;
+    }
+
+    .nav-bar .main-nav-panel .user-dropdown-menu {
+        position: static;
+        inset: auto;
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        margin-top: 10px;
+        box-sizing: border-box;
+    }
+}


### PR DESCRIPTION
Mobile header profile dropdown could render outside the opened hamburger menu panel.

This CSS-only patch keeps the account dropdown in the mobile nav panel flow.

Scope:
- css/global/global-header-language.css only
- no JS changes
- no API/backend/schema changes