### PR TITLE
refactor(viewer): delegate public canvas memory helpers

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -189,6 +189,52 @@
             };
     }
 
+    function createPublicCanvasMemoryHelpers(treeMemories) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        var rootUtils = window.LoveBudEditorUtils || {};
+        var memorySelectors = canvasEntry && typeof canvasEntry.createMemorySelectors === 'function'
+            ? canvasEntry.createMemorySelectors(treeMemories)
+            : null;
+
+        var getCanonicalRootId = memorySelectors && typeof memorySelectors.getCanonicalRootId === 'function'
+            ? function() { return memorySelectors.getCanonicalRootId(); }
+            : function() {
+                if (typeof rootUtils.getCanonicalRootId === 'function') {
+                    return rootUtils.getCanonicalRootId(treeMemories);
+                }
+                var roots = treeMemories.filter(function(m) { return m.parentId === null || m.parentId === undefined; });
+                if (roots.length === 0) return 'root';
+                return roots.sort(function(a, b) {
+                    return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
+                })[0].id;
+            };
+
+        var isRootMemory = memorySelectors && typeof memorySelectors.isRootMemory === 'function'
+            ? function(mem, rootId) { return memorySelectors.isRootMemory(mem, rootId); }
+            : function(mem, rootId) {
+                if (typeof rootUtils.isRootMemory === 'function') {
+                    return rootUtils.isRootMemory(mem, rootId);
+                }
+                return !!(mem && rootId && mem.id === rootId);
+            };
+
+        var canonicalRootId = getCanonicalRootId();
+
+        var findFirstSelectableMemory = memorySelectors && typeof memorySelectors.findFirstSelectableMemory === 'function'
+            ? function() { return memorySelectors.findFirstSelectableMemory(canonicalRootId); }
+            : function() {
+                var nonRoot = treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });
+                return nonRoot.length > 0 ? nonRoot[0] : treeMemories[0] || null;
+            };
+
+        return {
+            getCanonicalRootId: getCanonicalRootId,
+            isRootMemory: isRootMemory,
+            canonicalRootId: canonicalRootId,
+            findFirstSelectableMemory: findFirstSelectableMemory
+        };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -258,42 +304,11 @@
 
                 var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);
 
-                // Resolve root helpers via entry wrapper with fallback
-                var rootUtils = window.LoveBudEditorUtils || {};
-                var memorySelectors = canvasEntry && typeof canvasEntry.createMemorySelectors === 'function'
-                    ? canvasEntry.createMemorySelectors(normalized.treeMemories)
-                    : null;
-
-                var getCanonicalRootId = memorySelectors && typeof memorySelectors.getCanonicalRootId === 'function'
-                    ? function() { return memorySelectors.getCanonicalRootId(); }
-                    : function() {
-                        if (typeof rootUtils.getCanonicalRootId === 'function') {
-                            return rootUtils.getCanonicalRootId(normalized.treeMemories);
-                        }
-                        var roots = normalized.treeMemories.filter(function(m) { return m.parentId === null || m.parentId === undefined; });
-                        if (roots.length === 0) return 'root';
-                        return roots.sort(function(a, b) {
-                            return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;
-                        })[0].id;
-                    };
-
-                var isRootMemory = memorySelectors && typeof memorySelectors.isRootMemory === 'function'
-                    ? function(mem, rootId) { return memorySelectors.isRootMemory(mem, rootId); }
-                    : function(mem, rootId) {
-                        if (typeof rootUtils.isRootMemory === 'function') {
-                            return rootUtils.isRootMemory(mem, rootId);
-                        }
-                        return !!(mem && rootId && mem.id === rootId);
-                    };
-
-                var canonicalRootId = getCanonicalRootId();
-
-                var findFirstSelectableMemory = memorySelectors && typeof memorySelectors.findFirstSelectableMemory === 'function'
-                    ? function() { return memorySelectors.findFirstSelectableMemory(canonicalRootId); }
-                    : function() {
-                        var nonRoot = normalized.treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });
-                        return nonRoot.length > 0 ? nonRoot[0] : normalized.treeMemories[0] || null;
-                    };
+                var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);
+                var getCanonicalRootId = memoryHelpers.getCanonicalRootId;
+                var isRootMemory = memoryHelpers.isRootMemory;
+                var canonicalRootId = memoryHelpers.canonicalRootId;
+                var findFirstSelectableMemory = memoryHelpers.findFirstSelectableMemory;
 
                 // Delegate read-only/no-op actions to entry wrapper
                 var readOnlyActions = canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'

--- a/tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
@@ -61,7 +61,7 @@ test('public canvas init keeps empty guide updater behind a local helper', () =>
     'empty guide updater creation must remain after public canvas config creation'
   );
   assert.ok(
-    initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);') < initSrc.indexOf('// Resolve root helpers via entry wrapper with fallback'),
+    initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);') < initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);'),
     'empty guide updater creation must remain before root helper setup'
   );
 });

--- a/tests/routes/public-canvas-memory-helpers-contract.test.cjs
+++ b/tests/routes/public-canvas-memory-helpers-contract.test.cjs
@@ -1,0 +1,107 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps memory/root helpers behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasMemoryHelpers(treeMemories)'),
+    'public canvas init must expose a local memory helpers factory'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createMemorySelectors(treeMemories)'),
+    'memory helpers factory must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('var rootUtils = window.LoveBudEditorUtils || {};'),
+    'memory helpers factory must preserve editor utils fallback'
+  );
+  assert.ok(
+    initSrc.includes('return rootUtils.getCanonicalRootId(treeMemories);'),
+    'memory helpers factory must preserve getCanonicalRootId fallback'
+  );
+  assert.ok(
+    initSrc.includes('var roots = treeMemories.filter(function(m) { return m.parentId === null || m.parentId === undefined; });'),
+    'memory helpers factory must preserve root filtering fallback'
+  );
+  assert.ok(
+    initSrc.includes("if (roots.length === 0) return 'root';"),
+    'memory helpers factory must preserve root default fallback'
+  );
+  assert.ok(
+    initSrc.includes("return (a.createdAt || '9999') > (b.createdAt || '9999') ? 1 : -1;"),
+    'memory helpers factory must preserve createdAt root sort fallback'
+  );
+  assert.ok(
+    initSrc.includes('return rootUtils.isRootMemory(mem, rootId);'),
+    'memory helpers factory must preserve isRootMemory utility fallback'
+  );
+  assert.ok(
+    initSrc.includes('return !!(mem && rootId && mem.id === rootId);'),
+    'memory helpers factory must preserve direct root memory fallback'
+  );
+  assert.ok(
+    initSrc.includes('return memorySelectors.findFirstSelectableMemory(canonicalRootId);'),
+    'memory helpers factory must preserve first selectable delegation'
+  );
+  assert.ok(
+    initSrc.includes('var nonRoot = treeMemories.filter(function(m) { return !isRootMemory(m, canonicalRootId); });'),
+    'memory helpers factory must preserve non-root selectable fallback'
+  );
+  assert.ok(
+    initSrc.includes('return nonRoot.length > 0 ? nonRoot[0] : treeMemories[0] || null;'),
+    'memory helpers factory must preserve first selectable fallback'
+  );
+  assert.ok(
+    initSrc.includes('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);'),
+    'startCanvas must consume the memory helpers factory'
+  );
+  assert.ok(
+    initSrc.includes('var getCanonicalRootId = memoryHelpers.getCanonicalRootId;'),
+    'startCanvas must keep getCanonicalRootId from helper result'
+  );
+  assert.ok(
+    initSrc.includes('var isRootMemory = memoryHelpers.isRootMemory;'),
+    'startCanvas must keep isRootMemory from helper result'
+  );
+  assert.ok(
+    initSrc.includes('var canonicalRootId = memoryHelpers.canonicalRootId;'),
+    'startCanvas must keep canonicalRootId from helper result'
+  );
+  assert.ok(
+    initSrc.includes('var findFirstSelectableMemory = memoryHelpers.findFirstSelectableMemory;'),
+    'startCanvas must keep findFirstSelectableMemory from helper result'
+  );
+  assert.equal(
+    initSrc.includes('var rootUtils = window.LoveBudEditorUtils || {};\n                var memorySelectors = canvasEntry && typeof canvasEntry.createMemorySelectors'),
+    false,
+    'startCanvas should not inline memory selector setup'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasMemoryHelpers(treeMemories)') < initSrc.indexOf('function initPublicCanvas()'),
+    'memory helpers factory must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var updateCanvasEmptyGuide = createPublicCanvasEmptyGuideUpdater(normalized.treeMemories);') < initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);'),
+    'memory helpers must remain after empty guide setup'
+  );
+  assert.ok(
+    initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);') < initSrc.indexOf('// Delegate read-only/no-op actions to entry wrapper'),
+    'memory helpers must remain before read-only action setup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas memory selector/root helper setup into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasMemoryHelpers(normalized.treeMemories).
- Preserve entry-wrapper delegation, editor utility fallbacks, root detection, and first selectable memory behavior.
- Add focused contract coverage for the memory helper boundary.

Validation:
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test