### PR TITLE
refactor(viewer): delegate public bridge lookup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -79,7 +79,10 @@
             return;
         }
 
-        var bridge = window.LoveBudPublicCanvasBridge;
+        var bridge = canvasEntry && typeof canvasEntry.getPublicCanvasBridge === 'function'
+            ? canvasEntry.getPublicCanvasBridge()
+            : window.LoveBudPublicCanvasBridge;
+
         if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {
             console.error('[public-canvas] Bridge not loaded');
             return;

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -374,6 +374,14 @@
         };
     }
 
+    function getPublicCanvasBridge() {
+        var bridge = globalObject.LoveBudPublicCanvasBridge;
+        if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {
+            return null;
+        }
+        return bridge;
+    }
+
     globalObject.LoveBudPublicViewerCanvasEntry = Object.freeze({
         getCanvasRuntime: getCanvasRuntime,
         hasCanvasRuntime: hasCanvasRuntime,
@@ -395,6 +403,7 @@
         runPublicPostInitRefresh: runPublicPostInitRefresh,
         createEmptyGuideUpdater: createEmptyGuideUpdater,
         installToolbarCompactMode: installToolbarCompactMode,
-        getBoundaryState: getBoundaryState
+        getBoundaryState: getBoundaryState,
+        getPublicCanvasBridge: getPublicCanvasBridge
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -299,6 +299,9 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(missingRouteSrc.includes('textContent'), 'missing route helper must use textContent');
   assert.equal(missingRouteSrc.includes('innerHTML'), false, 'missing route helper must not use innerHTML');
   assert.ok(entrySrc.includes('Object.freeze'), 'entry wrapper must freeze the exported namespace');
+  assert.ok(entrySrc.includes('getPublicCanvasBridge'), 'entry wrapper must expose getPublicCanvasBridge');
+  assert.ok(entrySrc.includes('LoveBudPublicCanvasBridge'), 'entry wrapper bridge lookup must reference LoveBudPublicCanvasBridge');
+  assert.ok(entrySrc.includes('loadPublicTreeData'), 'entry wrapper bridge lookup must verify loadPublicTreeData');
 });
 
 test('public canvas init delegates metrics/profile setup through entry wrapper', () => {
@@ -397,4 +400,16 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
     'missing route state helper must be defined before bridge lookup path'
   );
   assert.ok(initSrc.includes('treeId parameter required. Usage: ?treeId=<id>'), 'public canvas init must retain fallback missing treeId message');
+  assert.ok(initSrc.includes('getPublicCanvasBridge'), 'public canvas init must delegate public bridge lookup through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.getPublicCanvasBridge'), 'public canvas init must call delegated bridge lookup helper');
+  assert.ok(initSrc.includes('window.LoveBudPublicCanvasBridge'), 'public canvas init must retain bridge lookup fallback');
+  assert.ok(initSrc.includes("console.error('[public-canvas] Bridge not loaded')"), 'public canvas init must preserve bridge missing error log');
+  assert.ok(
+    initSrc.indexOf('getPublicCanvasBridge') < initSrc.indexOf('bridge.loadPublicTreeData(treeId)'),
+    'public bridge lookup must remain before bridge data load'
+  );
+  assert.ok(initSrc.includes('bridge.loadPublicTreeData(treeId).then(function(result)'), 'public canvas init must keep data load promise chain local');
+  assert.ok(initSrc.includes('bridge.normalizeForCanvas(tree, memories)'), 'public canvas init must keep normalization local');
+  assert.ok(initSrc.includes('function waitForModules'), 'public canvas init must keep waitForModules local');
+  assert.ok(initSrc.includes('function startCanvas'), 'public canvas init must keep startCanvas local');
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public canvas bridge lookup through the viewer canvas entry wrapper.
- Keep bridge data loading, normalization, waitForModules, startCanvas, editorCanvas.initCanvas, and node click flow in public-canvas-init.
- Preserve fallback bridge lookup and missing bridge console error behavior.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`