### PR TITLE
refactor(viewer): delegate public load failure state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -17,6 +17,11 @@
     }
 
     function createLoadFailureState(message) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.createLoadFailureState === 'function') {
+            return canvasEntry.createLoadFailureState(message);
+        }
+
         var errState = document.createElement('div');
         var icon = document.createElement('span');
         var title = document.createElement('h2');

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -233,6 +233,33 @@
         };
     }
 
+    function createLoadFailureState(message) {
+        var doc = globalObject.document;
+        if (!doc || typeof doc.createElement !== 'function') return null;
+
+        var errState = doc.createElement('div');
+        var icon = doc.createElement('span');
+        var title = doc.createElement('h2');
+        var description = doc.createElement('p');
+
+        errState.style.cssText = 'display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:2rem;text-align:center;';
+
+        icon.className = 'material-symbols-outlined';
+        icon.style.cssText = 'font-size:48px;color:var(--error);margin-bottom:16px;';
+        icon.textContent = 'error_outline';
+
+        title.style.cssText = 'margin:0 0 8px;';
+        title.textContent = '트리를 불러올 수 없어요';
+
+        description.style.cssText = 'margin:0;color:var(--on-surface-variant);';
+        description.textContent = message || 'Public endpoint returned an error';
+
+        errState.appendChild(icon);
+        errState.appendChild(title);
+        errState.appendChild(description);
+        return errState;
+    }
+
     function createEmptyGuideUpdater(treeMemories) {
         var memories = Array.isArray(treeMemories) ? treeMemories : [];
 
@@ -293,6 +320,7 @@
         createSelectionState: createSelectionState,
         createDetailUIOptions: createDetailUIOptions,
         createCanvasOptions: createCanvasOptions,
+        createLoadFailureState: createLoadFailureState,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -272,6 +272,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('resolveMemoryThumbnail'), 'entry wrapper canvas options must preserve thumbnail resolver');
   assert.ok(entrySrc.includes('openAddMoment'), 'entry wrapper canvas options must preserve read-only add moment callback');
   assert.ok(entrySrc.includes('canEdit: false'), 'entry wrapper canvas options must force read-only mode');
+  assert.ok(entrySrc.includes('createLoadFailureState'), 'entry wrapper must expose createLoadFailureState');
+  assert.ok(entrySrc.includes('트리를 불러올 수 없어요'), 'entry wrapper load failure state must preserve Korean failure title');
+  assert.ok(entrySrc.includes('Public endpoint returned an error'), 'entry wrapper load failure state must preserve fallback failure message');
+  assert.ok(entrySrc.includes('error_outline'), 'entry wrapper load failure state must preserve failure icon');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -321,4 +325,8 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
     false,
     'public canvas init should not construct editor canvas options inline'
   );
+  assert.ok(initSrc.includes('createLoadFailureState'), 'public canvas init must keep createLoadFailureState call path');
+  assert.ok(initSrc.includes('canvasEntry.createLoadFailureState'), 'public canvas init must delegate load failure state through entry wrapper');
+  assert.ok(initSrc.includes('typeof canvasEntry.createLoadFailureState === \'function\''), 'public canvas init must guard delegated load failure state helper');
+  assert.ok(initSrc.includes('document.createElement'), 'public canvas init must retain fallback load failure DOM builder');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public load failure state creation through the viewer canvas entry wrapper.
- Keep the existing public-canvas-init fallback path and failure call sites.
- Preserve current public viewer behavior and shared editor canvas runtime loading.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`