### PR TITLE
refactor(viewer): delegate public canvas initialization guard

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -366,6 +366,14 @@
         return false;
     }
 
+    function initializePublicEditorCanvas(editorCanvas) {
+        if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {
+            editorCanvas.initCanvas();
+            return true;
+        }
+        return false;
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -499,10 +507,7 @@
 
                 installPublicCanvasReadOnlyState(canvas, editorCanvas);
 
-                // Initialize canvas
-                if (editorCanvas && typeof editorCanvas.initCanvas === 'function') {
-                    editorCanvas.initCanvas();
-                }
+                initializePublicEditorCanvas(editorCanvas);
 
                 // Refresh public canvas UI after initialization
                 if (canvasEntry && typeof canvasEntry.runPublicPostInitRefresh === 'function') {

--- a/tests/routes/public-canvas-init-guard-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-init-guard-helper-contract.test.cjs
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps editor canvas initialization behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function initializePublicEditorCanvas(editorCanvas)'),
+    'public canvas init must expose a local editor canvas init helper'
+  );
+  assert.ok(
+    initSrc.includes("if (editorCanvas && typeof editorCanvas.initCanvas === 'function')"),
+    'editor canvas init helper must preserve initCanvas guard'
+  );
+  assert.ok(
+    initSrc.includes('editorCanvas.initCanvas();'),
+    'editor canvas init helper must preserve initCanvas call'
+  );
+  assert.ok(
+    initSrc.includes('return true;'),
+    'editor canvas init helper must return true after initialization'
+  );
+  assert.ok(
+    initSrc.includes('return false;'),
+    'editor canvas init helper must return false when initialization is skipped'
+  );
+  assert.ok(
+    initSrc.includes('initializePublicEditorCanvas(editorCanvas);'),
+    'startCanvas must consume the local editor canvas init helper'
+  );
+
+  const startCanvasSrc = initSrc.substring(
+    initSrc.indexOf('function startCanvas()'),
+    initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')")
+  );
+
+  assert.equal(
+    startCanvasSrc.includes("if (editorCanvas && typeof editorCanvas.initCanvas === 'function')"),
+    false,
+    'startCanvas should not inline editorCanvas.initCanvas guard'
+  );
+
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function initializePublicEditorCanvas(editorCanvas)') < initSrc.indexOf('function initPublicCanvas()'),
+    'editor canvas init helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);'),
+    'editor canvas init must remain after read-only state installation'
+  );
+  assert.ok(
+    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('// Refresh public canvas UI after initialization'),
+    'editor canvas init must remain before post-init refresh'
+  );
+});

--- a/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
@@ -58,8 +58,12 @@ test('public canvas init keeps read-only editor state install behind a local hel
     'read-only state install must remain after editor canvas creation'
   );
   assert.ok(
-    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('// Initialize canvas'),
+    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);'),
     'read-only state install must remain before canvas initialization'
+  );
+  assert.ok(
+    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('// Refresh public canvas UI after initialization'),
+    'editor canvas initialization must remain before post-init refresh'
   );
 
   assert.equal(

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -365,7 +365,7 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   assert.ok(initSrc.includes('window.LoveBudEditor.canEdit = false'), 'public canvas init must retain fallback canEdit false assignment');
   assert.ok(initSrc.includes('canvas.__editorCanvasInstance = editorCanvas'), 'public canvas init must retain fallback canvas instance storage');
   assert.ok(
-    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('editorCanvas.initCanvas'),
+    initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);') < initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);'),
     'public read-only state setup must remain before editorCanvas.initCanvas'
   );
   assert.ok(initSrc.includes('runPublicPostInitRefresh'), 'public canvas init must delegate post-init refresh through entry wrapper');


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public editor canvas initialization guard into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming initializePublicEditorCanvas(editorCanvas).
- Preserve initCanvas guard behavior and ordering before post-init refresh.
- Add focused contract coverage for the editor canvas init helper boundary.

Validation:
- node --test tests/routes/public-canvas-init-guard-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test