### PR TITLE
refactor(viewer): remove editor detail UI script

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -79,7 +79,6 @@
 
     <script src="../js/viewer/public-viewer-detail-tree-meta.js?v=20260526-2"></script>
     <script src="../js/viewer/public-viewer-detail-builders.js?v=20260526-1"></script>
-    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
     <script src="../js/viewer/public-viewer-detail-ui.js?v=20260529-2"></script>
     <script src="../js/viewer/public-viewer-detail-channel-link.js?v=20260528-1"></script>
 

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -175,6 +175,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-detail-channel-link.js',
     'js/editor/editor-detail-tree-meta.js',
     'js/editor/editor-detail-ui-builders.js',
+    'js/editor/editor-detail-ui.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];
@@ -188,22 +189,24 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
   });
 });
 
-test('public canvas route currently uses remaining editor detail UI core stack before public init', () => {
+test('public canvas route loads viewer detail helpers before public init', () => {
   const scripts = getScriptSrcs();
 
-  const detailScripts = [
+  const detailHelperScripts = [
     'js/viewer/public-viewer-detail-tree-meta.js',
     'js/viewer/public-viewer-detail-builders.js',
-    'js/editor/editor-detail-ui.js',
   ];
 
-  detailScripts.forEach((needle) => {
-    assert.ok(scriptIncludes(scripts, needle), `view.html currently loads detail dependency: ${needle}`);
+  detailHelperScripts.forEach((needle) => {
+    assert.ok(scriptIncludes(scripts, needle), `view.html loads detail helper: ${needle}`);
     assertScriptOrder(scripts, needle, 'js/viewer/public-canvas-init.js');
   });
 
-  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-tree-meta.js', 'js/editor/editor-detail-ui.js');
-  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-builders.js', 'js/editor/editor-detail-ui.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-tree-meta.js', 'js/viewer/public-viewer-detail-ui.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-builders.js', 'js/viewer/public-viewer-detail-ui.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
+  assert.ok(scriptIncludes(scripts, 'js/viewer/public-viewer-detail-ui.js'), 'view.html loads viewer detail UI adapter');
+  assert.ok(scriptIncludes(scripts, 'js/viewer/public-viewer-detail-channel-link.js'), 'view.html loads viewer detail channel link helper');
 });
 
 test('public canvas route delegates detail channel link rendering to viewer helper', () => {
@@ -219,7 +222,7 @@ test('public canvas route delegates detail channel link rendering to viewer help
     scriptIncludes(scripts, 'js/viewer/public-viewer-detail-channel-link.js'),
     'view.html must load viewer detail channel link helper'
   );
-  assertScriptOrder(scripts, 'js/editor/editor-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-channel-link.js', 'js/viewer/public-canvas-init.js');
   assert.ok(helperSrc.includes('window.LoveBudPublicViewerDetailChannelLink'), 'viewer channel link helper must expose inspectable namespace');
   assert.ok(helperSrc.includes('renderDetailChannelLink'), 'viewer channel link helper must expose renderDetailChannelLink');

--- a/tests/routes/public-viewer-detail-adapter-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-adapter-contract.test.cjs
@@ -66,11 +66,11 @@ test('public viewer detail adapter owns detail render flow from heading boundary
   assert.ok(tagsCall < reactionsCall);
 });
 
-test('public viewer detail adapter loads after editor detail UI core and before channel patch', () => {
+test('public viewer detail adapter loads after viewer helper scripts and before channel patch', () => {
   const scripts = getScriptSrcs();
 
-  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-tree-meta.js', 'js/editor/editor-detail-ui.js');
-  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-builders.js', 'js/editor/editor-detail-ui.js');
-  assertScriptOrder(scripts, 'js/editor/editor-detail-ui.js', 'js/viewer/public-viewer-detail-ui.js');
+  assert.equal(scriptIndex(scripts, 'js/editor/editor-detail-ui.js'), -1, 'public viewer no longer loads editor detail UI core script');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-tree-meta.js', 'js/viewer/public-viewer-detail-ui.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-builders.js', 'js/viewer/public-viewer-detail-ui.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-detail-ui.js', 'js/viewer/public-viewer-detail-channel-link.js');
 });

--- a/tests/routes/public-viewer-detail-boundary-fallback-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-boundary-fallback-contract.test.cjs
@@ -18,12 +18,12 @@ function scriptIndex(scripts, needle) {
 test('viewer detail builders install fallback boundaries before detail UI loads', () => {
   const scripts = getScriptSrcs();
   const buildersIndex = scriptIndex(scripts, 'js/viewer/public-viewer-detail-builders.js');
-  const detailUiIndex = scriptIndex(scripts, 'js/editor/editor-detail-ui.js');
+  const detailUiIndex = scriptIndex(scripts, 'js/viewer/public-viewer-detail-ui.js');
   const source = fs.readFileSync('js/viewer/public-viewer-detail-builders.js', 'utf8');
 
   assert.notEqual(buildersIndex, -1, 'public view must load viewer detail builders');
-  assert.notEqual(detailUiIndex, -1, 'public view must load detail UI');
-  assert.ok(buildersIndex < detailUiIndex, 'viewer detail builders must load before detail UI');
+  assert.notEqual(detailUiIndex, -1, 'public view must load viewer detail UI adapter');
+  assert.ok(buildersIndex < detailUiIndex, 'viewer detail builders must load before viewer detail UI adapter');
   assert.equal(scripts.includes('../js/editor/editor-detail-ui-builders.js'), false, 'public view must not load editor detail UI builders');
   assert.ok(source.includes('installPublicDetailBoundaryFallbacks'), 'builders must install public detail boundary fallbacks');
   assert.ok(source.includes("typeof window.createEditorDetailInlineEditBoundary !== 'function'"), 'inline edit fallback must not overwrite an existing implementation');

--- a/tests/routes/public-viewer-detail-builders-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-builders-contract.test.cjs
@@ -19,6 +19,6 @@ test('public viewer detail builders provide editor core compatibility without ed
   assert.ok(buildersSource.includes('window.createEditorDetailSidebarStatusBoundary = createNoopSidebarStatusBoundary'), 'sidebar status fallback is published only when missing');
   assert.equal(viewHtml.includes('js/editor/editor-detail-inline-edit.js'), false, 'public viewer does not load editor inline edit helper');
   assert.equal(viewHtml.includes('js/editor/editor-detail-sidebar-status-boundary.js'), false, 'public viewer does not load editor sidebar status helper');
-  assert.ok(viewHtml.includes('js/viewer/public-viewer-detail-builders.js'), 'public viewer loads viewer detail builders before editor detail core');
-  assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-builders.js') < viewHtml.indexOf('js/editor/editor-detail-ui.js'), 'fallbacks load before editor detail core');
+  assert.ok(viewHtml.includes('js/viewer/public-viewer-detail-builders.js'), 'public viewer loads viewer detail builders before viewer detail adapter');
+  assert.ok(viewHtml.indexOf('js/viewer/public-viewer-detail-builders.js') < viewHtml.indexOf('js/viewer/public-viewer-detail-ui.js'), 'fallbacks load before viewer detail adapter');
 });

--- a/tests/routes/public-viewer-detail-script-trim-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-script-trim-contract.test.cjs
@@ -21,22 +21,22 @@ test('public viewer does not load editor detail edit/status boundary scripts', (
 test('public viewer keeps viewer detail builders before detail UI for fallback boundaries', () => {
   const scripts = getScriptSrcs();
   const buildersIndex = scripts.findIndex((src) => src.includes('js/viewer/public-viewer-detail-builders.js'));
-  const detailUiIndex = scripts.findIndex((src) => src.includes('js/editor/editor-detail-ui.js'));
+  const detailUiIndex = scripts.findIndex((src) => src.includes('js/viewer/public-viewer-detail-ui.js'));
 
   assert.equal(scripts.includes('../js/editor/editor-detail-ui-builders.js'), false, 'public view must not load editor detail UI builders');
   assert.notEqual(buildersIndex, -1, 'public view must load viewer detail builders');
-  assert.notEqual(detailUiIndex, -1, 'public view must load detail UI');
-  assert.ok(buildersIndex < detailUiIndex, 'viewer detail builders must load before detail UI so fallback boundaries exist');
+  assert.notEqual(detailUiIndex, -1, 'public view must load viewer detail UI adapter');
+  assert.ok(buildersIndex < detailUiIndex, 'viewer detail builders must load before viewer detail UI adapter so fallback boundaries exist');
 });
 
 test('public viewer delegates channel link patch to viewer-owned helper', () => {
   const scripts = getScriptSrcs();
-  const detailUiIndex = scripts.findIndex((src) => src.includes('js/editor/editor-detail-ui.js'));
+  const detailUiIndex = scripts.findIndex((src) => src.includes('js/viewer/public-viewer-detail-ui.js'));
   const helperIndex = scripts.findIndex((src) => src.includes('js/viewer/public-viewer-detail-channel-link.js'));
 
   assert.equal(scripts.includes('../js/editor/editor-detail-channel-link.js'), false, 'public view must not load editor detail channel link patch');
   assert.ok(scripts.includes('../js/viewer/public-viewer-detail-channel-link.js'), 'public view must load viewer detail channel link helper');
-  assert.notEqual(detailUiIndex, -1, 'public view must load detail UI');
+  assert.notEqual(detailUiIndex, -1, 'public view must load viewer detail UI adapter');
   assert.notEqual(helperIndex, -1, 'public view must load viewer channel link helper');
-  assert.ok(detailUiIndex < helperIndex, 'viewer channel link helper must load after detail UI so it can patch the factory');
+  assert.ok(detailUiIndex < helperIndex, 'viewer channel link helper must load after viewer detail adapter so it can patch the factory');
 });

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -19,18 +19,16 @@ test('public viewer loads detail UI through the viewer adapter layer', () => {
   const scripts = getScriptSrcs();
   const detailTreeMetaIndex = indexOfScript(scripts, 'js/viewer/public-viewer-detail-tree-meta.js');
   const detailBuildersIndex = indexOfScript(scripts, 'js/viewer/public-viewer-detail-builders.js');
-  const editorDetailUiIndex = indexOfScript(scripts, 'js/editor/editor-detail-ui.js');
   const viewerDetailUiIndex = indexOfScript(scripts, 'js/viewer/public-viewer-detail-ui.js');
   const channelLinkIndex = indexOfScript(scripts, 'js/viewer/public-viewer-detail-channel-link.js');
 
   assert.notEqual(detailTreeMetaIndex, -1, 'viewer tree meta helper is loaded');
   assert.notEqual(detailBuildersIndex, -1, 'viewer detail builders helper is loaded');
-  assert.notEqual(editorDetailUiIndex, -1, 'editor detail UI core is still loaded for now');
   assert.notEqual(viewerDetailUiIndex, -1, 'viewer detail UI adapter is loaded');
   assert.notEqual(channelLinkIndex, -1, 'viewer channel link helper is loaded');
-  assert.ok(detailTreeMetaIndex < editorDetailUiIndex, 'tree meta helper loads before detail UI core');
-  assert.ok(detailBuildersIndex < editorDetailUiIndex, 'detail builders helper loads before detail UI core');
-  assert.ok(editorDetailUiIndex < viewerDetailUiIndex, 'viewer detail UI adapter loads after detail UI core');
+  assert.equal(scripts.some(function(s) { return s.includes('js/editor/editor-detail-ui.js'); }), false, 'editor detail UI core is no longer loaded');
+  assert.ok(detailTreeMetaIndex < viewerDetailUiIndex, 'tree meta helper loads before viewer detail UI adapter');
+  assert.ok(detailBuildersIndex < viewerDetailUiIndex, 'detail builders helper loads before viewer detail UI adapter');
   assert.ok(viewerDetailUiIndex < channelLinkIndex, 'channel link helper loads after viewer detail adapter');
 });
 


### PR DESCRIPTION
Refs #1748

Summary:
- Remove the unused editor detail UI script from the public viewer page.
- Keep viewer detail tree-meta/builders helpers loaded before the public viewer detail adapter.
- Keep editor canvas runtime loaded for now.
- Update route dependency contracts for the viewer-owned detail renderer path.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `node --test tests/routes/public-viewer-detail-adapter-contract.test.cjs`
- `npm run verify`
- `npm test`