### PR TITLE
refactor(viewer): delegate public detail shell template

### DIFF
--- a/js/viewer/public-viewer-detail-panel-shell-template.js
+++ b/js/viewer/public-viewer-detail-panel-shell-template.js
@@ -1,0 +1,44 @@
+(function() {
+    'use strict';
+
+    const mount = document.getElementById('editorDetailPanelShellTemplateMount');
+    if (!mount) return;
+
+    const panel = document.createElement('aside');
+    panel.className = 'detail-panel memory-detail-section reveal-fade';
+    panel.id = 'detailPanel';
+
+    const header = document.createElement('div');
+    header.className = 'panel-header';
+
+    const heading = document.createElement('h3');
+    heading.className = 'headline editor-panel-headline';
+    header.appendChild(heading);
+
+    const content = document.createElement('div');
+    content.className = 'detail-content';
+    content.id = 'detailContent';
+
+    const emptyMount = document.createElement('div');
+    emptyMount.id = 'editorDetailEmptyStateTemplateMount';
+
+    const viewMount = document.createElement('div');
+    viewMount.id = 'editorDetailViewModeTemplateMount';
+
+    const editMount = document.createElement('div');
+    editMount.id = 'editorDetailEditModeTemplateMount';
+
+    content.appendChild(emptyMount);
+    content.appendChild(viewMount);
+    content.appendChild(editMount);
+
+    panel.appendChild(header);
+    panel.appendChild(content);
+    mount.replaceWith(panel);
+
+    window.LoveBudPublicViewerDetailPanelShellTemplate = {
+        mountId: 'editorDetailPanelShellTemplateMount',
+        detailPanelId: 'detailPanel',
+        detailContentId: 'detailContent'
+    };
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/editor.css?v=20260510-1006">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
     <style>
         body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
         .editor-layout { flex: 1; }
@@ -43,61 +42,8 @@
     <script src="../js/utils/media.js?v=20260418-1"></script>
 
     <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
-    <script src="../js/editor/templates/editor-detail-panel-shell-template.js?v=20260525-1280"></script>
+    <script src="../js/viewer/public-viewer-detail-panel-shell-template.js?v=20260526-1"></script>
     <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260525-1280"></script>
-
-    <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
-    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
-    <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
-    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
-    <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
-    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
-    <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-scale.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-projection.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-targets.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-feedback.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-state.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-fit.js?v=20260524-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-initial.js?v=20260524-1505"></script>
-    <script src="../js/viewer/public-canvas-mobile-profile.js?v=20260525-2"></script>
-    <script src="../js/editor/editor-canvas-viewport-branches.js?v=20260523-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
-    <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>
-    <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
-
-    <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
-    <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
-    <script src="../js/viewer/public-canvas-mobile-layout.js?v=20260525-1"></script>
-    <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
-    <script src="../js/viewer/public-canvas-affordance-fallback.js?v=20260526-1"></script>
-    <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
-
-    <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260526-1"></script>
-
-    <script src="../js/api/auth-policy.js?v=20260420-1"></script>
-    <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
-    <script src="../js/postgres-client.js?v=20260422-1"></script>
-
-    <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
-    <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
-    <script src="../js/i18n/i18n-editor.js?v=20260525-3"></script>
-    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
-    <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
-    <script src="../js/i18n.js?v=20260419-2"></script>
-
-    <script src="../js/shared-header.js?v=20260421-2"></script>
-    <script src="../js/page-transitions.js?v=20260430-1"></script>
-    <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
-    <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
-    <script src="../js/viewer/public-viewer-copy-helper.js?v=20260525-1"></script>
-    <script src="../js/viewer/public-viewer-copy-polish.js?v=20260525-1"></script>
 </body>
 </html>

--- a/pages/view.html
+++ b/pages/view.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="../css/global.css?v=20260509-994-1">
     <link rel="stylesheet" href="../css/editor.css?v=20260510-1006">
     <link rel="stylesheet" href="../css/page-transitions.css?v=20260430-1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
     <style>
         body { min-height: 100vh; display: flex; flex-direction: column; overflow-x: hidden; }
         .editor-layout { flex: 1; }

--- a/pages/view.html
+++ b/pages/view.html
@@ -45,5 +45,58 @@
     <script src="../js/viewer/public-viewer-detail-panel-shell-template.js?v=20260526-1"></script>
     <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260525-1280"></script>
+
+    <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
+    <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
+    <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-scale.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-projection.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-targets.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-feedback.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-state.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-fit.js?v=20260524-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-initial.js?v=20260524-1505"></script>
+    <script src="../js/viewer/public-canvas-mobile-profile.js?v=20260525-2"></script>
+    <script src="../js/editor/editor-canvas-viewport-branches.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>
+    <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
+
+    <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
+    <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
+    <script src="../js/viewer/public-canvas-mobile-layout.js?v=20260525-1"></script>
+    <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
+    <script src="../js/viewer/public-canvas-affordance-fallback.js?v=20260526-1"></script>
+    <script type="module" src="../js/editor/editor-canvas.js?v=20260507-655"></script>
+
+    <script src="../js/editor/editor-detail-tree-meta.js?v=20260502-1"></script>
+    <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
+    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
+    <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260526-1"></script>
+
+    <script src="../js/api/auth-policy.js?v=20260420-1"></script>
+    <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>
+    <script src="../js/postgres-client.js?v=20260422-1"></script>
+
+    <script src="../js/i18n/i18n-core.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-shared.js?v=20260421-4"></script>
+    <script src="../js/i18n/i18n-editor.js?v=20260525-3"></script>
+    <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
+    <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
+    <script src="../js/i18n.js?v=20260419-2"></script>
+
+    <script src="../js/shared-header.js?v=20260421-2"></script>
+    <script src="../js/page-transitions.js?v=20260430-1"></script>
+    <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
+    <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
+    <script src="../js/viewer/public-viewer-copy-helper.js?v=20260525-1"></script>
+    <script src="../js/viewer/public-viewer-copy-polish.js?v=20260525-1"></script>
 </body>
 </html>

--- a/tests/routes/public-viewer-sidebar-shell-contract.test.cjs
+++ b/tests/routes/public-viewer-sidebar-shell-contract.test.cjs
@@ -25,7 +25,8 @@ test('public viewer keeps detail and canvas shells for the current implementatio
   const scripts = getScriptSrcs();
 
   assert.ok(html.includes('id="editorCanvasTopbarTemplateMount"'), 'canvas topbar shell is still used by public viewer');
-  assert.ok(html.includes('id="editorDetailPanelShellTemplateMount"'), 'detail panel shell is still used by public viewer');
+  assert.ok(html.includes('id="editorDetailPanelShellTemplateMount"'), 'detail panel shell mount is still used by public viewer');
   assert.ok(scripts.includes('../js/editor/templates/editor-canvas-topbar-template.js'), 'canvas topbar template remains loaded');
-  assert.ok(scripts.includes('../js/editor/templates/editor-detail-panel-shell-template.js'), 'detail panel shell template remains loaded');
+  assert.ok(scripts.includes('../js/viewer/public-viewer-detail-panel-shell-template.js'), 'viewer detail panel shell template is loaded');
+  assert.equal(scripts.includes('../js/editor/templates/editor-detail-panel-shell-template.js'), false, 'public view must not load the editor detail panel shell template');
 });


### PR DESCRIPTION
Refs #1711

## Summary
- add a viewer-owned public detail panel shell template helper
- switch `pages/view.html` from the editor detail panel shell template to the viewer helper
- preserve the existing detail shell DOM ids required by the current detail UI stack

## Validation
- pending CI

## Note
- No API, backend, schema, auth, canvas runtime, detail UI core, or CSS changes.