### PR TITLE
refactor(viewer): trim detail tree meta setup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -160,21 +160,6 @@
                 var formatI18nText = function(key, fallback) { return fallback || key; };
                 var showToast = function(msg) { console.log('[public-canvas]', msg); };
 
-                var detailUIBuilders = window.createEditorDetailUIBuilders({ formatI18nText: formatI18nText });
-                var treeMetaBoundary = window.createEditorDetailTreeMetaBoundary({
-                    i18n: function(k) { return k; },
-                    formatI18nText: formatI18nText,
-                    resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
-                    createInlineIcon: detailUIBuilders.createInlineIcon,
-                    showToast: showToast,
-                    openCurrentMomentDetail: function() {
-                        var mem = currentEditingMemory || findFirstSelectableMemory();
-                        if (mem && mem.id) {
-                            window.location.href = 'detail.html?id=' + encodeURIComponent(mem.id) + '&tree=' + encodeURIComponent(treeId) + '&from=public';
-                        }
-                    }
-                });
-
                 var detailUI = window.createPublicViewerDetailUI({
                     detailPanel: detailPanel,
                     i18n: function(k) { return k; },

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -40,6 +40,7 @@ test('public canvas init uses the viewer detail UI adapter factory', () => {
   assert.ok(source.includes('typeof window.createPublicViewerDetailUI === \'function\''), 'public canvas init waits for the viewer detail adapter');
   assert.ok(source.includes('window.createPublicViewerDetailUI({'), 'public canvas init creates detail UI through the viewer adapter');
   assert.equal(source.includes('window.createEditorDetailUI({'), false, 'public canvas init does not call the editor detail factory directly');
+  assert.equal(source.includes('window.createEditorDetailTreeMetaBoundary({'), false, 'public canvas init does not create an unused tree meta boundary');
 });
 
 test('public viewer detail UI adapter owns focus selected button updates', () => {


### PR DESCRIPTION
Refs #1711

Summary:
- Trim unused tree meta boundary setup in `public-canvas-init.js`.
- Keep detail UI creation through `createPublicViewerDetailUI(...)`.
- Add a contract assertion for the public canvas init path.

Validation:
- Diff checked against `db4e09b629751dde6527c280ca2ef6d2c0953d79`.
- Changed files: `js/viewer/public-canvas-init.js`, `tests/routes/public-viewer-detail-ui-core-contract.test.cjs`.

Notes:
- `pages/view.html` unchanged.
- Detail panel rendering behavior unchanged.