### PR TITLE
refactor(viewer): delegate public canvas runtime wait loop

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -97,6 +97,29 @@
         return canvasRuntimeReady && detailRuntimeReady;
     }
 
+    function waitForPublicRuntime(startCanvas) {
+        var maxWait = 100;
+        var waitInterval = 50;
+
+        function waitForModules(attempt) {
+            if (attempt >= maxWait) {
+                console.error('[public-canvas] Timeout waiting for editor modules');
+                return;
+            }
+
+            var runtimeReady = isPublicRuntimeReady();
+
+            if (runtimeReady) {
+                startCanvas();
+                return;
+            }
+
+            setTimeout(function() { waitForModules(attempt + 1); }, waitInterval);
+        }
+
+        waitForModules(0);
+    }
+
     function createPublicEditorCanvas(canvasOptions) {
         var adapter = window.LoveBudPublicViewerCanvasAdapter;
         var editorCanvas = adapter && typeof adapter.createPublicViewerCanvas === 'function'
@@ -171,24 +194,6 @@
 
             console.log('[public-canvas] Loaded tree:', normalized.treeData.id, 'memories:', normalized.treeMemories.length);
 
-            // Wait for all required modules
-            var maxWait = 100;
-            var waitInterval = 50;
-
-            function waitForModules(attempt) {
-                if (attempt >= maxWait) {
-                    console.error('[public-canvas] Timeout waiting for editor modules');
-                    return;
-                }
-
-                var runtimeReady = isPublicRuntimeReady();
-
-                if (runtimeReady) {
-                    startCanvas();
-                    return;
-                }
-                setTimeout(function() { waitForModules(attempt + 1); }, waitInterval);
-            }
 
             function startCanvas() {
                 var targets = resolvePublicCanvasTargets();
@@ -459,7 +464,7 @@
                 }
             }
 
-            waitForModules(0);
+            waitForPublicRuntime(startCanvas);
         }).catch(function(error) {
             console.error('[public-canvas] Load failed:', error);
             var container = document.getElementById('canvasArea');

--- a/tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps runtime wait loop behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function waitForPublicRuntime(startCanvas)'),
+    'public canvas init must expose a local runtime wait helper'
+  );
+  assert.ok(
+    initSrc.includes('var maxWait = 100;'),
+    'runtime wait helper must preserve maxWait'
+  );
+  assert.ok(
+    initSrc.includes('var waitInterval = 50;'),
+    'runtime wait helper must preserve wait interval'
+  );
+  assert.ok(
+    initSrc.includes("console.error('[public-canvas] Timeout waiting for editor modules')"),
+    'runtime wait helper must preserve timeout error'
+  );
+  assert.ok(
+    initSrc.includes('var runtimeReady = isPublicRuntimeReady();'),
+    'runtime wait helper must use readiness helper'
+  );
+  assert.ok(
+    initSrc.includes('setTimeout(function() { waitForModules(attempt + 1); }, waitInterval);'),
+    'runtime wait helper must preserve retry scheduling'
+  );
+  assert.ok(
+    initSrc.includes('waitForModules(0);'),
+    'runtime wait helper must start polling at attempt 0'
+  );
+  assert.ok(
+    initSrc.includes('waitForPublicRuntime(startCanvas);'),
+    'public tree load flow must consume the runtime wait helper'
+  );
+  assert.equal(
+    initSrc.includes('// Wait for all required modules\n            var maxWait = 100;'),
+    false,
+    'public tree load flow should not inline runtime wait loop'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function waitForPublicRuntime(startCanvas)') < initSrc.indexOf('function initPublicCanvas()'),
+    'runtime wait helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('function startCanvas()') < initSrc.indexOf('waitForPublicRuntime(startCanvas);'),
+    'startCanvas must be defined before runtime wait helper is invoked'
+  );
+  assert.ok(
+    initSrc.indexOf('waitForPublicRuntime(startCanvas);') < initSrc.indexOf('.catch(function(error)'),
+    'runtime wait invocation must remain before load error handling'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract the public canvas runtime polling loop into a local helper in public-canvas-init.js.
- Keep the public tree load flow focused on orchestration by consuming waitForPublicRuntime(startCanvas).
- Preserve timeout, readiness, retry scheduling, and startCanvas ordering behavior.
- Add focused contract coverage for the runtime wait helper boundary.

Validation:
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test