### PR TITLE
refactor(viewer): render tree meta from detail adapter flow

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -373,12 +373,122 @@
         };
     }
 
+    function createPublicViewerTreeMetaBoundary(deps) {
+        var i18n = deps && typeof deps.i18n === 'function'
+            ? deps.i18n
+            : function() { return ''; };
+        var resolveTreeTitleText = deps && typeof deps.resolveTreeTitleText === 'function'
+            ? deps.resolveTreeTitleText
+            : function(title) { return title || '러브트리'; };
+        var isRootMemory = deps && typeof deps.isRootMemory === 'function'
+            ? deps.isRootMemory
+            : function() { return false; };
+        var getCanonicalRootId = deps && typeof deps.getCanonicalRootId === 'function'
+            ? deps.getCanonicalRootId
+            : function() { return null; };
+        var getTreeMemories = deps && typeof deps.getTreeMemories === 'function'
+            ? deps.getTreeMemories
+            : function() { return []; };
+        var getCurrentTreeData = deps && typeof deps.getCurrentTreeData === 'function'
+            ? deps.getCurrentTreeData
+            : function() { return {}; };
+        var getLocalSaveMode = deps && typeof deps.getLocalSaveMode === 'function'
+            ? deps.getLocalSaveMode
+            : function() { return false; };
+        var showToast = deps && typeof deps.showToast === 'function'
+            ? deps.showToast
+            : function() {};
+
+        function formatI18nText(key, fallback, replacements) {
+            var text = i18n(key) || fallback;
+            if (!text || text === key) text = fallback;
+            if (replacements && typeof replacements === 'object') {
+                Object.keys(replacements).forEach(function(name) {
+                    text = String(text).replace(new RegExp('\\{' + name + '\\}', 'g'), String(replacements[name] ?? ''));
+                });
+            }
+            return text;
+        }
+
+        function createInlineIcon(name, size) {
+            if (typeof window.createEditorDetailUIBuilders === 'function') {
+                var builders = window.createEditorDetailUIBuilders({ formatI18nText: formatI18nText });
+                if (builders && typeof builders.createInlineIcon === 'function') {
+                    return builders.createInlineIcon(name, size);
+                }
+            }
+
+            var icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined';
+            icon.style.fontSize = size || '12px';
+            icon.textContent = name;
+            return icon;
+        }
+
+        function getTreeState() {
+            var canonicalRootId = getCanonicalRootId();
+            var treeMemories = getTreeMemories();
+            var rootMemory = treeMemories.find(function(memory) {
+                return isRootMemory(memory, canonicalRootId);
+            }) || null;
+            var nonRootMemories = treeMemories.filter(function(memory) {
+                return !isRootMemory(memory, canonicalRootId);
+            });
+            var totalMomentCount = treeMemories.length;
+            var visibleMomentCount = nonRootMemories.length > 0 ? nonRootMemories.length : (rootMemory ? 1 : 0);
+
+            return {
+                canonicalRootId: canonicalRootId,
+                treeMemories: treeMemories,
+                rootMemory: rootMemory,
+                nonRootMemories: nonRootMemories,
+                totalMomentCount: totalMomentCount,
+                visibleMomentCount: visibleMomentCount,
+                hasMoments: totalMomentCount > 0,
+                hasVisibleMoments: visibleMomentCount > 0
+            };
+        }
+
+        var boundary = null;
+        if (typeof window.createEditorDetailTreeMetaBoundary === 'function') {
+            boundary = window.createEditorDetailTreeMetaBoundary({
+                i18n: i18n,
+                formatI18nText: formatI18nText,
+                resolveTreeTitleText: resolveTreeTitleText,
+                createInlineIcon: createInlineIcon,
+                showToast: showToast
+            });
+        }
+
+        return function updatePublicViewerTreeMeta(data) {
+            var treeMetaMount = document.getElementById('detailTreeMetaMount');
+            if (!treeMetaMount || !boundary) return;
+
+            var currentTree = getCurrentTreeData() || {};
+            var treeState = getTreeState();
+            var isEmptyState = !!(data && data.isNewTree) && !treeState.hasMoments;
+            var localSaveMode = getLocalSaveMode();
+            var treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
+
+            var model = boundary.buildTreeMetaRenderModel({
+                currentTree: currentTree,
+                treeState: treeState,
+                data: data,
+                isEmptyState: isEmptyState,
+                localSaveMode: localSaveMode
+            });
+
+            boundary.renderTreeMetaBoundary(treeMetaMount, model, treeId, data);
+        };
+    }
+
     function createPublicViewerDetailUI(deps) {
         if (typeof window.createEditorDetailUI !== 'function') {
             throw new Error('createEditorDetailUI is required for public viewer detail UI adapter');
         }
 
         var detailUI = window.createEditorDetailUI(deps);
+        var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps);
         var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps);
         var updateCurrentMomentTitle = createPublicViewerCurrentMomentTitleBoundary(deps);
         var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps);
@@ -394,6 +504,7 @@
         detailUI.setDetailEmptyState = createPublicViewerSetDetailEmptyState(deps);
         detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data) {
             delegatedUpdateDetailPanel(data);
+            updateTreeMeta(data);
             updateCurrentMomentBadge(data);
             updateCurrentMomentTitle(data);
             updatePublicViewerDetailChannelLink(data);
@@ -422,6 +533,7 @@
         createPublicViewerMemoBodyBoundary: createPublicViewerMemoBodyBoundary,
         createPublicViewerCurrentMomentTagsBoundary: createPublicViewerCurrentMomentTagsBoundary,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
+        createPublicViewerTreeMetaBoundary: createPublicViewerTreeMetaBoundary,
         delegatesToEditorDetailUI: true
     };
 })();

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-1"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-2"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -136,6 +136,28 @@ test('public viewer detail UI adapter exposes read-only reaction summary boundar
   assert.equal(boundarySource.includes('from=editor'), false, 'read-only reactions boundary must not navigate through editor detail context');
 });
 
+test('public viewer detail UI adapter renders tree meta via viewer boundary after delegated render', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function createPublicViewerTreeMetaBoundary(deps)'), 'viewer adapter exposes tree meta boundary factory');
+  assert.ok(source.includes('window.createEditorDetailTreeMetaBoundary'), 'viewer adapter uses the viewer-provided tree meta boundary');
+  assert.ok(source.includes('detailTreeMetaMount'), 'tree meta boundary targets detailTreeMetaMount');
+  assert.ok(source.includes('boundary.buildTreeMetaRenderModel'), 'tree meta boundary builds the render model');
+  assert.ok(source.includes('boundary.renderTreeMetaBoundary'), 'tree meta boundary renders the model');
+  assert.ok(source.includes('createPublicViewerTreeMetaBoundary: createPublicViewerTreeMetaBoundary'), 'viewer adapter publishes tree meta boundary factory');
+
+  const panelStart = source.indexOf('detailUI.updateDetailPanel = function');
+  const panelEnd = source.indexOf('};', panelStart);
+  const panelSource = source.slice(panelStart, panelEnd);
+
+  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
+  const treeMetaIndex = panelSource.indexOf('updateTreeMeta(data);');
+  const badgeIndex = panelSource.indexOf('updateCurrentMomentBadge(data);');
+
+  assert.ok(delegatedIndex < treeMetaIndex, 'tree meta runs after delegated detail render');
+  assert.ok(treeMetaIndex < badgeIndex, 'tree meta runs before badge post-processing');
+});
+
 test('public viewer detail UI adapter renders channel link via viewer namespace', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
@@ -161,11 +183,13 @@ test('public viewer detail UI adapter wraps detail panel updates with viewer-own
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
   assert.ok(source.includes('var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === \'function\''), 'viewer adapter captures delegated detail panel update');
+  assert.ok(source.includes('var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps)'), 'viewer adapter creates tree meta updater');
   assert.ok(source.includes('var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps)'), 'viewer adapter creates the badge updater');
   assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');
   assert.ok(source.includes('var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps)'), 'viewer adapter creates the read-only reaction updater');
   assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter wraps updateDetailPanel for public viewer');
   assert.ok(source.includes('delegatedUpdateDetailPanel(data);'), 'viewer wrapper runs delegated detail rendering first');
+  assert.ok(source.includes('updateTreeMeta(data);'), 'viewer wrapper applies tree meta post-processing after delegated rendering');
   assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer wrapper applies badge post-processing after delegated rendering');
   assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer wrapper applies hint post-processing after badge post-processing');
   assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer wrapper applies image post-processing after hint post-processing');


### PR DESCRIPTION
Refs #1748

Summary:
- Render public viewer tree metadata from the public viewer detail adapter flow.
- Keep delegated editor detail rendering in place for now.
- Keep editor-detail-ui.js and editor-canvas.js loaded.
- Preserve existing tree meta helper behavior and DOM-safe rendering.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs` ✅
- `npm run verify`: 265/265 ✅
- `npm test`: 1269/1269 ✅