### PR TITLE
refactor(viewer): own detail UI object shell

### DIFF
--- a/js/viewer/public-viewer-detail-ui.js
+++ b/js/viewer/public-viewer-detail-ui.js
@@ -561,11 +561,7 @@
     }
 
     function createPublicViewerDetailUI(deps) {
-        if (typeof window.createEditorDetailUI !== 'function') {
-            throw new Error('createEditorDetailUI is required for public viewer detail UI adapter');
-        }
-
-        var detailUI = window.createEditorDetailUI(deps);
+        var detailUI = {};
         var updateDetailHeading = createPublicViewerDetailHeadingBoundary(deps);
         var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps);
         var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps);
@@ -617,6 +613,6 @@
         createPublicViewerReadOnlyReactionSummaryBoundary: createPublicViewerReadOnlyReactionSummaryBoundary,
         createPublicViewerTreeMetaBoundary: createPublicViewerTreeMetaBoundary,
         createPublicViewerSelectedMomentActionsBoundary: createPublicViewerSelectedMomentActionsBoundary,
-        delegatesToEditorDetailUI: true
+        delegatesToEditorDetailUI: false
     };
 })();

--- a/pages/view.html
+++ b/pages/view.html
@@ -80,7 +80,7 @@
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
     <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
-    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260529-1"></script>
+    <script src="../js/viewer/public-viewer-detail-ui.js?v=20260529-2"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 
     <script src="../js/api/auth-policy.js?v=20260420-1"></script>

--- a/tests/routes/public-viewer-detail-adapter-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-adapter-contract.test.cjs
@@ -29,13 +29,14 @@ function getDetailAdapterSlice() {
   return source.slice(start, end);
 }
 
-test('public viewer detail adapter keeps explicit editor detail UI delegation seam', () => {
+test('public viewer detail adapter owns detail UI object shell', () => {
   const adapter = getDetailAdapterSlice();
 
-  assert.ok(adapter.includes("typeof window.createEditorDetailUI !== 'function'"));
-  assert.ok(adapter.includes("throw new Error('createEditorDetailUI is required for public viewer detail UI adapter')"));
-  assert.ok(adapter.includes('var detailUI = window.createEditorDetailUI(deps);'));
-  assert.ok(source.includes('delegatesToEditorDetailUI: true'));
+  assert.ok(adapter.includes("var detailUI = {};"), 'public viewer adapter creates its own detail UI shell');
+  assert.equal(adapter.includes('window.createEditorDetailUI(deps)'), false, 'public viewer adapter no longer constructs through editor detail factory');
+  assert.equal(adapter.includes('delegatedUpdateDetailPanel(data);'), false, 'public viewer adapter no longer delegates detail panel rendering');
+  assert.ok(source.includes('delegatesToEditorDetailUI: false'), 'public viewer adapter marks editor detail delegation as removed');
+  assert.ok(adapter.includes('detailUI.updateDetailPanel = function updatePublicViewerDetailPanel(data)'), 'public viewer adapter owns the updateDetailPanel function');
 });
 
 test('public viewer detail adapter owns detail render flow from heading boundary', () => {

--- a/tests/routes/public-viewer-detail-output-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-output-contract.test.cjs
@@ -37,7 +37,8 @@ test('public viewer detail template exposes the current rendered output mounts',
 test('public viewer adapter no longer delegates detail rendering to editor core', () => {
   const adapterSrc = readFile('js/viewer/public-viewer-detail-ui.js');
 
-  assert.ok(adapterSrc.includes('window.createEditorDetailUI(deps)'), 'public viewer adapter still creates detail UI via editor factory');
+  assert.ok(adapterSrc.includes("var detailUI = {};"), 'public viewer adapter creates its own detail UI shell');
+  assert.equal(adapterSrc.includes('window.createEditorDetailUI(deps)'), false, 'public viewer adapter no longer constructs through editor detail factory');
   assert.equal(adapterSrc.includes('var delegatedUpdateDetailPanel'), false, 'public viewer adapter no longer captures delegated detail update');
   assert.equal(adapterSrc.includes('delegatedUpdateDetailPanel(data);'), false, 'public viewer adapter no longer delegates detail rendering to editor core');
   assert.ok(adapterSrc.includes('updateReadOnlyReactionSummary(data);'), 'public viewer adapter applies read-only reaction summary');

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -52,7 +52,8 @@ test('public viewer detail UI adapter owns focus selected button updates', () =>
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
   assert.ok(source.includes('function createPublicViewerDetailUI(deps)'), 'viewer detail adapter exposes createPublicViewerDetailUI');
-  assert.ok(source.includes('window.createEditorDetailUI(deps)'), 'viewer detail adapter delegates to current detail UI core');
+  assert.ok(source.includes("var detailUI = {};"), 'viewer detail adapter creates its own detail UI object');
+  assert.equal(source.includes('window.createEditorDetailUI(deps)'), false, 'viewer detail adapter no longer constructs through editor detail factory');
   assert.ok(source.includes('function createPublicViewerUpdateFocusSelectedBtn(deps)'), 'viewer detail adapter exposes focus updater factory');
   assert.ok(source.includes('detailUI.updateFocusSelectedBtn = createPublicViewerUpdateFocusSelectedBtn(deps)'), 'viewer detail adapter assigns focus updater');
   assert.ok(source.includes('document.getElementById(\'focusSelectedBtn\')'), 'viewer focus updater targets focusSelectedBtn');
@@ -249,9 +250,10 @@ test('public viewer detail UI adapter owns visible detail heading boundary', () 
 test('public viewer detail UI adapter owns detail panel render flow', () => {
   const source = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
 
-  assert.ok(source.includes('var detailUI = window.createEditorDetailUI(deps)'), 'viewer adapter still creates detail UI object through editor factory for now');
+  assert.ok(source.includes("var detailUI = {};"), 'viewer adapter creates its own detail UI shell');
   assert.equal(source.includes('var delegatedUpdateDetailPanel'), false, 'viewer adapter no longer captures delegated detail panel renderer');
   assert.equal(source.includes('delegatedUpdateDetailPanel(data);'), false, 'viewer adapter no longer delegates detail panel rendering');
+  assert.ok(source.includes('delegatesToEditorDetailUI: false'), 'viewer adapter marks editor detail delegation as removed');
   assert.ok(source.includes('var updateTreeMeta = createPublicViewerTreeMetaBoundary(deps)'), 'viewer adapter creates tree meta updater');
   assert.ok(source.includes('var updateCurrentMomentBadge = createPublicViewerCurrentMomentBadgeBoundary(deps)'), 'viewer adapter creates the badge updater');
   assert.ok(source.includes('var updateCurrentMomentImage = createPublicViewerCurrentMomentImageBoundary(deps)'), 'viewer adapter creates the image updater');


### PR DESCRIPTION
Refs #1748

Summary:
- Create the public viewer detail UI object directly instead of constructing it through the editor detail factory.
- Keep editor-detail-ui.js loaded for now.
- Preserve the viewer-owned detail render flow and read-only behavior.
- Mark editor detail delegation as removed in the public viewer detail UI namespace.

Validation:
- `node --test tests/routes/public-viewer-detail-ui-core-contract.test.cjs`
- `node --test tests/routes/public-viewer-detail-adapter-contract.test.cjs`
- `node --test tests/routes/public-viewer-detail-output-contract.test.cjs`
- `npm run verify`
- `npm test`