### PR TITLE
refactor(viewer): delegate public canvas target lookup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -104,6 +104,14 @@
         return editorCanvas;
     }
 
+    function resolvePublicCanvasTargets() {
+        return {
+            canvas: document.getElementById('canvasArea'),
+            svg: document.getElementById('canvasSvg'),
+            detailPanel: document.getElementById('detailPanel')
+        };
+    }
+
     function initPublicCanvas() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
@@ -170,9 +178,10 @@
             }
 
             function startCanvas() {
-                var canvas = document.getElementById('canvasArea');
-                var svg = document.getElementById('canvasSvg');
-                var detailPanel = document.getElementById('detailPanel');
+                var targets = resolvePublicCanvasTargets();
+                var canvas = targets.canvas;
+                var svg = targets.svg;
+                var detailPanel = targets.detailPanel;
 
                 if (!canvas || !svg) {
                     console.error('[public-canvas] Canvas or SVG element not found');

--- a/tests/routes/public-canvas-target-lookup-contract.test.cjs
+++ b/tests/routes/public-canvas-target-lookup-contract.test.cjs
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps DOM target lookup behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function resolvePublicCanvasTargets()'),
+    'public canvas init must expose a local target lookup helper'
+  );
+  assert.ok(
+    initSrc.includes("canvas: document.getElementById('canvasArea')"),
+    'target helper must resolve canvasArea'
+  );
+  assert.ok(
+    initSrc.includes("svg: document.getElementById('canvasSvg')"),
+    'target helper must resolve canvasSvg'
+  );
+  assert.ok(
+    initSrc.includes("detailPanel: document.getElementById('detailPanel')"),
+    'target helper must resolve detailPanel'
+  );
+  assert.ok(
+    initSrc.includes('var targets = resolvePublicCanvasTargets();'),
+    'startCanvas must consume the local target lookup helper'
+  );
+  assert.ok(
+    initSrc.includes('var canvas = targets.canvas;'),
+    'startCanvas must keep canvas variable from targets'
+  );
+  assert.ok(
+    initSrc.includes('var svg = targets.svg;'),
+    'startCanvas must keep svg variable from targets'
+  );
+  assert.ok(
+    initSrc.includes('var detailPanel = targets.detailPanel;'),
+    'startCanvas must keep detailPanel variable from targets'
+  );
+  assert.equal(
+    initSrc.includes("var canvas = document.getElementById('canvasArea');"),
+    false,
+    'startCanvas should not inline canvas DOM lookup'
+  );
+  assert.ok(
+    initSrc.includes("console.error('[public-canvas] Canvas or SVG element not found')"),
+    'missing canvas/svg error must be preserved'
+  );
+  assert.ok(
+    initSrc.indexOf('function resolvePublicCanvasTargets()') < initSrc.indexOf('function initPublicCanvas()'),
+    'target lookup helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var targets = resolvePublicCanvasTargets();') < initSrc.indexOf('installPublicMetrics'),
+    'target lookup must happen before metrics installation'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas DOM target lookup into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming resolvePublicCanvasTargets().
- Preserve canvas/svg missing-target guard and existing initialization order.
- Add a focused contract test for the target lookup boundary.

Validation:
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test