### PR TITLE
refactor(viewer): trim stale copy rules

### DIFF
--- a/js/viewer/public-viewer-copy-helper.js
+++ b/js/viewer/public-viewer-copy-helper.js
@@ -6,8 +6,6 @@
         { selector: '#detailTreeStatusLabel', text: '러브트리 정보' },
         { selector: '#detailCurrentMomentBadge', text: '선택한 순간' },
         { selector: '#detailCurrentMomentHint', text: '이 순간의 장면과 메모를 감상해 보세요.' },
-        { selector: '#detailActionsPrimaryLabel', text: '감상 동선' },
-        { selector: '#viewMomentDetailBtnLabel', text: '순간 자세히 보기' },
         { selector: '#detailMomentInfoLabel', text: '순간 기록' },
         { selector: '#detailDateLabel', text: '기록일' },
         { selector: '#detailTagsLabel', text: '감정 태그' },

--- a/tests/routes/public-viewer-action-visibility-contract.test.cjs
+++ b/tests/routes/public-viewer-action-visibility-contract.test.cjs
@@ -30,13 +30,17 @@ test('public viewer control visibility helper no longer carries stale editor-onl
   assert.ok(helperSrc.includes('return [];'), 'public viewer helper should currently return no fallback control selectors');
 });
 
-test('public viewer copy helper remains focused on copy rules', () => {
+test('public viewer copy helper remains focused on active copy rules', () => {
   const copyHelperSrc = readFile('js/viewer/public-viewer-copy-helper.js');
 
   assert.ok(copyHelperSrc.includes('LoveBudPublicViewerCopyHelper'), 'public viewer copy helper must expose an inspectable namespace');
   assert.ok(copyHelperSrc.includes('getTextRules'), 'public viewer copy helper must still expose text rules');
   assert.ok(copyHelperSrc.includes('getRawLayoutLabel'), 'public viewer copy helper must still expose layout label fallback rules');
   assert.equal(copyHelperSrc.includes('getHideSelectors'), false, 'copy helper must not own control visibility selector rules');
+  assert.equal(copyHelperSrc.includes('#detailActionsPrimaryLabel'), false, 'copy helper must not keep stale action card copy');
+  assert.equal(copyHelperSrc.includes('#viewMomentDetailBtnLabel'), false, 'copy helper must not keep stale detail action copy');
+  assert.ok(copyHelperSrc.includes('#detailMomentInfoLabel'), 'copy helper keeps active moment info copy');
+  assert.ok(copyHelperSrc.includes('#detailMemoLabel'), 'copy helper keeps active memo label copy');
 });
 
 test('public viewer copy polish applies control visibility rules only in readonly viewer mode', () => {


### PR DESCRIPTION
Refs #1711

Summary:
- Trim stale viewer copy rules.
- Update the viewer action visibility contract.

Validation:
- Connector diff check passed.