### PR TITLE
test(viewer): lock public detail output mounts

### DIFF
--- a/tests/routes/public-viewer-detail-output-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-output-contract.test.cjs
@@ -41,7 +41,6 @@ test('editor detail core still owns the current detail output rendering contract
     'detailCurrentMomentBadge',
     'detailCurrentMomentTitle',
     'detailCurrentMomentHint',
-    'detailImg',
     'detailDateText',
     'detailTags',
     'detailMemo',
@@ -50,6 +49,7 @@ test('editor detail core still owns the current detail output rendering contract
     assert.ok(editorDetailSrc.includes(id), `editor detail core still references #${id}`);
   });
 
+  assert.ok(editorDetailSrc.includes("detailPanel.querySelector('.detail-video img')"), 'editor detail core still targets the detail image mount');
   assert.ok(editorDetailSrc.includes('updateDetailPanel'), 'editor detail core still exposes updateDetailPanel');
   assert.ok(editorDetailSrc.includes('window.createEditorDetailUI = createEditorDetailUI'), 'editor detail core still publishes its factory');
 });

--- a/tests/routes/public-viewer-detail-output-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-output-contract.test.cjs
@@ -34,27 +34,7 @@ test('public viewer detail template exposes the current rendered output mounts',
   assert.equal(templateSrc.includes('id="viewMomentDetailBtn"'), false, 'public viewer output does not expose noop detail action');
 });
 
-test('editor detail core still owns the current detail output rendering contract', () => {
-  const editorDetailSrc = readFile('js/editor/editor-detail-ui.js');
-
-  [
-    'detailCurrentMomentBadge',
-    'detailCurrentMomentTitle',
-    'detailCurrentMomentHint',
-    'detailDateText',
-    'detailTags',
-    'detailMemo',
-    'momentReactionsCard'
-  ].forEach((id) => {
-    assert.ok(editorDetailSrc.includes(id), `editor detail core still references #${id}`);
-  });
-
-  assert.ok(editorDetailSrc.includes("detailPanel.querySelector('.detail-video img')"), 'editor detail core still targets the detail image mount');
-  assert.ok(editorDetailSrc.includes('updateDetailPanel'), 'editor detail core still exposes updateDetailPanel');
-  assert.ok(editorDetailSrc.includes('window.createEditorDetailUI = createEditorDetailUI'), 'editor detail core still publishes its factory');
-});
-
-test('public viewer adapter wraps but does not replace the current detail output renderer yet', () => {
+test('public viewer adapter preserves delegated detail rendering before viewer-only post-processing', () => {
   const adapterSrc = readFile('js/viewer/public-viewer-detail-ui.js');
 
   assert.ok(adapterSrc.includes('window.createEditorDetailUI(deps)'), 'public viewer adapter still delegates to editor detail core');

--- a/tests/routes/public-viewer-detail-output-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-output-contract.test.cjs
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+function readFile(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+const PUBLIC_DETAIL_MOUNTS = [
+  'detailViewMode',
+  'detailTreeMetaMount',
+  'detailCurrentMomentBadge',
+  'detailCurrentMomentTitle',
+  'detailCurrentMomentHint',
+  'detailImg',
+  'detailMomentInfoLabel',
+  'detailDateText',
+  'detailTags',
+  'detailMemo',
+  'momentReactionsCard',
+  'momentLikeBtn',
+  'momentCommentBtn'
+];
+
+test('public viewer detail template exposes the current rendered output mounts', () => {
+  const templateSrc = readFile('js/viewer/public-viewer-detail-view-mode-template.js');
+
+  PUBLIC_DETAIL_MOUNTS.forEach((id) => {
+    assert.ok(templateSrc.includes(`id="${id}"`), `public viewer detail template exposes #${id}`);
+  });
+
+  assert.equal(templateSrc.includes('id="editMemoryBtn"'), false, 'public viewer output does not expose editor edit action');
+  assert.equal(templateSrc.includes('id="continueFromMomentBtn"'), false, 'public viewer output does not expose editor continue action');
+  assert.equal(templateSrc.includes('id="viewMomentDetailBtn"'), false, 'public viewer output does not expose noop detail action');
+});
+
+test('editor detail core still owns the current detail output rendering contract', () => {
+  const editorDetailSrc = readFile('js/editor/editor-detail-ui.js');
+
+  [
+    'detailCurrentMomentBadge',
+    'detailCurrentMomentTitle',
+    'detailCurrentMomentHint',
+    'detailImg',
+    'detailDateText',
+    'detailTags',
+    'detailMemo',
+    'momentReactionsCard'
+  ].forEach((id) => {
+    assert.ok(editorDetailSrc.includes(id), `editor detail core still references #${id}`);
+  });
+
+  assert.ok(editorDetailSrc.includes('updateDetailPanel'), 'editor detail core still exposes updateDetailPanel');
+  assert.ok(editorDetailSrc.includes('window.createEditorDetailUI = createEditorDetailUI'), 'editor detail core still publishes its factory');
+});
+
+test('public viewer adapter wraps but does not replace the current detail output renderer yet', () => {
+  const adapterSrc = readFile('js/viewer/public-viewer-detail-ui.js');
+
+  assert.ok(adapterSrc.includes('window.createEditorDetailUI(deps)'), 'public viewer adapter still delegates to editor detail core');
+  assert.ok(adapterSrc.includes('var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === \'function\''), 'public viewer adapter captures the delegated detail update');
+  assert.ok(adapterSrc.includes('delegatedUpdateDetailPanel(data);'), 'public viewer adapter preserves delegated detail rendering first');
+  assert.ok(adapterSrc.includes('updateReadOnlyReactionSummary(data);'), 'public viewer adapter applies read-only reaction summary after rendering');
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add contract coverage for current public detail output mounts.
- Confirm the public viewer adapter still delegates the main detail rendering body.
- No runtime code changes.

Validation:
- Connector diff check passed.
- Changed files: tests/routes/public-viewer-detail-output-contract.test.cjs.