### PR TITLE
refactor(viewer): patch public viewer detail adapter for channel link

### DIFF
--- a/js/viewer/public-viewer-detail-channel-link.js
+++ b/js/viewer/public-viewer-detail-channel-link.js
@@ -107,7 +107,7 @@
     }
 
     function installDetailChannelLinkPatch() {
-        const originalFactory = window.createEditorDetailUI;
+        const originalFactory = window.createPublicViewerDetailUI;
         if (typeof originalFactory !== 'function' || originalFactory.__publicViewerChannelLinkPatched) return;
 
         const patchedFactory = function(deps) {
@@ -124,7 +124,7 @@
         };
 
         patchedFactory.__publicViewerChannelLinkPatched = true;
-        window.createEditorDetailUI = patchedFactory;
+        window.createPublicViewerDetailUI = patchedFactory;
     }
 
     window.LoveBudPublicViewerDetailChannelLink = {

--- a/tests/routes/public-viewer-channel-link-contract.test.cjs
+++ b/tests/routes/public-viewer-channel-link-contract.test.cjs
@@ -41,8 +41,10 @@ test('viewer channel link renders DOM nodes without html sinks', () => {
 });
 
 test('viewer channel link patch loads after detail adapter', () => {
-  assert.ok(source.includes('window.createEditorDetailUI = patchedFactory'));
+  assert.ok(source.includes('const originalFactory = window.createPublicViewerDetailUI'));
+  assert.ok(source.includes('window.createPublicViewerDetailUI = patchedFactory'));
   assert.ok(source.includes('originalUpdateDetailPanel(data);'));
   assert.ok(source.includes('renderDetailChannelLink(data);'));
+  assert.equal(source.includes('window.createEditorDetailUI = patchedFactory'), false);
   assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-ui.js') < viewHtml.indexOf('js/viewer/public-viewer-detail-channel-link.js'));
 });

--- a/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
@@ -61,7 +61,7 @@ function createPublicViewerDetailChannelContext(options = {}) {
   const context = {
     URL,
     window: {
-      createEditorDetailUI: options.createEditorDetailUI || (() => ({
+      createPublicViewerDetailUI: options.createPublicViewerDetailUI || (() => ({
         updateDetailPanel: () => {}
       }))
     },
@@ -142,12 +142,12 @@ test('public viewer detail channel link removes stale row when selected memory l
 test('public viewer detail channel link patch wraps updateDetailPanel without replacing original behavior', () => {
   let originalCalled = false;
   const harness = createPublicViewerDetailChannelContext({
-    createEditorDetailUI: () => ({
+    createPublicViewerDetailUI: () => ({
       updateDetailPanel: () => { originalCalled = true; }
     })
   });
 
-  const detailUI = harness.context.window.createEditorDetailUI({});
+  const detailUI = harness.context.window.createPublicViewerDetailUI({});
   detailUI.updateDetailPanel({
     channelId: '@woowayoung',
     channelName: '@woowayoung',


### PR DESCRIPTION
Refs #1748

Summary:
- Migrate `installDetailChannelLinkPatch` from `window.createEditorDetailUI` to `window.createPublicViewerDetailUI`.
- Keep `renderDetailChannelLink(data)` and all DOM rendering unchanged.
- Update contract tests to reflect the new patch target.
- No JS/CSS/HTML/backend changes beyond the patch target shift.

Validation:
- Changed files: 3
- `node --test tests/routes/public-viewer-channel-link-contract.test.cjs` ✅
- `node --test tests/routes/public-viewer-detail-channel-link-contract.test.cjs` ✅
- `npm test`: 1267/1267 pass, 0 fail ✅
- `npm run verify`: 265/265 pass ✅