### PR TITLE
refactor(viewer): delegate public canvas bridge readiness

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -134,6 +134,10 @@
         return { treeId: treeId };
     }
 
+    function isPublicCanvasBridgeReady(bridge) {
+        return !!(bridge && typeof bridge.loadPublicTreeData === 'function');
+    }
+
     function initPublicCanvas() {
         var routeSetup = setupPublicRoute();
         var treeId = routeSetup && routeSetup.treeId;
@@ -145,7 +149,7 @@
 
         var bridge = getPublicCanvasBridge();
 
-        if (!bridge || typeof bridge.loadPublicTreeData !== 'function') {
+        if (!isPublicCanvasBridgeReady(bridge)) {
             console.error('[public-canvas] Bridge not loaded');
             return;
         }

--- a/tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps bridge readiness behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function isPublicCanvasBridgeReady(bridge)'),
+    'public canvas init must expose a local bridge readiness helper'
+  );
+  assert.ok(
+    initSrc.includes("return !!(bridge && typeof bridge.loadPublicTreeData === 'function');"),
+    'bridge readiness helper must validate loadPublicTreeData'
+  );
+  assert.ok(
+    initSrc.includes('if (!isPublicCanvasBridgeReady(bridge))'),
+    'initPublicCanvas must consume the bridge readiness helper'
+  );
+  assert.equal(
+    initSrc.includes("if (!bridge || typeof bridge.loadPublicTreeData !== 'function')"),
+    false,
+    'initPublicCanvas should not inline bridge readiness logic'
+  );
+  assert.ok(
+    initSrc.includes("console.error('[public-canvas] Bridge not loaded')"),
+    'bridge missing error must be preserved'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('var bridge = getPublicCanvasBridge();') < initSrc.indexOf('if (!isPublicCanvasBridgeReady(bridge))'),
+    'bridge lookup must happen before bridge readiness guard'
+  );
+  assert.ok(
+    initSrc.indexOf('if (!isPublicCanvasBridgeReady(bridge))') < initSrc.indexOf("console.error('[public-canvas] Bridge not loaded')"),
+    'bridge readiness guard must preserve missing bridge error flow'
+  );
+  assert.ok(
+    initSrc.indexOf("console.error('[public-canvas] Bridge not loaded')") < initSrc.indexOf('bridge.loadPublicTreeData(treeId)'),
+    'missing bridge error must remain before public tree loading'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas bridge readiness check into a local helper in public-canvas-init.js.
- Keep initPublicCanvas focused on orchestration by consuming isPublicCanvasBridgeReady(bridge).
- Preserve missing bridge error handling and public tree loading order.
- Add focused contract coverage for the bridge readiness helper boundary.

Validation:
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test