### PR TITLE
refactor(viewer): remove unused editor DOM selectors script

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -47,7 +47,6 @@
     <script src="../js/viewer/public-viewer-detail-empty-state-template.js?v=20260526-1"></script>
     <script src="../js/viewer/public-viewer-detail-view-mode-template.js?v=20260526-1"></script>
 
-    <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
     <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -176,6 +176,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-detail-tree-meta.js',
     'js/editor/editor-detail-ui-builders.js',
     'js/editor/editor-detail-ui.js',
+    'js/editor/editor-dom-selectors.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];


### PR DESCRIPTION
Refs #1711

Summary:
- Remove the unused editor DOM selectors script from the public viewer route.
- Keep editor canvas runtime loaded for now.
- Update route dependency contract to keep the editor-only script out of public view.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`