### PR TITLE
refactor(viewer): delegate public runtime readiness check

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -85,14 +85,18 @@
                 }
 
                 var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
-                var canvasReady = canvasEntry && typeof canvasEntry.isCanvasRuntimeReady === 'function'
-                    ? canvasEntry.isCanvasRuntimeReady()
-                    : typeof window.createEditorCanvas === 'function';
-                var detailReady = canvasEntry && typeof canvasEntry.isDetailRuntimeReady === 'function'
-                    ? canvasEntry.isDetailRuntimeReady()
-                    : typeof window.createPublicViewerDetailUI === 'function';
+                var runtimeReady = canvasEntry && typeof canvasEntry.isPublicRuntimeReady === 'function'
+                    ? canvasEntry.isPublicRuntimeReady()
+                    : (
+                        (canvasEntry && typeof canvasEntry.isCanvasRuntimeReady === 'function'
+                            ? canvasEntry.isCanvasRuntimeReady()
+                            : typeof window.createEditorCanvas === 'function')
+                        && (canvasEntry && typeof canvasEntry.isDetailRuntimeReady === 'function'
+                            ? canvasEntry.isDetailRuntimeReady()
+                            : typeof window.createPublicViewerDetailUI === 'function')
+                    );
 
-                if (canvasReady && detailReady) {
+                if (runtimeReady) {
                     startCanvas();
                     return;
                 }

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -22,6 +22,10 @@
         return typeof globalObject.createPublicViewerDetailUI === 'function';
     }
 
+    function isPublicRuntimeReady() {
+        return isCanvasRuntimeReady() && isDetailRuntimeReady();
+    }
+
     function installPublicMetrics(canvas) {
         var geometry = globalObject.EditorCanvasGeometry;
         if (!geometry || typeof geometry.getMetrics !== 'function') return;
@@ -347,6 +351,7 @@
         hasCanvasRuntime: hasCanvasRuntime,
         isCanvasRuntimeReady: isCanvasRuntimeReady,
         isDetailRuntimeReady: isDetailRuntimeReady,
+        isPublicRuntimeReady: isPublicRuntimeReady,
         installPublicMetrics: installPublicMetrics,
         installPublicViewportProfile: installPublicViewportProfile,
         createReadOnlyActions: createReadOnlyActions,

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -285,6 +285,8 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('updateSidebarStatus'), 'entry wrapper post-init refresh must call sidebar status updater');
   assert.ok(entrySrc.includes('getCurrentEditingMemory'), 'entry wrapper post-init refresh must read current editing memory');
   assert.ok(entrySrc.includes('setDetailEmptyState(false)'), 'entry wrapper post-init refresh must preserve non-empty detail state update');
+  assert.ok(entrySrc.includes('isPublicRuntimeReady'), 'entry wrapper must expose isPublicRuntimeReady');
+  assert.ok(entrySrc.includes('isCanvasRuntimeReady() && isDetailRuntimeReady()'), 'entry wrapper runtime readiness must combine canvas and detail readiness');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -358,4 +360,14 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
     initSrc.indexOf('editorCanvas.initCanvas') < initSrc.indexOf('runPublicPostInitRefresh'),
     'public post-init refresh must remain after editorCanvas.initCanvas'
   );
+  assert.ok(initSrc.includes('isPublicRuntimeReady'), 'public canvas init must delegate combined runtime readiness through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.isPublicRuntimeReady'), 'public canvas init must call delegated runtime readiness helper');
+  assert.ok(initSrc.includes('typeof window.createEditorCanvas === \'function\''), 'public canvas init must retain canvas runtime fallback readiness check');
+  assert.ok(initSrc.includes('typeof window.createPublicViewerDetailUI === \'function\''), 'public canvas init must retain detail runtime fallback readiness check');
+  assert.ok(
+    initSrc.indexOf('isPublicRuntimeReady') < initSrc.indexOf('startCanvas();'),
+    'public runtime readiness check must remain before startCanvas call'
+  );
+  assert.ok(initSrc.includes('function waitForModules'), 'public canvas init must keep waitForModules orchestration local');
+  assert.ok(initSrc.includes('function startCanvas'), 'public canvas init must keep startCanvas orchestration local');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate the combined public runtime readiness predicate through the viewer canvas entry wrapper.
- Keep waitForModules polling, startCanvas orchestration, editorCanvas.initCanvas, and node click flow in public-canvas-init.
- Preserve fallback readiness checks for the existing canvas and detail runtime globals.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`