### PR TITLE
test(viewer): cover image boundary

### DIFF
--- a/tests/routes/public-viewer-image-contract.test.cjs
+++ b/tests/routes/public-viewer-image-contract.test.cjs
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+function getImageBoundary() {
+  const start = source.indexOf('function createPublicViewerCurrentMomentImageBoundary(deps)');
+  const end = source.indexOf('function updatePublicViewerCurrentMomentDate(data)');
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  return source.slice(start, end);
+}
+
+test('viewer image boundary is exposed', () => {
+  assert.ok(source.includes('function createPublicViewerCurrentMomentImageBoundary(deps)'));
+  assert.ok(source.includes('createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary'));
+  assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'));
+  assert.ok(source.includes('updateCurrentMomentImage(data);'));
+});
+
+test('viewer image boundary owns src and alt output', () => {
+  const boundary = getImageBoundary();
+
+  assert.ok(boundary.includes('resolveMemoryThumbnail'));
+  assert.ok(boundary.includes('detailImg'));
+  assert.ok(boundary.includes("document.querySelector('.detail-video img')"));
+  assert.ok(boundary.includes('imgEl.src = resolveMemoryThumbnail(data);'));
+  assert.ok(boundary.includes("imgEl.alt = isEmptyState ? '' : ((data && data.title) || '')"));
+  assert.equal(boundary.includes('innerHTML'), false);
+});
+
+test('viewer image boundary order is stable', () => {
+  const delegatedIndex = source.indexOf('delegatedUpdateDetailPanel(data);');
+  const hintIndex = source.indexOf('updatePublicViewerCurrentMomentHint();');
+  const imageIndex = source.indexOf('updateCurrentMomentImage(data);');
+  const dateIndex = source.indexOf('updatePublicViewerCurrentMomentDate(data);');
+
+  assert.ok(delegatedIndex < imageIndex);
+  assert.ok(hintIndex < imageIndex);
+  assert.ok(imageIndex < dateIndex);
+});


### PR DESCRIPTION
Refs #1748

Add viewer image boundary contract test. Runtime unchanged.