### PR TITLE
refactor(viewer): delegate public canvas profile setup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -16,38 +16,6 @@
             .replace(/'/g, '&#39;');
     }
 
-    function installPublicMetrics(canvas) {
-        var geometry = window.EditorCanvasGeometry;
-        if (!geometry || typeof geometry.getMetrics !== 'function') return;
-        if (geometry.__publicViewMetricsInstalled) return;
-        var originalGetMetrics = geometry.getMetrics;
-        geometry.getMetrics = function(targetCanvas) {
-            var node = targetCanvas || canvas;
-            var rect = node && typeof node.getBoundingClientRect === 'function'
-                ? node.getBoundingClientRect()
-                : null;
-            var width = Math.round((rect && rect.width) || (node && node.clientWidth) || window.innerWidth || 0);
-            var height = Math.round((rect && rect.height) || (node && node.clientHeight) || window.innerHeight || 0);
-            if (width > 0 && height > 0) {
-                return {
-                    width: Math.max(width, 320),
-                    height: Math.max(height, 420)
-                };
-            }
-            return originalGetMetrics(targetCanvas);
-        };
-        geometry.__publicViewMetricsInstalled = true;
-    }
-
-    function installPublicViewportProfile() {
-        var viewport = window.LoveBudEditorCanvasViewport;
-        if (!viewport || viewport.__publicViewProfileInstalled) return;
-        viewport.minScale = Math.max(Number(viewport.minScale) || 0.2, 0.5);
-        viewport.zoomLevels = [0.5, 0.75, 1, 1.25, 1.5];
-        viewport.readableCenter = { x: 0.5, y: 0.46 };
-        viewport.__publicViewProfileInstalled = true;
-    }
-
     function createLoadFailureState(message) {
         var errState = document.createElement('div');
         var icon = document.createElement('span');
@@ -111,8 +79,13 @@
                     return;
                 }
 
-                var canvasReady = typeof window.createEditorCanvas === 'function';
-                var detailReady = typeof window.createPublicViewerDetailUI === 'function';
+                var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+                var canvasReady = canvasEntry && typeof canvasEntry.isCanvasRuntimeReady === 'function'
+                    ? canvasEntry.isCanvasRuntimeReady()
+                    : typeof window.createEditorCanvas === 'function';
+                var detailReady = canvasEntry && typeof canvasEntry.isDetailRuntimeReady === 'function'
+                    ? canvasEntry.isDetailRuntimeReady()
+                    : typeof window.createPublicViewerDetailUI === 'function';
 
                 if (canvasReady && detailReady) {
                     startCanvas();
@@ -131,8 +104,13 @@
                     return;
                 }
 
-                installPublicMetrics(canvas);
-                installPublicViewportProfile();
+                var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+                if (canvasEntry && typeof canvasEntry.installPublicMetrics === 'function') {
+                    canvasEntry.installPublicMetrics(canvas);
+                }
+                if (canvasEntry && typeof canvasEntry.installPublicViewportProfile === 'function') {
+                    canvasEntry.installPublicViewportProfile();
+                }
 
                 // Set up empty guide UI
                 var updateCanvasEmptyGuide = function() {

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    const globalObject = window;
+    var globalObject = window;
 
     function getCanvasRuntime() {
         return globalObject.LoveBudEditorCanvas
@@ -14,9 +14,50 @@
         return Boolean(getCanvasRuntime());
     }
 
+    function isCanvasRuntimeReady() {
+        return typeof globalObject.createEditorCanvas === 'function';
+    }
+
+    function isDetailRuntimeReady() {
+        return typeof globalObject.createPublicViewerDetailUI === 'function';
+    }
+
+    function installPublicMetrics(canvas) {
+        var geometry = globalObject.EditorCanvasGeometry;
+        if (!geometry || typeof geometry.getMetrics !== 'function') return;
+        if (geometry.__publicViewMetricsInstalled) return;
+        var originalGetMetrics = geometry.getMetrics;
+        geometry.getMetrics = function(targetCanvas) {
+            var node = targetCanvas || canvas;
+            var rect = node && typeof node.getBoundingClientRect === 'function'
+                ? node.getBoundingClientRect()
+                : null;
+            var width = Math.round((rect && rect.width) || (node && node.clientWidth) || globalObject.innerWidth || 0);
+            var height = Math.round((rect && rect.height) || (node && node.clientHeight) || globalObject.innerHeight || 0);
+            if (width > 0 && height > 0) {
+                return {
+                    width: Math.max(width, 320),
+                    height: Math.max(height, 420)
+                };
+            }
+            return originalGetMetrics(targetCanvas);
+        };
+        geometry.__publicViewMetricsInstalled = true;
+    }
+
+    function installPublicViewportProfile() {
+        var viewport = globalObject.LoveBudEditorCanvasViewport;
+        if (!viewport || viewport.__publicViewProfileInstalled) return;
+        viewport.minScale = Math.max(Number(viewport.minScale) || 0.2, 0.5);
+        viewport.zoomLevels = [0.5, 0.75, 1, 1.25, 1.5];
+        viewport.readableCenter = { x: 0.5, y: 0.46 };
+        viewport.__publicViewProfileInstalled = true;
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
+            hasDetailRuntime: isDetailRuntimeReady(),
             hasPublicCanvasBridge: Boolean(globalObject.LoveBudPublicCanvasBridge),
             hasPublicCanvasInit: Boolean(globalObject.LoveBudPublicCanvasInit)
         };
@@ -25,6 +66,10 @@
     globalObject.LoveBudPublicViewerCanvasEntry = Object.freeze({
         getCanvasRuntime: getCanvasRuntime,
         hasCanvasRuntime: hasCanvasRuntime,
+        isCanvasRuntimeReady: isCanvasRuntimeReady,
+        isDetailRuntimeReady: isDetailRuntimeReady,
+        installPublicMetrics: installPublicMetrics,
+        installPublicViewportProfile: installPublicViewportProfile,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -232,3 +232,25 @@ test('public canvas route delegates detail channel link rendering to viewer help
   assert.ok(helperSrc.includes('renderDetailChannelLink'), 'viewer channel link helper must expose renderDetailChannelLink');
   assert.equal(helperSrc.includes('createPublicViewerDetailUI'), false, 'viewer channel link helper must not patch the viewer detail adapter');
 });
+
+test('public canvas entry wrapper exposes boundary and setup methods', () => {
+  const entrySrc = fs.readFileSync('js/viewer/public-viewer-canvas-entry.js', 'utf8');
+
+  assert.ok(entrySrc.includes('LoveBudPublicViewerCanvasEntry'), 'entry wrapper must expose LoveBudPublicViewerCanvasEntry namespace');
+  assert.ok(entrySrc.includes('installPublicMetrics'), 'entry wrapper must expose installPublicMetrics');
+  assert.ok(entrySrc.includes('installPublicViewportProfile'), 'entry wrapper must expose installPublicViewportProfile');
+  assert.ok(entrySrc.includes('isCanvasRuntimeReady'), 'entry wrapper must expose isCanvasRuntimeReady');
+  assert.ok(entrySrc.includes('isDetailRuntimeReady'), 'entry wrapper must expose isDetailRuntimeReady');
+  assert.ok(entrySrc.includes('getBoundaryState'), 'entry wrapper must expose getBoundaryState');
+  assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
+});
+
+test('public canvas init delegates metrics/profile setup through entry wrapper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(initSrc.includes('LoveBudPublicViewerCanvasEntry'), 'public canvas init must reference the entry wrapper');
+  assert.ok(initSrc.includes('installPublicMetrics'), 'public canvas init must delegate installPublicMetrics through entry wrapper');
+  assert.ok(initSrc.includes('installPublicViewportProfile'), 'public canvas init must delegate installPublicViewportProfile through entry wrapper');
+  assert.ok(initSrc.includes('isCanvasRuntimeReady'), 'public canvas init must delegate isCanvasRuntimeReady through entry wrapper');
+  assert.ok(initSrc.includes('isDetailRuntimeReady'), 'public canvas init must delegate isDetailRuntimeReady through entry wrapper');
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Move public canvas metrics/profile setup behind the viewer canvas entry wrapper.
- Delegate public canvas runtime readiness checks through the wrapper.
- Keep editor canvas runtime loaded with no behavior change.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`