### PR TITLE
refactor(viewer): delegate public canvas selection state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -248,6 +248,38 @@
             };
     }
 
+    function createPublicCanvasSelectionState(canonicalRootId) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createSelectionState === 'function'
+            ? canvasEntry.createSelectionState(canonicalRootId)
+            : (function() {
+                var selectedNodeId = canonicalRootId;
+                var currentEditingMemory = null;
+
+                return {
+                    getSelectedNodeId: function() {
+                        return selectedNodeId;
+                    },
+                    setSelectedNodeId: function(nextSelectedNodeId) {
+                        selectedNodeId = nextSelectedNodeId || null;
+                        return selectedNodeId;
+                    },
+                    getCurrentEditingMemory: function() {
+                        return currentEditingMemory;
+                    },
+                    setCurrentEditingMemory: function(memory) {
+                        currentEditingMemory = memory || null;
+                        return currentEditingMemory;
+                    },
+                    selectMemory: function(memory) {
+                        currentEditingMemory = memory || null;
+                        selectedNodeId = memory && memory.id ? memory.id : selectedNodeId;
+                        return currentEditingMemory;
+                    }
+                };
+            })();
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -325,35 +357,7 @@
 
                 var readOnlyActions = createPublicCanvasReadOnlyActions();
 
-                // Delegate selection state to entry wrapper with fallback
-                var selectionState = canvasEntry && typeof canvasEntry.createSelectionState === 'function'
-                    ? canvasEntry.createSelectionState(canonicalRootId)
-                    : (function() {
-                        var selectedNodeId = canonicalRootId;
-                        var currentEditingMemory = null;
-
-                        return {
-                            getSelectedNodeId: function() {
-                                return selectedNodeId;
-                            },
-                            setSelectedNodeId: function(nextSelectedNodeId) {
-                                selectedNodeId = nextSelectedNodeId || null;
-                                return selectedNodeId;
-                            },
-                            getCurrentEditingMemory: function() {
-                                return currentEditingMemory;
-                            },
-                            setCurrentEditingMemory: function(memory) {
-                                currentEditingMemory = memory || null;
-                                return currentEditingMemory;
-                            },
-                            selectMemory: function(memory) {
-                                currentEditingMemory = memory || null;
-                                selectedNodeId = memory && memory.id ? memory.id : selectedNodeId;
-                                return currentEditingMemory;
-                            }
-                        };
-                    })();
+                var selectionState = createPublicCanvasSelectionState(canonicalRootId);
 
                 // Delegate detail UI options to entry wrapper with fallback
                 var detailUIOptions = canvasEntry && typeof canvasEntry.createDetailUIOptions === 'function'

--- a/tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
@@ -65,7 +65,7 @@ test('public canvas init keeps read-only actions behind a local helper', () => {
     'read-only actions must remain after memory helper setup'
   );
   assert.ok(
-    initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();') < initSrc.indexOf('// Delegate selection state to entry wrapper with fallback'),
+    initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();') < initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);'),
     'read-only actions must remain before selection state setup'
   );
 });

--- a/tests/routes/public-canvas-selection-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-selection-state-helper-contract.test.cjs
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps selection state behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasSelectionState(canonicalRootId)'),
+    'public canvas init must expose a local selection state helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createSelectionState(canonicalRootId)'),
+    'selection state helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('var selectedNodeId = canonicalRootId;'),
+    'selection state helper must preserve selectedNodeId initial value'
+  );
+  assert.ok(
+    initSrc.includes('var currentEditingMemory = null;'),
+    'selection state helper must preserve currentEditingMemory initial value'
+  );
+  assert.ok(
+    initSrc.includes('getSelectedNodeId: function()'),
+    'selection state helper must preserve getSelectedNodeId'
+  );
+  assert.ok(
+    initSrc.includes('setSelectedNodeId: function(nextSelectedNodeId)'),
+    'selection state helper must preserve setSelectedNodeId'
+  );
+  assert.ok(
+    initSrc.includes('selectedNodeId = nextSelectedNodeId || null;'),
+    'selection state helper must preserve selected node setter fallback'
+  );
+  assert.ok(
+    initSrc.includes('getCurrentEditingMemory: function()'),
+    'selection state helper must preserve getCurrentEditingMemory'
+  );
+  assert.ok(
+    initSrc.includes('setCurrentEditingMemory: function(memory)'),
+    'selection state helper must preserve setCurrentEditingMemory'
+  );
+  assert.ok(
+    initSrc.includes('currentEditingMemory = memory || null;'),
+    'selection state helper must preserve current editing memory setter'
+  );
+  assert.ok(
+    initSrc.includes('selectMemory: function(memory)'),
+    'selection state helper must preserve selectMemory'
+  );
+  assert.ok(
+    initSrc.includes('selectedNodeId = memory && memory.id ? memory.id : selectedNodeId;'),
+    'selection state helper must preserve selected node update on selectMemory'
+  );
+  assert.ok(
+    initSrc.includes('var selectionState = createPublicCanvasSelectionState(canonicalRootId);'),
+    'startCanvas must consume the local selection state helper'
+  );
+  assert.equal(
+    initSrc.includes("var selectionState = canvasEntry && typeof canvasEntry.createSelectionState === 'function'"),
+    false,
+    'startCanvas should not inline selection state delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasSelectionState(canonicalRootId)') < initSrc.indexOf('function initPublicCanvas()'),
+    'selection state helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var readOnlyActions = createPublicCanvasReadOnlyActions();') < initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);'),
+    'selection state must remain after read-only actions setup'
+  );
+  assert.ok(
+    initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);') < initSrc.indexOf('// Delegate detail UI options to entry wrapper with fallback'),
+    'selection state must remain before detail UI options setup'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas selection state creation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasSelectionState(canonicalRootId).
- Preserve entry-wrapper delegation and local selection/current-editing fallback behavior.
- Add focused contract coverage for the selection state helper boundary.

Validation:
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test