### PR TITLE
refactor(viewer): remove delegated detail render call

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -575,9 +575,6 @@
         var updateCurrentMomentTags = createPublicViewerCurrentMomentTagsBoundary(deps);
         var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps);
         var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps);
-        var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === 'function'
-            ? detailUI.updateDetailPanel
-            : function() {};
 
         detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps);
         detailUI.updateSidebarStatus = updatePublicViewerSidebarStatus;
@@ -585,7 +582,6 @@
         var installSelectedMomentActions = createPublicViewerSelectedMomentActionsBoundary(deps);
         installSelectedMomentActions();
         detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data) {
-            delegatedUpdateDetailPanel(data);
             updateDetailHeading();
             updateTreeMeta(data);
             updateCurrentMomentBadge(data);

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260528-5"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260529-1"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-adapter-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-adapter-contract.test.cjs
@@ -38,9 +38,9 @@ test('public viewer detail adapter keeps explicit editor detail UI delegation se
   assert.ok(source.includes('delegatesToEditorDetailUI: true'));
 });
 
-test('public viewer detail adapter post-processes only after delegated detail render', () => {
+test('public viewer detail adapter owns detail render flow from heading boundary', () => {
   const adapter = getDetailAdapterSlice();
-  const delegatedCall = adapter.indexOf('delegatedUpdateDetailPanel(data);');
+  const headingCall = adapter.indexOf('updateDetailHeading();');
   const badgeCall = adapter.indexOf('updateCurrentMomentBadge(data);');
   const titleCall = adapter.indexOf('updateCurrentMomentTitle(data);');
   const hintCall = adapter.indexOf('updatePublicViewerCurrentMomentHint();');
@@ -50,19 +50,12 @@ test('public viewer detail adapter post-processes only after delegated detail re
   const tagsCall = adapter.indexOf('updateCurrentMomentTags(data);');
   const reactionsCall = adapter.indexOf('updateReadOnlyReactionSummary(data);');
 
-  [
-    delegatedCall,
-    badgeCall,
-    titleCall,
-    hintCall,
-    imageCall,
-    dateCall,
-    memoCall,
-    tagsCall,
-    reactionsCall
-  ].forEach((index) => assert.notEqual(index, -1));
+  assert.equal(adapter.indexOf('delegatedUpdateDetailPanel(data);'), -1, 'adapter no longer delegates detail panel rendering');
 
-  assert.ok(delegatedCall < badgeCall);
+  [headingCall, badgeCall, titleCall, hintCall, imageCall, dateCall, memoCall, tagsCall, reactionsCall]
+    .forEach((index) => assert.notEqual(index, -1));
+
+  assert.ok(headingCall < badgeCall);
   assert.ok(badgeCall < titleCall);
   assert.ok(titleCall < hintCall);
   assert.ok(hintCall < imageCall);

--- a/tests/routes/public-viewer-detail-output-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-output-contract.test.cjs
@@ -34,11 +34,11 @@ test('public viewer detail template exposes the current rendered output mounts',
   assert.equal(templateSrc.includes('id="viewMomentDetailBtn"'), false, 'public viewer output does not expose noop detail action');
 });
 
-test('public viewer adapter preserves delegated detail rendering before viewer-only post-processing', () => {
+test('public viewer adapter no longer delegates detail rendering to editor core', () => {
   const adapterSrc = readFile('js/viewer/public-viewer-detail-ui.js');
 
-  assert.ok(adapterSrc.includes('window.createEditorDetailUI(deps)'), 'public viewer adapter still delegates to editor detail core');
-  assert.ok(adapterSrc.includes('var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === \'function\''), 'public viewer adapter captures the delegated detail update');
-  assert.ok(adapterSrc.includes('delegatedUpdateDetailPanel(data);'), 'public viewer adapter preserves delegated detail rendering first');
-  assert.ok(adapterSrc.includes('updateReadOnlyReactionSummary(data);'), 'public viewer adapter applies read-only reaction summary after rendering');
+  assert.ok(adapterSrc.includes('window.createEditorDetailUI(deps)'), 'public viewer adapter still creates detail UI via editor factory');
+  assert.equal(adapterSrc.includes('var delegatedUpdateDetailPanel'), false, 'public viewer adapter no longer captures delegated detail update');
+  assert.equal(adapterSrc.includes('delegatedUpdateDetailPanel(data);'), false, 'public viewer adapter no longer delegates detail rendering to editor core');
+  assert.ok(adapterSrc.includes('updateReadOnlyReactionSummary(data);'), 'public viewer adapter applies read-only reaction summary');
 });

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -136,7 +136,7 @@ test('public viewer detail UI adapter exposes read-only reaction summary boundar
   assert.equal(boundarySource.includes('from=editor'), false, 'read-only reactions boundary must not navigate through editor detail context');
 });
 
-test('public viewer detail UI adapter renders tree meta via viewer boundary after delegated render', () => {
+test('public viewer detail UI adapter renders tree meta after heading boundary', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
   assert.ok(source.includes('function createPublicViewerTreeMetaBoundary(deps)'), 'viewer adapter exposes tree meta boundary factory');
@@ -150,11 +150,12 @@ test('public viewer detail UI adapter renders tree meta via viewer boundary afte
   const panelEnd = source.indexOf('};', panelStart);
   const panelSource = source.slice(panelStart, panelEnd);
 
-  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
+  const headingIndex = panelSource.indexOf('updateDetailHeading();');
   const treeMetaIndex = panelSource.indexOf('updateTreeMeta(data);');
   const badgeIndex = panelSource.indexOf('updateCurrentMomentBadge(data);');
 
-  assert.ok(delegatedIndex < treeMetaIndex, 'tree meta runs after delegated detail render');
+  assert.notEqual(headingIndex, -1, 'heading update is present');
+  assert.ok(headingIndex < treeMetaIndex, 'tree meta runs after heading update');
   assert.ok(treeMetaIndex < badgeIndex, 'tree meta runs before badge post-processing');
 });
 
@@ -212,10 +213,12 @@ test('public viewer detail UI adapter owns memory actions display boundary', () 
   const panelEnd = source.indexOf('};', panelStart);
   const panelSource = source.slice(panelStart, panelEnd);
 
-  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
   const memoryActionsIndex = panelSource.indexOf('updateMemoryActions(data);');
+  const reactionsIndex = panelSource.indexOf('updateReadOnlyReactionSummary(data);');
 
-  assert.ok(delegatedIndex < memoryActionsIndex, 'memory actions update runs after delegated detail render');
+  assert.notEqual(memoryActionsIndex, -1, 'memory actions update is present');
+  assert.notEqual(reactionsIndex, -1, 'reactions update is present after memory actions');
+  assert.ok(memoryActionsIndex < reactionsIndex, 'memory actions update runs before reactions');
 });
 
 test('public viewer detail UI adapter owns visible detail heading boundary', () => {
@@ -235,33 +238,34 @@ test('public viewer detail UI adapter owns visible detail heading boundary', () 
   const panelEnd = source.indexOf('};', panelStart);
   const panelSource = source.slice(panelStart, panelEnd);
 
-  const delegatedIndex = panelSource.indexOf('delegatedUpdateDetailPanel(data);');
+  assert.equal(panelSource.indexOf('delegatedUpdateDetailPanel(data);'), -1, 'no delegated detail render call remains in panel flow');
   const headingIndex = panelSource.indexOf('updateDetailHeading();');
   const treeMetaIndex = panelSource.indexOf('updateTreeMeta(data);');
 
-  assert.ok(delegatedIndex < headingIndex, 'heading update runs after delegated detail render');
+  assert.notEqual(headingIndex, -1, 'heading update is present in panel flow');
   assert.ok(headingIndex < treeMetaIndex, 'heading update runs before tree meta post-processing');
 });
 
-test('public viewer detail UI adapter wraps detail panel updates with viewer-owned post-processing', () => {
+test('public viewer detail UI adapter owns detail panel render flow', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
-  assert.ok(source.includes('var delegatedUpdateDetailPanel = typeof detailUI.updateDetailPanel === \'function\''), 'viewer adapter captures delegated detail panel update');
+  assert.ok(source.includes('var detailUI = window.createEditorDetailUI(deps)'), 'viewer adapter still creates detail UI object through editor factory for now');
+  assert.equal(source.includes('var delegatedUpdateDetailPanel'), false, 'viewer adapter no longer captures delegated detail panel renderer');
+  assert.equal(source.includes('delegatedUpdateDetailPanel(data);'), false, 'viewer adapter no longer delegates detail panel rendering');
   assert.ok(source.includes('var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps)'), 'viewer adapter creates tree meta updater');
   assert.ok(source.includes('var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps)'), 'viewer adapter creates the badge updater');
   assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');
   assert.ok(source.includes('var updateReadOnlyReactionSummary = createPublicViewerReadOnlyReactionSummaryBoundary(deps)'), 'viewer adapter creates the read-only reaction updater');
   assert.ok(source.includes('var updateMemoryActions = createPublicViewerMemoryActionsBoundary(deps)'), 'viewer adapter creates memory actions updater');
   assert.ok(source.includes('var updateDetailHeading = createPublicViewerDetailHeadingBoundary(deps)'), 'viewer adapter creates heading updater');
-  assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter wraps updateDetailPanel for public viewer');
-  assert.ok(source.includes('delegatedUpdateDetailPanel(data);'), 'viewer wrapper runs delegated detail rendering first');
-  assert.ok(source.includes('updateDetailHeading();'), 'viewer wrapper applies heading post-processing after delegated render');
-  assert.ok(source.includes('updateTreeMeta(data);'), 'viewer wrapper applies tree meta post-processing after heading');
-  assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer wrapper applies badge post-processing after delegated rendering');
-  assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer wrapper applies hint post-processing after badge post-processing');
-  assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer wrapper applies image post-processing after hint post-processing');
-  assert.ok(source.includes('updateMemoryActions(data);'), 'viewer wrapper applies memory actions display after image post-processing');
-  assert.ok(source.includes('updateReadOnlyReactionSummary(data);'), 'viewer wrapper applies read-only reactions after image post-processing');
+  assert.ok(source.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'viewer adapter owns the updateDetailPanel function');
+  assert.ok(source.includes('updateDetailHeading();'), 'viewer flow starts with heading update');
+  assert.ok(source.includes('updateTreeMeta(data);'), 'viewer flow applies tree meta post-processing');
+  assert.ok(source.includes('updateCurrentMomentBadge(data);'), 'viewer flow applies badge post-processing');
+  assert.ok(source.includes('updatePublicViewerCurrentMomentHint();'), 'viewer flow applies hint post-processing');
+  assert.ok(source.includes('updateCurrentMomentImage(data);'), 'viewer flow applies image post-processing');
+  assert.ok(source.includes('updateMemoryActions(data);'), 'viewer flow applies memory actions display');
+  assert.ok(source.includes('updateReadOnlyReactionSummary(data);'), 'viewer flow applies read-only reactions');
 });
 
 test('public viewer keeps extracted detail helpers on viewer-owned paths', () => {

--- a/tests/routes/public-viewer-memo-contract.test.cjs
+++ b/tests/routes/public-viewer-memo-contract.test.cjs
@@ -32,20 +32,18 @@ test('public viewer memo body boundary does not wire editor memo editing or hint
   assert.equal(boundary.includes('memoHint'), false);
 });
 
-test('public viewer memo body boundary post-processes delegated editor detail rendering', () => {
-  const delegatedIndex = source.indexOf('delegatedUpdateDetailPanel(data);');
+test('public viewer memo body boundary order in viewer-owned detail panel flow', () => {
   const dateIndex = source.indexOf('updatePublicViewerCurrentMomentDate(data);');
   const memoIndex = source.indexOf('updateMemoBody(data);');
   const tagsIndex = source.indexOf('updateCurrentMomentTags(data);');
   const reactionsIndex = source.indexOf('updateReadOnlyReactionSummary(data);');
 
-  assert.notEqual(delegatedIndex, -1, 'viewer wrapper delegates to editor detail rendering first');
-  assert.notEqual(dateIndex, -1, 'viewer wrapper updates current moment date');
-  assert.notEqual(memoIndex, -1, 'viewer wrapper updates memo body');
-  assert.notEqual(tagsIndex, -1, 'viewer wrapper updates tags after memo body');
-  assert.notEqual(reactionsIndex, -1, 'viewer wrapper updates read-only reactions after tags');
-  assert.ok(delegatedIndex < memoIndex, 'memo body must run after delegated editor render to replace editor memo hint/edit output');
-  assert.ok(dateIndex < memoIndex, 'date boundary should run before memo boundary');
-  assert.ok(memoIndex < tagsIndex, 'memo boundary should run before tags boundary');
-  assert.ok(tagsIndex < reactionsIndex, 'tags boundary should run before read-only reactions');
+  assert.notEqual(dateIndex, -1, 'viewer flow updates current moment date');
+  assert.notEqual(memoIndex, -1, 'viewer flow updates memo body');
+  assert.notEqual(tagsIndex, -1, 'viewer flow updates tags after memo body');
+  assert.notEqual(reactionsIndex, -1, 'viewer flow updates read-only reactions after tags');
+  assert.equal(source.indexOf('delegatedUpdateDetailPanel(data);'), -1, 'delegated editor detail render call is removed');
+  assert.ok(dateIndex < memoIndex, 'date boundary runs before memo boundary');
+  assert.ok(memoIndex < tagsIndex, 'memo boundary runs before tags boundary');
+  assert.ok(tagsIndex < reactionsIndex, 'tags boundary runs before read-only reactions');
 });

--- a/tests/routes/public-viewer-reactions-contract.test.cjs
+++ b/tests/routes/public-viewer-reactions-contract.test.cjs
@@ -17,17 +17,15 @@ test('public viewer reaction summary boundary stays read-only', () => {
   assert.equal(boundary.includes('from=editor'), false, 'public viewer does not use editor comment context');
 });
 
-test('public viewer reaction summary runs after other detail post-processing', () => {
-  const delegatedIndex = source.indexOf('delegatedUpdateDetailPanel(data);');
+test('public viewer reaction summary runs after memo and tags post-processing', () => {
   const memoIndex = source.indexOf('updateMemoBody(data);');
   const tagsIndex = source.indexOf('updateCurrentMomentTags(data);');
   const reactionsIndex = source.indexOf('updateReadOnlyReactionSummary(data);');
 
-  assert.notEqual(delegatedIndex, -1, 'delegated render exists');
   assert.notEqual(memoIndex, -1, 'memo post-processing exists');
   assert.notEqual(tagsIndex, -1, 'tags post-processing exists');
   assert.notEqual(reactionsIndex, -1, 'reaction post-processing exists');
-  assert.ok(delegatedIndex < reactionsIndex, 'reaction summary follows delegated render');
+  assert.equal(source.indexOf('delegatedUpdateDetailPanel(data);'), -1, 'delegated editor detail render call is removed');
   assert.ok(memoIndex < reactionsIndex, 'reaction summary follows memo post-processing');
   assert.ok(tagsIndex < reactionsIndex, 'reaction summary follows tag post-processing');
 });


### PR DESCRIPTION
Refs #1748

Summary:
- Remove the delegated editor detail panel render call from the public viewer detail adapter.
- Keep editor detail factory construction in place for now.
- Keep editor-detail-ui.js and editor-canvas.js loaded.
- Preserve public viewer-owned detail render order.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs`
- `node --test tests/routes/public-viewer-detail-adapter-contract.test.cjs`
- `npm run verify`
- `npm test`