### PR TITLE
refactor(viewer): delegate public canvas detail options

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -280,6 +280,42 @@
             })();
     }
 
+    function createPublicCanvasDetailUIOptions(ctx) {
+        var selectionState = ctx.selectionState;
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createDetailUIOptions === 'function'
+            ? canvasEntry.createDetailUIOptions({
+                detailPanel: ctx.detailPanel,
+                i18n: function(k) { return k; },
+                publicCanvasConfig: ctx.publicCanvasConfig,
+                readOnlyActions: ctx.readOnlyActions,
+                selectionState: ctx.selectionState,
+                escapeHtml: ctx.escapeHtml,
+                isRootMemory: ctx.isRootMemory,
+                getCanonicalRootId: function() { return ctx.canonicalRootId; }
+            })
+            : {
+                detailPanel: ctx.detailPanel,
+                i18n: function(k) { return k; },
+                resolveTreeTitleText: ctx.publicCanvasConfig.resolveTreeTitleText,
+                resolveHintText: ctx.publicCanvasConfig.resolveHintText,
+                resolveInfoText: ctx.publicCanvasConfig.resolveInfoText,
+                resolveMemoryThumbnail: ctx.publicCanvasConfig.resolveMemoryThumbnail,
+                escapeHtml: ctx.escapeHtml,
+                isRootMemory: ctx.isRootMemory,
+                getCanonicalRootId: function() { return ctx.canonicalRootId; },
+                getSelectedNodeId: selectionState.getSelectedNodeId,
+                getTreeMemories: ctx.publicCanvasConfig.getTreeMemories,
+                getCurrentTreeData: ctx.publicCanvasConfig.getCurrentTreeData,
+                getLocalSaveMode: ctx.readOnlyActions.getLocalSaveMode,
+                showToast: ctx.readOnlyActions.showToast,
+                updateTreeVisibility: ctx.readOnlyActions.noopAsync,
+                openCurrentMomentDetail: ctx.readOnlyActions.noop,
+                focusSelectedMoment: ctx.readOnlyActions.noop,
+                updateSelectedMemoryFields: ctx.readOnlyActions.noopFalseAsync
+            };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -359,38 +395,15 @@
 
                 var selectionState = createPublicCanvasSelectionState(canonicalRootId);
 
-                // Delegate detail UI options to entry wrapper with fallback
-                var detailUIOptions = canvasEntry && typeof canvasEntry.createDetailUIOptions === 'function'
-                    ? canvasEntry.createDetailUIOptions({
-                        detailPanel: detailPanel,
-                        i18n: function(k) { return k; },
-                        publicCanvasConfig: publicCanvasConfig,
-                        readOnlyActions: readOnlyActions,
-                        selectionState: selectionState,
-                        escapeHtml: escapeHtml,
-                        isRootMemory: isRootMemory,
-                        getCanonicalRootId: function() { return canonicalRootId; }
-                    })
-                    : {
-                        detailPanel: detailPanel,
-                        i18n: function(k) { return k; },
-                        resolveTreeTitleText: publicCanvasConfig.resolveTreeTitleText,
-                        resolveHintText: publicCanvasConfig.resolveHintText,
-                        resolveInfoText: publicCanvasConfig.resolveInfoText,
-                        resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
-                        escapeHtml: escapeHtml,
-                        isRootMemory: isRootMemory,
-                        getCanonicalRootId: function() { return canonicalRootId; },
-                        getSelectedNodeId: selectionState.getSelectedNodeId,
-                        getTreeMemories: publicCanvasConfig.getTreeMemories,
-                        getCurrentTreeData: publicCanvasConfig.getCurrentTreeData,
-                        getLocalSaveMode: readOnlyActions.getLocalSaveMode,
-                        showToast: readOnlyActions.showToast,
-                        updateTreeVisibility: readOnlyActions.noopAsync,
-                        openCurrentMomentDetail: readOnlyActions.noop,
-                        focusSelectedMoment: readOnlyActions.noop,
-                        updateSelectedMemoryFields: readOnlyActions.noopFalseAsync
-                    };
+                var detailUIOptions = createPublicCanvasDetailUIOptions({
+                    detailPanel: detailPanel,
+                    publicCanvasConfig: publicCanvasConfig,
+                    readOnlyActions: readOnlyActions,
+                    selectionState: selectionState,
+                    escapeHtml: escapeHtml,
+                    isRootMemory: isRootMemory,
+                    canonicalRootId: canonicalRootId
+                });
 
                 var detailUI = window.createPublicViewerDetailUI(detailUIOptions);
 

--- a/tests/routes/public-canvas-detail-options-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-detail-options-helper-contract.test.cjs
@@ -1,0 +1,135 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps detail UI options behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasDetailUIOptions(ctx)'),
+    'public canvas init must expose a local detail UI options helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createDetailUIOptions({'),
+    'detail UI options helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('detailPanel: ctx.detailPanel'),
+    'detail UI options helper must preserve detailPanel'
+  );
+  assert.ok(
+    initSrc.includes('i18n: function(k) { return k; }'),
+    'detail UI options helper must preserve identity i18n fallback'
+  );
+  assert.ok(
+    initSrc.includes('publicCanvasConfig: ctx.publicCanvasConfig'),
+    'detail UI options helper must pass publicCanvasConfig to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('readOnlyActions: ctx.readOnlyActions'),
+    'detail UI options helper must pass readOnlyActions to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('selectionState: ctx.selectionState'),
+    'detail UI options helper must pass selectionState to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('escapeHtml: ctx.escapeHtml'),
+    'detail UI options helper must preserve escapeHtml'
+  );
+  assert.ok(
+    initSrc.includes('isRootMemory: ctx.isRootMemory'),
+    'detail UI options helper must preserve isRootMemory'
+  );
+  assert.ok(
+    initSrc.includes('getCanonicalRootId: function() { return ctx.canonicalRootId; }'),
+    'detail UI options helper must preserve canonical root getter'
+  );
+  assert.ok(
+    initSrc.includes('resolveTreeTitleText: ctx.publicCanvasConfig.resolveTreeTitleText'),
+    'detail UI options helper must preserve tree title resolver'
+  );
+  assert.ok(
+    initSrc.includes('resolveHintText: ctx.publicCanvasConfig.resolveHintText'),
+    'detail UI options helper must preserve hint resolver'
+  );
+  assert.ok(
+    initSrc.includes('resolveInfoText: ctx.publicCanvasConfig.resolveInfoText'),
+    'detail UI options helper must preserve info resolver'
+  );
+  assert.ok(
+    initSrc.includes('resolveMemoryThumbnail: ctx.publicCanvasConfig.resolveMemoryThumbnail'),
+    'detail UI options helper must preserve thumbnail resolver'
+  );
+  assert.ok(
+    initSrc.includes('getSelectedNodeId: selectionState.getSelectedNodeId'),
+    'detail UI options helper must preserve selected node accessor'
+  );
+  assert.ok(
+    initSrc.includes('getTreeMemories: ctx.publicCanvasConfig.getTreeMemories'),
+    'detail UI options helper must preserve tree memories accessor'
+  );
+  assert.ok(
+    initSrc.includes('getCurrentTreeData: ctx.publicCanvasConfig.getCurrentTreeData'),
+    'detail UI options helper must preserve current tree data accessor'
+  );
+  assert.ok(
+    initSrc.includes('getLocalSaveMode: ctx.readOnlyActions.getLocalSaveMode'),
+    'detail UI options helper must preserve local save mode accessor'
+  );
+  assert.ok(
+    initSrc.includes('showToast: ctx.readOnlyActions.showToast'),
+    'detail UI options helper must preserve showToast'
+  );
+  assert.ok(
+    initSrc.includes('updateTreeVisibility: ctx.readOnlyActions.noopAsync'),
+    'detail UI options helper must preserve updateTreeVisibility no-op'
+  );
+  assert.ok(
+    initSrc.includes('openCurrentMomentDetail: ctx.readOnlyActions.noop'),
+    'detail UI options helper must preserve open detail no-op'
+  );
+  assert.ok(
+    initSrc.includes('focusSelectedMoment: ctx.readOnlyActions.noop'),
+    'detail UI options helper must preserve focus selected no-op'
+  );
+  assert.ok(
+    initSrc.includes('updateSelectedMemoryFields: ctx.readOnlyActions.noopFalseAsync'),
+    'detail UI options helper must preserve update fields no-op'
+  );
+  assert.ok(
+    initSrc.includes('var detailUIOptions = createPublicCanvasDetailUIOptions({'),
+    'startCanvas must consume the local detail UI options helper'
+  );
+  assert.equal(
+    initSrc.includes("var detailUIOptions = canvasEntry && typeof canvasEntry.createDetailUIOptions === 'function'"),
+    false,
+    'startCanvas should not inline detail UI options delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasDetailUIOptions(ctx)') < initSrc.indexOf('function initPublicCanvas()'),
+    'detail UI options helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);') < initSrc.indexOf('var detailUIOptions = createPublicCanvasDetailUIOptions({'),
+    'detail UI options must remain after selection state setup'
+  );
+  assert.ok(
+    initSrc.indexOf('var detailUIOptions = createPublicCanvasDetailUIOptions({') < initSrc.indexOf('var detailUI = window.createPublicViewerDetailUI(detailUIOptions);'),
+    'detail UI options must remain before detail UI creation'
+  );
+});

--- a/tests/routes/public-canvas-selection-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-selection-state-helper-contract.test.cjs
@@ -85,7 +85,7 @@ test('public canvas init keeps selection state behind a local helper', () => {
     'selection state must remain after read-only actions setup'
   );
   assert.ok(
-    initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);') < initSrc.indexOf('// Delegate detail UI options to entry wrapper with fallback'),
+    initSrc.indexOf('var selectionState = createPublicCanvasSelectionState(canonicalRootId);') < initSrc.indexOf('var detailUIOptions = createPublicCanvasDetailUIOptions({'),
     'selection state must remain before detail UI options setup'
   );
 });


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas detail UI options creation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasDetailUIOptions(ctx).
- Preserve entry-wrapper delegation and fallback detail UI option behavior.
- Add focused contract coverage for the detail UI options helper boundary.

Validation:
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test