### PR TITLE
refactor(viewer): delegate public canvas missing route state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -57,6 +57,15 @@
         return errEl;
     }
 
+    function appendMissingRouteState() {
+        var errEl = createMissingRouteState();
+        if (errEl) {
+            document.body.appendChild(errEl);
+            return true;
+        }
+        return false;
+    }
+
     function appendPublicLoadFailureState(container, error) {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.appendPublicLoadFailureState === 'function') {
@@ -130,10 +139,7 @@
         var treeId = routeSetup && routeSetup.treeId;
 
         if (!treeId) {
-            var errEl = createMissingRouteState();
-            if (errEl) {
-                document.body.appendChild(errEl);
-            }
+            appendMissingRouteState();
             return;
         }
 

--- a/tests/routes/public-canvas-missing-route-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-missing-route-helper-contract.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps missing route append behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function appendMissingRouteState()'),
+    'public canvas init must expose a local missing route append helper'
+  );
+  assert.ok(
+    initSrc.includes('var errEl = createMissingRouteState();'),
+    'missing route helper must create the missing route state'
+  );
+  assert.ok(
+    initSrc.includes('document.body.appendChild(errEl);'),
+    'missing route helper must append the missing route state'
+  );
+  assert.ok(
+    initSrc.includes('appendMissingRouteState();'),
+    'initPublicCanvas must consume the missing route helper'
+  );
+  assert.equal(
+    initSrc.includes('var errEl = createMissingRouteState();\n            if (errEl)'),
+    false,
+    'initPublicCanvas should not inline missing route append logic'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function appendMissingRouteState()') < initSrc.indexOf('function initPublicCanvas()'),
+    'missing route helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('if (!treeId)') < initSrc.indexOf('appendMissingRouteState();'),
+    'missing route guard must call the helper'
+  );
+  assert.ok(
+    initSrc.indexOf('appendMissingRouteState();') < initSrc.indexOf('var bridge = getPublicCanvasBridge();'),
+    'missing route handling must remain before bridge lookup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract missing treeId route-state append logic into a local helper in public-canvas-init.js.
- Keep initPublicCanvas focused on orchestration by consuming appendMissingRouteState().
- Preserve createMissingRouteState() fallback behavior and missing-route guard order.
- Add focused contract coverage for the missing route helper boundary.

Validation:
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test