### PR TITLE
chore(viewer): bump detail adapter asset version

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260527-3"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260527-4"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260526-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>


### PR DESCRIPTION
Refs #1748

Summary:
- Bump the public viewer detail adapter asset query after the memo body boundary update.
- Keep script order and runtime code unchanged.

Validation:
- Changed files must be exactly 1: pages/view.html
- No JS/CSS/backend changes.
- Run lint/build/verify if available.
- Wait for CI green.
- Squash merge only if PR head SHA matches.