### PR TITLE
refactor(viewer): delegate public load failure append

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -57,6 +57,20 @@
         return errEl;
     }
 
+    function appendPublicLoadFailureState(container, error) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.appendPublicLoadFailureState === 'function') {
+            return canvasEntry.appendPublicLoadFailureState(container, error);
+        }
+
+        if (container) {
+            container.textContent = '';
+            container.appendChild(createLoadFailureState(error && error.message));
+            return true;
+        }
+        return false;
+    }
+
     function initPublicCanvas() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
@@ -404,10 +418,7 @@
         }).catch(function(error) {
             console.error('[public-canvas] Load failed:', error);
             var container = document.getElementById('canvasArea');
-            if (container) {
-                container.textContent = '';
-                container.appendChild(createLoadFailureState(error && error.message));
-            }
+            appendPublicLoadFailureState(container, error);
         });
     }
 

--- a/js/viewer/public-viewer-canvas-entry.js
+++ b/js/viewer/public-viewer-canvas-entry.js
@@ -389,6 +389,17 @@
         return bridge.normalizeForCanvas(tree, memories);
     }
 
+    function appendPublicLoadFailureState(container, error) {
+        if (!container) return false;
+        container.textContent = '';
+        var errEl = createLoadFailureState(error && error.message);
+        if (errEl) {
+            container.appendChild(errEl);
+            return true;
+        }
+        return false;
+    }
+
     globalObject.LoveBudPublicViewerCanvasEntry = Object.freeze({
         getCanvasRuntime: getCanvasRuntime,
         hasCanvasRuntime: hasCanvasRuntime,
@@ -412,6 +423,7 @@
         installToolbarCompactMode: installToolbarCompactMode,
         getBoundaryState: getBoundaryState,
         getPublicCanvasBridge: getPublicCanvasBridge,
-        normalizePublicCanvasData: normalizePublicCanvasData
+        normalizePublicCanvasData: normalizePublicCanvasData,
+        appendPublicLoadFailureState: appendPublicLoadFailureState
     });
 })();

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -305,6 +305,9 @@ test('public canvas entry wrapper exposes boundary and setup methods', () => {
   assert.ok(entrySrc.includes('normalizePublicCanvasData'), 'entry wrapper must expose normalizePublicCanvasData');
   assert.ok(entrySrc.includes('bridge.normalizeForCanvas(tree, memories)'), 'entry wrapper normalization helper must call bridge.normalizeForCanvas');
   assert.ok(entrySrc.includes("typeof bridge.normalizeForCanvas !== 'function'"), 'entry wrapper normalization helper must guard normalizeForCanvas');
+  assert.ok(entrySrc.includes('appendPublicLoadFailureState'), 'entry wrapper must expose appendPublicLoadFailureState');
+  assert.ok(entrySrc.includes("container.textContent = ''"), 'entry wrapper load failure append must clear container');
+  assert.ok(entrySrc.includes('container.appendChild'), 'entry wrapper load failure append must append error element');
 });
 
 test('public canvas init delegates metrics/profile setup through entry wrapper', () => {
@@ -427,4 +430,11 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('function startCanvas'), 'public canvas init must keep startCanvas local');
   assert.ok(initSrc.includes('var onPublicCanvasNodeClick = function(el, data)'), 'public canvas init must keep node click flow local');
   assert.ok(initSrc.includes('editorCanvas.initCanvas();'), 'public canvas init must keep editorCanvas init call local');
+  assert.ok(initSrc.includes('appendPublicLoadFailureState'), 'public canvas init must delegate load failure appending through entry wrapper');
+  assert.ok(initSrc.includes('canvasEntry.appendPublicLoadFailureState'), 'public canvas init must call delegated load failure append helper');
+  assert.ok(initSrc.includes('container.appendChild(createLoadFailureState(error && error.message))'), 'public canvas init must retain load failure appending fallback');
+  assert.ok(
+    initSrc.indexOf('appendPublicLoadFailureState') < initSrc.indexOf('initPublicCanvas()'),
+    'local load failure append helper must be defined before init public canvas function'
+  );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Delegate public load failure clear/append logic to the viewer canvas entry wrapper.
- Keep data loading sequence, promise catch routing, and init orchestration inside public-canvas-init.
- Preserve local load failure DOM building fallback path.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `npm run verify`
- `npm test`