### PR TITLE
refactor(viewer): delegate public toolbar compact helper

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -277,14 +277,18 @@
                 console.log('[public-canvas] Canvas initialized successfully');
 
                 // Auto-enable compact mode on narrow viewports (toolbar labels would overflow)
-                var compactMql = window.matchMedia('(max-width: 480px)');
-                function updateToolbarCompact(e) {
-                    var tb = document.querySelector('.editor-canvas-toolbar');
-                    if (!tb) return;
-                    tb.classList.toggle('is-compact', e.matches);
+                if (canvasEntry && typeof canvasEntry.installToolbarCompactMode === 'function') {
+                    canvasEntry.installToolbarCompactMode();
+                } else {
+                    var compactMql = window.matchMedia('(max-width: 480px)');
+                    function updateToolbarCompact(e) {
+                        var tb = document.querySelector('.editor-canvas-toolbar');
+                        if (!tb) return;
+                        tb.classList.toggle('is-compact', e.matches);
+                    }
+                    updateToolbarCompact(compactMql);
+                    compactMql.addEventListener('change', updateToolbarCompact);
                 }
-                updateToolbarCompact(compactMql);
-                compactMql.addEventListener('change', updateToolbarCompact);
             }
 
             waitForModules(0);

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -160,6 +160,30 @@
         };
     }
 
+    function installToolbarCompactMode() {
+        var mql = globalObject.matchMedia
+            ? globalObject.matchMedia('(max-width: 480px)')
+            : null;
+
+        function updateToolbarCompact(eventOrQuery) {
+            var doc = globalObject.document;
+            var toolbar = doc && typeof doc.querySelector === 'function'
+                ? doc.querySelector('.editor-canvas-toolbar')
+                : null;
+            if (!toolbar || !eventOrQuery) return;
+            toolbar.classList.toggle('is-compact', Boolean(eventOrQuery.matches));
+        }
+
+        if (!mql) return;
+        updateToolbarCompact(mql);
+
+        if (typeof mql.addEventListener === 'function') {
+            mql.addEventListener('change', updateToolbarCompact);
+        } else if (typeof mql.addListener === 'function') {
+            mql.addListener(updateToolbarCompact);
+        }
+    }
+
     function getBoundaryState() {
         return {
             hasCanvasRuntime: hasCanvasRuntime(),
@@ -180,6 +204,7 @@
         createMemorySelectors: createMemorySelectors,
         createPublicCanvasConfig: createPublicCanvasConfig,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
+        installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -251,6 +251,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('createEmptyGuideUpdater'), 'entry wrapper must expose createEmptyGuideUpdater');
   assert.ok(entrySrc.includes('canvasEmptyGuide'), 'entry wrapper empty guide updater must target canvasEmptyGuide');
   assert.ok(entrySrc.includes('editor-canvas-empty-guide-hidden'), 'entry wrapper empty guide updater must toggle hidden empty guide class');
+  assert.ok(entrySrc.includes('installToolbarCompactMode'), 'entry wrapper must expose installToolbarCompactMode');
+  assert.ok(entrySrc.includes('matchMedia'), 'entry wrapper toolbar compact helper must use matchMedia');
+  assert.ok(entrySrc.includes('editor-canvas-toolbar'), 'entry wrapper toolbar compact helper must target editor canvas toolbar');
+  assert.ok(entrySrc.includes('is-compact'), 'entry wrapper toolbar compact helper must toggle compact toolbar class');
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
@@ -282,4 +286,6 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('publicCanvasConfig.createInitialMemory'), 'public canvas init must use delegated initial memory builder');
   assert.ok(initSrc.includes('createEmptyGuideUpdater'), 'public canvas init must delegate createEmptyGuideUpdater through entry wrapper');
   assert.ok(initSrc.includes('updateCanvasEmptyGuide'), 'public canvas init must keep updateCanvasEmptyGuide call path');
+  assert.ok(initSrc.includes('installToolbarCompactMode'), 'public canvas init must delegate toolbar compact mode through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.installToolbarCompactMode'), 'public canvas init must call delegated toolbar compact helper');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate the public viewer toolbar compact mode helper through the viewer canvas entry wrapper.
- Keep the existing public-canvas-init fallback path.
- Preserve current public viewer behavior and shared editor canvas runtime loading.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`