### PR TITLE
test(viewer): cover hint boundary

### DIFF
--- a/tests/routes/public-viewer-hint-contract.test.cjs
+++ b/tests/routes/public-viewer-hint-contract.test.cjs
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+function getHintBoundary() {
+  const start = source.indexOf('function updatePublicViewerCurrentMomentHint()');
+  const end = source.indexOf('function createPublicViewerCurrentMomentImageBoundary(deps)');
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  return source.slice(start, end);
+}
+
+test('viewer hint boundary is exposed', () => {
+  assert.ok(source.includes('function updatePublicViewerCurrentMomentHint()'));
+  assert.ok(source.includes('updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint'));
+  assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'));
+});
+
+test('viewer hint boundary clears and hides hint output', () => {
+  const boundary = getHintBoundary();
+
+  assert.ok(boundary.includes('detailCurrentMomentHint'));
+  assert.ok(boundary.includes("hintEl.textContent = ''"));
+  assert.ok(boundary.includes('hintEl.hidden = true'));
+  assert.equal(boundary.includes('innerHTML'), false);
+});
+
+test('viewer hint boundary order is stable', () => {
+  const titleIndex = source.indexOf('updateCurrentMomentTitle(data);');
+  const hintIndex = source.indexOf('updatePublicViewerCurrentMomentHint();');
+  const imageIndex = source.indexOf('updateCurrentMomentImage(data);');
+
+  assert.ok(titleIndex < hintIndex);
+  assert.ok(hintIndex < imageIndex);
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add public viewer hint boundary contract coverage.
- Confirm the hint boundary clears text, hides the hint mount, avoids innerHTML, and runs between title and image post-processing.
- Runtime unchanged.

Validation:
- Changed files must be exactly 1:
  tests/routes/public-viewer-hint-contract.test.cjs
- No JS/CSS/HTML/backend runtime changes.
- Wait for CI green.
- Squash merge only if PR head SHA matches 15652562eac558334e4f8e3f0215ff1ee72c72c9.
- After merge, report full merge SHA and current main HEAD.