### PR TITLE
refactor(viewer): remove unused canvas interaction helpers script

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -52,7 +52,6 @@
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
-    <script src="../js/editor/editor-canvas-interaction-helpers.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-scale.js?v=20260524-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-projection.js?v=20260524-1505"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -177,6 +177,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-detail-ui-builders.js',
     'js/editor/editor-detail-ui.js',
     'js/editor/editor-dom-selectors.js',
+    'js/editor/editor-canvas-interaction-helpers.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];


### PR DESCRIPTION
Refs #1711

Summary:
- Remove the unused canvas interaction helpers script from the public viewer route.
- Keep editor-canvas-interaction.js and the main editor canvas runtime loaded for now.
- Update the route dependency contract to keep the removed helper out of public view.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`