### PR TITLE
refactor(viewer): delegate public canvas runtime profile setup

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -150,6 +150,16 @@
         };
     }
 
+    function installPublicCanvasRuntimeProfile(canvas) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.installPublicMetrics === 'function') {
+            canvasEntry.installPublicMetrics(canvas);
+        }
+        if (canvasEntry && typeof canvasEntry.installPublicViewportProfile === 'function') {
+            canvasEntry.installPublicViewportProfile();
+        }
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -213,12 +223,7 @@
                 }
 
                 var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
-                if (canvasEntry && typeof canvasEntry.installPublicMetrics === 'function') {
-                    canvasEntry.installPublicMetrics(canvas);
-                }
-                if (canvasEntry && typeof canvasEntry.installPublicViewportProfile === 'function') {
-                    canvasEntry.installPublicViewportProfile();
-                }
+                installPublicCanvasRuntimeProfile(canvas);
 
                 // Delegate public canvas config helpers to entry wrapper
                 var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig === 'function'

--- a/tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps runtime profile installation behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function installPublicCanvasRuntimeProfile(canvas)'),
+    'public canvas init must expose a local runtime profile helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.installPublicMetrics(canvas);'),
+    'runtime profile helper must preserve public metrics installation'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.installPublicViewportProfile();'),
+    'runtime profile helper must preserve public viewport profile installation'
+  );
+  assert.ok(
+    initSrc.includes('installPublicCanvasRuntimeProfile(canvas);'),
+    'startCanvas must consume the runtime profile helper'
+  );
+  assert.equal(
+    initSrc.includes("if (canvasEntry && typeof canvasEntry.installPublicMetrics === 'function') {\n                    canvasEntry.installPublicMetrics(canvas);\n                }\n                if (canvasEntry && typeof canvasEntry.installPublicViewportProfile === 'function')"),
+    false,
+    'startCanvas should not inline runtime profile installation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function installPublicCanvasRuntimeProfile(canvas)') < initSrc.indexOf('function initPublicCanvas()'),
+    'runtime profile helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf("console.error('[public-canvas] Canvas or SVG element not found')") < initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);'),
+    'runtime profile installation must remain after canvas/svg guard'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);') < initSrc.indexOf('var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig'),
+    'runtime profile installation must remain before public canvas config creation'
+  );
+});

--- a/tests/routes/public-canvas-target-lookup-contract.test.cjs
+++ b/tests/routes/public-canvas-target-lookup-contract.test.cjs
@@ -51,7 +51,7 @@ test('public canvas init keeps DOM target lookup behind a local helper', () => {
     'target lookup helper must be defined before initPublicCanvas'
   );
   assert.ok(
-    initSrc.indexOf('var targets = resolvePublicCanvasTargets();') < initSrc.indexOf('installPublicMetrics'),
+    initSrc.indexOf('var targets = resolvePublicCanvasTargets();') < initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);'),
     'target lookup must happen before metrics installation'
   );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas runtime profile setup into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming installPublicCanvasRuntimeProfile(canvas).
- Preserve installPublicMetrics and installPublicViewportProfile behavior and ordering.
- Add focused contract coverage for the runtime profile helper boundary.

Validation:
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test