### PR TITLE
refactor(viewer): remove inert tree meta detail action

### DIFF
--- a/js/viewer/public-viewer-detail-tree-meta.js
+++ b/js/viewer/public-viewer-detail-tree-meta.js
@@ -5,8 +5,7 @@
             formatI18nText,
             resolveTreeTitleText,
             createInlineIcon,
-            showToast,
-            openCurrentMomentDetail
+            showToast
         } = deps;
 
         const createPillButton = ({ label, icon, tone = 'soft' }) => {
@@ -30,16 +29,7 @@
             btn.style.background = tone === 'primary'
                 ? 'linear-gradient(180deg, rgba(144,73,81,0.98), rgba(144,73,81,0.90))'
                 : 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(247,242,239,0.96))';
-            btn.style.color = tone === 'primary'
-                ? '#fff'
-                : tone === 'ghost'
-                    ? 'var(--on-surface-variant)'
-                    : 'var(--primary)';
-
-            if (tone === 'ghost') {
-                btn.style.background = 'rgba(255,255,255,0.72)';
-                btn.style.borderColor = 'rgba(144,73,81,0.08)';
-            }
+            btn.style.color = tone === 'primary' ? '#fff' : 'var(--primary)';
 
             if (icon) btn.appendChild(createInlineIcon(icon, '14px'));
             btn.appendChild(document.createTextNode(label));
@@ -60,12 +50,6 @@
             tone: 'soft'
         });
 
-        const createOpenDetailButton = () => createPillButton({
-            label: formatI18nText('editor_open_detail', '상세로 보기'),
-            icon: 'open_in_new',
-            tone: 'ghost'
-        });
-
         const bindShareButton = ({ btn, data, treeId }) => {
             if (!btn || !data?.id) return;
             if (btn.dataset.shareBound === '1') return;
@@ -83,15 +67,6 @@
             });
         };
 
-        const bindOpenDetailButton = (btn) => {
-            if (!btn || typeof openCurrentMomentDetail !== 'function') return;
-            if (btn.dataset.openDetailBound === '1') return;
-            btn.dataset.openDetailBound = '1';
-            btn.addEventListener('click', () => {
-                openCurrentMomentDetail();
-            });
-        };
-
         const createTreeMetaBlock = ({
             displayTreeTitle,
             visIcon,
@@ -99,8 +74,7 @@
             visInfo,
             isPublic,
             countLabel,
-            shareButtonEl = null,
-            openDetailButtonEl = null
+            shareButtonEl = null
         }) => {
             const wrap = document.createElement('div');
             wrap.style.padding = '20px 20px 18px';
@@ -192,7 +166,6 @@
             actionsRow.style.paddingTop = '2px';
 
             if (shareButtonEl) actionsRow.appendChild(shareButtonEl);
-            if (openDetailButtonEl) actionsRow.appendChild(openDetailButtonEl);
 
             if (actionsRow.children.length > 0) {
                 wrap.appendChild(actionsRow);
@@ -235,9 +208,7 @@
                 isPublic,
                 countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
                 shareButtonEl: shareBtn,
-                openDetailButtonEl: null,
-                shareBtn,
-                openDetailBtn: null
+                shareBtn
             };
         };
 
@@ -252,8 +223,7 @@
                 visInfo: model.visInfo,
                 isPublic: model.isPublic,
                 countLabel: model.countLabel,
-                shareButtonEl: model.shareButtonEl,
-                openDetailButtonEl: model.openDetailButtonEl
+                shareButtonEl: model.shareButtonEl
             }));
 
             if (model.shareBtn) {
@@ -263,7 +233,6 @@
                     treeId
                 });
             }
-            bindOpenDetailButton(model.openDetailBtn);
         };
 
         return {

--- a/js/viewer/public-viewer-detail-tree-meta.js
+++ b/js/viewer/public-viewer-detail-tree-meta.js
@@ -223,10 +223,8 @@
                 : formatI18nText('editor_tree_status_empty', '아직 첫 순간을 기다리고 있어요.');
 
             let shareBtn = null;
-            let openDetailBtn = null;
             if (!isEmptyState && data?.id) {
                 shareBtn = createShareTreeButton();
-                openDetailBtn = createOpenDetailButton();
             }
 
             return {
@@ -237,9 +235,9 @@
                 isPublic,
                 countLabel: localBadgeText ? `${treeCountLabel} · ${localBadgeText}` : treeCountLabel,
                 shareButtonEl: shareBtn,
-                openDetailButtonEl: openDetailBtn,
+                openDetailButtonEl: null,
                 shareBtn,
-                openDetailBtn
+                openDetailBtn: null
             };
         };
 

--- a/tests/routes/public-viewer-tree-meta-contract.test.cjs
+++ b/tests/routes/public-viewer-tree-meta-contract.test.cjs
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-tree-meta.js', 'utf8');
+
+test('public viewer tree meta helper keeps share action but omits inert detail action', () => {
+  assert.ok(source.includes('const createShareTreeButton = () => createPillButton'), 'share button helper remains');
+  assert.ok(source.includes('shareButtonEl: shareBtn'), 'render model still exposes share button element');
+  assert.ok(source.includes('bindShareButton({'), 'render boundary still binds share action');
+
+  assert.equal(source.includes('createOpenDetailButton'), false, 'public viewer tree meta must not create detail action button');
+  assert.equal(source.includes('bindOpenDetailButton'), false, 'public viewer tree meta must not bind inert detail action');
+  assert.equal(source.includes('openDetailButtonEl'), false, 'render model must not expose detail action element');
+  assert.equal(source.includes('openDetailBtn'), false, 'render model must not expose detail action button');
+});
+
+test('public viewer tree meta helper no longer depends on openCurrentMomentDetail', () => {
+  assert.equal(source.includes('openCurrentMomentDetail'), false, 'public tree meta helper should not depend on editor detail navigation');
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Remove the public viewer tree meta detail action that was wired to a noop in public view.
- Keep the share link action unchanged.
- Add focused contract coverage for public viewer tree meta actions.

Validation:
- Changed files must stay limited to the viewer tree meta helper and its route contract test.
- No HTML/CSS/backend changes.