### PR TITLE
fix(viewer): improve mobile public canvas readability

### DIFF
--- a/js/viewer/public-canvas-mobile-profile.js
+++ b/js/viewer/public-canvas-mobile-profile.js
@@ -1,0 +1,49 @@
+(function() {
+    'use strict';
+
+    var viewport = window.LoveBudEditorCanvasViewport;
+    if (!viewport || viewport.__publicMobileReadableInitialViewportInstalled) return;
+    if (typeof viewport.prepareInitialViewport !== 'function') return;
+
+    var originalPrepareInitialViewport = viewport.prepareInitialViewport.bind(viewport);
+
+    function isNarrowPublicViewport() {
+        return !!(window.matchMedia && window.matchMedia('(max-width: 560px)').matches);
+    }
+
+    function getReadableScale() {
+        return isNarrowPublicViewport() ? 0.75 : 1;
+    }
+
+    viewport.prepareInitialViewport = function publicMobilePrepareInitialViewport(options) {
+        var viewportState = options && options.viewportState;
+        if (!viewportState || !isNarrowPublicViewport()) {
+            return originalPrepareInitialViewport(options);
+        }
+
+        if (typeof viewport.setScale === 'function') {
+            viewport.setScale(viewportState, viewportState.scale || 1);
+        }
+        if (viewportState.initialViewportApplied) return;
+        viewportState.initialViewportApplied = true;
+
+        var readableViewport = typeof viewport.getReadableViewportOffset === 'function'
+            ? viewport.getReadableViewportOffset(options, getReadableScale())
+            : null;
+        var fallbackViewport = typeof viewport.getFitViewport === 'function'
+            ? viewport.getFitViewport(options)
+            : { scale: 1, offsetX: 0, offsetY: 0 };
+        var nextViewport = readableViewport || fallbackViewport;
+
+        if (typeof viewport.applyViewport === 'function') {
+            viewport.applyViewport(viewportState, nextViewport, true);
+            return;
+        }
+
+        viewportState.scale = nextViewport.scale || viewportState.scale || 1;
+        viewportState.offsetX = nextViewport.offsetX || 0;
+        viewportState.offsetY = nextViewport.offsetY || 0;
+    };
+
+    viewport.__publicMobileReadableInitialViewportInstalled = true;
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -13,6 +13,14 @@
     <style>
         body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
         .editor-layout { flex: 1; }
+        @media (max-width: 560px) {
+            body.editor-readonly .editor-layout { height: calc(100vh - 44px); }
+            body.editor-readonly .canvas-area { min-height: calc(100vh - 44px); }
+            body.editor-readonly .node-info-label { display: flex; }
+            body.editor-readonly .node-title { font-size: 12px; }
+            body.editor-readonly .node-date,
+            body.editor-readonly .node-mood { font-size: 10px; }
+        }
     </style>
 </head>
 <body class="editor-preload">
@@ -59,6 +67,7 @@
     <script src="../js/editor/editor-canvas-viewport-state.js?v=20260524-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-fit.js?v=20260524-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-initial.js?v=20260524-1505"></script>
+    <script src="../js/viewer/public-canvas-mobile-profile.js?v=20260525-2"></script>
     <script src="../js/editor/editor-canvas-viewport-branches.js?v=20260523-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>


### PR DESCRIPTION
Mobile public viewer readability follow-up based on 430px QA screenshot.

Scope:
- Add a public viewer mobile viewport profile helper.
- Use a readable initial viewport on narrow public viewer screens instead of forcing full-tree fit.
- Restore read-only node labels on narrow public viewer screens, where the editor mobile CSS hides them.

Files changed:
- js/viewer/public-canvas-mobile-profile.js
- pages/view.html

No API/backend/schema changes.
No My Trees or landing hero changes.