### PR TITLE
fix(viewer): load page transitions

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -11,7 +11,6 @@
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
     <style>
-        /* Public canvas: ensure canvas fills viewport */
         body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
         .editor-layout { flex: 1; }
     </style>
@@ -31,14 +30,12 @@
         <div id="editorDetailPanelShellTemplateMount"></div>
     </div>
 
-    <!-- Utility scripts -->
     <script src="../js/cache-utils.js?v=20260418-1"></script>
     <script src="../js/utils/normalize.js?v=20260422-1"></script>
     <script src="../js/utils/path.js?v=20260418-1"></script>
     <script src="../js/utils/ui.js?v=20260418-1"></script>
     <script src="../js/utils/media.js?v=20260418-1"></script>
 
-    <!-- Editor templates (view-mode only, no edit/add forms) -->
     <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>
@@ -47,7 +44,6 @@
     <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260525-1280"></script>
 
-    <!-- Canvas core modules -->
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
     <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
@@ -71,7 +67,6 @@
     <script src="../js/editor/editor-canvas-growth-affordance.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-branch-ports.js?v=20260518-1"></script>
 
-    <!-- Floating toolbar -->
     <script src="../js/editor/editor-floating-toolbar-actions.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-keyboard.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar-tooltip.js?v=20260519-1275"></script>
@@ -84,7 +79,6 @@
     <script src="../js/editor/editor-floating-toolbar-elements.js?v=20260519-1275"></script>
     <script src="../js/editor/editor-floating-toolbar.js?v=20260519-1275"></script>
 
-    <!-- Canvas support -->
     <script src="../js/editor/editor-mobile-bottom-bar.js?v=20260518-1"></script>
     <script src="../js/editor/editor-url-drop.js?v=20260518-1"></script>
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
@@ -96,7 +90,6 @@
     <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
     <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
 
-    <!-- Detail panel -->
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
     <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
@@ -104,12 +97,10 @@
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
 
-    <!-- API scripts (no Firebase/ auth) -->
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
     <script src="../js/postgres-client.js?v=20260422-1"></script>
 
-    <!-- i18n -->
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
@@ -117,13 +108,9 @@
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>
 
-    <!-- Shared header (no auth scripts — lightweight) -->
     <script src="../js/shared-header.js?v=20260421-2"></script>
-
-    <!-- Public canvas bridge -->
+    <script src="../js/page-transitions.js?v=20260430-1"></script>
     <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
-
-    <!-- Public canvas init -->
     <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
 </body>
 </html>


### PR DESCRIPTION
Public view used reveal classes from page-transitions.css but did not load the corresponding page-transitions.js script.

This loads the shared transition script so the public canvas page becomes visible after initialization.

Scope:
- pages/view.html only
- no CSS changes
- no API/backend/schema changes