### PR TITLE
refactor(viewer): delegate public canvas options

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -316,6 +316,43 @@
             };
     }
 
+    function createPublicCanvasOptions(ctx) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        return canvasEntry && typeof canvasEntry.createCanvasOptions === 'function'
+            ? canvasEntry.createCanvasOptions({
+                canvas: ctx.canvas,
+                svg: ctx.svg,
+                publicCanvasConfig: ctx.publicCanvasConfig,
+                readOnlyActions: ctx.readOnlyActions,
+                getCanonicalRootId: function() { return ctx.canonicalRootId; },
+                isRootMemory: ctx.isRootMemory,
+                updateDetailPanel: ctx.updateDetailPanel,
+                setDetailEmptyState: ctx.setDetailEmptyState,
+                updateFocusSelectedBtn: ctx.updateFocusSelectedBtn,
+                createInitialMemory: function() {
+                    return ctx.publicCanvasConfig.createInitialMemory(ctx.canonicalRootId);
+                },
+                onNodeClick: ctx.onNodeClick
+            })
+            : {
+                canvas: ctx.canvas,
+                svg: ctx.svg,
+                getTreeMemories: ctx.publicCanvasConfig.getTreeMemories,
+                getCanonicalRootId: function() { return ctx.canonicalRootId; },
+                isRootMemory: ctx.isRootMemory,
+                resolveMemoryThumbnail: ctx.publicCanvasConfig.resolveMemoryThumbnail,
+                updateDetailPanel: ctx.updateDetailPanel,
+                setDetailEmptyState: ctx.setDetailEmptyState,
+                updateFocusSelectedBtn: ctx.updateFocusSelectedBtn,
+                createInitialMemory: function() {
+                    return ctx.publicCanvasConfig.createInitialMemory(ctx.canonicalRootId);
+                },
+                onNodeClick: ctx.onNodeClick,
+                openAddMoment: ctx.readOnlyActions.noop,
+                canEdit: false
+            };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -432,39 +469,18 @@
                     }
                 };
 
-                var canvasOptions = canvasEntry && typeof canvasEntry.createCanvasOptions === 'function'
-                    ? canvasEntry.createCanvasOptions({
-                        canvas: canvas,
-                        svg: svg,
-                        publicCanvasConfig: publicCanvasConfig,
-                        readOnlyActions: readOnlyActions,
-                        getCanonicalRootId: function() { return canonicalRootId; },
-                        isRootMemory: isRootMemory,
-                        updateDetailPanel: updateDetailPanel,
-                        setDetailEmptyState: setDetailEmptyState,
-                        updateFocusSelectedBtn: updateFocusSelectedBtn,
-                        createInitialMemory: function() {
-                            return publicCanvasConfig.createInitialMemory(canonicalRootId);
-                        },
-                        onNodeClick: onPublicCanvasNodeClick
-                    })
-                    : {
-                        canvas: canvas,
-                        svg: svg,
-                        getTreeMemories: publicCanvasConfig.getTreeMemories,
-                        getCanonicalRootId: function() { return canonicalRootId; },
-                        isRootMemory: isRootMemory,
-                        resolveMemoryThumbnail: publicCanvasConfig.resolveMemoryThumbnail,
-                        updateDetailPanel: updateDetailPanel,
-                        setDetailEmptyState: setDetailEmptyState,
-                        updateFocusSelectedBtn: updateFocusSelectedBtn,
-                        createInitialMemory: function() {
-                            return publicCanvasConfig.createInitialMemory(canonicalRootId);
-                        },
-                        onNodeClick: onPublicCanvasNodeClick,
-                        openAddMoment: readOnlyActions.noop,
-                        canEdit: false
-                    };
+                var canvasOptions = createPublicCanvasOptions({
+                    canvas: canvas,
+                    svg: svg,
+                    publicCanvasConfig: publicCanvasConfig,
+                    readOnlyActions: readOnlyActions,
+                    canonicalRootId: canonicalRootId,
+                    isRootMemory: isRootMemory,
+                    updateDetailPanel: updateDetailPanel,
+                    setDetailEmptyState: setDetailEmptyState,
+                    updateFocusSelectedBtn: updateFocusSelectedBtn,
+                    onNodeClick: onPublicCanvasNodeClick
+                });
 
                 var editorCanvas = createPublicEditorCanvas(canvasOptions);
 

--- a/tests/routes/public-canvas-detail-options-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-detail-options-helper-contract.test.cjs
@@ -132,4 +132,8 @@ test('public canvas init keeps detail UI options behind a local helper', () => {
     initSrc.indexOf('var detailUIOptions = createPublicCanvasDetailUIOptions({') < initSrc.indexOf('var detailUI = window.createPublicViewerDetailUI(detailUIOptions);'),
     'detail UI options must remain before detail UI creation'
   );
+  assert.ok(
+    initSrc.indexOf('var detailUI = window.createPublicViewerDetailUI(detailUIOptions);') < initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({'),
+    'detail UI creation must remain before canvas options creation'
+  );
 });

--- a/tests/routes/public-canvas-options-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-options-helper-contract.test.cjs
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps canvas options behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasOptions(ctx)'),
+    'public canvas init must expose a local canvas options helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.createCanvasOptions({'),
+    'canvas options helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('canvas: ctx.canvas'),
+    'canvas options helper must preserve canvas'
+  );
+  assert.ok(
+    initSrc.includes('svg: ctx.svg'),
+    'canvas options helper must preserve svg'
+  );
+  assert.ok(
+    initSrc.includes('publicCanvasConfig: ctx.publicCanvasConfig'),
+    'canvas options helper must pass publicCanvasConfig to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('readOnlyActions: ctx.readOnlyActions'),
+    'canvas options helper must pass readOnlyActions to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('getCanonicalRootId: function() { return ctx.canonicalRootId; }'),
+    'canvas options helper must preserve canonical root getter'
+  );
+  assert.ok(
+    initSrc.includes('isRootMemory: ctx.isRootMemory'),
+    'canvas options helper must preserve isRootMemory'
+  );
+  assert.ok(
+    initSrc.includes('updateDetailPanel: ctx.updateDetailPanel'),
+    'canvas options helper must preserve updateDetailPanel'
+  );
+  assert.ok(
+    initSrc.includes('setDetailEmptyState: ctx.setDetailEmptyState'),
+    'canvas options helper must preserve setDetailEmptyState'
+  );
+  assert.ok(
+    initSrc.includes('updateFocusSelectedBtn: ctx.updateFocusSelectedBtn'),
+    'canvas options helper must preserve updateFocusSelectedBtn'
+  );
+  assert.ok(
+    initSrc.includes('return ctx.publicCanvasConfig.createInitialMemory(ctx.canonicalRootId);'),
+    'canvas options helper must preserve initial memory creation'
+  );
+  assert.ok(
+    initSrc.includes('onNodeClick: ctx.onNodeClick'),
+    'canvas options helper must preserve onNodeClick'
+  );
+  assert.ok(
+    initSrc.includes('getTreeMemories: ctx.publicCanvasConfig.getTreeMemories'),
+    'canvas options fallback must preserve getTreeMemories'
+  );
+  assert.ok(
+    initSrc.includes('resolveMemoryThumbnail: ctx.publicCanvasConfig.resolveMemoryThumbnail'),
+    'canvas options fallback must preserve thumbnail resolver'
+  );
+  assert.ok(
+    initSrc.includes('openAddMoment: ctx.readOnlyActions.noop'),
+    'canvas options fallback must preserve add moment no-op'
+  );
+  assert.ok(
+    initSrc.includes('canEdit: false'),
+    'canvas options fallback must preserve read-only canEdit flag'
+  );
+  assert.ok(
+    initSrc.includes('var canvasOptions = createPublicCanvasOptions({'),
+    'startCanvas must consume the local canvas options helper'
+  );
+  assert.equal(
+    initSrc.includes("var canvasOptions = canvasEntry && typeof canvasEntry.createCanvasOptions === 'function'"),
+    false,
+    'startCanvas should not inline canvas options delegation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasOptions(ctx)') < initSrc.indexOf('function initPublicCanvas()'),
+    'canvas options helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var onPublicCanvasNodeClick = function(el, data)') < initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({'),
+    'canvas options must remain after public canvas click handler'
+  );
+  assert.ok(
+    initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({') < initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    'canvas options must remain before editor canvas creation'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas options creation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasOptions(ctx).
- Preserve entry-wrapper delegation and fallback read-only canvas option behavior.
- Add focused contract coverage for the canvas options helper boundary.

Validation:
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test