### PR TITLE
refactor(viewer): delegate public empty guide helper

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -128,12 +128,14 @@
                     };
 
                 // Set up empty guide UI
-                var updateCanvasEmptyGuide = function() {
-                    var guide = document.getElementById('canvasEmptyGuide');
-                    if (!guide) return;
-                    var hasMoments = normalized.treeMemories.length > 0;
-                    guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
-                };
+                var updateCanvasEmptyGuide = canvasEntry && typeof canvasEntry.createEmptyGuideUpdater === 'function'
+                    ? canvasEntry.createEmptyGuideUpdater(normalized.treeMemories)
+                    : function() {
+                        var guide = document.getElementById('canvasEmptyGuide');
+                        if (!guide) return;
+                        var hasMoments = normalized.treeMemories.length > 0;
+                        guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
+                    };
 
                 // Resolve root helpers via entry wrapper with fallback
                 var rootUtils = window.LoveBudEditorUtils || {};

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -146,6 +146,20 @@
         };
     }
 
+    function createEmptyGuideUpdater(treeMemories) {
+        var memories = Array.isArray(treeMemories) ? treeMemories : [];
+
+        return function updateCanvasEmptyGuide() {
+            var doc = globalObject.document;
+            var guide = doc && typeof doc.getElementById === 'function'
+                ? doc.getElementById('canvasEmptyGuide')
+                : null;
+            if (!guide) return;
+            var hasMoments = memories.length > 0;
+            guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
+        };
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
@@ -165,6 +179,7 @@
         createReadOnlyActions: createReadOnlyActions,
         createMemorySelectors: createMemorySelectors,
         createPublicCanvasConfig: createPublicCanvasConfig,
+        createEmptyGuideUpdater: createEmptyGuideUpdater,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -248,6 +248,9 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('resolveTreeTitleText'), 'entry wrapper createPublicCanvasConfig must expose resolveTreeTitleText');
   assert.ok(entrySrc.includes('resolveMemoryThumbnail'), 'entry wrapper createPublicCanvasConfig must expose resolveMemoryThumbnail');
   assert.ok(entrySrc.includes('createInitialMemory'), 'entry wrapper createPublicCanvasConfig must expose createInitialMemory');
+  assert.ok(entrySrc.includes('createEmptyGuideUpdater'), 'entry wrapper must expose createEmptyGuideUpdater');
+  assert.ok(entrySrc.includes('canvasEmptyGuide'), 'entry wrapper empty guide updater must target canvasEmptyGuide');
+  assert.ok(entrySrc.includes('editor-canvas-empty-guide-hidden'), 'entry wrapper empty guide updater must toggle hidden empty guide class');
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
@@ -277,4 +280,6 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('publicCanvasConfig.resolveTreeTitleText'), 'public canvas init must use delegated tree title resolver');
   assert.ok(initSrc.includes('publicCanvasConfig.resolveMemoryThumbnail'), 'public canvas init must use delegated thumbnail resolver');
   assert.ok(initSrc.includes('publicCanvasConfig.createInitialMemory'), 'public canvas init must use delegated initial memory builder');
+  assert.ok(initSrc.includes('createEmptyGuideUpdater'), 'public canvas init must delegate createEmptyGuideUpdater through entry wrapper');
+  assert.ok(initSrc.includes('updateCanvasEmptyGuide'), 'public canvas init must keep updateCanvasEmptyGuide call path');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate the public canvas empty guide updater through the viewer canvas entry wrapper.
- Keep the existing public-canvas-init fallback path.
- Preserve current public viewer behavior and shared editor canvas runtime loading.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`