### PR TITLE
refactor(viewer): delegate public detail ui options

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -215,28 +215,40 @@
                         };
                     })();
 
-                // Initialize detail UI
+                // Delegate detail UI options to entry wrapper with fallback
+                var detailUIOptions = canvasEntry && typeof canvasEntry.createDetailUIOptions === 'function'
+                    ? canvasEntry.createDetailUIOptions({
+                        detailPanel: detailPanel,
+                        i18n: function(k) { return k; },
+                        publicCanvasConfig: publicCanvasConfig,
+                        readOnlyActions: readOnlyActions,
+                        selectionState: selectionState,
+                        escapeHtml: escapeHtml,
+                        isRootMemory: isRootMemory,
+                        getCanonicalRootId: function() { return canonicalRootId; }
+                    })
+                    : {
+                        detailPanel: detailPanel,
+                        i18n: function(k) { return k; },
+                        resolveTreeTitleText: publicCanvasConfig.resolveTreeTitleText,
+                        resolveHintText: publicCanvasConfig.resolveHintText,
+                        resolveInfoText: publicCanvasConfig.resolveInfoText,
+                        resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
+                        escapeHtml: escapeHtml,
+                        isRootMemory: isRootMemory,
+                        getCanonicalRootId: function() { return canonicalRootId; },
+                        getSelectedNodeId: selectionState.getSelectedNodeId,
+                        getTreeMemories: publicCanvasConfig.getTreeMemories,
+                        getCurrentTreeData: publicCanvasConfig.getCurrentTreeData,
+                        getLocalSaveMode: readOnlyActions.getLocalSaveMode,
+                        showToast: readOnlyActions.showToast,
+                        updateTreeVisibility: readOnlyActions.noopAsync,
+                        openCurrentMomentDetail: readOnlyActions.noop,
+                        focusSelectedMoment: readOnlyActions.noop,
+                        updateSelectedMemoryFields: readOnlyActions.noopFalseAsync
+                    };
 
-                var detailUI = window.createPublicViewerDetailUI({
-                    detailPanel: detailPanel,
-                    i18n: function(k) { return k; },
-                    resolveTreeTitleText: publicCanvasConfig.resolveTreeTitleText,
-                    resolveHintText: publicCanvasConfig.resolveHintText,
-                    resolveInfoText: publicCanvasConfig.resolveInfoText,
-                    resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
-                    escapeHtml: escapeHtml,
-                    isRootMemory: isRootMemory,
-                    getCanonicalRootId: function() { return canonicalRootId; },
-                    getSelectedNodeId: selectionState.getSelectedNodeId,
-                    getTreeMemories: publicCanvasConfig.getTreeMemories,
-                    getCurrentTreeData: publicCanvasConfig.getCurrentTreeData,
-                    getLocalSaveMode: readOnlyActions.getLocalSaveMode,
-                    showToast: readOnlyActions.showToast,
-                    updateTreeVisibility: readOnlyActions.noopAsync,
-                    openCurrentMomentDetail: readOnlyActions.noop,
-                    focusSelectedMoment: readOnlyActions.noop,
-                    updateSelectedMemoryFields: readOnlyActions.noopFalseAsync
-                });
+                var detailUI = window.createPublicViewerDetailUI(detailUIOptions);
 
                 var setDetailEmptyState = detailUI.setDetailEmptyState;
                 var updateFocusSelectedBtn = detailUI.updateFocusSelectedBtn;

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -183,6 +183,34 @@
         };
     }
 
+    function createDetailUIOptions(ctx) {
+        var options = ctx || {};
+        var cfg = options.publicCanvasConfig || {};
+        var roa = options.readOnlyActions || {};
+        var sel = options.selectionState || {};
+
+        return {
+            detailPanel: options.detailPanel,
+            i18n: options.i18n,
+            resolveTreeTitleText: cfg.resolveTreeTitleText,
+            resolveHintText: cfg.resolveHintText,
+            resolveInfoText: cfg.resolveInfoText,
+            resolveMemoryThumbnail: cfg.resolveMemoryThumbnail,
+            escapeHtml: options.escapeHtml,
+            isRootMemory: options.isRootMemory,
+            getCanonicalRootId: options.getCanonicalRootId,
+            getSelectedNodeId: sel.getSelectedNodeId,
+            getTreeMemories: cfg.getTreeMemories,
+            getCurrentTreeData: cfg.getCurrentTreeData,
+            getLocalSaveMode: roa.getLocalSaveMode,
+            showToast: roa.showToast,
+            updateTreeVisibility: roa.noopAsync,
+            openCurrentMomentDetail: roa.noop,
+            focusSelectedMoment: roa.noop,
+            updateSelectedMemoryFields: roa.noopFalseAsync
+        };
+    }
+
     function createEmptyGuideUpdater(treeMemories) {
         var memories = Array.isArray(treeMemories) ? treeMemories : [];
 
@@ -241,6 +269,7 @@
         createMemorySelectors: createMemorySelectors,
         createPublicCanvasConfig: createPublicCanvasConfig,
         createSelectionState: createSelectionState,
+        createDetailUIOptions: createDetailUIOptions,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -259,6 +259,11 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('getSelectedNodeId'), 'entry wrapper selection state must expose getSelectedNodeId');
   assert.ok(entrySrc.includes('getCurrentEditingMemory'), 'entry wrapper selection state must expose getCurrentEditingMemory');
   assert.ok(entrySrc.includes('selectMemory'), 'entry wrapper selection state must expose selectMemory');
+  assert.ok(entrySrc.includes('createDetailUIOptions'), 'entry wrapper must expose createDetailUIOptions');
+  assert.ok(entrySrc.includes('publicCanvasConfig'), 'entry wrapper detail UI options must consume publicCanvasConfig');
+  assert.ok(entrySrc.includes('readOnlyActions'), 'entry wrapper detail UI options must consume readOnlyActions');
+  assert.ok(entrySrc.includes('selectionState'), 'entry wrapper detail UI options must consume selectionState');
+  assert.ok(entrySrc.includes('updateSelectedMemoryFields'), 'entry wrapper detail UI options must preserve read-only detail update callback');
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
@@ -297,4 +302,8 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('selectionState.getSelectedNodeId'), 'public canvas init must use delegated selected node getter');
   assert.ok(initSrc.includes('selectionState.selectMemory'), 'public canvas init must use delegated memory selector');
   assert.ok(initSrc.includes('selectionState.getCurrentEditingMemory'), 'public canvas init must use delegated current memory getter');
+  assert.ok(initSrc.includes('createDetailUIOptions'), 'public canvas init must delegate detail UI options through entry wrapper');
+  assert.ok(initSrc.includes('detailUIOptions'), 'public canvas init must consume detailUIOptions from wrapper');
+  assert.ok(initSrc.includes('window.createPublicViewerDetailUI(detailUIOptions)'), 'public canvas init must pass delegated options into detail UI factory');
+  assert.ok(initSrc.includes('getSelectedNodeId: selectionState.getSelectedNodeId'), 'fallback detail UI options must keep delegated selected node getter');
 });

--- a/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-ui-core-contract.test.cjs
@@ -36,7 +36,7 @@ test('public canvas init uses the viewer detail UI adapter factory', () => {
   const source = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
 
   assert.ok(source.includes('typeof window.createPublicViewerDetailUI === \'function\''), 'public canvas init waits for the viewer detail adapter');
-  assert.ok(source.includes('window.createPublicViewerDetailUI({'), 'public canvas init creates detail UI through the viewer adapter');
+  assert.ok(source.includes('window.createPublicViewerDetailUI(detailUIOptions)'), 'public canvas init creates detail UI through the viewer adapter with delegated options');
   assert.equal(
     source.includes('typeof window.createEditorDetailUIBuilders === \'function\''),
     false,


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public detail UI option construction through the viewer canvas entry wrapper.
- Keep createPublicViewerDetailUI invocation, onNodeClick, and editorCanvas option assembly in public-canvas-init.
- Preserve current public viewer behavior and fallback paths.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`