### PR TITLE
fix(viewer): default mobile public canvas to structured layout

### DIFF
--- a/js/viewer/public-canvas-mobile-layout.js
+++ b/js/viewer/public-canvas-mobile-layout.js
@@ -1,0 +1,24 @@
+(function() {
+    'use strict';
+
+    function isPortraitPublicViewer() {
+        var width = window.innerWidth || document.documentElement.clientWidth || 0;
+        var height = window.innerHeight || document.documentElement.clientHeight || 0;
+        return width > 0 && height > 0 && width <= 560 && height >= width;
+    }
+
+    function installMobileStructuredLayoutDefault() {
+        var storage = window.LoveBudEditorCanvasLayoutStorage;
+        if (!storage || storage.__publicMobileLayoutDefaultInstalled) return;
+        if (typeof storage.loadLayoutMode !== 'function') return;
+
+        var originalLoadLayoutMode = storage.loadLayoutMode.bind(storage);
+        storage.loadLayoutMode = function publicViewerLoadLayoutMode(layoutModeStorageKey) {
+            if (isPortraitPublicViewer()) return 'structured';
+            return originalLoadLayoutMode(layoutModeStorageKey);
+        };
+        storage.__publicMobileLayoutDefaultInstalled = true;
+    }
+
+    installMobileStructuredLayoutDefault();
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -96,6 +96,7 @@
     <script src="../js/editor/editor-empty-guide-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
+    <script src="../js/viewer/public-canvas-mobile-layout.js?v=20260525-1"></script>
     <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
     <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
 
@@ -112,7 +113,7 @@
 
     <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
-    <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260525-3"></script>
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n.js?v=20260419-2"></script>


### PR DESCRIPTION
Public viewer should keep the tree as the primary experience on mobile.

This makes portrait mobile public view default to the structured tree layout while leaving desktop and wider layouts unchanged.

Also refreshes the i18n-editor script version on view.html so layout labels resolve instead of showing raw keys.

Scope:
- js/viewer/public-canvas-mobile-layout.js
- pages/view.html

No API/backend/schema changes.