### PR TITLE
refactor(viewer): trim public init readiness gate

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -89,9 +89,8 @@
 
                 var canvasReady = typeof window.createEditorCanvas === 'function';
                 var detailReady = typeof window.createPublicViewerDetailUI === 'function';
-                var detailUIBuildersReady = typeof window.createEditorDetailUIBuilders === 'function';
 
-                if (canvasReady && detailReady && detailUIBuildersReady) {
+                if (canvasReady && detailReady) {
                     startCanvas();
                     return;
                 }

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -39,6 +39,11 @@ test('public canvas init uses the viewer detail UI adapter factory', () => {
 
   assert.ok(source.includes('typeof window.createPublicViewerDetailUI === \'function\''), 'public canvas init waits for the viewer detail adapter');
   assert.ok(source.includes('window.createPublicViewerDetailUI({'), 'public canvas init creates detail UI through the viewer adapter');
+  assert.equal(
+    source.includes('typeof window.createEditorDetailUIBuilders === \'function\''),
+    false,
+    'public canvas init does not wait on a builder helper it does not call directly'
+  );
   assert.equal(source.includes('window.createEditorDetailUI({'), false, 'public canvas init does not call the editor detail factory directly');
   assert.equal(source.includes('window.createEditorDetailTreeMetaBoundary({'), false, 'public canvas init does not create an unused tree meta boundary');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Remove the extra public-canvas-init readiness gate for createEditorDetailUIBuilders.
- Keep detail UI creation routed through createPublicViewerDetailUI.
- Add a contract assertion for the public canvas init path.

Validation:
- npm run lint
- npm run build
- npm run verify
- npm test
- node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs