### PR TITLE
refactor(viewer): remove unused canvas state boundary script

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -65,7 +65,6 @@
     <script src="../js/editor/editor-canvas-viewport-actions.js?v=20260523-1505"></script>
     <script src="../js/editor/editor-canvas-viewport-controls.js?v=20260523-1505"></script>
     <script src="../js/editor/editor-canvas-edges.js?v=20260502-1"></script>
-    <script src="../js/editor/editor-canvas-state-boundary.js?v=20260503-1"></script>
 
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -178,6 +178,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-detail-ui.js',
     'js/editor/editor-dom-selectors.js',
     'js/editor/editor-canvas-interaction-helpers.js',
+    'js/editor/editor-canvas-state-boundary.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];


### PR DESCRIPTION
Refs #1711

Summary:
- Remove the unused canvas state boundary script from the public viewer route.
- Keep editor canvas runtime core loaded for now.
- Update route dependency contract to keep the removed script out of public view.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`