### PR TITLE
refactor(viewer): delegate public canvas runtime readiness

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -71,6 +71,23 @@
         return false;
     }
 
+    function isPublicRuntimeReady() {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.isPublicRuntimeReady === 'function') {
+            return canvasEntry.isPublicRuntimeReady();
+        }
+
+        var canvasRuntimeReady = canvasEntry && typeof canvasEntry.isCanvasRuntimeReady === 'function'
+            ? canvasEntry.isCanvasRuntimeReady()
+            : typeof window.createEditorCanvas === 'function';
+
+        var detailRuntimeReady = canvasEntry && typeof canvasEntry.isDetailRuntimeReady === 'function'
+            ? canvasEntry.isDetailRuntimeReady()
+            : typeof window.createPublicViewerDetailUI === 'function';
+
+        return canvasRuntimeReady && detailRuntimeReady;
+    }
+
     function initPublicCanvas() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
@@ -127,17 +144,7 @@
                     return;
                 }
 
-                var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
-                var runtimeReady = canvasEntry && typeof canvasEntry.isPublicRuntimeReady === 'function'
-                    ? canvasEntry.isPublicRuntimeReady()
-                    : (
-                        (canvasEntry && typeof canvasEntry.isCanvasRuntimeReady === 'function'
-                            ? canvasEntry.isCanvasRuntimeReady()
-                            : typeof window.createEditorCanvas === 'function')
-                        && (canvasEntry && typeof canvasEntry.isDetailRuntimeReady === 'function'
-                            ? canvasEntry.isDetailRuntimeReady()
-                            : typeof window.createPublicViewerDetailUI === 'function')
-                    );
+                var runtimeReady = isPublicRuntimeReady();
 
                 if (runtimeReady) {
                     startCanvas();

--- a/tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps runtime readiness behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(initSrc.includes('function isPublicRuntimeReady()'), 'public canvas init must expose a local runtime readiness helper');
+  assert.ok(initSrc.includes('canvasEntry.isPublicRuntimeReady()'), 'readiness helper must delegate to canvas entry when available');
+  assert.ok(initSrc.includes('typeof window.createEditorCanvas === \'function\''), 'readiness helper must preserve direct canvas runtime fallback');
+  assert.ok(initSrc.includes('typeof window.createPublicViewerDetailUI === \'function\''), 'readiness helper must preserve direct detail runtime fallback');
+  assert.ok(initSrc.includes('var runtimeReady = isPublicRuntimeReady();'), 'wait loop must consume the local readiness helper');
+  assert.equal(
+    initSrc.includes('var runtimeReady = canvasEntry && typeof canvasEntry.isPublicRuntimeReady'),
+    false,
+    'wait loop should not inline the full readiness decision'
+  );
+  assert.ok(
+    initSrc.indexOf('function isPublicRuntimeReady()') < initSrc.indexOf('function initPublicCanvas()'),
+    'readiness helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var runtimeReady = isPublicRuntimeReady();') < initSrc.indexOf('startCanvas();'),
+    'runtime readiness must be checked before starting the canvas'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas runtime readiness fallback logic into a local helper in public-canvas-init.js.
- Keep the wait loop focused on orchestration by consuming isPublicRuntimeReady().
- Preserve entry-wrapper delegation and direct window.createEditorCanvas / createPublicViewerDetailUI fallback behavior.
- Add a focused contract test for the readiness helper boundary.

Validation:
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- npm run verify
- npm test