### PR TITLE
test(viewer): cover detail builder fallbacks

### DIFF
--- a/tests/routes/public-viewer-detail-builders-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-builders-contract.test.cjs
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const buildersSource = fs.readFileSync('js/viewer/public-viewer-detail-builders.js', 'utf8');
+const viewHtml = fs.readFileSync('pages/view.html', 'utf8');
+
+test('public viewer detail builders install editor boundary fallbacks', () => {
+  assert.ok(buildersSource.includes('function createNoopInlineEditBoundary()'), 'inline edit fallback factory exists');
+  assert.ok(buildersSource.includes('createTitleEditBoundary: noop'), 'title edit fallback is noop');
+  assert.ok(buildersSource.includes('createMemoEditBoundary: noop'), 'memo edit fallback is noop');
+  assert.ok(buildersSource.includes('function createNoopSidebarStatusBoundary()'), 'sidebar status fallback factory exists');
+  assert.ok(buildersSource.includes('updateSidebarStatus: noop'), 'sidebar status fallback is noop');
+  assert.ok(buildersSource.includes('installPublicDetailBoundaryFallbacks();'), 'fallbacks are installed on load');
+});
+
+test('public viewer detail builders provide editor core compatibility without editor edit scripts', () => {
+  assert.ok(buildersSource.includes('window.createEditorDetailInlineEditBoundary = createNoopInlineEditBoundary'), 'inline edit fallback is published only when missing');
+  assert.ok(buildersSource.includes('window.createEditorDetailSidebarStatusBoundary = createNoopSidebarStatusBoundary'), 'sidebar status fallback is published only when missing');
+  assert.equal(viewHtml.includes('js/editor/editor-detail-inline-edit.js'), false, 'public viewer does not load editor inline edit helper');
+  assert.equal(viewHtml.includes('js/editor/editor-detail-sidebar-status-boundary.js'), false, 'public viewer does not load editor sidebar status helper');
+  assert.ok(viewHtml.includes('js/viewer/public-viewer-detail-builders.js'), 'public viewer loads viewer detail builders before editor detail core');
+  assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-builders.js') < viewHtml.indexOf('js/editor/editor-detail-ui.js'), 'fallbacks load before editor detail core');
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add contract coverage for public viewer detail builder fallbacks.
- Confirm public viewer supplies noop inline-edit/sidebar-status compatibility for editor detail core.
- Runtime unchanged.

Validation:
- Changed files must be exactly 1:
  tests/routes/public-viewer-detail-builders-contract.test.cjs
- No JS/CSS/HTML/backend runtime changes.
- Wait for CI green.
- Squash merge only if PR head SHA matches adddfa67f0bb9f8f3b684aa35d7ba25541ff779e.
- After merge, report full merge SHA and current main HEAD.