### PR TITLE
refactor(viewer): add date boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -102,6 +102,14 @@
         };
     }
 
+    function updatePublicViewerCurrentMomentDate(data) {
+        var dateEl = document.getElementById('detailDateText');
+        if (!dateEl) return;
+
+        var isEmptyState = !!(data && data.isNewTree);
+        dateEl.textContent = isEmptyState ? '' : ((data && data.timestamp) || '');
+    }
+
     function createPublicViewerReadOnlyReactionSummaryBoundary(deps) {
         var isRootMemory = deps && typeof deps.isRootMemory === 'function'
             ? deps.isRootMemory
@@ -182,6 +190,7 @@
             updateCurrentMomentBadge(data);
             updatePublicViewerCurrentMomentHint();
             updateCurrentMomentImage(data);
+            updatePublicViewerCurrentMomentDate(data);
             updateReadOnlyReactionSummary(data);
         };
         return detailUI;
@@ -196,6 +205,7 @@
         createPublicViewerCurrentMomentBadgeBoundary: createPublicViewerCurrentMomentBadgeBoundary,
         updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint,
         createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary,
+        updatePublicViewerCurrentMomentDate: updatePublicViewerCurrentMomentDate,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         delegatesToEditorDetailUI: true
     };

--- a/tests/routes/public-viewer-date-contract.test.cjs
+++ b/tests/routes/public-viewer-date-contract.test.cjs
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+test('viewer date helper is exposed', () => {
+  assert.ok(source.includes('function updatePublicViewerCurrentMomentDate(data)'));
+  assert.ok(source.includes('updatePublicViewerCurrentMomentDate: updatePublicViewerCurrentMomentDate'));
+  assert.ok(source.includes('detailDateText'));
+  assert.ok(source.includes('data.timestamp'));
+});
+
+test('viewer date helper is called by detail wrapper', () => {
+  assert.ok(source.includes('updatePublicViewerCurrentMomentDate(data);'));
+  assert.ok(source.includes('updateCurrentMomentImage(data);'));
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add viewer date helper.
- Keep main rendering delegated.
- Add small contract coverage.

Validation:
- Connector diff check passed.