### PR TITLE
refactor(viewer): add memo body boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -155,6 +155,61 @@
         dateEl.textContent = isEmptyState ? '' : ((data && data.timestamp) || '');
     }
 
+    function createPublicViewerMemoBodyBoundary(deps) {
+        var i18n = deps && typeof deps.i18n === 'function'
+            ? deps.i18n
+            : function() { return ''; };
+        var getTreeMemories = deps && typeof deps.getTreeMemories === 'function'
+            ? deps.getTreeMemories
+            : function() { return []; };
+
+        function formatI18nText(key, fallback) {
+            var text = i18n(key) || fallback;
+            return !text || text === key ? fallback : text;
+        }
+
+        function hasAnyMoments() {
+            var memories = getTreeMemories();
+            return Array.isArray(memories) && memories.length > 0;
+        }
+
+        function getMemoFallbackText(options) {
+            if (typeof window.createEditorDetailUIBuilders === 'function') {
+                var builders = window.createEditorDetailUIBuilders({ formatI18nText: formatI18nText });
+                if (builders && typeof builders.getMemoFallbackText === 'function') {
+                    return builders.getMemoFallbackText(options);
+                }
+            }
+            return formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요');
+        }
+
+        return function updatePublicViewerMemoBody(data) {
+            var noteEl = document.getElementById('detailMemo') || document.querySelector('.diary-note');
+            if (!noteEl) return;
+
+            var isEmptyState = !!(data && data.isNewTree) && !hasAnyMoments();
+            var memoContainer = document.createElement('div');
+            var memoBody = document.createElement('div');
+
+            while (noteEl.firstChild) {
+                noteEl.removeChild(noteEl.firstChild);
+            }
+
+            memoContainer.style.width = '100%';
+
+            memoBody.style.lineHeight = '1.8';
+            memoBody.style.fontSize = '0.95rem';
+            memoBody.style.color = 'var(--on-surface)';
+            memoBody.style.whiteSpace = 'pre-line';
+            memoBody.textContent = isEmptyState
+                ? getMemoFallbackText({ isEmptyState: true })
+                : ((data && data.memo) || formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요'));
+
+            memoContainer.appendChild(memoBody);
+            noteEl.appendChild(memoContainer);
+        };
+    }
+
     function createPublicViewerCurrentMomentTagsBoundary(deps) {
         var i18n = deps && typeof deps.i18n === 'function'
             ? deps.i18n
@@ -287,6 +342,7 @@
         var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps);
         var updateCurrentMomentTitle = createPublicViewerCurrentMomentTitleBoundary(deps);
         var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps);
+        var updateMemoBody = createPublicViewerMemoBodyBoundary(deps);
         var updateCurrentMomentTags = createPublicViewerCurrentMomentTagsBoundary(deps);
         var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps);
         var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === 'function'
@@ -303,6 +359,7 @@
             updatePublicViewerCurrentMomentHint();
             updateCurrentMomentImage(data);
             updatePublicViewerCurrentMomentDate(data);
+            updateMemoBody(data);
             updateCurrentMomentTags(data);
             updateReadOnlyReactionSummary(data);
         };
@@ -320,6 +377,7 @@
         updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint,
         createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary,
         updatePublicViewerCurrentMomentDate: updatePublicViewerCurrentMomentDate,
+        createPublicViewerMemoBodyBoundary: createPublicViewerMemoBodyBoundary,
         createPublicViewerCurrentMomentTagsBoundary: createPublicViewerCurrentMomentTagsBoundary,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         delegatesToEditorDetailUI: true

--- a/tests/routes/public-viewer-memo-contract.test.cjs
+++ b/tests/routes/public-viewer-memo-contract.test.cjs
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+test('public viewer detail UI adapter exposes memo body boundary', () => {
+  assert.ok(source.includes('function createPublicViewerMemoBodyBoundary(deps)'));
+  assert.ok(source.includes('createPublicViewerMemoBodyBoundary: createPublicViewerMemoBodyBoundary'));
+  assert.ok(source.includes("document.getElementById('detailMemo') || document.querySelector('.diary-note')"));
+});
+
+test('public viewer memo body boundary clears without innerHTML', () => {
+  const start = source.indexOf('function createPublicViewerMemoBodyBoundary(deps)');
+  const end = source.indexOf('function createPublicViewerCurrentMomentTagsBoundary(deps)');
+  const boundary = source.slice(start, end);
+
+  assert.notEqual(start, -1, 'memo body boundary exists');
+  assert.notEqual(end, -1, 'tags boundary follows memo body boundary');
+  assert.ok(boundary.includes('while (noteEl.firstChild)'));
+  assert.ok(boundary.includes('noteEl.removeChild(noteEl.firstChild)'));
+  assert.equal(boundary.includes('innerHTML'), false);
+});
+
+test('public viewer memo body boundary does not wire editor memo editing or hint markup', () => {
+  const start = source.indexOf('function createPublicViewerMemoBodyBoundary(deps)');
+  const end = source.indexOf('function createPublicViewerCurrentMomentTagsBoundary(deps)');
+  const boundary = source.slice(start, end);
+
+  assert.equal(boundary.includes('createMemoEditBoundary'), false);
+  assert.equal(boundary.includes('updateSelectedMemoryFields'), false);
+  assert.equal(boundary.includes('memoHint'), false);
+});
+
+test('public viewer memo body boundary is called by detail wrapper', () => {
+  assert.ok(source.includes('var updateMemoBody = createPublicViewerMemoBodyBoundary(deps)'));
+  assert.ok(source.includes('updateMemoBody(data);'));
+  assert.ok(source.indexOf('updatePublicViewerCurrentMomentDate(data);') < source.indexOf('updateMemoBody(data);'));
+  assert.ok(source.indexOf('updateMemoBody(data);') < source.indexOf('updateCurrentMomentTags(data);'));
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add a public viewer memo body boundary that post-processes the delegated editor detail render.
- Clear the memo mount with removeChild loop instead of adding new innerHTML usage.
- Keep memo edit boundary and memo hint behavior untouched.
- Add a focused memo body contract test.