### PR TITLE
refactor(viewer): delegate public canvas empty guide updater

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -177,6 +177,18 @@
             };
     }
 
+    function createPublicCanvasEmptyGuideUpdater(treeMemories) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createEmptyGuideUpdater === 'function'
+            ? canvasEntry.createEmptyGuideUpdater(treeMemories)
+            : function() {
+                var guide = document.getElementById('canvasEmptyGuide');
+                if (!guide) return;
+                var hasMoments = treeMemories.length > 0;
+                guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
+            };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -244,15 +256,7 @@
 
                 var publicCanvasConfig = createPublicCanvasConfig(normalized);
 
-                // Set up empty guide UI
-                var updateCanvasEmptyGuide = canvasEntry && typeof canvasEntry.createEmptyGuideUpdater === 'function'
-                    ? canvasEntry.createEmptyGuideUpdater(normalized.treeMemories)
-                    : function() {
-                        var guide = document.getElementById('canvasEmptyGuide');
-                        if (!guide) return;
-                        var hasMoments = normalized.treeMemories.length > 0;
-                        guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);
-                    };
+                var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);
 
                 // Resolve root helpers via entry wrapper with fallback
                 var rootUtils = window.LoveBudEditorUtils || {};

--- a/tests/routes/public-canvas-config-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-config-helper-contract.test.cjs
@@ -73,7 +73,7 @@ test('public canvas init keeps public canvas config behind a local helper', () =
     'public canvas config creation must remain after runtime profile setup'
   );
   assert.ok(
-    initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);') < initSrc.indexOf('// Set up empty guide UI'),
+    initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);') < initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);'),
     'public canvas config creation must remain before empty guide setup'
   );
 });

--- a/tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps empty guide updater behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasEmptyGuideUpdater(treeMemories)'),
+    'public canvas init must expose a local empty guide updater helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createEmptyGuideUpdater(treeMemories)'),
+    'empty guide updater helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes("var guide = document.getElementById('canvasEmptyGuide');"),
+    'empty guide updater helper must preserve canvasEmptyGuide lookup'
+  );
+  assert.ok(
+    initSrc.includes('if (!guide) return;'),
+    'empty guide updater helper must preserve missing guide guard'
+  );
+  assert.ok(
+    initSrc.includes('var hasMoments = treeMemories.length > 0;'),
+    'empty guide updater helper must preserve hasMoments calculation'
+  );
+  assert.ok(
+    initSrc.includes("guide.classList.toggle('editor-canvas-empty-guide-hidden', hasMoments);"),
+    'empty guide updater helper must preserve hidden class toggle'
+  );
+  assert.ok(
+    initSrc.includes('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);'),
+    'startCanvas must consume the local empty guide updater helper'
+  );
+  assert.equal(
+    initSrc.includes("var updateCanvasEmptyGuide = canvasEntry && typeof canvasEntry.createEmptyGuideUpdater === 'function'"),
+    false,
+    'startCanvas should not inline empty guide updater delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasEmptyGuideUpdater(treeMemories)') < initSrc.indexOf('function initPublicCanvas()'),
+    'empty guide updater helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var publicCanvasConfig = createPublicCanvasConfig(normalized);') < initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);'),
+    'empty guide updater creation must remain after public canvas config creation'
+  );
+  assert.ok(
+    initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);') < initSrc.indexOf('// Resolve root helpers via entry wrapper with fallback'),
+    'empty guide updater creation must remain before root helper setup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas empty guide updater creation/fallback into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasEmptyGuideUpdater(normalized.treeMemories).
- Preserve entry-wrapper delegation and canvasEmptyGuide fallback behavior.
- Add focused contract coverage for the empty guide updater helper boundary.

Validation:
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test