### PR TITLE
refactor(viewer): remove unused canvas layout helpers script

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -49,7 +49,6 @@
 
     <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
-    <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-viewport.js?v=20260524-1505"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -107,7 +107,6 @@ test('public canvas route currently depends on editor canvas runtime before publ
 
   const requiredCanvasScripts = [
     'js/editor/editor-canvas-layout.js',
-    'js/editor/editor-canvas-layout-helpers.js',
     'js/editor/editor-canvas-node.js',
     'js/editor/editor-canvas-interaction.js',
     'js/editor/editor-canvas-viewport.js',
@@ -179,6 +178,7 @@ test('public canvas route keeps removed editor-only runtime scripts and unused s
     'js/editor/editor-dom-selectors.js',
     'js/editor/editor-canvas-interaction-helpers.js',
     'js/editor/editor-canvas-state-boundary.js',
+    'js/editor/editor-canvas-layout-helpers.js',
     'js/editor/templates/editor-floating-toolbar-template.js',
     'js/editor/templates/editor-empty-guide-template.js',
   ];


### PR DESCRIPTION
Refs #1711

Summary:
- Remove the unused canvas layout helpers script from the public viewer route.
- Keep editor canvas runtime core loaded for now.
- Move the script from required public canvas runtime list to removed runtime guard list.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`