### PR TITLE
refactor(viewer): delegate public selection state helper

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -185,9 +185,35 @@
                         showToast: function(msg) { console.log('[public-canvas]', msg); }
                     };
 
-                // Initially select first non-root memory or first memory
-                var selectedNodeId = canonicalRootId;
-                var currentEditingMemory = null;
+                // Delegate selection state to entry wrapper with fallback
+                var selectionState = canvasEntry && typeof canvasEntry.createSelectionState === 'function'
+                    ? canvasEntry.createSelectionState(canonicalRootId)
+                    : (function() {
+                        var selectedNodeId = canonicalRootId;
+                        var currentEditingMemory = null;
+
+                        return {
+                            getSelectedNodeId: function() {
+                                return selectedNodeId;
+                            },
+                            setSelectedNodeId: function(nextSelectedNodeId) {
+                                selectedNodeId = nextSelectedNodeId || null;
+                                return selectedNodeId;
+                            },
+                            getCurrentEditingMemory: function() {
+                                return currentEditingMemory;
+                            },
+                            setCurrentEditingMemory: function(memory) {
+                                currentEditingMemory = memory || null;
+                                return currentEditingMemory;
+                            },
+                            selectMemory: function(memory) {
+                                currentEditingMemory = memory || null;
+                                selectedNodeId = memory && memory.id ? memory.id : selectedNodeId;
+                                return currentEditingMemory;
+                            }
+                        };
+                    })();
 
                 // Initialize detail UI
 
@@ -201,7 +227,7 @@
                     escapeHtml: escapeHtml,
                     isRootMemory: isRootMemory,
                     getCanonicalRootId: function() { return canonicalRootId; },
-                    getSelectedNodeId: function() { return selectedNodeId; },
+                    getSelectedNodeId: selectionState.getSelectedNodeId,
                     getTreeMemories: publicCanvasConfig.getTreeMemories,
                     getCurrentTreeData: publicCanvasConfig.getCurrentTreeData,
                     getLocalSaveMode: readOnlyActions.getLocalSaveMode,
@@ -220,8 +246,7 @@
                 // Select first memory
                 var firstSelectable = findFirstSelectableMemory();
                 if (firstSelectable) {
-                    selectedNodeId = firstSelectable.id;
-                    currentEditingMemory = firstSelectable;
+                    selectionState.selectMemory(firstSelectable);
                 }
 
                 // Create canvas instance
@@ -240,8 +265,7 @@
                     },
                     onNodeClick: function(el, data) {
                         if (!data) return;
-                        selectedNodeId = data.id;
-                        currentEditingMemory = data;
+                        selectionState.selectMemory(data);
                         document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
                         if (el) el.classList.add('selected');
                         updateDetailPanel(data);
@@ -269,6 +293,7 @@
                 updateSidebarStatus();
 
                 // Select first memory in detail panel
+                var currentEditingMemory = selectionState.getCurrentEditingMemory();
                 if (currentEditingMemory) {
                     updateDetailPanel(currentEditingMemory);
                     setDetailEmptyState(false);

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -146,6 +146,43 @@
         };
     }
 
+    function createSelectionState(initialSelectedNodeId) {
+        var selectedNodeId = initialSelectedNodeId || null;
+        var currentEditingMemory = null;
+
+        function getSelectedNodeId() {
+            return selectedNodeId;
+        }
+
+        function setSelectedNodeId(nextSelectedNodeId) {
+            selectedNodeId = nextSelectedNodeId || null;
+            return selectedNodeId;
+        }
+
+        function getCurrentEditingMemory() {
+            return currentEditingMemory;
+        }
+
+        function setCurrentEditingMemory(memory) {
+            currentEditingMemory = memory || null;
+            return currentEditingMemory;
+        }
+
+        function selectMemory(memory) {
+            currentEditingMemory = memory || null;
+            selectedNodeId = memory && memory.id ? memory.id : selectedNodeId;
+            return currentEditingMemory;
+        }
+
+        return {
+            getSelectedNodeId: getSelectedNodeId,
+            setSelectedNodeId: setSelectedNodeId,
+            getCurrentEditingMemory: getCurrentEditingMemory,
+            setCurrentEditingMemory: setCurrentEditingMemory,
+            selectMemory: selectMemory
+        };
+    }
+
     function createEmptyGuideUpdater(treeMemories) {
         var memories = Array.isArray(treeMemories) ? treeMemories : [];
 
@@ -203,6 +240,7 @@
         createReadOnlyActions: createReadOnlyActions,
         createMemorySelectors: createMemorySelectors,
         createPublicCanvasConfig: createPublicCanvasConfig,
+        createSelectionState: createSelectionState,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -255,6 +255,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('matchMedia'), 'entry wrapper toolbar compact helper must use matchMedia');
   assert.ok(entrySrc.includes('editor-canvas-toolbar'), 'entry wrapper toolbar compact helper must target editor canvas toolbar');
   assert.ok(entrySrc.includes('is-compact'), 'entry wrapper toolbar compact helper must toggle compact toolbar class');
+  assert.ok(entrySrc.includes('createSelectionState'), 'entry wrapper must expose createSelectionState');
+  assert.ok(entrySrc.includes('getSelectedNodeId'), 'entry wrapper selection state must expose getSelectedNodeId');
+  assert.ok(entrySrc.includes('getCurrentEditingMemory'), 'entry wrapper selection state must expose getCurrentEditingMemory');
+  assert.ok(entrySrc.includes('selectMemory'), 'entry wrapper selection state must expose selectMemory');
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
@@ -288,4 +292,9 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('updateCanvasEmptyGuide'), 'public canvas init must keep updateCanvasEmptyGuide call path');
   assert.ok(initSrc.includes('installToolbarCompactMode'), 'public canvas init must delegate toolbar compact mode through entry wrapper');
   assert.ok(initSrc.includes('canvasEntry.installToolbarCompactMode'), 'public canvas init must call delegated toolbar compact helper');
+  assert.ok(initSrc.includes('createSelectionState'), 'public canvas init must delegate createSelectionState through entry wrapper');
+  assert.ok(initSrc.includes('selectionState'), 'public canvas init must consume selectionState from wrapper');
+  assert.ok(initSrc.includes('selectionState.getSelectedNodeId'), 'public canvas init must use delegated selected node getter');
+  assert.ok(initSrc.includes('selectionState.selectMemory'), 'public canvas init must use delegated memory selector');
+  assert.ok(initSrc.includes('selectionState.getCurrentEditingMemory'), 'public canvas init must use delegated current memory getter');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public canvas selected memory state through the viewer canvas entry wrapper.
- Keep onNodeClick and detail/canvas option assembly in public-canvas-init.
- Preserve current public viewer behavior and fallback paths.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`