### PR TITLE
test(viewer): remove stale detail UI sink allowlist

### DIFF
--- a/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
+++ b/tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
@@ -128,10 +128,7 @@ const FILE_ALLOWLIST = {
     count: 1, classification: 'safe',
     reason: 'Public read-only canvas route. innerHTML on fresh error element with escapeHtml for user-visible error message; uses textContent for primary error'
   },
-  'js/viewer/public-viewer-detail-ui.js': {
-    count: 1, classification: 'safe',
-    reason: 'emptyState.innerHTML — static public viewer detail empty state template with hardcoded Korean text, no user content'
-  },
+
   'js/viewer/public-viewer-detail-view-mode-template.js': {
     count: 1, classification: 'safe',
     reason: 'mount.outerHTML = template — static public viewer detail view template, no user content'


### PR DESCRIPTION
Refs #1748

Summary:
- Remove the stale DOM XSS guardrail allowlist entry for js/viewer/public-viewer-detail-ui.js.
- That file no longer contains an innerHTML/insertAdjacentHTML/outerHTML sink after the DOM-safe empty state update.
- Keep the guardrail logic unchanged.

Validation:
- Changed files must be exactly 1: tests/contracts/dom-xss-renderer-guardrail-contract.test.cjs
- Run lint/build/verify if available.
- Confirm DOM XSS guardrail still passes.
- Wait for CI green.
- Squash merge only if PR head SHA matches.
- After merge, report merge SHA and current main HEAD.