### PR TITLE
refactor(viewer): add public canvas entry wrapper

### DIFF
--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -1,0 +1,30 @@
+(function () {
+    'use strict';
+
+    const globalObject = window;
+
+    function getCanvasRuntime() {
+        return globalObject.LoveBudEditorCanvas
+            || globalObject.EditorCanvas
+            || globalObject.createEditorCanvas
+            || null;
+    }
+
+    function hasCanvasRuntime() {
+        return Boolean(getCanvasRuntime());
+    }
+
+    function getBoundaryState() {
+        return {
+            hasCanvasRuntime: hasCanvasRuntime(),
+            hasPublicCanvasBridge: Boolean(globalObject.LoveBudPublicCanvasBridge),
+            hasPublicCanvasInit: Boolean(globalObject.LoveBudPublicCanvasInit)
+        };
+    }
+
+    globalObject.LoveBudPublicViewerCanvasEntry = Object.freeze({
+        getCanvasRuntime: getCanvasRuntime,
+        hasCanvasRuntime: hasCanvasRuntime,
+        getBoundaryState: getBoundaryState
+    });
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -92,6 +92,7 @@
     <script src="../js/shared-header.js?v=20260421-2"></script>
     <script src="../js/page-transitions.js?v=20260430-1"></script>
     <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
+    <script src="../js/viewer/public-viewer-canvas-entry.js?v=20260528-1"></script>
     <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
     <script src="../js/viewer/public-viewer-copy-helper.js?v=20260525-1"></script>
     <script src="../js/viewer/public-viewer-control-visibility-helper.js?v=20260526-1"></script>

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -56,7 +56,8 @@ test('public canvas route page exists and avoids unused editor shell mounts afte
 test('public canvas route keeps public viewer bootstrap scripts in required order', () => {
   const scripts = getScriptSrcs();
 
-  assertScriptOrder(scripts, 'js/viewer/public-canvas-bridge.js', 'js/viewer/public-canvas-init.js');
+  assertScriptOrder(scripts, 'js/viewer/public-canvas-bridge.js', 'js/viewer/public-viewer-canvas-entry.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-canvas-entry.js', 'js/viewer/public-canvas-init.js');
   assertScriptOrder(scripts, 'js/viewer/public-canvas-init.js', 'js/viewer/public-viewer-copy-helper.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-copy-helper.js', 'js/viewer/public-viewer-control-visibility-helper.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-control-visibility-helper.js', 'js/viewer/public-viewer-copy-polish.js');


### PR DESCRIPTION
Refs #1711

Summary:
- Add a thin viewer-owned public canvas entry wrapper.
- Load the wrapper before public canvas init.
- Add route dependency contract coverage for wrapper/load order.
- Keep editor canvas runtime loaded for now.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`