### PR TITLE
refactor(viewer): own public detail empty state

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -18,6 +18,28 @@
 
     function updatePublicViewerSidebarStatus() {}
 
+    function createPublicViewerSetDetailEmptyState(deps) {
+        return function setPublicViewerDetailEmptyState(isEmpty) {
+            var detailContent = document.getElementById('detailContent');
+            if (!detailContent) return;
+
+            var emptyState = document.getElementById('detailEmptyState');
+            if (!emptyState) {
+                emptyState = document.createElement('div');
+                emptyState.id = 'detailEmptyState';
+                emptyState.innerHTML = '<div style="text-align:center;padding:40px 24px;color:var(--on-surface-variant);"><span class="material-symbols-outlined" style="font-size:48px;opacity:0.4;margin-bottom:16px;display:block;">sentiment_satisfied</span><p style="font-size:1rem;font-weight:700;margin-bottom:8px;color:var(--on-surface);">첫 순간이 트리를 깨워요</p><p style="font-size:0.9rem;opacity:0.78;line-height:1.6;">첫 순간을 심으면 이 패널이 현재 순간 허브로 바뀝니다.</p></div>';
+                detailContent.appendChild(emptyState);
+            }
+
+            var viewMode = document.getElementById('detailViewMode');
+            var footer = document.getElementById('detailPanelFooter');
+
+            if (emptyState) emptyState.style.display = isEmpty ? 'block' : 'none';
+            if (viewMode) viewMode.style.display = isEmpty ? 'none' : 'block';
+            if (footer) footer.style.display = isEmpty ? 'none' : '';
+        };
+    }
+
     function createPublicViewerDetailUI(deps) {
         if (typeof window.createEditorDetailUI !== 'function') {
             throw new Error('createEditorDetailUI is required for public viewer detail UI adapter');
@@ -26,6 +48,7 @@
         var detailUI = window.createEditorDetailUI(deps);
         detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps);
         detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus;
+        detailUI.setDetailEmptyState = createPublicViewerSetDetailEmptyState(deps);
         return detailUI;
     }
 
@@ -34,6 +57,7 @@
         createPublicViewerDetailUI: createPublicViewerDetailUI,
         createPublicViewerUpdateFocusSelectedBtn: createPublicViewerUpdateFocusSelectedBtn,
         updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus,
+        createPublicViewerSetDetailEmptyState: createPublicViewerSetDetailEmptyState,
         delegatesToEditorDetailUI: true
     };
 })();

--- a/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
+++ b/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
@@ -128,6 +128,10 @@ const FILE_ALLOWLIST = {
     count: 1, classification: 'safe',
     reason: 'Public read-only canvas route. innerHTML on fresh error element with escapeHtml for user-visible error message; uses textContent for primary error'
   },
+  'js/viewer/public-viewer-detail-ui.js': {
+    count: 1, classification: 'safe',
+    reason: 'emptyState.innerHTML — static public viewer detail empty state template with hardcoded Korean text, no user content'
+  },
   'js/viewer/public-viewer-detail-view-mode-template.js': {
     count: 1, classification: 'safe',
     reason: 'mount.outerHTML = template — static public viewer detail view template, no user content'

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -69,6 +69,16 @@ test('public viewer detail UI adapter owns sidebar status as noop', () => {
   assert.ok(source.includes('updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus'), 'viewer adapter publishes sidebar status noop for inspection');
 });
 
+test('public viewer detail UI adapter owns empty state', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function createPublicViewerSetDetailEmptyState(deps)'), 'viewer adapter exposes empty state factory');
+  assert.ok(source.includes('detailUI.setDetailEmptyState = createPublicViewerSetDetailEmptyState(deps)'), 'viewer adapter overrides setDetailEmptyState');
+  assert.ok(source.includes('LoveBudPublicViewerDetailUI'), 'viewer adapter exposes the inspectable namespace');
+  assert.ok(source.includes('createPublicViewerSetDetailEmptyState'), 'viewer adapter publishes empty state factory on namespace');
+  assert.equal(source.includes('detailUI.updateDetailPanel ='), false, 'viewer adapter does NOT override updateDetailPanel — still delegates to editor detail core');
+});
+
 test('public viewer keeps extracted detail helpers on viewer-owned paths', () => {
   const scripts = getScriptSrcs();
 


### PR DESCRIPTION
Refs #1711

Summary:
- Add createPublicViewerSetDetailEmptyState(deps) to public-viewer-detail-ui.js.
- Override detailUI.setDetailEmptyState with a viewer-owned version that only
  controls public-viewer-relevant DOM (empty state template, view mode, footer).
- Does NOT call editor-core resetDetailViewState (which resets edit inputs,
  save indicators, etc. — not applicable to public viewer).
- updateDetailPanel still delegates to editor detail core.
- Add contract assertions: viewer adapter overrides setDetailEmptyState but
  NOT updateDetailPanel.
- Add dom-xss-renderer-guardrail allowlist entry for the new static innerHTML.

Validation:
- npm run lint
- npm run build
- npm run verify
- npm test
- node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs