### PR TITLE
refactor(viewer): delegate public canvas config helpers

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -112,6 +112,21 @@
                     canvasEntry.installPublicViewportProfile();
                 }
 
+                // Delegate public canvas config helpers to entry wrapper
+                var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig === 'function'
+                    ? canvasEntry.createPublicCanvasConfig(normalized)
+                    : {
+                        resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
+                        resolveHintText: function() { return ''; },
+                        resolveInfoText: function() { return ''; },
+                        resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                        getTreeMemories: function() { return normalized.treeMemories; },
+                        getCurrentTreeData: function() { return window.currentTreeData || {}; },
+                        createInitialMemory: function(rootId) {
+                            return { id: rootId, title: normalized.treeData.title || '러브트리', parentId: null };
+                        }
+                    };
+
                 // Set up empty guide UI
                 var updateCanvasEmptyGuide = function() {
                     var guide = document.getElementById('canvasEmptyGuide');
@@ -177,16 +192,16 @@
                 var detailUI = window.createPublicViewerDetailUI({
                     detailPanel: detailPanel,
                     i18n: function(k) { return k; },
-                    resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
-                    resolveHintText: function() { return ''; },
-                    resolveInfoText: function() { return ''; },
-                    resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                    resolveTreeTitleText: publicCanvasConfig.resolveTreeTitleText,
+                    resolveHintText: publicCanvasConfig.resolveHintText,
+                    resolveInfoText: publicCanvasConfig.resolveInfoText,
+                    resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
                     escapeHtml: escapeHtml,
                     isRootMemory: isRootMemory,
                     getCanonicalRootId: function() { return canonicalRootId; },
                     getSelectedNodeId: function() { return selectedNodeId; },
-                    getTreeMemories: function() { return normalized.treeMemories; },
-                    getCurrentTreeData: function() { return window.currentTreeData || {}; },
+                    getTreeMemories: publicCanvasConfig.getTreeMemories,
+                    getCurrentTreeData: publicCanvasConfig.getCurrentTreeData,
                     getLocalSaveMode: readOnlyActions.getLocalSaveMode,
                     showToast: readOnlyActions.showToast,
                     updateTreeVisibility: readOnlyActions.noopAsync,
@@ -211,15 +226,15 @@
                 var editorCanvas = window.createEditorCanvas({
                     canvas: canvas,
                     svg: svg,
-                    getTreeMemories: function() { return normalized.treeMemories; },
+                    getTreeMemories: publicCanvasConfig.getTreeMemories,
                     getCanonicalRootId: function() { return canonicalRootId; },
                     isRootMemory: isRootMemory,
-                    resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                    resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
                     updateDetailPanel: updateDetailPanel,
                     setDetailEmptyState: setDetailEmptyState,
                     updateFocusSelectedBtn: updateFocusSelectedBtn,
                     createInitialMemory: function() {
-                        return { id: canonicalRootId, title: normalized.treeData.title || '러브트리', parentId: null };
+                        return publicCanvasConfig.createInitialMemory(canonicalRootId);
                     },
                     onNodeClick: function(el, data) {
                         if (!data) return;

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -102,6 +102,50 @@
         };
     }
 
+    function createPublicCanvasConfig(normalized) {
+        var payload = normalized || {};
+        var treeData = payload.treeData || {};
+        var treeMemories = Array.isArray(payload.treeMemories) ? payload.treeMemories : [];
+
+        function resolveTreeTitleText() {
+            return treeData.title || '러브트리';
+        }
+
+        function resolveHintText() {
+            return '';
+        }
+
+        function resolveInfoText() {
+            return '';
+        }
+
+        function resolveMemoryThumbnail(memory) {
+            return memory && memory.thumbnail ? memory.thumbnail : '';
+        }
+
+        function getTreeMemories() {
+            return treeMemories;
+        }
+
+        function getCurrentTreeData() {
+            return globalObject.currentTreeData || {};
+        }
+
+        function createInitialMemory(rootId) {
+            return { id: rootId, title: treeData.title || '러브트리', parentId: null };
+        }
+
+        return {
+            resolveTreeTitleText: resolveTreeTitleText,
+            resolveHintText: resolveHintText,
+            resolveInfoText: resolveInfoText,
+            resolveMemoryThumbnail: resolveMemoryThumbnail,
+            getTreeMemories: getTreeMemories,
+            getCurrentTreeData: getCurrentTreeData,
+            createInitialMemory: createInitialMemory
+        };
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
@@ -120,6 +164,7 @@
         installPublicViewportProfile: installPublicViewportProfile,
         createReadOnlyActions: createReadOnlyActions,
         createMemorySelectors: createMemorySelectors,
+        createPublicCanvasConfig: createPublicCanvasConfig,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -244,6 +244,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('getBoundaryState'), 'entry wrapper must expose getBoundaryState');
   assert.ok(entrySrc.includes('createReadOnlyActions'), 'entry wrapper must expose createReadOnlyActions');
   assert.ok(entrySrc.includes('createMemorySelectors'), 'entry wrapper must expose createMemorySelectors');
+  assert.ok(entrySrc.includes('createPublicCanvasConfig'), 'entry wrapper must expose createPublicCanvasConfig');
+  assert.ok(entrySrc.includes('resolveTreeTitleText'), 'entry wrapper createPublicCanvasConfig must expose resolveTreeTitleText');
+  assert.ok(entrySrc.includes('resolveMemoryThumbnail'), 'entry wrapper createPublicCanvasConfig must expose resolveMemoryThumbnail');
+  assert.ok(entrySrc.includes('createInitialMemory'), 'entry wrapper createPublicCanvasConfig must expose createInitialMemory');
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
@@ -268,4 +272,9 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('createMemorySelectors'), 'public canvas init must delegate createMemorySelectors through entry wrapper');
   assert.ok(initSrc.includes('memorySelectors'), 'public canvas init must consume memorySelectors from wrapper');
   assert.ok(initSrc.includes('findFirstSelectableMemory'), 'public canvas init must delegate findFirstSelectableMemory through memorySelectors');
+  assert.ok(initSrc.includes('createPublicCanvasConfig'), 'public canvas init must delegate createPublicCanvasConfig through entry wrapper');
+  assert.ok(initSrc.includes('publicCanvasConfig'), 'public canvas init must consume publicCanvasConfig from wrapper');
+  assert.ok(initSrc.includes('publicCanvasConfig.resolveTreeTitleText'), 'public canvas init must use delegated tree title resolver');
+  assert.ok(initSrc.includes('publicCanvasConfig.resolveMemoryThumbnail'), 'public canvas init must use delegated thumbnail resolver');
+  assert.ok(initSrc.includes('publicCanvasConfig.createInitialMemory'), 'public canvas init must use delegated initial memory builder');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public canvas config resolver helpers through the viewer canvas entry wrapper.
- Keep public canvas init behavior unchanged with fallback paths.
- Keep shared editor canvas runtime scripts loaded.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`