### PR TITLE
test(viewer): cover sidebar noop boundary

### DIFF
--- a/tests/routes/public-viewer-sidebar-contract.test.cjs
+++ b/tests/routes/public-viewer-sidebar-contract.test.cjs
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+test('viewer sidebar status boundary is a noop', () => {
+  assert.ok(source.includes('function updatePublicViewerSidebarStatus() {}'));
+  assert.ok(source.includes('detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus'));
+  assert.ok(source.includes('updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus'));
+});
+
+test('viewer sidebar status boundary stays before empty state boundary', () => {
+  const focusIndex = source.indexOf('function createPublicViewerUpdateFocusSelectedBtn(deps)');
+  const sidebarIndex = source.indexOf('function updatePublicViewerSidebarStatus() {}');
+  const emptyIndex = source.indexOf('function createPublicViewerEmptyStateContent()');
+
+  assert.notEqual(focusIndex, -1);
+  assert.notEqual(sidebarIndex, -1);
+  assert.notEqual(emptyIndex, -1);
+  assert.ok(focusIndex < sidebarIndex);
+  assert.ok(sidebarIndex < emptyIndex);
+});


### PR DESCRIPTION
Refs #1748

Summary:
- Add public viewer sidebar status noop boundary contract coverage.
- Confirm the adapter overrides editor sidebar status behavior with a noop.
- Runtime unchanged.

Validation:
- Changed files should be exactly 1:
  tests/routes/public-viewer-sidebar-contract.test.cjs
- No JS/CSS/HTML/backend runtime changes.
- Wait for CI green.
- Squash merge only after confirming head SHA.
- After merge, report full merge SHA and current main HEAD.