### PR TITLE
refactor(viewer): delegate public editor readonly state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -316,10 +316,14 @@
 
                 var editorCanvas = window.createEditorCanvas(canvasOptions);
 
-                // Store instance
-                if (canvas) canvas.__editorCanvasInstance = editorCanvas;
-                window.LoveBudEditor = window.LoveBudEditor || {};
-                window.LoveBudEditor.canEdit = false;
+                // Store instance and public read-only editor state
+                if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {
+                    canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas);
+                } else {
+                    if (canvas) canvas.__editorCanvasInstance = editorCanvas;
+                    window.LoveBudEditor = window.LoveBudEditor || {};
+                    window.LoveBudEditor.canEdit = false;
+                }
 
                 // Initialize canvas
                 if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -260,6 +260,13 @@
         return errState;
     }
 
+    function installPublicEditorReadOnlyState(canvas, editorCanvas) {
+        if (canvas) canvas.__editorCanvasInstance = editorCanvas;
+        globalObject.LoveBudEditor = globalObject.LoveBudEditor || {};
+        globalObject.LoveBudEditor.canEdit = false;
+        return globalObject.LoveBudEditor;
+    }
+
     function createEmptyGuideUpdater(treeMemories) {
         var memories = Array.isArray(treeMemories) ? treeMemories : [];
 
@@ -321,6 +328,7 @@
         createDetailUIOptions: createDetailUIOptions,
         createCanvasOptions: createCanvasOptions,
         createLoadFailureState: createLoadFailureState,
+        installPublicEditorReadOnlyState: installPublicEditorReadOnlyState,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -276,6 +276,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('트리를 불러올 수 없어요'), 'entry wrapper load failure state must preserve Korean failure title');
   assert.ok(entrySrc.includes('Public endpoint returned an error'), 'entry wrapper load failure state must preserve fallback failure message');
   assert.ok(entrySrc.includes('error_outline'), 'entry wrapper load failure state must preserve failure icon');
+  assert.ok(entrySrc.includes('installPublicEditorReadOnlyState'), 'entry wrapper must expose installPublicEditorReadOnlyState');
+  assert.ok(entrySrc.includes('__editorCanvasInstance'), 'entry wrapper read-only state helper must store editor canvas instance');
+  assert.ok(entrySrc.includes('LoveBudEditor'), 'entry wrapper read-only state helper must preserve LoveBudEditor global state');
+  assert.ok(entrySrc.includes('canEdit = false'), 'entry wrapper read-only state helper must force canEdit false');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -329,4 +333,12 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('canvasEntry.createLoadFailureState'), 'public canvas init must delegate load failure state through entry wrapper');
   assert.ok(initSrc.includes('typeof canvasEntry.createLoadFailureState === \'function\''), 'public canvas init must guard delegated load failure state helper');
   assert.ok(initSrc.includes('document.createElement'), 'public canvas init must retain fallback load failure DOM builder');
+  assert.ok(initSrc.includes('installPublicEditorReadOnlyState'), 'public canvas init must delegate public editor read-only state through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas)'), 'public canvas init must pass canvas and editorCanvas to delegated read-only state helper');
+  assert.ok(initSrc.includes('window.LoveBudEditor.canEdit = false'), 'public canvas init must retain fallback canEdit false assignment');
+  assert.ok(initSrc.includes('canvas.__editorCanvasInstance = editorCanvas'), 'public canvas init must retain fallback canvas instance storage');
+  assert.ok(
+    initSrc.indexOf('installPublicEditorReadOnlyState') < initSrc.indexOf('editorCanvas.initCanvas'),
+    'public read-only state setup must remain before editorCanvas.initCanvas'
+  );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public editor read-only state setup through the viewer canvas entry wrapper.
- Keep the existing public-canvas-init fallback path.
- Preserve canvas lifecycle, node click flow, and post-init refresh in public-canvas-init.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`