### PR TITLE
refactor(viewer): render channel link from detail adapter flow

### DIFF
--- a/js/viewer/public-viewer-detail-channel-link.js
+++ b/js/viewer/public-viewer-detail-channel-link.js
@@ -106,32 +106,9 @@
         titleEl.insertAdjacentElement('afterend', row);
     }
 
-    function installDetailChannelLinkPatch() {
-        const originalFactory = window.createPublicViewerDetailUI;
-        if (typeof originalFactory !== 'function' || originalFactory.__publicViewerChannelLinkPatched) return;
-
-        const patchedFactory = function(deps) {
-            const detailUI = originalFactory(deps);
-            if (!detailUI || typeof detailUI.updateDetailPanel !== 'function') return detailUI;
-
-            const originalUpdateDetailPanel = detailUI.updateDetailPanel;
-            detailUI.updateDetailPanel = function(data) {
-                originalUpdateDetailPanel(data);
-                renderDetailChannelLink(data);
-            };
-
-            return detailUI;
-        };
-
-        patchedFactory.__publicViewerChannelLinkPatched = true;
-        window.createPublicViewerDetailUI = patchedFactory;
-    }
-
     window.LoveBudPublicViewerDetailChannelLink = {
         renderDetailChannelLink,
         sanitizeYouTubeChannelUrl,
         buildChannelUrlFromId
     };
-
-    installDetailChannelLinkPatch();
 })();

--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -166,6 +166,12 @@
         hintEl.hidden = true;
     }
 
+    function updatePublicViewerDetailChannelLink(data) {
+        var helper = window.LoveBudPublicViewerDetailChannelLink;
+        if (!helper || typeof helper.renderDetailChannelLink !== 'function') return;
+        helper.renderDetailChannelLink(data);
+    }
+
     function createPublicViewerCurrentMomentImageBoundary(deps) {
         var resolveMemoryThumbnail = deps && typeof deps.resolveMemoryThumbnail === 'function'
             ? deps.resolveMemoryThumbnail
@@ -390,6 +396,7 @@
             delegatedUpdateDetailPanel(data);
             updateCurrentMomentBadge(data);
             updateCurrentMomentTitle(data);
+            updatePublicViewerDetailChannelLink(data);
             updatePublicViewerCurrentMomentHint();
             updateCurrentMomentImage(data);
             updatePublicViewerCurrentMomentDate(data);
@@ -409,6 +416,7 @@
         createPublicViewerCurrentMomentBadgeBoundary: createPublicViewerCurrentMomentBadgeBoundary,
         createPublicViewerCurrentMomentTitleBoundary: createPublicViewerCurrentMomentTitleBoundary,
         updatePublicViewerCurrentMomentHint: updatePublicViewerCurrentMomentHint,
+        updatePublicViewerDetailChannelLink: updatePublicViewerDetailChannelLink,
         createPublicViewerCurrentMomentImageBoundary: createPublicViewerCurrentMomentImageBoundary,
         updatePublicViewerCurrentMomentDate: updatePublicViewerCurrentMomentDate,
         createPublicViewerMemoBodyBoundary: createPublicViewerMemoBodyBoundary,

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,8 +80,8 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260527-4"></script>
-    <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260526-1"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-1"></script>
+    <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>
     <script src="../js/api/base-api-fetch.js?v=20260420-1"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -206,7 +206,7 @@ test('public canvas route currently uses remaining editor detail UI core stack b
   assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-builders.js', 'js/editor/editor-detail-ui.js');
 });
 
-test('public canvas route delegates detail channel link patch to viewer helper', () => {
+test('public canvas route delegates detail channel link rendering to viewer helper', () => {
   const scripts = getScriptSrcs();
   const helperSrc = fs.readFileSync('js/viewer/public-viewer-detail-channel-link.js', 'utf8');
 
@@ -222,5 +222,6 @@ test('public canvas route delegates detail channel link patch to viewer helper',
   assertScriptOrder(scripts, 'js/editor/editor-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-channel-link.js', 'js/viewer/public-canvas-init.js');
   assert.ok(helperSrc.includes('window.LoveBudPublicViewerDetailChannelLink'), 'viewer channel link helper must expose inspectable namespace');
-  assert.ok(helperSrc.includes('__publicViewerChannelLinkPatched'), 'viewer channel link helper must mark the patched detail factory');
+  assert.ok(helperSrc.includes('renderDetailChannelLink'), 'viewer channel link helper must expose renderDetailChannelLink');
+  assert.equal(helperSrc.includes('createPublicViewerDetailUI'), false, 'viewer channel link helper must not patch the viewer detail adapter');
 });

--- a/tests/routes/public-viewer-channel-link-contract.test.cjs
+++ b/tests/routes/public-viewer-channel-link-contract.test.cjs
@@ -25,7 +25,7 @@ test('viewer channel link helper restricts youtube channel urls', () => {
 
 test('viewer channel link renders DOM nodes without html sinks', () => {
   const start = source.indexOf('function renderDetailChannelLink(data)');
-  const end = source.indexOf('function installDetailChannelLinkPatch()');
+  const end = source.indexOf('window.LoveBudPublicViewerDetailChannelLink');
   const boundary = source.slice(start, end);
 
   assert.notEqual(start, -1);
@@ -41,10 +41,10 @@ test('viewer channel link renders DOM nodes without html sinks', () => {
 });
 
 test('viewer channel link patch loads after detail adapter', () => {
-  assert.ok(source.includes('const originalFactory = window.createPublicViewerDetailUI'));
-  assert.ok(source.includes('window.createPublicViewerDetailUI = patchedFactory'));
-  assert.ok(source.includes('originalUpdateDetailPanel(data);'));
-  assert.ok(source.includes('renderDetailChannelLink(data);'));
-  assert.equal(source.includes('window.createEditorDetailUI = patchedFactory'), false);
+  assert.equal(source.includes('createPublicViewerDetailUI = patchedFactory'), false);
+  assert.equal(source.includes('createEditorDetailUI = patchedFactory'), false);
+  assert.equal(source.includes('originalUpdateDetailPanel'), false);
+  assert.ok(source.includes('renderDetailChannelLink'));
   assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-ui.js') < viewHtml.indexOf('js/viewer/public-viewer-detail-channel-link.js'));
+  assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-channel-link.js') < viewHtml.indexOf('js/viewer/public-canvas-init.js'));
 });

--- a/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-channel-link-contract.test.cjs
@@ -139,21 +139,20 @@ test('public viewer detail channel link removes stale row when selected memory l
   assert.equal(harness.getChannelRow(), null);
 });
 
-test('public viewer detail channel link patch wraps updateDetailPanel without replacing original behavior', () => {
-  let originalCalled = false;
-  const harness = createPublicViewerDetailChannelContext({
-    createPublicViewerDetailUI: () => ({
-      updateDetailPanel: () => { originalCalled = true; }
-    })
-  });
+test('public viewer detail channel link helper renders channel row via direct namespace call', () => {
+  const harness = createPublicViewerDetailChannelContext();
 
-  const detailUI = harness.context.window.createPublicViewerDetailUI({});
-  detailUI.updateDetailPanel({
+  const helper = harness.context.window.LoveBudPublicViewerDetailChannelLink;
+  assert.equal(typeof helper.renderDetailChannelLink, 'function');
+
+  helper.renderDetailChannelLink({
     channelId: '@woowayoung',
     channelName: '@woowayoung',
     channelUrl: 'https://www.youtube.com/@woowayoung'
   });
 
-  assert.equal(originalCalled, true);
-  assert.ok(harness.getChannelRow());
+  const row = harness.getChannelRow();
+  assert.ok(row);
+  assert.equal(row.children[2].tagName, 'A');
+  assert.equal(row.children[2].href, 'https://www.youtube.com/@woowayoung');
 });

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -136,6 +136,27 @@ test('public viewer detail UI adapter exposes read-only reaction summary boundar
   assert.equal(boundarySource.includes('from=editor'), false, 'read-only reactions boundary must not navigate through editor detail context');
 });
 
+test('public viewer detail UI adapter renders channel link via viewer namespace', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function updatePublicViewerDetailChannelLink(data)'), 'viewer adapter exposes channel link updater');
+  assert.ok(source.includes('window.LoveBudPublicViewerDetailChannelLink'), 'viewer adapter reads channel link helper namespace');
+  assert.ok(source.includes('helper.renderDetailChannelLink(data)'), 'viewer adapter delegates channel link rendering to helper');
+  assert.ok(source.includes('updatePublicViewerDetailChannelLink(data);'), 'viewer adapter runs channel link update in detail panel flow');
+  assert.ok(source.includes('updatePublicViewerDetailChannelLink: updatePublicViewerDetailChannelLink'), 'viewer adapter publishes channel link updater');
+
+  const panelStart = source.indexOf('detailUI.updateDetailPanel = function');
+  const panelEnd = source.indexOf('};', panelStart);
+  const panelSource = source.slice(panelStart, panelEnd);
+
+  const titleIndex = panelSource.indexOf('updateCurrentMomentTitle(data);');
+  const channelLinkIndex = panelSource.indexOf('updatePublicViewerDetailChannelLink(data);');
+  const hintIndex = panelSource.indexOf('updatePublicViewerCurrentMomentHint();');
+
+  assert.ok(titleIndex < channelLinkIndex, 'channel link runs after title update');
+  assert.ok(channelLinkIndex < hintIndex, 'channel link runs before hint update');
+});
+
 test('public viewer detail UI adapter wraps detail panel updates with viewer-owned post-processing', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 


### PR DESCRIPTION
Refs #1748

Summary:
- Remove the channel link factory patch and render the channel link from the public viewer detail adapter flow.
- Keep channel URL sanitization and DOM rendering behavior unchanged.
- Keep editor-detail-ui.js and editor-canvas.js loaded for now.
- Bump public viewer detail asset versions.

Validation:
- `node --test tests/routes/public-viewer-channel-link-contract.test.cjs` ✅
- `node --test tests/routes/public-viewer-detail-channel-link-contract.test.cjs` ✅
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs` ✅
- `npm run verify`: 265/265 ✅
- `npm test`: 1268/1268 ✅