### PR TITLE
refactor(viewer): delegate public canvas load failure handling

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -80,6 +80,12 @@
         return false;
     }
 
+    function handlePublicCanvasLoadFailure(error) {
+        console.error('[public-canvas] Load failed:', error);
+        var container = document.getElementById('canvasArea');
+        appendPublicLoadFailureState(container, error);
+    }
+
     function isPublicRuntimeReady() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.isPublicRuntimeReady === 'function') {
@@ -465,11 +471,7 @@
             }
 
             waitForPublicRuntime(startCanvas);
-        }).catch(function(error) {
-            console.error('[public-canvas] Load failed:', error);
-            var container = document.getElementById('canvasArea');
-            appendPublicLoadFailureState(container, error);
-        });
+        }).catch(handlePublicCanvasLoadFailure);
     }
 
     function getPublicCanvasBridge() {

--- a/tests/routes/public-canvas-load-failure-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-load-failure-helper-contract.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps load failure handling behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function handlePublicCanvasLoadFailure(error)'),
+    'public canvas init must expose a local load failure helper'
+  );
+  assert.ok(
+    initSrc.includes("console.error('[public-canvas] Load failed:', error)"),
+    'load failure helper must preserve load failed logging'
+  );
+  assert.ok(
+    initSrc.includes("var container = document.getElementById('canvasArea');"),
+    'load failure helper must preserve canvasArea lookup'
+  );
+  assert.ok(
+    initSrc.includes('appendPublicLoadFailureState(container, error);'),
+    'load failure helper must append public load failure state'
+  );
+  assert.ok(
+    initSrc.includes('}).catch(handlePublicCanvasLoadFailure);'),
+    'public tree load flow must consume the load failure helper'
+  );
+  assert.equal(
+    initSrc.includes("}).catch(function(error) {\n            console.error('[public-canvas] Load failed:', error);"),
+    false,
+    'public tree load flow should not inline load failure handling'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function handlePublicCanvasLoadFailure(error)') < initSrc.indexOf('function initPublicCanvas()'),
+    'load failure helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('waitForPublicRuntime(startCanvas);') < initSrc.indexOf('}).catch(handlePublicCanvasLoadFailure);'),
+    'load failure handler must remain after runtime wait invocation'
+  );
+});

--- a/tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
@@ -65,7 +65,7 @@ test('public canvas init keeps runtime wait loop behind a local helper', () => {
     'startCanvas must be defined before runtime wait helper is invoked'
   );
   assert.ok(
-    initSrc.indexOf('waitForPublicRuntime(startCanvas);') < initSrc.indexOf('.catch(function(error)'),
+    initSrc.indexOf('waitForPublicRuntime(startCanvas);') < initSrc.indexOf('.catch(handlePublicCanvasLoadFailure)'),
     'runtime wait invocation must remain before load error handling'
   );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas load failure handling into a local helper in public-canvas-init.js.
- Keep the public tree load flow focused on orchestration by consuming handlePublicCanvasLoadFailure.
- Preserve load failure logging, canvasArea lookup, and appendPublicLoadFailureState behavior.
- Add focused contract coverage for the load failure helper boundary.

Validation:
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test