### PR TITLE
refactor(viewer): own detail heading boundary

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -507,6 +507,26 @@
         };
     }
 
+    function createPublicViewerDetailHeadingBoundary(deps) {
+        var detailPanel = deps && deps.detailPanel;
+        var i18n = deps && typeof deps.i18n === 'function'
+            ? deps.i18n
+            : function() { return ''; };
+
+        function getText(key, fallback) {
+            var text = i18n(key);
+            return text && text !== key ? text : fallback;
+        }
+
+        return function updatePublicViewerDetailHeading() {
+            var headerEl = detailPanel && typeof detailPanel.querySelector === 'function'
+                ? detailPanel.querySelector('h3')
+                : document.querySelector('#detailPanel h3');
+            if (!headerEl) return;
+            headerEl.textContent = getText('editor_current_hub_heading', '현재 순간 허브');
+        };
+    }
+
     function createPublicViewerSelectedMomentActionsBoundary(deps) {
         var openCurrentMomentDetail = deps && typeof deps.openCurrentMomentDetail === 'function'
             ? deps.openCurrentMomentDetail
@@ -546,6 +566,7 @@
         }
 
         var detailUI = window.createEditorDetailUI(deps);
+        var updateDetailHeading = createPublicViewerDetailHeadingBoundary(deps);
         var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps);
         var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps);
         var updateCurrentMomentTitle = createPublicViewerCurrentMomentTitleBoundary(deps);
@@ -565,6 +586,7 @@
         installSelectedMomentActions();
         detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data) {
             delegatedUpdateDetailPanel(data);
+            updateDetailHeading();
             updateTreeMeta(data);
             updateCurrentMomentBadge(data);
             updateCurrentMomentTitle(data);
@@ -583,6 +605,7 @@
     window.createPublicViewerDetailUI = createPublicViewerDetailUI;
     window.LoveBudPublicViewerDetailUI = {
         createPublicViewerDetailUI: createPublicViewerDetailUI,
+        createPublicViewerDetailHeadingBoundary: createPublicViewerDetailHeadingBoundary,
         createPublicViewerUpdateFocusSelectedBtn: createPublicViewerUpdateFocusSelectedBtn,
         updatePublicViewerSidebarStatus: updatePublicViewerSidebarStatus,
         createPublicViewerSetDetailEmptyState: createPublicViewerSetDetailEmptyState,

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-4"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-5"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -218,6 +218,31 @@ test('public viewer detail UI adapter owns memory actions display boundary', () 
   assert.ok(delegatedIndex < memoryActionsIndex, 'memory actions update runs after delegated detail render');
 });
 
+test('public viewer detail UI adapter owns visible detail heading boundary', () => {
+  const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+  assert.ok(source.includes('function createPublicViewerDetailHeadingBoundary(deps)'), 'viewer adapter exposes detail heading boundary factory');
+  assert.ok(source.includes("detailPanel.querySelector('h3')"), 'heading boundary uses detailPanel h3 querySelector');
+  assert.ok(source.includes("document.querySelector('#detailPanel h3')"), 'heading boundary has fallback selector');
+  assert.ok(source.includes('editor_current_hub_heading'), 'heading boundary references editor_current_hub_heading i18n key');
+  assert.ok(source.includes("'현재 순간 허브'"), 'heading boundary has explicit fallback text');
+  assert.ok(source.includes('headerEl.textContent'), 'heading boundary uses textContent to set heading');
+  assert.ok(source.includes('createPublicViewerDetailHeadingBoundary: createPublicViewerDetailHeadingBoundary'), 'viewer adapter publishes heading boundary on namespace');
+  assert.ok(source.includes('var updateDetailHeading = createPublicViewerDetailHeadingBoundary(deps)'), 'viewer adapter creates heading updater');
+  assert.ok(source.includes('updateDetailHeading();'), 'viewer adapter runs heading update in detail panel flow');
+
+  const panelStart = source.indexOf('detailUI.updateDetailPanel = function');
+  const panelEnd = source.indexOf('};', panelStart);
+  const panelSource = source.slice(panelStart, panelEnd);
+
+  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
+  const headingIndex = panelSource.indexOf('updateDetailHeading();');
+  const treeMetaIndex = panelSource.indexOf('updateTreeMeta(data);');
+
+  assert.ok(delegatedIndex < headingIndex, 'heading update runs after delegated detail render');
+  assert.ok(headingIndex < treeMetaIndex, 'heading update runs before tree meta post-processing');
+});
+
 test('public viewer detail UI adapter wraps detail panel updates with viewer-owned post-processing', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
@@ -227,9 +252,11 @@ test('public viewer detail UI adapter wraps detail panel updates with viewer-own
   assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');
   assert.ok(source.includes('var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps)'), 'viewer adapter creates the read-only reaction updater');
   assert.ok(source.includes('var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps)'), 'viewer adapter creates memory actions updater');
+  assert.ok(source.includes('var updateDetailHeading = createPublicViewerDetailHeadingBoundary(deps)'), 'viewer adapter creates heading updater');
   assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter wraps updateDetailPanel for public viewer');
   assert.ok(source.includes('delegatedUpdateDetailPanel(data);'), 'viewer wrapper runs delegated detail rendering first');
-  assert.ok(source.includes('updateTreeMeta(data);'), 'viewer wrapper applies tree meta post-processing after delegated rendering');
+  assert.ok(source.includes('updateDetailHeading();'), 'viewer wrapper applies heading post-processing after delegated render');
+  assert.ok(source.includes('updateTreeMeta(data);'), 'viewer wrapper applies tree meta post-processing after heading');
   assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer wrapper applies badge post-processing after delegated rendering');
   assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer wrapper applies hint post-processing after badge post-processing');
   assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer wrapper applies image post-processing after hint post-processing');


### PR DESCRIPTION
Refs #1748

Summary:
- Add a public viewer-owned boundary for the visible detail panel heading.
- Keep delegated editor detail rendering in place for now.
- Keep editor-detail-ui.js and editor-canvas.js loaded.
- Preserve current public viewer heading text with textContent.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs`
- `npm run verify`
- `npm test`