### PR TITLE
refactor(viewer): own detail sidebar status noop

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -16,6 +16,8 @@
         };
     }
 
+    function updatePublicViewerSidebarStatus() {}
+
     function createPublicViewerDetailUI(deps) {
         if (typeof window.createEditorDetailUI !== 'function') {
             throw new Error('createEditorDetailUI is required for public viewer detail UI adapter');
@@ -23,6 +25,7 @@
 
         var detailUI = window.createEditorDetailUI(deps);
         detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps);
+        detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus;
         return detailUI;
     }
 
@@ -30,6 +33,7 @@
     window.LoveBudPublicViewerDetailUI = {
         createPublicViewerDetailUI: createPublicViewerDetailUI,
         createPublicViewerUpdateFocusSelectedBtn: createPublicViewerUpdateFocusSelectedBtn,
+        updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus,
         delegatesToEditorDetailUI: true
     };
 })();

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -55,6 +55,14 @@ test('public viewer detail UI adapter owns focus selected button updates', () =>
   assert.ok(source.includes('LoveBudPublicViewerDetailUI'), 'viewer detail adapter exposes an inspectable namespace');
 });
 
+test('public viewer detail UI adapter owns sidebar status as noop', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function updatePublicViewerSidebarStatus() {}'), 'viewer adapter exposes a sidebar status noop');
+  assert.ok(source.includes('detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus'), 'viewer adapter assigns sidebar status noop');
+  assert.ok(source.includes('updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus'), 'viewer adapter publishes sidebar status noop for inspection');
+});
+
 test('public viewer keeps extracted detail helpers on viewer-owned paths', () => {
   const scripts = getScriptSrcs();
 


### PR DESCRIPTION
Refs #1711

## Summary
- keep the public viewer detail UI adapter delegation to `editor-detail-ui.js`
- override `updateSidebarStatus` with a viewer-owned noop because public viewer no longer mounts the editor sidebar status DOM
- add a public viewer detail contract assertion covering the sidebar-status noop override

## Validation
- Connector diff check: branch is 2 commits ahead of `6b7a6c813d3105b14e661fb8c1d792fcf48f1cd7`, 0 behind
- Changed files limited to:
  - `js/viewer/public-viewer-detail-ui.js`
  - `tests/routes/public-viewer-detail-ui-core-contract.test.cjs`

## Notes
- `pages/view.html` still loads `js/editor/editor-detail-ui.js` intentionally.
- `setDetailEmptyState` and `updateDetailPanel` are untouched.