### PR TITLE
refactor(viewer): delegate public root selectors

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -120,27 +120,42 @@
                     guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
                 };
 
-                // Resolve root helpers
+                // Resolve root helpers via entry wrapper with fallback
                 var rootUtils = window.LoveBudEditorUtils || {};
-                var getCanonicalRootId = function() {
-                    if (typeof rootUtils.getCanonicalRootId === 'function') {
-                        return rootUtils.getCanonicalRootId(normalized.treeMemories);
-                    }
-                    var roots = normalized.treeMemories.filter(function(m) { return m.parentId === null || m.parentId === undefined; });
-                    if (roots.length === 0) return 'root';
-                    return roots.sort(function(a, b) {
-                        return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
-                    })[0].id;
-                };
+                var memorySelectors = canvasEntry && typeof canvasEntry.createMemorySelectors === 'function'
+                    ? canvasEntry.createMemorySelectors(normalized.treeMemories)
+                    : null;
 
-                var isRootMemory = function(mem, rootId) {
-                    if (typeof rootUtils.isRootMemory === 'function') {
-                        return rootUtils.isRootMemory(mem, rootId);
-                    }
-                    return !!(mem && rootId && mem.id === rootId);
-                };
+                var getCanonicalRootId = memorySelectors && typeof memorySelectors.getCanonicalRootId === 'function'
+                    ? function() { return memorySelectors.getCanonicalRootId(); }
+                    : function() {
+                        if (typeof rootUtils.getCanonicalRootId === 'function') {
+                            return rootUtils.getCanonicalRootId(normalized.treeMemories);
+                        }
+                        var roots = normalized.treeMemories.filter(function(m) { return m.parentId === null || m.parentId === undefined; });
+                        if (roots.length === 0) return 'root';
+                        return roots.sort(function(a, b) {
+                            return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
+                        })[0].id;
+                    };
+
+                var isRootMemory = memorySelectors && typeof memorySelectors.isRootMemory === 'function'
+                    ? function(mem, rootId) { return memorySelectors.isRootMemory(mem, rootId); }
+                    : function(mem, rootId) {
+                        if (typeof rootUtils.isRootMemory === 'function') {
+                            return rootUtils.isRootMemory(mem, rootId);
+                        }
+                        return !!(mem && rootId && mem.id === rootId);
+                    };
 
                 var canonicalRootId = getCanonicalRootId();
+
+                var findFirstSelectableMemory = memorySelectors && typeof memorySelectors.findFirstSelectableMemory === 'function'
+                    ? function() { return memorySelectors.findFirstSelectableMemory(canonicalRootId); }
+                    : function() {
+                        var nonRoot = normalized.treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });
+                        return nonRoot.length > 0 ? nonRoot[0] : normalized.treeMemories[0] || null;
+                    };
 
                 // Delegate read-only/no-op actions to entry wrapper
                 var readOnlyActions = canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'
@@ -156,11 +171,6 @@
                 // Initially select first non-root memory or first memory
                 var selectedNodeId = canonicalRootId;
                 var currentEditingMemory = null;
-
-                function findFirstSelectableMemory() {
-                    var nonRoot = normalized.treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });
-                    return nonRoot.length > 0 ? nonRoot[0] : normalized.treeMemories[0] || null;
-                }
 
                 // Initialize detail UI
 

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -64,6 +64,44 @@
         };
     }
 
+    function createMemorySelectors(treeMemories) {
+        var memories = Array.isArray(treeMemories) ? treeMemories : [];
+        var rootUtils = globalObject.LoveBudEditorUtils || {};
+
+        function getCanonicalRootId() {
+            if (typeof rootUtils.getCanonicalRootId === 'function') {
+                return rootUtils.getCanonicalRootId(memories);
+            }
+            var roots = memories.filter(function(memory) {
+                return memory.parentId === null || memory.parentId === undefined;
+            });
+            if (roots.length === 0) return 'root';
+            return roots.sort(function(a, b) {
+                return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
+            })[0].id;
+        }
+
+        function isRootMemory(memory, rootId) {
+            if (typeof rootUtils.isRootMemory === 'function') {
+                return rootUtils.isRootMemory(memory, rootId);
+            }
+            return !!(memory && rootId && memory.id === rootId);
+        }
+
+        function findFirstSelectableMemory(rootId) {
+            var nonRoot = memories.filter(function(memory) {
+                return !isRootMemory(memory, rootId);
+            });
+            return nonRoot.length > 0 ? nonRoot[0] : memories[0] || null;
+        }
+
+        return {
+            getCanonicalRootId: getCanonicalRootId,
+            isRootMemory: isRootMemory,
+            findFirstSelectableMemory: findFirstSelectableMemory
+        };
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
@@ -81,6 +119,7 @@
         installPublicMetrics: installPublicMetrics,
         installPublicViewportProfile: installPublicViewportProfile,
         createReadOnlyActions: createReadOnlyActions,
+        createMemorySelectors: createMemorySelectors,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -243,6 +243,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('isDetailRuntimeReady'), 'entry wrapper must expose isDetailRuntimeReady');
   assert.ok(entrySrc.includes('getBoundaryState'), 'entry wrapper must expose getBoundaryState');
   assert.ok(entrySrc.includes('createReadOnlyActions'), 'entry wrapper must expose createReadOnlyActions');
+  assert.ok(entrySrc.includes('createMemorySelectors'), 'entry wrapper must expose createMemorySelectors');
+  assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
+  assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
+  assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -261,4 +265,7 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('readOnlyActions.noopAsync'), 'public canvas init must delegate noopAsync through readOnlyActions');
   assert.ok(initSrc.includes('readOnlyActions.noop'), 'public canvas init must delegate noop through readOnlyActions');
   assert.ok(initSrc.includes('readOnlyActions.noopFalseAsync'), 'public canvas init must delegate noopFalseAsync through readOnlyActions');
+  assert.ok(initSrc.includes('createMemorySelectors'), 'public canvas init must delegate createMemorySelectors through entry wrapper');
+  assert.ok(initSrc.includes('memorySelectors'), 'public canvas init must consume memorySelectors from wrapper');
+  assert.ok(initSrc.includes('findFirstSelectableMemory'), 'public canvas init must delegate findFirstSelectableMemory through memorySelectors');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public viewer canonical root and selectable memory helpers through the viewer canvas entry wrapper.
- Keep public canvas init behavior unchanged.
- Keep editor canvas runtime loaded.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`