### PR TITLE
refactor(viewer): delegate public canvas route setup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -112,19 +112,21 @@
         };
     }
 
+    function setupPublicRoute() {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
+            return canvasEntry.setupPublicRoute();
+        }
+
+        var params = new URLSearchParams(window.location.search);
+        var treeId = params.get('treeId');
+        document.body.classList.add('editor-readonly');
+        document.body.classList.remove('editor-preload');
+        return { treeId: treeId };
+    }
 
     function initPublicCanvas() {
-        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
-        var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute === 'function'
-            ? canvasEntry.setupPublicRoute()
-            : (function() {
-                var params = new URLSearchParams(window.location.search);
-                var treeId = params.get('treeId');
-                document.body.classList.add('editor-readonly');
-                document.body.classList.remove('editor-preload');
-                return { treeId: treeId };
-            })();
-
+        var routeSetup = setupPublicRoute();
         var treeId = routeSetup && routeSetup.treeId;
 
         if (!treeId) {

--- a/tests/routes/public-canvas-route-setup-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-route-setup-helper-contract.test.cjs
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps route setup behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function setupPublicRoute()'),
+    'public canvas init must expose a local route setup helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.setupPublicRoute()'),
+    'route setup helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('new URLSearchParams(window.location.search)'),
+    'route setup helper must preserve URLSearchParams fallback'
+  );
+  assert.ok(
+    initSrc.includes("params.get('treeId')"),
+    'route setup helper must preserve treeId query lookup'
+  );
+  assert.ok(
+    initSrc.includes("document.body.classList.add('editor-readonly')"),
+    'route setup helper must preserve read-only body class fallback'
+  );
+  assert.ok(
+    initSrc.includes("document.body.classList.remove('editor-preload')"),
+    'route setup helper must preserve preload class removal fallback'
+  );
+  assert.ok(
+    initSrc.includes('var routeSetup = setupPublicRoute();'),
+    'initPublicCanvas must consume the local route setup helper'
+  );
+  assert.equal(
+    initSrc.includes('var routeSetup = canvasEntry && typeof canvasEntry.setupPublicRoute'),
+    false,
+    'initPublicCanvas should not inline route setup delegation'
+  );
+  assert.ok(
+    initSrc.indexOf('function setupPublicRoute()') < initSrc.indexOf('function initPublicCanvas()'),
+    'route setup helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var routeSetup = setupPublicRoute();') < initSrc.indexOf('var treeId = routeSetup && routeSetup.treeId;'),
+    'route setup must happen before treeId extraction'
+  );
+  assert.ok(
+    initSrc.indexOf('var treeId = routeSetup && routeSetup.treeId;') < initSrc.indexOf('if (!treeId)'),
+    'treeId extraction must remain before missing route guard'
+  );
+  assert.ok(
+    initSrc.indexOf('if (!treeId)') < initSrc.indexOf('var bridge = getPublicCanvasBridge();'),
+    'missing route guard must remain before bridge lookup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public route setup fallback into a local helper in public-canvas-init.js.
- Keep initPublicCanvas focused on orchestration by consuming setupPublicRoute().
- Preserve entry-wrapper delegation and URLSearchParams/body-class fallback behavior.
- Add focused contract coverage for the route setup helper boundary.

Validation:
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test