### PR TITLE
refactor(viewer): delegate public missing route state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -45,6 +45,18 @@
         return errState;
     }
 
+    function createMissingRouteState() {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.createMissingRouteState === 'function') {
+            return canvasEntry.createMissingRouteState();
+        }
+
+        var errEl = document.createElement('div');
+        errEl.style.cssText = 'padding:2rem;text-align:center;font-size:1.2rem;';
+        errEl.textContent = 'treeId parameter required. Usage: ?treeId=<id>';
+        return errEl;
+    }
+
     function initPublicCanvas() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
@@ -60,10 +72,10 @@
         var treeId = routeSetup && routeSetup.treeId;
 
         if (!treeId) {
-            var errEl = document.createElement('div');
-            errEl.style.cssText = 'padding:2rem;text-align:center;font-size:1.2rem;';
-            errEl.textContent = 'treeId parameter required. Usage: ?treeId=<id>';
-            document.body.appendChild(errEl);
+            var errEl = createMissingRouteState();
+            if (errEl) {
+                document.body.appendChild(errEl);
+            }
             return;
         }
 

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -282,6 +282,16 @@
         return errState;
     }
 
+    function createMissingRouteState() {
+        var doc = globalObject.document;
+        if (!doc || typeof doc.createElement !== 'function') return null;
+
+        var errEl = doc.createElement('div');
+        errEl.style.cssText = 'padding:2rem;text-align:center;font-size:1.2rem;';
+        errEl.textContent = 'treeId parameter required. Usage: ?treeId=<id>';
+        return errEl;
+    }
+
     function installPublicEditorReadOnlyState(canvas, editorCanvas) {
         if (canvas) canvas.__editorCanvasInstance = editorCanvas;
         globalObject.LoveBudEditor = globalObject.LoveBudEditor || {};
@@ -380,6 +390,7 @@
         createDetailUIOptions: createDetailUIOptions,
         createCanvasOptions: createCanvasOptions,
         createLoadFailureState: createLoadFailureState,
+        createMissingRouteState: createMissingRouteState,
         installPublicEditorReadOnlyState: installPublicEditorReadOnlyState,
         runPublicPostInitRefresh: runPublicPostInitRefresh,
         createEmptyGuideUpdater: createEmptyGuideUpdater,

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -291,6 +291,13 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('URLSearchParams'), 'entry wrapper route helper must use URLSearchParams');
   assert.ok(entrySrc.includes('classList.add(\'editor-readonly\')'), 'entry wrapper route helper must add editor-readonly class');
   assert.ok(entrySrc.includes('classList.remove(\'editor-preload\')'), 'entry wrapper route helper must remove editor-preload class');
+  const missingRouteMatch = entrySrc.match(/function createMissingRouteState\(\) \{[\s\S]*?\n    \}/);
+  assert.ok(missingRouteMatch, 'entry wrapper must define createMissingRouteState');
+  const missingRouteSrc = missingRouteMatch[0];
+  assert.ok(missingRouteSrc.includes('document') || missingRouteSrc.includes('globalObject.document'), 'missing route helper must use document safely');
+  assert.ok(missingRouteSrc.includes('createElement'), 'missing route helper must create DOM nodes safely');
+  assert.ok(missingRouteSrc.includes('textContent'), 'missing route helper must use textContent');
+  assert.equal(missingRouteSrc.includes('innerHTML'), false, 'missing route helper must not use innerHTML');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
 });
 
@@ -382,4 +389,12 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
     initSrc.indexOf('setupPublicRoute') < initSrc.indexOf('bridge.loadPublicTreeData'),
     'public route setup must remain before bridge loading start'
   );
+  assert.ok(initSrc.includes('createMissingRouteState'), 'public canvas init must delegate missing route state creation');
+  assert.ok(initSrc.includes('canvasEntry.createMissingRouteState'), 'public canvas init must call delegated missing route state helper');
+  assert.ok(initSrc.includes('document.body.appendChild(errEl)'), 'public canvas init must keep appending missing route state locally');
+  assert.ok(
+    initSrc.indexOf('createMissingRouteState') < initSrc.indexOf('LoveBudPublicCanvasBridge'),
+    'missing route state helper must be defined before bridge lookup path'
+  );
+  assert.ok(initSrc.includes('treeId parameter required. Usage: ?treeId=<id>'), 'public canvas init must retain fallback missing treeId message');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public missing route state creation through the viewer canvas entry wrapper.
- Keep missing route append behavior, route setup, bridge loading, waitForModules, startCanvas, editorCanvas.initCanvas, and node click flow in public-canvas-init.
- Preserve fallback DOM creation without using innerHTML.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`