### PR TITLE
refactor(viewer): delegate read-only canvas actions

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -142,10 +142,16 @@
 
                 var canonicalRootId = getCanonicalRootId();
 
-                // Create noop stubs for mutation functions
-                var noop = function() {};
-                var noopAsync = function() { return Promise.resolve(); };
-                var noopFalseAsync = function() { return Promise.resolve(false); };
+                // Delegate read-only/no-op actions to entry wrapper
+                var readOnlyActions = canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'
+                    ? canvasEntry.createReadOnlyActions()
+                    : {
+                        noop: function() {},
+                        noopAsync: function() { return Promise.resolve(); },
+                        noopFalseAsync: function() { return Promise.resolve(false); },
+                        getLocalSaveMode: function() { return false; },
+                        showToast: function(msg) { console.log('[public-canvas]', msg); }
+                    };
 
                 // Initially select first non-root memory or first memory
                 var selectedNodeId = canonicalRootId;
@@ -157,7 +163,6 @@
                 }
 
                 // Initialize detail UI
-                var showToast = function(msg) { console.log('[public-canvas]', msg); };
 
                 var detailUI = window.createPublicViewerDetailUI({
                     detailPanel: detailPanel,
@@ -172,12 +177,12 @@
                     getSelectedNodeId: function() { return selectedNodeId; },
                     getTreeMemories: function() { return normalized.treeMemories; },
                     getCurrentTreeData: function() { return window.currentTreeData || {}; },
-                    getLocalSaveMode: function() { return false; },
-                    showToast: showToast,
-                    updateTreeVisibility: noopAsync,
-                    openCurrentMomentDetail: noop,
-                    focusSelectedMoment: noop,
-                    updateSelectedMemoryFields: noopFalseAsync
+                    getLocalSaveMode: readOnlyActions.getLocalSaveMode,
+                    showToast: readOnlyActions.showToast,
+                    updateTreeVisibility: readOnlyActions.noopAsync,
+                    openCurrentMomentDetail: readOnlyActions.noop,
+                    focusSelectedMoment: readOnlyActions.noop,
+                    updateSelectedMemoryFields: readOnlyActions.noopFalseAsync
                 });
 
                 var setDetailEmptyState = detailUI.setDetailEmptyState;
@@ -219,7 +224,7 @@
                             editorCanvas.updateAffordance();
                         }
                     },
-                    openAddMoment: noop,
+                    openAddMoment: readOnlyActions.noop,
                     canEdit: false
                 });
 

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -54,6 +54,16 @@
         viewport.__publicViewProfileInstalled = true;
     }
 
+    function createReadOnlyActions() {
+        return {
+            noop: function() {},
+            noopAsync: function() { return Promise.resolve(); },
+            noopFalseAsync: function() { return Promise.resolve(false); },
+            getLocalSaveMode: function() { return false; },
+            showToast: function(msg) { console.log('[public-canvas]', msg); }
+        };
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
@@ -70,6 +80,7 @@
         isDetailRuntimeReady: isDetailRuntimeReady,
         installPublicMetrics: installPublicMetrics,
         installPublicViewportProfile: installPublicViewportProfile,
+        createReadOnlyActions: createReadOnlyActions,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -242,6 +242,7 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('isCanvasRuntimeReady'), 'entry wrapper must expose isCanvasRuntimeReady');
   assert.ok(entrySrc.includes('isDetailRuntimeReady'), 'entry wrapper must expose isDetailRuntimeReady');
   assert.ok(entrySrc.includes('getBoundaryState'), 'entry wrapper must expose getBoundaryState');
+  assert.ok(entrySrc.includes('createReadOnlyActions'), 'entry wrapper must expose createReadOnlyActions');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -253,4 +254,11 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('installPublicViewportProfile'), 'public canvas init must delegate installPublicViewportProfile through entry wrapper');
   assert.ok(initSrc.includes('isCanvasRuntimeReady'), 'public canvas init must delegate isCanvasRuntimeReady through entry wrapper');
   assert.ok(initSrc.includes('isDetailRuntimeReady'), 'public canvas init must delegate isDetailRuntimeReady through entry wrapper');
+  assert.ok(initSrc.includes('createReadOnlyActions'), 'public canvas init must delegate createReadOnlyActions through entry wrapper');
+  assert.ok(initSrc.includes('readOnlyActions'), 'public canvas init must consume readOnlyActions from wrapper');
+  assert.ok(initSrc.includes('readOnlyActions.getLocalSaveMode'), 'public canvas init must delegate getLocalSaveMode through readOnlyActions');
+  assert.ok(initSrc.includes('readOnlyActions.showToast'), 'public canvas init must delegate showToast through readOnlyActions');
+  assert.ok(initSrc.includes('readOnlyActions.noopAsync'), 'public canvas init must delegate noopAsync through readOnlyActions');
+  assert.ok(initSrc.includes('readOnlyActions.noop'), 'public canvas init must delegate noop through readOnlyActions');
+  assert.ok(initSrc.includes('readOnlyActions.noopFalseAsync'), 'public canvas init must delegate noopFalseAsync through readOnlyActions');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public viewer read-only/no-op canvas actions through the viewer canvas entry wrapper.
- Keep public canvas init behavior unchanged.
- Keep editor canvas runtime loaded.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`