### PR TITLE
refactor(viewer): delegate public canvas options

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -262,34 +262,54 @@
                 }
 
                 // Create canvas instance
-                var editorCanvas = window.createEditorCanvas({
-                    canvas: canvas,
-                    svg: svg,
-                    getTreeMemories: publicCanvasConfig.getTreeMemories,
-                    getCanonicalRootId: function() { return canonicalRootId; },
-                    isRootMemory: isRootMemory,
-                    resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
-                    updateDetailPanel: updateDetailPanel,
-                    setDetailEmptyState: setDetailEmptyState,
-                    updateFocusSelectedBtn: updateFocusSelectedBtn,
-                    createInitialMemory: function() {
-                        return publicCanvasConfig.createInitialMemory(canonicalRootId);
-                    },
-                    onNodeClick: function(el, data) {
-                        if (!data) return;
-                        selectionState.selectMemory(data);
-                        document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
-                        if (el) el.classList.add('selected');
-                        updateDetailPanel(data);
-                        updateFocusSelectedBtn();
-                        setDetailEmptyState(false);
-                        if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
-                            editorCanvas.updateAffordance();
-                        }
-                    },
-                    openAddMoment: readOnlyActions.noop,
-                    canEdit: false
-                });
+                var onPublicCanvasNodeClick = function(el, data) {
+                    if (!data) return;
+                    selectionState.selectMemory(data);
+                    document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
+                    if (el) el.classList.add('selected');
+                    updateDetailPanel(data);
+                    updateFocusSelectedBtn();
+                    setDetailEmptyState(false);
+                    if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
+                        editorCanvas.updateAffordance();
+                    }
+                };
+
+                var canvasOptions = canvasEntry && typeof canvasEntry.createCanvasOptions === 'function'
+                    ? canvasEntry.createCanvasOptions({
+                        canvas: canvas,
+                        svg: svg,
+                        publicCanvasConfig: publicCanvasConfig,
+                        readOnlyActions: readOnlyActions,
+                        getCanonicalRootId: function() { return canonicalRootId; },
+                        isRootMemory: isRootMemory,
+                        updateDetailPanel: updateDetailPanel,
+                        setDetailEmptyState: setDetailEmptyState,
+                        updateFocusSelectedBtn: updateFocusSelectedBtn,
+                        createInitialMemory: function() {
+                            return publicCanvasConfig.createInitialMemory(canonicalRootId);
+                        },
+                        onNodeClick: onPublicCanvasNodeClick
+                    })
+                    : {
+                        canvas: canvas,
+                        svg: svg,
+                        getTreeMemories: publicCanvasConfig.getTreeMemories,
+                        getCanonicalRootId: function() { return canonicalRootId; },
+                        isRootMemory: isRootMemory,
+                        resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
+                        updateDetailPanel: updateDetailPanel,
+                        setDetailEmptyState: setDetailEmptyState,
+                        updateFocusSelectedBtn: updateFocusSelectedBtn,
+                        createInitialMemory: function() {
+                            return publicCanvasConfig.createInitialMemory(canonicalRootId);
+                        },
+                        onNodeClick: onPublicCanvasNodeClick,
+                        openAddMoment: readOnlyActions.noop,
+                        canEdit: false
+                    };
+
+                var editorCanvas = window.createEditorCanvas(canvasOptions);
 
                 // Store instance
                 if (canvas) canvas.__editorCanvasInstance = editorCanvas;

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -211,6 +211,28 @@
         };
     }
 
+    function createCanvasOptions(ctx) {
+        var options = ctx || {};
+        var publicCanvasConfig = options.publicCanvasConfig || {};
+        var readOnlyActions = options.readOnlyActions || {};
+
+        return {
+            canvas: options.canvas,
+            svg: options.svg,
+            getTreeMemories: publicCanvasConfig.getTreeMemories,
+            getCanonicalRootId: options.getCanonicalRootId,
+            isRootMemory: options.isRootMemory,
+            resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
+            updateDetailPanel: options.updateDetailPanel,
+            setDetailEmptyState: options.setDetailEmptyState,
+            updateFocusSelectedBtn: options.updateFocusSelectedBtn,
+            createInitialMemory: options.createInitialMemory,
+            onNodeClick: options.onNodeClick,
+            openAddMoment: readOnlyActions.noop,
+            canEdit: false
+        };
+    }
+
     function createEmptyGuideUpdater(treeMemories) {
         var memories = Array.isArray(treeMemories) ? treeMemories : [];
 
@@ -270,6 +292,7 @@
         createPublicCanvasConfig: createPublicCanvasConfig,
         createSelectionState: createSelectionState,
         createDetailUIOptions: createDetailUIOptions,
+        createCanvasOptions: createCanvasOptions,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -267,6 +267,11 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('getCanonicalRootId'), 'entry wrapper createMemorySelectors must expose getCanonicalRootId');
   assert.ok(entrySrc.includes('isRootMemory'), 'entry wrapper createMemorySelectors must expose isRootMemory');
   assert.ok(entrySrc.includes('findFirstSelectableMemory'), 'entry wrapper createMemorySelectors must expose findFirstSelectableMemory');
+  assert.ok(entrySrc.includes('createCanvasOptions'), 'entry wrapper must expose createCanvasOptions');
+  assert.ok(entrySrc.includes('getTreeMemories'), 'entry wrapper canvas options must preserve getTreeMemories');
+  assert.ok(entrySrc.includes('resolveMemoryThumbnail'), 'entry wrapper canvas options must preserve thumbnail resolver');
+  assert.ok(entrySrc.includes('openAddMoment'), 'entry wrapper canvas options must preserve read-only add moment callback');
+  assert.ok(entrySrc.includes('canEdit: false'), 'entry wrapper canvas options must force read-only mode');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -306,4 +311,14 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('detailUIOptions'), 'public canvas init must consume detailUIOptions from wrapper');
   assert.ok(initSrc.includes('window.createPublicViewerDetailUI(detailUIOptions)'), 'public canvas init must pass delegated options into detail UI factory');
   assert.ok(initSrc.includes('getSelectedNodeId: selectionState.getSelectedNodeId'), 'fallback detail UI options must keep delegated selected node getter');
+  assert.ok(initSrc.includes('createCanvasOptions'), 'public canvas init must delegate canvas options through entry wrapper');
+  assert.ok(initSrc.includes('canvasOptions'), 'public canvas init must consume canvasOptions from wrapper');
+  assert.ok(initSrc.includes('window.createEditorCanvas(canvasOptions)'), 'public canvas init must pass delegated options into canvas factory');
+  assert.ok(initSrc.includes('onPublicCanvasNodeClick'), 'public canvas init must keep public canvas node click callback in init');
+  assert.ok(initSrc.includes('editorCanvas.updateAffordance'), 'public canvas init must preserve affordance refresh in node click flow');
+  assert.equal(
+    initSrc.includes('window.createEditorCanvas({'),
+    false,
+    'public canvas init should not construct editor canvas options inline'
+  );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public editor canvas option construction through the viewer canvas entry wrapper.
- Keep onNodeClick, createEditorCanvas invocation, canvas lifecycle, and post-init refresh in public-canvas-init.
- Preserve current public viewer behavior and fallback paths.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`