### PR TITLE
refactor(viewer): add image boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -87,6 +87,21 @@
         hintEl.hidden = true;
     }
 
+    function createPublicViewerCurrentMomentImageBoundary(deps) {
+        var resolveMemoryThumbnail = deps && typeof deps.resolveMemoryThumbnail === 'function'
+            ? deps.resolveMemoryThumbnail
+            : function() { return ''; };
+
+        return function updatePublicViewerCurrentMomentImage(data) {
+            var imgEl = document.getElementById('detailImg') || document.querySelector('.detail-video img');
+            if (!imgEl) return;
+
+            var isEmptyState = !!(data && data.isNewTree);
+            imgEl.src = resolveMemoryThumbnail(data);
+            imgEl.alt = isEmptyState ? '' : ((data && data.title) || '');
+        };
+    }
+
     function createPublicViewerReadOnlyReactionSummaryBoundary(deps) {
         var isRootMemory = deps && typeof deps.isRootMemory === 'function'
             ? deps.isRootMemory
@@ -153,6 +168,7 @@
 
         var detailUI = window.createEditorDetailUI(deps);
         var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps);
+        var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps);
         var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps);
         var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === 'function'
             ? detailUI.updateDetailPanel
@@ -165,6 +181,7 @@
             delegatedUpdateDetailPanel(data);
             updateCurrentMomentBadge(data);
             updatePublicViewerCurrentMomentHint();
+            updateCurrentMomentImage(data);
             updateReadOnlyReactionSummary(data);
         };
         return detailUI;
@@ -178,6 +195,7 @@
         createPublicViewerSetDetailEmptyState: createPublicViewerSetDetailEmptyState,
         createPublicViewerCurrentMomentBadgeBoundary: createPublicViewerCurrentMomentBadgeBoundary,
         updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint,
+        createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         delegatesToEditorDetailUI: true
     };

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -96,15 +96,30 @@ test('public viewer detail UI adapter exposes current moment badge boundary', ()
 test('public viewer detail UI adapter owns current moment hint boundary', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
   const boundaryStart = source.indexOf('function updatePublicViewerCurrentMomentHint()');
-  const boundaryEnd = source.indexOf('function createPublicViewerReadOnlyReactionSummaryBoundary(deps)');
+  const boundaryEnd = source.indexOf('function createPublicViewerCurrentMomentImageBoundary(deps)');
   const boundarySource = source.slice(boundaryStart, boundaryEnd);
 
   assert.notEqual(boundaryStart, -1, 'viewer adapter exposes current moment hint boundary');
-  assert.notEqual(boundaryEnd, -1, 'viewer adapter keeps hint boundary before reactions boundary');
+  assert.notEqual(boundaryEnd, -1, 'viewer adapter keeps image boundary after hint boundary');
   assert.ok(source.includes('updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint'), 'viewer adapter publishes hint boundary on namespace');
   assert.ok(boundarySource.includes('detailCurrentMomentHint'), 'hint boundary targets the current moment hint mount');
   assert.ok(boundarySource.includes("hintEl.textContent = ''"), 'hint boundary clears hint text');
   assert.ok(boundarySource.includes('hintEl.hidden = true'), 'hint boundary hides the hint mount');
+});
+
+test('public viewer detail UI adapter owns current moment image boundary', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+  const boundaryStart = source.indexOf('function createPublicViewerCurrentMomentImageBoundary(deps)');
+  const boundaryEnd = source.indexOf('function createPublicViewerReadOnlyReactionSummaryBoundary(deps)');
+  const boundarySource = source.slice(boundaryStart, boundaryEnd);
+
+  assert.notEqual(boundaryStart, -1, 'viewer adapter exposes current moment image boundary factory');
+  assert.notEqual(boundaryEnd, -1, 'viewer adapter keeps image boundary before reactions boundary');
+  assert.ok(source.includes('createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary'), 'viewer adapter publishes image boundary on namespace');
+  assert.ok(boundarySource.includes('resolveMemoryThumbnail'), 'image boundary uses injected thumbnail resolver');
+  assert.ok(boundarySource.includes('detailImg'), 'image boundary targets the detail image mount');
+  assert.ok(boundarySource.includes('imgEl.src = resolveMemoryThumbnail(data);'), 'image boundary sets image src from resolver');
+  assert.ok(boundarySource.includes("imgEl.alt = isEmptyState ? '' : ((data && data.title) || '')"), 'image boundary sets alt text consistently');
 });
 
 test('public viewer detail UI adapter exposes read-only reaction summary boundary', () => {
@@ -126,12 +141,14 @@ test('public viewer detail UI adapter wraps detail panel updates with viewer-own
 
   assert.ok(source.includes('var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === \'function\''), 'viewer adapter captures delegated detail panel update');
   assert.ok(source.includes('var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps)'), 'viewer adapter creates the badge updater');
+  assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');
   assert.ok(source.includes('var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps)'), 'viewer adapter creates the read-only reaction updater');
   assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter wraps updateDetailPanel for public viewer');
   assert.ok(source.includes('delegatedUpdateDetailPanel(data);'), 'viewer wrapper runs delegated detail rendering first');
   assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer wrapper applies badge post-processing after delegated rendering');
   assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer wrapper applies hint post-processing after badge post-processing');
-  assert.ok(source.includes('updateReadOnlyReactionSummary(data);'), 'viewer wrapper applies read-only reactions after hint post-processing');
+  assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer wrapper applies image post-processing after hint post-processing');
+  assert.ok(source.includes('updateReadOnlyReactionSummary(data);'), 'viewer wrapper applies read-only reactions after image post-processing');
 });
 
 test('public viewer keeps extracted detail helpers on viewer-owned paths', () => {


### PR DESCRIPTION
Refs #1748

Summary:
- Add viewer image boundary.
- Keep main detail rendering delegated.
- Add contract coverage.

Validation:
- Connector diff check passed.