### PR TITLE
refactor(viewer): delegate public canvas post-init refresh

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -374,6 +374,36 @@
         return false;
     }
 
+    function runPublicCanvasPostInitRefresh(ctx) {
+        var updateCanvasEmptyGuide = ctx.updateCanvasEmptyGuide;
+        var updateSidebarStatus = ctx.updateSidebarStatus;
+        var selectionState = ctx.selectionState;
+        var updateDetailPanel = ctx.updateDetailPanel;
+        var setDetailEmptyState = ctx.setDetailEmptyState;
+
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.runPublicPostInitRefresh === 'function') {
+            canvasEntry.runPublicPostInitRefresh({
+                updateCanvasEmptyGuide: updateCanvasEmptyGuide,
+                updateSidebarStatus: updateSidebarStatus,
+                selectionState: selectionState,
+                updateDetailPanel: updateDetailPanel,
+                setDetailEmptyState: setDetailEmptyState
+            });
+            return true;
+        }
+
+        updateCanvasEmptyGuide();
+        updateSidebarStatus();
+
+        var currentEditingMemory = selectionState.getCurrentEditingMemory();
+        if (currentEditingMemory) {
+            updateDetailPanel(currentEditingMemory);
+            setDetailEmptyState(false);
+        }
+        return false;
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -509,25 +539,13 @@
 
                 initializePublicEditorCanvas(editorCanvas);
 
-                // Refresh public canvas UI after initialization
-                if (canvasEntry && typeof canvasEntry.runPublicPostInitRefresh === 'function') {
-                    canvasEntry.runPublicPostInitRefresh({
-                        updateCanvasEmptyGuide: updateCanvasEmptyGuide,
-                        updateSidebarStatus: updateSidebarStatus,
-                        selectionState: selectionState,
-                        updateDetailPanel: updateDetailPanel,
-                        setDetailEmptyState: setDetailEmptyState
-                    });
-                } else {
-                    updateCanvasEmptyGuide();
-                    updateSidebarStatus();
-
-                    var currentEditingMemory = selectionState.getCurrentEditingMemory();
-                    if (currentEditingMemory) {
-                        updateDetailPanel(currentEditingMemory);
-                        setDetailEmptyState(false);
-                    }
-                }
+                runPublicCanvasPostInitRefresh({
+                    updateCanvasEmptyGuide: updateCanvasEmptyGuide,
+                    updateSidebarStatus: updateSidebarStatus,
+                    selectionState: selectionState,
+                    updateDetailPanel: updateDetailPanel,
+                    setDetailEmptyState: setDetailEmptyState
+                });
 
                 console.log('[public-canvas] Canvas initialized successfully');
 

--- a/tests/routes/public-canvas-init-guard-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-init-guard-helper-contract.test.cjs
@@ -64,7 +64,7 @@ test('public canvas init keeps editor canvas initialization behind a local helpe
     'editor canvas init must remain after read-only state installation'
   );
   assert.ok(
-    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('// Refresh public canvas UI after initialization'),
+    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('runPublicCanvasPostInitRefresh({'),
     'editor canvas init must remain before post-init refresh'
   );
 });

--- a/tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps post-init refresh behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function runPublicCanvasPostInitRefresh(ctx)'),
+    'public canvas init must expose a local post-init refresh helper'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.runPublicPostInitRefresh({'),
+    'post-init refresh helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('updateCanvasEmptyGuide: updateCanvasEmptyGuide'),
+    'post-init refresh helper must pass empty guide updater to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('updateSidebarStatus: updateSidebarStatus'),
+    'post-init refresh helper must pass sidebar updater to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('selectionState: selectionState'),
+    'post-init refresh helper must pass selectionState to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('updateDetailPanel: updateDetailPanel'),
+    'post-init refresh helper must pass detail panel updater to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('setDetailEmptyState: setDetailEmptyState'),
+    'post-init refresh helper must pass empty state updater to entry wrapper'
+  );
+  assert.ok(
+    initSrc.includes('updateCanvasEmptyGuide();'),
+    'post-init refresh helper must preserve fallback empty guide updater call'
+  );
+  assert.ok(
+    initSrc.includes('updateSidebarStatus();'),
+    'post-init refresh helper must preserve fallback sidebar updater call'
+  );
+  assert.ok(
+    initSrc.includes('var currentEditingMemory = selectionState.getCurrentEditingMemory();'),
+    'post-init refresh helper must preserve fallback current memory lookup'
+  );
+  assert.ok(
+    initSrc.includes('updateDetailPanel(currentEditingMemory);'),
+    'post-init refresh helper must preserve fallback detail panel refresh'
+  );
+  assert.ok(
+    initSrc.includes('setDetailEmptyState(false);'),
+    'post-init refresh helper must preserve fallback empty state hide'
+  );
+  assert.ok(
+    initSrc.includes('runPublicCanvasPostInitRefresh({'),
+    'startCanvas must consume the local post-init refresh helper'
+  );
+
+  const startCanvasSrc = initSrc.substring(
+    initSrc.indexOf('function startCanvas()'),
+    initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')")
+  );
+
+  assert.equal(
+    startCanvasSrc.includes('canvasEntry.runPublicPostInitRefresh({'),
+    false,
+    'startCanvas should not inline runPublicPostInitRefresh delegation'
+  );
+
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function runPublicCanvasPostInitRefresh(ctx)') < initSrc.indexOf('function initPublicCanvas()'),
+    'post-init refresh helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('runPublicCanvasPostInitRefresh({'),
+    'post-init refresh helper call must remain after editor canvas initialization'
+  );
+  assert.ok(
+    initSrc.indexOf('runPublicCanvasPostInitRefresh({') < initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')"),
+    'post-init refresh helper call must remain before post-init logging'
+  );
+});

--- a/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
@@ -62,7 +62,7 @@ test('public canvas init keeps read-only editor state install behind a local hel
     'read-only state install must remain before canvas initialization'
   );
   assert.ok(
-    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('// Refresh public canvas UI after initialization'),
+    initSrc.indexOf('initializePublicEditorCanvas(editorCanvas);') < initSrc.indexOf('runPublicCanvasPostInitRefresh({'),
     'editor canvas initialization must remain before post-init refresh'
   );
 


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas post-init refresh block into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming runPublicCanvasPostInitRefresh(ctx).
- Preserve delegation and fallback UI refreshes after canvas init.
- Add focused contract coverage for the post-init refresh helper boundary.

Validation:
- node --test tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test