### PR TITLE
refactor(viewer): own selected action button boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -482,6 +482,39 @@
         };
     }
 
+    function createPublicViewerSelectedMomentActionsBoundary(deps) {
+        var openCurrentMomentDetail = deps && typeof deps.openCurrentMomentDetail === 'function'
+            ? deps.openCurrentMomentDetail
+            : null;
+        var focusSelectedMoment = deps && typeof deps.focusSelectedMoment === 'function'
+            ? deps.focusSelectedMoment
+            : null;
+
+        return function installSelectedMomentActions() {
+            var viewMomentDetailBtn = document.getElementById('viewMomentDetailBtn');
+            if (viewMomentDetailBtn && viewMomentDetailBtn.dataset.publicViewerBound !== '1') {
+                viewMomentDetailBtn.dataset.publicViewerBound = '1';
+                viewMomentDetailBtn.addEventListener('click', function() {
+                    if (typeof openCurrentMomentDetail === 'function') {
+                        openCurrentMomentDetail();
+                        return;
+                    }
+                    if (typeof focusSelectedMoment === 'function') {
+                        focusSelectedMoment();
+                    }
+                });
+            }
+
+            var continueFromMomentBtn = document.getElementById('continueFromMomentBtn');
+            if (continueFromMomentBtn && continueFromMomentBtn.dataset.publicViewerBound !== '1') {
+                continueFromMomentBtn.dataset.publicViewerBound = '1';
+                continueFromMomentBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                });
+            }
+        };
+    }
+
     function createPublicViewerDetailUI(deps) {
         if (typeof window.createEditorDetailUI !== 'function') {
             throw new Error('createEditorDetailUI is required for public viewer detail UI adapter');
@@ -502,6 +535,8 @@
         detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps);
         detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus;
         detailUI.setDetailEmptyState = createPublicViewerSetDetailEmptyState(deps);
+        var installSelectedMomentActions = createPublicViewerSelectedMomentActionsBoundary(deps);
+        installSelectedMomentActions();
         detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data) {
             delegatedUpdateDetailPanel(data);
             updateTreeMeta(data);
@@ -534,6 +569,7 @@
         createPublicViewerCurrentMomentTagsBoundary: createPublicViewerCurrentMomentTagsBoundary,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         createPublicViewerTreeMetaBoundary: createPublicViewerTreeMetaBoundary,
+        createPublicViewerSelectedMomentActionsBoundary: createPublicViewerSelectedMomentActionsBoundary,
         delegatesToEditorDetailUI: true
     };
 })();

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-2"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-3"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -179,6 +179,25 @@ test('public viewer detail UI adapter renders channel link via viewer namespace'
   assert.ok(channelLinkIndex < hintIndex, 'channel link runs before hint update');
 });
 
+test('public viewer detail UI adapter owns selected moment action button boundary', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function createPublicViewerSelectedMomentActionsBoundary(deps)'), 'viewer adapter exposes selected action boundary factory');
+  assert.ok(source.includes("document.getElementById('viewMomentDetailBtn')"), 'viewer action boundary targets viewMomentDetailBtn');
+  assert.ok(source.includes("document.getElementById('continueFromMomentBtn')"), 'viewer action boundary targets continueFromMomentBtn');
+  assert.ok(source.includes("viewMomentDetailBtn.dataset.publicViewerBound !== '1'"), 'viewer action boundary uses dataset dedup flag');
+  assert.ok(source.includes("continueFromMomentBtn.dataset.publicViewerBound !== '1'"), 'viewer action boundary uses dataset dedup flag for continue btn');
+  assert.ok(source.includes('typeof openCurrentMomentDetail === \'function\''), 'viewer action boundary checks openCurrentMomentDetail fallback');
+  assert.ok(source.includes('typeof focusSelectedMoment === \'function\''), 'viewer action boundary checks focusSelectedMoment fallback');
+  assert.ok(source.includes('addEventListener'), 'viewer action boundary attaches event listeners');
+  assert.equal(source.includes("openCurrentMomentDetail();"), true, 'viewer action boundary calls openCurrentMomentDetail when available');
+  assert.equal(source.includes("document.getElementById('addMemoryBtn')"), false, 'viewer action boundary must not reference addMemoryBtn');
+  assert.equal(source.includes("document.getElementById('canvasEmptyStartBtn')"), false, 'viewer action boundary must not reference canvasEmptyStartBtn');
+  assert.ok(source.includes('createPublicViewerSelectedMomentActionsBoundary: createPublicViewerSelectedMomentActionsBoundary'), 'viewer adapter publishes selected action boundary on namespace');
+  assert.ok(source.includes('var installSelectedMomentActions = createPublicViewerSelectedMomentActionsBoundary(deps)'), 'viewer adapter creates selected action installer');
+  assert.ok(source.includes('installSelectedMomentActions();'), 'viewer adapter runs selected action installer at construction');
+});
+
 test('public viewer detail UI adapter wraps detail panel updates with viewer-owned post-processing', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 


### PR DESCRIPTION
Refs #1748

Summary:
- Add a public viewer-owned boundary for selected moment action buttons.
- Keep delegated editor detail rendering in place for now.
- Keep editor-detail-ui.js and editor-canvas.js loaded.
- Preserve read-only behavior for public viewer actions.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs` ✅
- `npm run verify`: 265/265 ✅
- `npm test`: 1270/1270 ✅