### PR TITLE
refactor(viewer): remove unused public init locals

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -112,7 +112,6 @@
                 installPublicViewportProfile();
 
                 // Set up empty guide UI
-                var emptyGuideHelper = window.LoveBudEditorEmptyGuideUI || {};
                 var updateCanvasEmptyGuide = function() {
                     var guide = document.getElementById('canvasEmptyGuide');
                     if (!guide) return;
@@ -157,7 +156,6 @@
                 }
 
                 // Initialize detail UI
-                var formatI18nText = function(key, fallback) { return fallback || key; };
                 var showToast = function(msg) { console.log('[public-canvas]', msg); };
 
                 var detailUI = window.createPublicViewerDetailUI({


### PR DESCRIPTION
Refs #1711

Summary:
- Remove two unused local variables from `public-canvas-init.js`.
- Keep public canvas init behavior unchanged.

Validation:
- Diff checked against `7a31b284bf3a169434dfd7c5e6cdc53a10d76d41`.
- Changed file: `js/viewer/public-canvas-init.js`.