### PR TITLE
refactor(viewer): delegate public canvas config creation

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -160,6 +160,23 @@
         }
     }
 
+    function createPublicCanvasConfig(normalized) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createPublicCanvasConfig === 'function'
+            ? canvasEntry.createPublicCanvasConfig(normalized)
+            : {
+                resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
+                resolveHintText: function() { return ''; },
+                resolveInfoText: function() { return ''; },
+                resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
+                getTreeMemories: function() { return normalized.treeMemories; },
+                getCurrentTreeData: function() { return window.currentTreeData || {}; },
+                createInitialMemory: function(rootId) {
+                    return { id: rootId, title: normalized.treeData.title || '러브트리', parentId: null };
+                }
+            };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -225,20 +242,7 @@
                 var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
                 installPublicCanvasRuntimeProfile(canvas);
 
-                // Delegate public canvas config helpers to entry wrapper
-                var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig === 'function'
-                    ? canvasEntry.createPublicCanvasConfig(normalized)
-                    : {
-                        resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; },
-                        resolveHintText: function() { return ''; },
-                        resolveInfoText: function() { return ''; },
-                        resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; },
-                        getTreeMemories: function() { return normalized.treeMemories; },
-                        getCurrentTreeData: function() { return window.currentTreeData || {}; },
-                        createInitialMemory: function(rootId) {
-                            return { id: rootId, title: normalized.treeData.title || '러브트리', parentId: null };
-                        }
-                    };
+                var publicCanvasConfig = createPublicCanvasConfig(normalized);
 
                 // Set up empty guide UI
                 var updateCanvasEmptyGuide = canvasEntry && typeof canvasEntry.createEmptyGuideUpdater === 'function'

--- a/tests/routes/public-canvas-config-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-config-helper-contract.test.cjs
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps public canvas config behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasConfig(normalized)'),
+    'public canvas init must expose a local public canvas config helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createPublicCanvasConfig(normalized)'),
+    'public canvas config helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes("resolveTreeTitleText: function() { return normalized.treeData.title || '러브트리'; }"),
+    'public canvas config helper must preserve tree title fallback'
+  );
+  assert.ok(
+    initSrc.includes("resolveHintText: function() { return ''; }"),
+    'public canvas config helper must preserve hint fallback'
+  );
+  assert.ok(
+    initSrc.includes("resolveInfoText: function() { return ''; }"),
+    'public canvas config helper must preserve info fallback'
+  );
+  assert.ok(
+    initSrc.includes("resolveMemoryThumbnail: function(mem) { return mem && mem.thumbnail ? mem.thumbnail : ''; }"),
+    'public canvas config helper must preserve thumbnail fallback'
+  );
+  assert.ok(
+    initSrc.includes('getTreeMemories: function() { return normalized.treeMemories; }'),
+    'public canvas config helper must preserve tree memories accessor'
+  );
+  assert.ok(
+    initSrc.includes('getCurrentTreeData: function() { return window.currentTreeData || {}; }'),
+    'public canvas config helper must preserve current tree data accessor'
+  );
+  assert.ok(
+    initSrc.includes("return { id: rootId, title: normalized.treeData.title || '러브트리', parentId: null };"),
+    'public canvas config helper must preserve initial root memory fallback'
+  );
+  assert.ok(
+    initSrc.includes('var publicCanvasConfig = createPublicCanvasConfig(normalized);'),
+    'startCanvas must consume the local public canvas config helper'
+  );
+  assert.equal(
+    initSrc.includes("var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig === 'function'"),
+    false,
+    'startCanvas should not inline public canvas config delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasConfig(normalized)') < initSrc.indexOf('function initPublicCanvas()'),
+    'public canvas config helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);') < initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);'),
+    'public canvas config creation must remain after runtime profile setup'
+  );
+  assert.ok(
+    initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);') < initSrc.indexOf('// Set up empty guide UI'),
+    'public canvas config creation must remain before empty guide setup'
+  );
+});

--- a/tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
@@ -49,7 +49,7 @@ test('public canvas init keeps runtime profile installation behind a local helpe
     'runtime profile installation must remain after canvas/svg guard'
   );
   assert.ok(
-    initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);') < initSrc.indexOf('var publicCanvasConfig = canvasEntry && typeof canvasEntry.createPublicCanvasConfig'),
+    initSrc.indexOf('installPublicCanvasRuntimeProfile(canvas);') < initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);'),
     'runtime profile installation must remain before public canvas config creation'
   );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas config creation/fallback into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasConfig(normalized).
- Preserve entry-wrapper delegation and fallback config behavior.
- Add focused contract coverage for the public canvas config helper boundary.

Validation:
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test