### PR TITLE
refactor(viewer): own memory actions display boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -482,6 +482,31 @@
         };
     }
 
+    function createPublicViewerMemoryActionsBoundary(deps) {
+        var getTreeMemories = deps && typeof deps.getTreeMemories === 'function'
+            ? deps.getTreeMemories
+            : function() { return []; };
+
+        function hasAnyMoments() {
+            var memories = getTreeMemories();
+            return Array.isArray(memories) && memories.length > 0;
+        }
+
+        return function updatePublicViewerMemoryActions(data) {
+            var isEmptyState = !!(data && data.isNewTree) && !hasAnyMoments();
+
+            var memoryActions = document.querySelector('.memory-actions');
+            if (memoryActions) {
+                memoryActions.style.display = isEmptyState ? 'none' : '';
+            }
+
+            var footer = document.getElementById('detailPanelFooter');
+            if (footer) {
+                footer.style.display = isEmptyState ? 'none' : '';
+            }
+        };
+    }
+
     function createPublicViewerSelectedMomentActionsBoundary(deps) {
         var openCurrentMomentDetail = deps && typeof deps.openCurrentMomentDetail === 'function'
             ? deps.openCurrentMomentDetail
@@ -527,6 +552,7 @@
         var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps);
         var updateMemoBody = createPublicViewerMemoBodyBoundary(deps);
         var updateCurrentMomentTags = createPublicViewerCurrentMomentTagsBoundary(deps);
+        var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps);
         var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps);
         var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === 'function'
             ? detailUI.updateDetailPanel
@@ -548,6 +574,7 @@
             updatePublicViewerCurrentMomentDate(data);
             updateMemoBody(data);
             updateCurrentMomentTags(data);
+            updateMemoryActions(data);
             updateReadOnlyReactionSummary(data);
         };
         return detailUI;
@@ -567,6 +594,7 @@
         updatePublicViewerCurrentMomentDate: updatePublicViewerCurrentMomentDate,
         createPublicViewerMemoBodyBoundary: createPublicViewerMemoBodyBoundary,
         createPublicViewerCurrentMomentTagsBoundary: createPublicViewerCurrentMomentTagsBoundary,
+        createPublicViewerMemoryActionsBoundary: createPublicViewerMemoryActionsBoundary,
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         createPublicViewerTreeMetaBoundary: createPublicViewerTreeMetaBoundary,
         createPublicViewerSelectedMomentActionsBoundary: createPublicViewerSelectedMomentActionsBoundary,

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-3"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-4"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -198,6 +198,26 @@ test('public viewer detail UI adapter owns selected moment action button boundar
   assert.ok(source.includes('installSelectedMomentActions();'), 'viewer adapter runs selected action installer at construction');
 });
 
+test('public viewer detail UI adapter owns memory actions display boundary', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function createPublicViewerMemoryActionsBoundary(deps)'), 'viewer adapter exposes memory actions boundary factory');
+  assert.ok(source.includes("document.querySelector('.memory-actions')"), 'viewer memory actions boundary targets .memory-actions');
+  assert.ok(source.includes("document.getElementById('detailPanelFooter')"), 'viewer memory actions boundary targets detailPanelFooter');
+  assert.ok(source.includes('createPublicViewerMemoryActionsBoundary: createPublicViewerMemoryActionsBoundary'), 'viewer adapter publishes memory actions boundary on namespace');
+  assert.ok(source.includes('var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps)'), 'viewer adapter creates memory actions updater');
+  assert.ok(source.includes('updateMemoryActions(data);'), 'viewer adapter runs memory actions update in detail panel flow');
+
+  const panelStart = source.indexOf('detailUI.updateDetailPanel = function');
+  const panelEnd = source.indexOf('};', panelStart);
+  const panelSource = source.slice(panelStart, panelEnd);
+
+  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
+  const memoryActionsIndex = panelSource.indexOf('updateMemoryActions(data);');
+
+  assert.ok(delegatedIndex < memoryActionsIndex, 'memory actions update runs after delegated detail render');
+});
+
 test('public viewer detail UI adapter wraps detail panel updates with viewer-owned post-processing', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
@@ -206,12 +226,14 @@ test('public viewer detail UI adapter wraps detail panel updates with viewer-own
   assert.ok(source.includes('var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps)'), 'viewer adapter creates the badge updater');
   assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');
   assert.ok(source.includes('var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps)'), 'viewer adapter creates the read-only reaction updater');
+  assert.ok(source.includes('var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps)'), 'viewer adapter creates memory actions updater');
   assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter wraps updateDetailPanel for public viewer');
   assert.ok(source.includes('delegatedUpdateDetailPanel(data);'), 'viewer wrapper runs delegated detail rendering first');
   assert.ok(source.includes('updateTreeMeta(data);'), 'viewer wrapper applies tree meta post-processing after delegated rendering');
   assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer wrapper applies badge post-processing after delegated rendering');
   assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer wrapper applies hint post-processing after badge post-processing');
   assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer wrapper applies image post-processing after hint post-processing');
+  assert.ok(source.includes('updateMemoryActions(data);'), 'viewer wrapper applies memory actions display after image post-processing');
   assert.ok(source.includes('updateReadOnlyReactionSummary(data);'), 'viewer wrapper applies read-only reactions after image post-processing');
 });
 


### PR DESCRIPTION
Refs #1748

Summary:
- Add a public viewer-owned boundary for memory action/footer display state.
- Keep delegated editor detail rendering in place for now.
- Keep editor-detail-ui.js and editor-canvas.js loaded.
- Preserve read-only public viewer behavior.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs` ✅
- `npm run verify`: 265/265 ✅
- `npm test`: 1271/1271 ✅