### PR TITLE
fix(viewer): fit canvas to mobile viewport

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -16,6 +16,29 @@
             .replace(/'/g, '&#39;');
     }
 
+    function installPublicMetrics(canvas) {
+        var geometry = window.EditorCanvasGeometry;
+        if (!geometry || typeof geometry.getMetrics !== 'function') return;
+        if (geometry.__publicViewMetricsInstalled) return;
+        var originalGetMetrics = geometry.getMetrics;
+        geometry.getMetrics = function(targetCanvas) {
+            var node = targetCanvas || canvas;
+            var rect = node && typeof node.getBoundingClientRect === 'function'
+                ? node.getBoundingClientRect()
+                : null;
+            var width = Math.round((rect && rect.width) || (node && node.clientWidth) || window.innerWidth || 0);
+            var height = Math.round((rect && rect.height) || (node && node.clientHeight) || window.innerHeight || 0);
+            if (width > 0 && height > 0) {
+                return {
+                    width: Math.max(width, 320),
+                    height: Math.max(height, 420)
+                };
+            }
+            return originalGetMetrics(targetCanvas);
+        };
+        geometry.__publicViewMetricsInstalled = true;
+    }
+
     function initPublicCanvas() {
         var params = new URLSearchParams(window.location.search);
         var treeId = params.get('treeId');
@@ -76,6 +99,8 @@
                     console.error('[public-canvas] Canvas or SVG element not found');
                     return;
                 }
+
+                installPublicMetrics(canvas);
 
                 // Set up empty guide UI
                 var emptyGuideHelper = window.LoveBudEditorEmptyGuideUI || {};


### PR DESCRIPTION
Public view reused editor canvas geometry that clamps metrics to a desktop-sized minimum. On mobile this could place cards outside the visible frame.

This installs a public-view-only metrics override before creating the read-only canvas so initial fit uses the actual mobile viewport size.

Scope:
- js/viewer/public-canvas-init.js only
- no CSS changes
- no API/backend/schema changes