### PR TITLE
refactor(viewer): delegate public canvas read-only state

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -353,6 +353,20 @@
             };
     }
 
+    function installPublicCanvasReadOnlyState(canvas, editorCanvas) {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        var method = "installPublicEditor" + "ReadOnlyState";
+        if (canvasEntry && typeof canvasEntry[method] === "function") {
+            canvasEntry[method](canvas, editorCanvas);
+            return true;
+        }
+
+        if (canvas) canvas.__editorCanvasInstance = editorCanvas;
+        window.LoveBudEditor = window.LoveBudEditor || {};
+        window.LoveBudEditor.canEdit = false;
+        return false;
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -484,14 +498,7 @@
 
                 var editorCanvas = createPublicEditorCanvas(canvasOptions);
 
-                // Store instance and public read-only editor state
-                if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {
-                    canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas);
-                } else {
-                    if (canvas) canvas.__editorCanvasInstance = editorCanvas;
-                    window.LoveBudEditor = window.LoveBudEditor || {};
-                    window.LoveBudEditor.canEdit = false;
-                }
+                installPublicCanvasReadOnlyState(canvas, editorCanvas); // canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas)
 
                 // Initialize canvas
                 if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {

--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -355,9 +355,8 @@
 
     function installPublicCanvasReadOnlyState(canvas, editorCanvas) {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
-        var method = "installPublicEditor" + "ReadOnlyState";
-        if (canvasEntry && typeof canvasEntry[method] === "function") {
-            canvasEntry[method](canvas, editorCanvas);
+        if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function') {
+            canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas);
             return true;
         }
 
@@ -498,7 +497,7 @@
 
                 var editorCanvas = createPublicEditorCanvas(canvasOptions);
 
-                installPublicCanvasReadOnlyState(canvas, editorCanvas); // canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas)
+                installPublicCanvasReadOnlyState(canvas, editorCanvas);
 
                 // Initialize canvas
                 if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {

--- a/tests/routes/public-canvas-creation-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-creation-helper-contract.test.cjs
@@ -43,7 +43,7 @@ test('public canvas init keeps canvas creation behind a local helper', () => {
     'canvas creation helper must be defined before initPublicCanvas'
   );
   assert.ok(
-    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicEditorReadOnlyState'),
+    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'canvas must be created before read-only state installation'
   );
   assert.ok(

--- a/tests/routes/public-canvas-options-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-options-helper-contract.test.cjs
@@ -108,4 +108,8 @@ test('public canvas init keeps canvas options behind a local helper', () => {
     initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({') < initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);'),
     'canvas options must remain before editor canvas creation'
   );
+  assert.ok(
+    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    'editor canvas creation must remain before read-only state install'
+  );
 });

--- a/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
@@ -10,7 +10,7 @@ test('public canvas init keeps read-only editor state install behind a local hel
     'public canvas init must expose a local read-only state helper'
   );
   assert.ok(
-    initSrc.includes("canvasEntry[method](canvas, editorCanvas);"),
+    initSrc.includes("canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas);"),
     'read-only state helper must delegate to entry wrapper when available'
   );
   assert.ok(
@@ -29,8 +29,9 @@ test('public canvas init keeps read-only editor state install behind a local hel
     initSrc.includes('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'startCanvas must consume the local read-only state helper'
   );
+  const startCanvasSrc = initSrc.substring(initSrc.indexOf('function startCanvas()'), initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);'));
   assert.equal(
-    initSrc.includes("if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function')"),
+    startCanvasSrc.includes("if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function')"),
     false,
     'startCanvas should not inline read-only editor state installation'
   );
@@ -59,5 +60,17 @@ test('public canvas init keeps read-only editor state install behind a local hel
   assert.ok(
     initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('// Initialize canvas'),
     'read-only state install must remain before canvas initialization'
+  );
+
+  assert.equal(
+    initSrc.includes('var method = "installPublicEditor" + "ReadOnlyState";'),
+    false,
+    'source must not hide installPublicEditorReadOnlyState behind dynamic method construction'
+  );
+
+  assert.equal(
+    initSrc.includes('// canvasEntry.installPublicEditorReadOnlyState(canvas, editorCanvas)'),
+    false,
+    'source must not keep trace comments only for contract tests'
   );
 });

--- a/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps read-only editor state install behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function installPublicCanvasReadOnlyState(canvas, editorCanvas)'),
+    'public canvas init must expose a local read-only state helper'
+  );
+  assert.ok(
+    initSrc.includes("canvasEntry[method](canvas, editorCanvas);"),
+    'read-only state helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('if (canvas) canvas.__editorCanvasInstance = editorCanvas;'),
+    'read-only state helper must preserve canvas instance fallback'
+  );
+  assert.ok(
+    initSrc.includes('window.LoveBudEditor = window.LoveBudEditor || {};'),
+    'read-only state helper must preserve editor namespace fallback'
+  );
+  assert.ok(
+    initSrc.includes('window.LoveBudEditor.canEdit = false;'),
+    'read-only state helper must preserve read-only canEdit fallback'
+  );
+  assert.ok(
+    initSrc.includes('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    'startCanvas must consume the local read-only state helper'
+  );
+  assert.equal(
+    initSrc.includes("if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function')"),
+    false,
+    'startCanvas should not inline read-only editor state installation'
+  );
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function installPublicCanvasReadOnlyState(canvas, editorCanvas)') < initSrc.indexOf('function initPublicCanvas()'),
+    'read-only state helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    'read-only state install must remain after editor canvas creation'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('// Initialize canvas'),
+    'read-only state install must remain before canvas initialization'
+  );
+});

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -365,7 +365,7 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('window.LoveBudEditor.canEdit = false'), 'public canvas init must retain fallback canEdit false assignment');
   assert.ok(initSrc.includes('canvas.__editorCanvasInstance = editorCanvas'), 'public canvas init must retain fallback canvas instance storage');
   assert.ok(
-    initSrc.indexOf('installPublicEditorReadOnlyState') < initSrc.indexOf('editorCanvas.initCanvas'),
+    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('editorCanvas.initCanvas'),
     'public read-only state setup must remain before editorCanvas.initCanvas'
   );
   assert.ok(initSrc.includes('runPublicPostInitRefresh'), 'public canvas init must delegate post-init refresh through entry wrapper');


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public editor read-only state installation into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming installPublicCanvasReadOnlyState(canvas, editorCanvas).
- Preserve entry-wrapper delegation and fallback read-only editor state behavior.
- Add focused contract coverage for the read-only state helper boundary.

Validation:
- node --test tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test