### PR TITLE
fix(mobile): polish hero copy and public viewer

### DIFF
--- a/css/index/components.css
+++ b/css/index/components.css
@@ -49,6 +49,43 @@
     transform: scale(1.08);
 }
 
+.home-hero-loop-container {
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: start;
+}
+
+.home-hero-copy-set {
+    grid-area: 1 / 1;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+    pointer-events: none;
+}
+
+.home-hero-copy-set.active {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .home-hero-copy-set {
+        transition: none !important;
+        transform: none !important;
+    }
+
+    #home-hero-set-1 {
+        opacity: 1 !important;
+        pointer-events: auto !important;
+    }
+
+    #home-hero-set-2 {
+        opacity: 0 !important;
+        pointer-events: none !important;
+    }
+}
+
 .home-intro-entry-wrapper {
     margin-top: 20px;
     display: block;

--- a/css/search/search-hero-controls.css
+++ b/css/search/search-hero-controls.css
@@ -52,19 +52,19 @@
 }
 
 .search-panel-header h1 .title-accent {
-    color: var(--hero-warm-color, var(--primary));
-    font-weight: 900;
+    color: var(--primary);
+    font-weight: 780;
     letter-spacing: -0.03em;
 }
 
 .search-panel-header h1 .title-line:nth-child(3) {
-    color: #5f504a;
-    font-weight: 800;
+    color: #b85c66;
+    font-weight: 900;
 }
 
 .search-panel-header .title-accent {
-    color: var(--hero-warm-color, var(--primary));
-    font-weight: 900;
+    color: var(--primary);
+    font-weight: 780;
 }
 
 .search-panel-header p {

--- a/js/i18n/i18n-home-v3.js
+++ b/js/i18n/i18n-home-v3.js
@@ -22,9 +22,25 @@
       ko: '러브트리로 읽어보세요',
       en: 'as a LoveTree'
     },
+    'home.v3.title2.soft': {
+      ko: '첫 순간이 하나의',
+      en: 'One first moment'
+    },
+    'home.v3.title2.warm': {
+      ko: '러브트리로',
+      en: 'becomes'
+    },
+    'home.v3.title2.accent': {
+      ko: '이어져요',
+      en: 'a LoveTree'
+    },
     'home.v3.desc': {
       ko: '첫 장면과 다시 보고 싶은 순간, 그때의 마음까지 감정의 경로로 엮어 보여줍니다.',
       en: 'It weaves the first scene, moments to revisit, and the heart at that time into an emotional path.'
+    },
+    'home.v3.desc2': {
+      ko: '반했던 장면과 오래 남은 마음을, 감정이 이어진 경로로 천천히 남겨 보세요.',
+      en: 'Save the scene that stayed with you and the feelings that followed as one gentle path.'
     },
     'home.v3.cta.start': {
       ko: '내 러브트리 시작하기',

--- a/js/index-inline-init.js
+++ b/js/index-inline-init.js
@@ -4,6 +4,22 @@
     const actions = document.querySelector('.home-v3-actions');
     if (!title || !desc || !actions || document.getElementById('home-hero-set-2')) return;
 
+    const createI18nSpan = (className, key, fallback) => {
+        const span = document.createElement('span');
+        span.className = className;
+        span.setAttribute('data-i18n', key);
+        span.textContent = fallback;
+        return span;
+    };
+
+    const createI18nParagraph = (key, fallback) => {
+        const paragraph = document.createElement('p');
+        paragraph.className = 'home-v3-desc';
+        paragraph.setAttribute('data-i18n', key);
+        paragraph.textContent = fallback;
+        return paragraph;
+    };
+
     const loop = document.createElement('div');
     loop.className = 'home-hero-loop-container';
 
@@ -16,14 +32,15 @@
     const set2 = document.createElement('div');
     set2.className = 'home-hero-copy-set';
     set2.id = 'home-hero-set-2';
-    set2.innerHTML = [
-        '<h1 class="home-v3-title">',
-        '<span class="soft" data-i18n="home.v3.title2.soft">첫 순간이 하나의</span>',
-        '<span class="warm" data-i18n="home.v3.title2.warm">러브트리로</span>',
-        '<span class="accent" data-i18n="home.v3.title2.accent">이어져요</span>',
-        '</h1>',
-        '<p class="home-v3-desc" data-i18n="home.v3.desc2">반했던 장면과 오래 남은 마음을, 감정이 이어진 경로로 천천히 남겨 보세요.</p>'
-    ].join('');
+
+    const alternateTitle = document.createElement('h1');
+    alternateTitle.className = 'home-v3-title';
+    alternateTitle.appendChild(createI18nSpan('soft', 'home.v3.title2.soft', '첫 순간이 하나의'));
+    alternateTitle.appendChild(createI18nSpan('warm', 'home.v3.title2.warm', '러브트리로'));
+    alternateTitle.appendChild(createI18nSpan('accent', 'home.v3.title2.accent', '이어져요'));
+
+    set2.appendChild(alternateTitle);
+    set2.appendChild(createI18nParagraph('home.v3.desc2', '반했던 장면과 오래 남은 마음을, 감정이 이어진 경로로 천천히 남겨 보세요.'));
 
     loop.appendChild(set1);
     loop.appendChild(set2);

--- a/js/index-inline-init.js
+++ b/js/index-inline-init.js
@@ -1,4 +1,52 @@
 (function() {
+    const title = document.querySelector('.home-v3-title');
+    const desc = document.querySelector('.home-v3-desc');
+    const actions = document.querySelector('.home-v3-actions');
+    if (!title || !desc || !actions || document.getElementById('home-hero-set-2')) return;
+
+    const loop = document.createElement('div');
+    loop.className = 'home-hero-loop-container';
+
+    const set1 = document.createElement('div');
+    set1.className = 'home-hero-copy-set active';
+    set1.id = 'home-hero-set-1';
+    set1.appendChild(title);
+    set1.appendChild(desc);
+
+    const set2 = document.createElement('div');
+    set2.className = 'home-hero-copy-set';
+    set2.id = 'home-hero-set-2';
+    set2.innerHTML = [
+        '<h1 class="home-v3-title">',
+        '<span class="soft" data-i18n="home.v3.title2.soft">첫 순간이 하나의</span>',
+        '<span class="warm" data-i18n="home.v3.title2.warm">러브트리로</span>',
+        '<span class="accent" data-i18n="home.v3.title2.accent">이어져요</span>',
+        '</h1>',
+        '<p class="home-v3-desc" data-i18n="home.v3.desc2">반했던 장면과 오래 남은 마음을, 감정이 이어진 경로로 천천히 남겨 보세요.</p>'
+    ].join('');
+
+    loop.appendChild(set1);
+    loop.appendChild(set2);
+    actions.parentNode.insertBefore(loop, actions);
+
+    const isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (isReducedMotion) return;
+
+    let activeSet = 1;
+    window.setInterval(function toggleHomeHeroCopy() {
+        if (activeSet === 1) {
+            set1.classList.remove('active');
+            set2.classList.add('active');
+            activeSet = 2;
+        } else {
+            set2.classList.remove('active');
+            set1.classList.add('active');
+            activeSet = 1;
+        }
+    }, 3500);
+})();
+
+(function() {
     const cards = Array.from(document.querySelectorAll('.growth-stage-card'));
     if (!cards.length || typeof fetch !== 'function') return;
     if (document.getElementById('hero-growth-video')) return;

--- a/js/intro/intro-page-init.js
+++ b/js/intro/intro-page-init.js
@@ -23,25 +23,13 @@ if (langBtn) {
   langBtn.classList.add('active');
 }
 
-// Two-message hero copy loop animation
+// Intro page keeps a stable explanatory hero. The rotating hero copy belongs on the landing page.
 var set1 = document.getElementById('hero-set-1');
 var set2 = document.getElementById('hero-set-2');
 if (set1 && set2) {
-  var isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (!isReducedMotion) {
-    var activeSet = 1;
-    setInterval(function toggleHeroCopy() {
-      if (activeSet === 1) {
-        set1.classList.remove('active');
-        set2.classList.add('active');
-        activeSet = 2;
-      } else {
-        set2.classList.remove('active');
-        set1.classList.add('active');
-        activeSet = 1;
-      }
-    }, 3500);
-  }
+  set1.classList.add('active');
+  set2.classList.remove('active');
+  set2.setAttribute('hidden', '');
 }
 
 });

--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -39,6 +39,15 @@
         geometry.__publicViewMetricsInstalled = true;
     }
 
+    function installPublicViewportProfile() {
+        var viewport = window.LoveBudEditorCanvasViewport;
+        if (!viewport || viewport.__publicViewProfileInstalled) return;
+        viewport.minScale = Math.max(Number(viewport.minScale) || 0.2, 0.5);
+        viewport.zoomLevels = [0.5, 0.75, 1, 1.25, 1.5];
+        viewport.readableCenter = { x: 0.5, y: 0.46 };
+        viewport.__publicViewProfileInstalled = true;
+    }
+
     function initPublicCanvas() {
         var params = new URLSearchParams(window.location.search);
         var treeId = params.get('treeId');
@@ -81,7 +90,6 @@
                 var canvasReady = typeof window.createEditorCanvas === 'function';
                 var detailReady = typeof window.createEditorDetailUI === 'function';
                 var detailUIBuildersReady = typeof window.createEditorDetailUIBuilders === 'function';
-                var edgesReady = typeof window.createEditorCanvasEdges === 'function';
 
                 if (canvasReady && detailReady && detailUIBuildersReady) {
                     startCanvas();
@@ -101,6 +109,7 @@
                 }
 
                 installPublicMetrics(canvas);
+                installPublicViewportProfile();
 
                 // Set up empty guide UI
                 var emptyGuideHelper = window.LoveBudEditorEmptyGuideUI || {};


### PR DESCRIPTION
Mobile UX polish based on current QA screenshots.

Scope:
- Move the two-message hero copy loop behavior to the landing page.
- Keep the intro page hero stable instead of rotating.
- Align Browse hero title colors with the landing hero rhythm.
- Improve public read-only canvas mobile readability by using a viewer-specific viewport profile.

Intentionally not included:
- My Trees hero title layout change is not touched.

Files changed:
- js/index-inline-init.js
- js/i18n/i18n-home-v3.js
- css/index/components.css
- js/intro/intro-page-init.js
- css/search/search-hero-controls.css
- js/viewer/public-canvas-init.js

No API/backend/schema changes.