### PR TITLE
refactor(viewer): delegate public route setup helpers

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -46,8 +46,19 @@
     }
 
     function initPublicCanvas() {
-        var params = new URLSearchParams(window.location.search);
-        var treeId = params.get('treeId');
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
+            ? canvasEntry.setupPublicRoute()
+            : (function() {
+                var params = new URLSearchParams(window.location.search);
+                var treeId = params.get('treeId');
+                document.body.classList.add('editor-readonly');
+                document.body.classList.remove('editor-preload');
+                return { treeId: treeId };
+            })();
+
+        var treeId = routeSetup && routeSetup.treeId;
+
         if (!treeId) {
             var errEl = document.createElement('div');
             errEl.style.cssText = 'padding:2rem;text-align:center;font-size:1.2rem;';
@@ -55,10 +66,6 @@
             document.body.appendChild(errEl);
             return;
         }
-
-        // Apply editor-readonly class for CSS hiding of mutation controls
-        document.body.classList.add('editor-readonly');
-        document.body.classList.remove('editor-preload');
 
         var bridge = window.LoveBudPublicCanvasBridge;
         if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -26,6 +26,24 @@
         return isCanvasRuntimeReady() && isDetailRuntimeReady();
     }
 
+    function setupPublicRoute(ctx) {
+        var options = ctx || {};
+        var loc = options.location || globalObject.location || {};
+        var doc = options.document || globalObject.document;
+        var body = options.body || (doc && doc.body) || null;
+        var params = new globalObject.URLSearchParams(loc.search || '');
+        var treeId = params.get('treeId');
+
+        if (body && body.classList) {
+            body.classList.add('editor-readonly');
+            body.classList.remove('editor-preload');
+        }
+
+        return {
+            treeId: treeId
+        };
+    }
+
     function installPublicMetrics(canvas) {
         var geometry = globalObject.EditorCanvasGeometry;
         if (!geometry || typeof geometry.getMetrics !== 'function') return;
@@ -352,6 +370,7 @@
         isCanvasRuntimeReady: isCanvasRuntimeReady,
         isDetailRuntimeReady: isDetailRuntimeReady,
         isPublicRuntimeReady: isPublicRuntimeReady,
+        setupPublicRoute: setupPublicRoute,
         installPublicMetrics: installPublicMetrics,
         installPublicViewportProfile: installPublicViewportProfile,
         createReadOnlyActions: createReadOnlyActions,

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -287,6 +287,10 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('setDetailEmptyState(false)'), 'entry wrapper post-init refresh must preserve non-empty detail state update');
   assert.ok(entrySrc.includes('isPublicRuntimeReady'), 'entry wrapper must expose isPublicRuntimeReady');
   assert.ok(entrySrc.includes('isCanvasRuntimeReady() && isDetailRuntimeReady()'), 'entry wrapper runtime readiness must combine canvas and detail readiness');
+  assert.ok(entrySrc.includes('setupPublicRoute'), 'entry wrapper must expose setupPublicRoute');
+  assert.ok(entrySrc.includes('URLSearchParams'), 'entry wrapper route helper must use URLSearchParams');
+  assert.ok(entrySrc.includes('classList.add(\'editor-readonly\')'), 'entry wrapper route helper must add editor-readonly class');
+  assert.ok(entrySrc.includes('classList.remove(\'editor-preload\')'), 'entry wrapper route helper must remove editor-preload class');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -370,4 +374,12 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   );
   assert.ok(initSrc.includes('function waitForModules'), 'public canvas init must keep waitForModules orchestration local');
   assert.ok(initSrc.includes('function startCanvas'), 'public canvas init must keep startCanvas orchestration local');
+  assert.ok(initSrc.includes('setupPublicRoute'), 'public canvas init must delegate public route setup through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.setupPublicRoute()'), 'public canvas init must call delegated route setup helper');
+  assert.ok(initSrc.includes('document.body.classList.add(\'editor-readonly\')'), 'public canvas init must retain fallback body class add');
+  assert.ok(initSrc.includes('document.body.classList.remove(\'editor-preload\')'), 'public canvas init must retain fallback body class remove');
+  assert.ok(
+    initSrc.indexOf('setupPublicRoute') < initSrc.indexOf('bridge.loadPublicTreeData'),
+    'public route setup must remain before bridge loading start'
+  );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public route setup logic (URL parameter parsing and body class mutations) through the viewer canvas entry wrapper.
- Keep data normalization, boot sequencing, and interaction handling inside public-canvas-init.
- Preserve fallback behaviors in the event of wrapper initialization delay.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`