### PR TITLE
refactor(viewer): add public canvas adapter wrapper

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -361,7 +361,13 @@
                         canEdit: false
                     };
 
-                var editorCanvas = window.createEditorCanvas(canvasOptions);
+                var adapter = window.LoveBudPublicViewerCanvasAdapter;
+                var editorCanvas = adapter && typeof adapter.createPublicViewerCanvas === 'function'
+                    ? adapter.createPublicViewerCanvas({
+                        createEditorCanvas: window.createEditorCanvas,
+                        canvasOptions: canvasOptions
+                    })
+                    : window.createEditorCanvas(canvasOptions);
 
                 // Store instance and public read-only editor state
                 if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {

--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -367,7 +367,11 @@
                         createEditorCanvas: window.createEditorCanvas,
                         canvasOptions: canvasOptions
                     })
-                    : window.createEditorCanvas(canvasOptions);
+                    : null;
+
+                if (!editorCanvas) {
+                    editorCanvas = window.createEditorCanvas(canvasOptions);
+                }
 
                 // Store instance and public read-only editor state
                 if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {

--- a/js/viewer/public-viewer-canvas-adapter.js
+++ b/js/viewer/public-viewer-canvas-adapter.js
@@ -1,0 +1,16 @@
+(function() {
+    'use strict';
+
+    var globalObject = typeof window !== 'undefined' ? window : globalThis;
+
+    function createPublicViewerCanvas(options) {
+        var factory = options && options.createEditorCanvas;
+        var canvasOptions = options && options.canvasOptions;
+        if (typeof factory !== 'function') return null;
+        return factory(canvasOptions);
+    }
+
+    globalObject.LoveBudPublicViewerCanvasAdapter = Object.freeze({
+        createPublicViewerCanvas: createPublicViewerCanvas
+    });
+})();

--- a/pages/view.html
+++ b/pages/view.html
@@ -93,6 +93,7 @@
     <script src="../js/page-transitions.js?v=20260430-1"></script>
     <script src="../js/viewer/public-canvas-bridge.js?v=20260525-1"></script>
     <script src="../js/viewer/public-viewer-canvas-entry.js?v=20260528-1"></script>
+    <script src="../js/viewer/public-viewer-canvas-adapter.js?v=20260529-1"></script>
     <script src="../js/viewer/public-canvas-init.js?v=20260525-1"></script>
     <script src="../js/viewer/public-viewer-copy-helper.js?v=20260525-1"></script>
     <script src="../js/viewer/public-viewer-control-visibility-helper.js?v=20260526-1"></script>

--- a/tests/routes/public-viewer-canvas-adapter-contract.test.cjs
+++ b/tests/routes/public-viewer-canvas-adapter-contract.test.cjs
@@ -30,6 +30,7 @@ function assertScriptOrder(scripts, beforeNeedle, afterNeedle) {
 test('public viewer canvas adapter script order in view.html', () => {
   const scripts = getScriptSrcs();
 
+  assertScriptOrder(scripts, 'js/editor/editor-canvas.js', 'js/viewer/public-viewer-canvas-adapter.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-canvas-entry.js', 'js/viewer/public-viewer-canvas-adapter.js');
   assertScriptOrder(scripts, 'js/viewer/public-viewer-canvas-adapter.js', 'js/viewer/public-canvas-init.js');
 });
@@ -49,4 +50,6 @@ test('public canvas init references the viewer canvas adapter', () => {
   assert.ok(initSrc.includes('LoveBudPublicViewerCanvasAdapter'), 'public canvas init must reference LoveBudPublicViewerCanvasAdapter');
   assert.ok(initSrc.includes('createPublicViewerCanvas'), 'public canvas init must call createPublicViewerCanvas');
   assert.ok(initSrc.includes('window.createEditorCanvas'), 'public canvas init must keep window.createEditorCanvas fallback');
+  assert.ok(initSrc.includes('if (!editorCanvas)'), 'public canvas init must have if (!editorCanvas) fallback guard');
+  assert.ok(initSrc.includes('editorCanvas = window.createEditorCanvas(canvasOptions);'), 'public canvas init must maintain direct fallback assignment');
 });

--- a/tests/routes/public-viewer-canvas-adapter-contract.test.cjs
+++ b/tests/routes/public-viewer-canvas-adapter-contract.test.cjs
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+function getViewHtml() {
+  return fs.readFileSync('pages/view.html', 'utf8');
+}
+
+function getScriptSrcs() {
+  const html = getViewHtml();
+  return [...html.matchAll(/<script(?:\s+type="module")?\s+src="([^"]+)"/g)].map((match) => match[1]);
+}
+
+function stripVersion(src) {
+  return String(src || '').split('?')[0];
+}
+
+function scriptIndex(scripts, needle) {
+  return scripts.findIndex((src) => stripVersion(src).includes(needle));
+}
+
+function assertScriptOrder(scripts, beforeNeedle, afterNeedle) {
+  const beforeIndex = scriptIndex(scripts, beforeNeedle);
+  const afterIndex = scriptIndex(scripts, afterNeedle);
+  assert.notEqual(beforeIndex, -1, `missing script: ${beforeNeedle}`);
+  assert.notEqual(afterIndex, -1, `missing script: ${afterNeedle}`);
+  assert.ok(beforeIndex < afterIndex, `${beforeNeedle} must load before ${afterNeedle}`);
+}
+
+test('public viewer canvas adapter script order in view.html', () => {
+  const scripts = getScriptSrcs();
+
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-canvas-entry.js', 'js/viewer/public-viewer-canvas-adapter.js');
+  assertScriptOrder(scripts, 'js/viewer/public-viewer-canvas-adapter.js', 'js/viewer/public-canvas-init.js');
+});
+
+test('public viewer canvas adapter implementation contract', () => {
+  const adapterSrc = fs.readFileSync('js/viewer/public-viewer-canvas-adapter.js', 'utf8');
+
+  assert.ok(adapterSrc.includes('LoveBudPublicViewerCanvasAdapter'), 'adapter must define LoveBudPublicViewerCanvasAdapter namespace');
+  assert.ok(adapterSrc.includes('createPublicViewerCanvas'), 'adapter must define createPublicViewerCanvas helper');
+  assert.ok(adapterSrc.includes('Object.freeze'), 'adapter must freeze exported namespace');
+  assert.equal(adapterSrc.includes('innerHTML'), false, 'adapter must not use innerHTML');
+});
+
+test('public canvas init references the viewer canvas adapter', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(initSrc.includes('LoveBudPublicViewerCanvasAdapter'), 'public canvas init must reference LoveBudPublicViewerCanvasAdapter');
+  assert.ok(initSrc.includes('createPublicViewerCanvas'), 'public canvas init must call createPublicViewerCanvas');
+  assert.ok(initSrc.includes('window.createEditorCanvas'), 'public canvas init must keep window.createEditorCanvas fallback');
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Add a public viewer canvas adapter wrapper.
- Delegate public canvas creation through the adapter while preserving the fallback direct creation.
- Load public viewer canvas adapter in pages/view.html before public-canvas-init.js.

Validation:
- `node --test tests/routes/public-canvas-route-dependency-contract.test.cjs`
- `node --test tests/routes/public-viewer-canvas-adapter-contract.test.cjs`
- `npm run verify`
- `npm test`