### PR TITLE
refactor(viewer): delegate public canvas read-only actions

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -235,6 +235,19 @@
         };
     }
 
+    function createPublicCanvasReadOnlyActions() {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'
+            ? canvasEntry.createReadOnlyActions()
+            : {
+                noop: function() {},
+                noopAsync: function() { return Promise.resolve(); },
+                noopFalseAsync: function() { return Promise.resolve(false); },
+                getLocalSaveMode: function() { return false; },
+                showToast: function(msg) { console.log('[public-canvas]', msg); }
+            };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -310,16 +323,7 @@
                 var canonicalRootId = memoryHelpers.canonicalRootId;
                 var findFirstSelectableMemory = memoryHelpers.findFirstSelectableMemory;
 
-                // Delegate read-only/no-op actions to entry wrapper
-                var readOnlyActions = canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'
-                    ? canvasEntry.createReadOnlyActions()
-                    : {
-                        noop: function() {},
-                        noopAsync: function() { return Promise.resolve(); },
-                        noopFalseAsync: function() { return Promise.resolve(false); },
-                        getLocalSaveMode: function() { return false; },
-                        showToast: function(msg) { console.log('[public-canvas]', msg); }
-                    };
+                var readOnlyActions = createPublicCanvasReadOnlyActions();
 
                 // Delegate selection state to entry wrapper with fallback
                 var selectionState = canvasEntry && typeof canvasEntry.createSelectionState === 'function'

--- a/tests/routes/public-canvas-memory-helpers-contract.test.cjs
+++ b/tests/routes/public-canvas-memory-helpers-contract.test.cjs
@@ -101,7 +101,7 @@ test('public canvas init keeps memory/root helpers behind a local helper', () =>
     'memory helpers must remain after empty guide setup'
   );
   assert.ok(
-    initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);') < initSrc.indexOf('// Delegate read-only/no-op actions to entry wrapper'),
+    initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);') < initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();'),
     'memory helpers must remain before read-only action setup'
   );
 });

--- a/tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps read-only actions behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasReadOnlyActions()'),
+    'public canvas init must expose a local read-only actions helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createReadOnlyActions()'),
+    'read-only actions helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('noop: function() {}'),
+    'read-only actions helper must preserve noop fallback'
+  );
+  assert.ok(
+    initSrc.includes('noopAsync: function() { return Promise.resolve(); }'),
+    'read-only actions helper must preserve async noop fallback'
+  );
+  assert.ok(
+    initSrc.includes('noopFalseAsync: function() { return Promise.resolve(false); }'),
+    'read-only actions helper must preserve false async noop fallback'
+  );
+  assert.ok(
+    initSrc.includes('getLocalSaveMode: function() { return false; }'),
+    'read-only actions helper must preserve local save mode fallback'
+  );
+  assert.ok(
+    initSrc.includes("showToast: function(msg) { console.log('[public-canvas]', msg); }"),
+    'read-only actions helper must preserve toast logging fallback'
+  );
+  assert.ok(
+    initSrc.includes('var readOnlyActions = createPublicCanvasReadOnlyActions();'),
+    'startCanvas must consume the local read-only actions helper'
+  );
+  assert.equal(
+    initSrc.includes("var readOnlyActions = canvasEntry && typeof canvasEntry.createReadOnlyActions === 'function'"),
+    false,
+    'startCanvas should not inline read-only actions delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasReadOnlyActions()') < initSrc.indexOf('function initPublicCanvas()'),
+    'read-only actions helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var memoryHelpers = createPublicCanvasMemoryHelpers(normalized.treeMemories);') < initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();'),
+    'read-only actions must remain after memory helper setup'
+  );
+  assert.ok(
+    initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();') < initSrc.indexOf('// Delegate selection state to entry wrapper with fallback'),
+    'read-only actions must remain before selection state setup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas read-only/no-op action creation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasReadOnlyActions().
- Preserve entry-wrapper delegation and no-op fallback behavior.
- Add focused contract coverage for the read-only actions helper boundary.

Validation:
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test