### PR TITLE
refactor(viewer): delegate public detail channel link helper

### DIFF
--- a/js/viewer/public-viewer-detail-channel-link.js
+++ b/js/viewer/public-viewer-detail-channel-link.js
@@ -1,0 +1,137 @@
+(function() {
+    'use strict';
+
+    const CHANNEL_ROW_ID = 'detailCurrentMomentChannel';
+
+    function normalizeYouTubeHost(hostname) {
+        return String(hostname || '')
+            .trim()
+            .toLowerCase()
+            .replace(/^www\./, '')
+            .replace(/^m\./, '');
+    }
+
+    function isSafeYouTubeChannelPath(pathname) {
+        const path = String(pathname || '').trim();
+        return /^\/@[0-9A-Za-z._-]{3,100}$/.test(path) ||
+            /^\/channel\/UC[0-9A-Za-z_-]{10,100}$/.test(path);
+    }
+
+    function sanitizeYouTubeChannelUrl(url) {
+        if (!url || typeof url !== 'string') return '';
+        try {
+            const parsed = new URL(url.trim());
+            const host = normalizeYouTubeHost(parsed.hostname);
+            if (parsed.protocol !== 'https:' || host !== 'youtube.com') return '';
+            if (!isSafeYouTubeChannelPath(parsed.pathname)) return '';
+            parsed.search = '';
+            parsed.hash = '';
+            return parsed.toString();
+        } catch (e) {
+            return '';
+        }
+    }
+
+    function buildChannelUrlFromId(channelId) {
+        const id = String(channelId || '').trim();
+        if (/^@[0-9A-Za-z._-]{3,100}$/.test(id)) {
+            return `https://www.youtube.com/${id}`;
+        }
+        if (/^UC[0-9A-Za-z_-]{10,100}$/.test(id)) {
+            return `https://www.youtube.com/channel/${id}`;
+        }
+        return '';
+    }
+
+    function resolveChannelLabel(data) {
+        const label = String(data?.channelName || data?.channelId || '').trim();
+        if (!label) return '';
+        return label.startsWith('@') ? label : `from ${label}`;
+    }
+
+    function resolveSafeChannelUrl(data) {
+        const explicitUrl = sanitizeYouTubeChannelUrl(data?.channelUrl || '');
+        if (explicitUrl) return explicitUrl;
+        return sanitizeYouTubeChannelUrl(buildChannelUrlFromId(data?.channelId || ''));
+    }
+
+    function removeExistingChannelRow() {
+        const existing = document.getElementById(CHANNEL_ROW_ID);
+        if (existing) existing.remove();
+    }
+
+    function renderDetailChannelLink(data) {
+        removeExistingChannelRow();
+
+        const titleEl = document.getElementById('detailCurrentMomentTitle');
+        if (!titleEl || !data || data.isNewTree) return;
+
+        const label = resolveChannelLabel(data);
+        const safeUrl = resolveSafeChannelUrl(data);
+        if (!label || !safeUrl) return;
+
+        const row = document.createElement('div');
+        row.id = CHANNEL_ROW_ID;
+        row.className = 'editor-current-moment-channel';
+        row.style.display = 'flex';
+        row.style.alignItems = 'center';
+        row.style.gap = '6px';
+        row.style.margin = '-4px 0 12px';
+        row.style.fontSize = '12px';
+        row.style.lineHeight = '1.45';
+        row.style.color = 'var(--on-surface-variant)';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.style.fontSize = '14px';
+        icon.textContent = 'account_circle';
+        row.appendChild(icon);
+
+        const prefix = document.createElement('span');
+        prefix.textContent = 'from';
+        row.appendChild(prefix);
+
+        const link = document.createElement('a');
+        link.href = safeUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = 'editor-current-moment-channel-link';
+        link.textContent = label.replace(/^from\s+/i, '');
+        link.style.color = 'var(--primary)';
+        link.style.textDecoration = 'none';
+        link.style.fontWeight = '700';
+        row.appendChild(link);
+
+        titleEl.insertAdjacentElement('afterend', row);
+    }
+
+    function installDetailChannelLinkPatch() {
+        const originalFactory = window.createEditorDetailUI;
+        if (typeof originalFactory !== 'function' || originalFactory.__publicViewerChannelLinkPatched) return;
+
+        const patchedFactory = function(deps) {
+            const detailUI = originalFactory(deps);
+            if (!detailUI || typeof detailUI.updateDetailPanel !== 'function') return detailUI;
+
+            const originalUpdateDetailPanel = detailUI.updateDetailPanel;
+            detailUI.updateDetailPanel = function(data) {
+                originalUpdateDetailPanel(data);
+                renderDetailChannelLink(data);
+            };
+
+            return detailUI;
+        };
+
+        patchedFactory.__publicViewerChannelLinkPatched = true;
+        window.createEditorDetailUI = patchedFactory;
+    }
+
+    window.LoveBudPublicViewerDetailChannelLink = {
+        renderDetailChannelLink,
+        sanitizeYouTubeChannelUrl,
+        buildChannelUrlFromId
+    };
+
+    installDetailChannelLinkPatch();
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
+    <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260526-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -170,6 +170,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-canvas-branch-ports.js',
     'js/editor/editor-detail-inline-edit.js',
     'js/editor/editor-detail-sidebar-status-boundary.js',
+    'js/editor/editor-detail-channel-link.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];
@@ -183,20 +184,38 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
   });
 });
 
-test('public canvas route currently uses remaining editor detail UI stack before public init', () => {
+test('public canvas route currently uses remaining editor detail UI core stack before public init', () => {
   const scripts = getScriptSrcs();
 
   const detailScripts = [
     'js/editor/editor-detail-tree-meta.js',
     'js/editor/editor-detail-ui-builders.js',
     'js/editor/editor-detail-ui.js',
-    'js/editor/editor-detail-channel-link.js',
   ];
 
   detailScripts.forEach((needle) => {
     assert.ok(scriptIncludes(scripts, needle), `view.html currently loads detail dependency: ${needle}`);
     assertScriptOrder(scripts, needle, 'js/viewer/public-canvas-init.js');
   });
+});
+
+test('public canvas route delegates detail channel link patch to viewer helper', () => {
+  const scripts = getScriptSrcs();
+  const helperSrc = fs.readFileSync('js/viewer/public-viewer-detail-channel-link.js', 'utf8');
+
+  assert.equal(
+    scriptIncludes(scripts, 'js/editor/editor-detail-channel-link.js'),
+    false,
+    'view.html must not load editor detail channel link patch'
+  );
+  assert.ok(
+    scriptIncludes(scripts, 'js/viewer/public-viewer-detail-channel-link.js'),
+    'view.html must load viewer detail channel link helper'
+  );
+  assertScriptOrder(scripts, 'js/editor/editor-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-channel-link.js', 'js/viewer/public-canvas-init.js');
+  assert.ok(helperSrc.includes('window.LoveBudPublicViewerDetailChannelLink'), 'viewer channel link helper must expose inspectable namespace');
+  assert.ok(helperSrc.includes('__publicViewerChannelLinkPatched'), 'viewer channel link helper must mark the patched detail factory');
 });
 
 test('public viewer copy helper centralizes viewer copy and hidden-control rules', () => {

--- a/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
@@ -1,0 +1,159 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+function createPublicViewerDetailChannelContext(options = {}) {
+  const elements = new Map();
+
+  function createElement(tagName) {
+    const children = [];
+    const element = {
+      tagName: String(tagName).toUpperCase(),
+      id: '',
+      className: '',
+      style: {},
+      attributes: {},
+      children,
+      parentElement: null,
+      textContent: '',
+      href: '',
+      target: '',
+      rel: '',
+      setAttribute(name, value) {
+        this.attributes[name] = String(value);
+      },
+      appendChild(child) {
+        child.parentElement = this;
+        children.push(child);
+        if (child.id) elements.set(child.id, child);
+        return child;
+      },
+      remove() {
+        if (this.parentElement) {
+          const index = this.parentElement.children.indexOf(this);
+          if (index >= 0) this.parentElement.children.splice(index, 1);
+        }
+        if (this.id) elements.delete(this.id);
+      },
+      insertAdjacentElement(position, child) {
+        child.parentElement = this.parentElement;
+        if (child.id) elements.set(child.id, child);
+        if (!this.parentElement || position !== 'afterend') return child;
+        const index = this.parentElement.children.indexOf(this);
+        this.parentElement.children.splice(index + 1, 0, child);
+        return child;
+      }
+    };
+    return element;
+  }
+
+  const title = createElement('h4');
+  title.id = 'detailCurrentMomentTitle';
+  elements.set(title.id, title);
+
+  const parent = createElement('div');
+  parent.appendChild(title);
+
+  const context = {
+    URL,
+    window: {
+      createEditorDetailUI: options.createEditorDetailUI || (() => ({
+        updateDetailPanel: () => {}
+      }))
+    },
+    document: {
+      createElement,
+      getElementById: (id) => elements.get(id) || null
+    }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/viewer/public-viewer-detail-channel-link.js'), 'utf8'), context);
+
+  return {
+    context,
+    title,
+    getChannelRow: () => elements.get('detailCurrentMomentChannel') || null
+  };
+}
+
+test('public viewer detail channel link exposes viewer namespace', () => {
+  const harness = createPublicViewerDetailChannelContext();
+
+  assert.equal(typeof harness.context.window.LoveBudPublicViewerDetailChannelLink.renderDetailChannelLink, 'function');
+  assert.equal(typeof harness.context.window.LoveBudPublicViewerDetailChannelLink.sanitizeYouTubeChannelUrl, 'function');
+  assert.equal(typeof harness.context.window.LoveBudPublicViewerDetailChannelLink.buildChannelUrlFromId, 'function');
+});
+
+test('public viewer detail channel link renders safe YouTube handle link after title', () => {
+  const harness = createPublicViewerDetailChannelContext();
+
+  harness.context.window.LoveBudPublicViewerDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+
+  const row = harness.getChannelRow();
+  assert.ok(row);
+  assert.equal(row.children[1].textContent, 'from');
+  assert.equal(row.children[2].tagName, 'A');
+  assert.equal(row.children[2].href, 'https://www.youtube.com/@woowayoung');
+  assert.equal(row.children[2].target, '_blank');
+  assert.equal(row.children[2].rel, 'noopener noreferrer');
+  assert.equal(row.children[2].textContent, '@woowayoung');
+});
+
+test('public viewer detail channel link does not use unsafe explicit channel URL', () => {
+  const harness = createPublicViewerDetailChannelContext();
+
+  harness.context.window.LoveBudPublicViewerDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'javascript:alert(1)'
+  });
+
+  const row = harness.getChannelRow();
+  assert.ok(row, 'safe channelId fallback should still render');
+  assert.equal(row.children[2].href, 'https://www.youtube.com/@woowayoung');
+});
+
+test('public viewer detail channel link removes stale row when selected memory lacks channel data', () => {
+  const harness = createPublicViewerDetailChannelContext();
+
+  harness.context.window.LoveBudPublicViewerDetailChannelLink.renderDetailChannelLink({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+  assert.ok(harness.getChannelRow());
+
+  harness.context.window.LoveBudPublicViewerDetailChannelLink.renderDetailChannelLink({
+    title: 'No channel memory'
+  });
+
+  assert.equal(harness.getChannelRow(), null);
+});
+
+test('public viewer detail channel link patch wraps updateDetailPanel without replacing original behavior', () => {
+  let originalCalled = false;
+  const harness = createPublicViewerDetailChannelContext({
+    createEditorDetailUI: () => ({
+      updateDetailPanel: () => { originalCalled = true; }
+    })
+  });
+
+  const detailUI = harness.context.window.createEditorDetailUI({});
+  detailUI.updateDetailPanel({
+    channelId: '@woowayoung',
+    channelName: '@woowayoung',
+    channelUrl: 'https://www.youtube.com/@woowayoung'
+  });
+
+  assert.equal(originalCalled, true);
+  assert.ok(harness.getChannelRow());
+});

--- a/tests/routes/public-viewer-detail-script-trim-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-script-trim-contract.test.cjs
@@ -28,9 +28,14 @@ test('public viewer keeps detail UI builders before detail UI for fallback bound
   assert.ok(buildersIndex < detailUiIndex, 'detail UI builders must load before detail UI so fallback boundaries exist');
 });
 
-
-test('public viewer keeps channel link patch until viewer-only detail rendering owns it', () => {
+test('public viewer delegates channel link patch to viewer-owned helper', () => {
   const scripts = getScriptSrcs();
+  const detailUiIndex = scripts.findIndex((src) => src.includes('js/editor/editor-detail-ui.js'));
+  const helperIndex = scripts.findIndex((src) => src.includes('js/viewer/public-viewer-detail-channel-link.js'));
 
-  assert.ok(scripts.includes('../js/editor/editor-detail-channel-link.js'), 'channel link patch remains loaded for public detail display');
+  assert.equal(scripts.includes('../js/editor/editor-detail-channel-link.js'), false, 'public view must not load editor detail channel link patch');
+  assert.ok(scripts.includes('../js/viewer/public-viewer-detail-channel-link.js'), 'public view must load viewer detail channel link helper');
+  assert.notEqual(detailUiIndex, -1, 'public view must load detail UI');
+  assert.notEqual(helperIndex, -1, 'public view must load viewer channel link helper');
+  assert.ok(detailUiIndex < helperIndex, 'viewer channel link helper must load after detail UI so it can patch the factory');
 });


### PR DESCRIPTION
Refs #1711

## Summary
- add viewer-owned `public-viewer-detail-channel-link.js` helper for the public detail channel link patch
- switch `pages/view.html` from the editor channel-link patch to the viewer helper
- update route contracts so the editor channel-link patch stays out of the public viewer route
- add viewer helper contract coverage for safe YouTube URLs and patch behavior

## Validation
- pending CI