### PR TITLE
test(viewer): cover focus selected boundary

### DIFF
--- a/tests/routes/public-viewer-focus-contract.test.cjs
+++ b/tests/routes/public-viewer-focus-contract.test.cjs
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+function getFocusBoundary() {
+  const start = source.indexOf('function createPublicViewerUpdateFocusSelectedBtn(deps)');
+  const end = source.indexOf('function updatePublicViewerSidebarStatus()');
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  return source.slice(start, end);
+}
+
+test('viewer focus selected boundary is exposed', () => {
+  assert.ok(source.includes('function createPublicViewerUpdateFocusSelectedBtn(deps)'));
+  assert.ok(source.includes('createPublicViewerUpdateFocusSelectedBtn: createPublicViewerUpdateFocusSelectedBtn'));
+  assert.ok(source.includes('detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps)'));
+});
+
+test('viewer focus selected boundary only reflects selected node state', () => {
+  const boundary = getFocusBoundary();
+
+  assert.ok(boundary.includes('getSelectedNodeId'));
+  assert.ok(boundary.includes("document.getElementById('focusSelectedBtn')"));
+  assert.ok(boundary.includes('btn.disabled = !hasSelection'));
+  assert.ok(boundary.includes("btn.classList.toggle('is-disabled', !hasSelection)"));
+  assert.equal(boundary.includes('innerHTML'), false);
+  assert.equal(boundary.includes('onclick'), false);
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add public viewer focus selected boundary contract coverage.
- Confirm the boundary only reflects selected-node state on focusSelectedBtn.
- Runtime unchanged.

Validation:
- Changed files must be exactly 1:
  tests/routes/public-viewer-focus-contract.test.cjs
- No JS/CSS/HTML/backend runtime changes.
- Wait for CI green.
- Squash merge only if PR head SHA matches.
- After merge, report merge SHA and current main HEAD.