### PR TITLE
refactor(viewer): delegate public canvas creation fallback

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -88,6 +88,22 @@
         return canvasRuntimeReady && detailRuntimeReady;
     }
 
+    function createPublicEditorCanvas(canvasOptions) {
+        var adapter = window.LoveBudPublicViewerCanvasAdapter;
+        var editorCanvas = adapter && typeof adapter.createPublicViewerCanvas === 'function'
+            ? adapter.createPublicViewerCanvas({
+                createEditorCanvas: window.createEditorCanvas,
+                canvasOptions: canvasOptions
+            })
+            : null;
+
+        if (!editorCanvas) {
+            editorCanvas = window.createEditorCanvas(canvasOptions);
+        }
+
+        return editorCanvas;
+    }
+
     function initPublicCanvas() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
@@ -368,17 +384,7 @@
                         canEdit: false
                     };
 
-                var adapter = window.LoveBudPublicViewerCanvasAdapter;
-                var editorCanvas = adapter && typeof adapter.createPublicViewerCanvas === 'function'
-                    ? adapter.createPublicViewerCanvas({
-                        createEditorCanvas: window.createEditorCanvas,
-                        canvasOptions: canvasOptions
-                    })
-                    : null;
-
-                if (!editorCanvas) {
-                    editorCanvas = window.createEditorCanvas(canvasOptions);
-                }
+                var editorCanvas = createPublicEditorCanvas(canvasOptions);
 
                 // Store instance and public read-only editor state
                 if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {

--- a/tests/routes/public-canvas-creation-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-creation-helper-contract.test.cjs
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps canvas creation behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicEditorCanvas(canvasOptions)'),
+    'public canvas init must expose a local canvas creation helper'
+  );
+  assert.ok(
+    initSrc.includes('LoveBudPublicViewerCanvasAdapter'),
+    'canvas creation helper must reference the public viewer canvas adapter'
+  );
+  assert.ok(
+    initSrc.includes('adapter.createPublicViewerCanvas'),
+    'canvas creation helper must delegate to adapter when available'
+  );
+  assert.ok(
+    initSrc.includes('createEditorCanvas: window.createEditorCanvas'),
+    'canvas creation helper must pass direct canvas factory into adapter'
+  );
+  assert.ok(
+    initSrc.includes('editorCanvas = window.createEditorCanvas(canvasOptions);'),
+    'canvas creation helper must preserve direct fallback assignment'
+  );
+  assert.ok(
+    initSrc.includes('return editorCanvas;'),
+    'canvas creation helper must return the created editor canvas'
+  );
+  assert.ok(
+    initSrc.includes('var editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    'startCanvas must consume the local canvas creation helper'
+  );
+  assert.equal(
+    initSrc.includes('var adapter = window.LoveBudPublicViewerCanvasAdapter;\n                var editorCanvas = adapter'),
+    false,
+    'startCanvas should not inline adapter canvas creation'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicEditorCanvas(canvasOptions)') < initSrc.indexOf('function initPublicCanvas()'),
+    'canvas creation helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicEditorReadOnlyState'),
+    'canvas must be created before read-only state installation'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicEditorReadOnlyState') < initSrc.indexOf('editorCanvas.initCanvas'),
+    'read-only state setup must remain before editorCanvas.initCanvas'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas adapter/direct fallback creation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicEditorCanvas(canvasOptions).
- Preserve LoveBudPublicViewerCanvasAdapter delegation and direct window.createEditorCanvas fallback behavior.
- Add a focused contract test for the canvas creation helper boundary.

Validation:
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test