### PR TITLE
refactor(viewer): delegate public canvas toolbar compact mode

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -404,6 +404,26 @@
         return false;
     }
 
+    function installPublicCanvasToolbarCompactMode() {
+        var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
+        if (canvasEntry && typeof canvasEntry.installToolbarCompactMode === 'function') {
+            canvasEntry.installToolbarCompactMode();
+            return true;
+        }
+
+        var compactMql = window.matchMedia('(max-width: 480px)');
+
+        function updateToolbarCompact(e) {
+            var tb = document.querySelector('.editor-canvas-toolbar');
+            if (!tb) return;
+            tb.classList.toggle('is-compact', e.matches);
+        }
+
+        updateToolbarCompact(compactMql);
+        compactMql.addEventListener('change', updateToolbarCompact);
+        return false;
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -549,19 +569,7 @@
 
                 console.log('[public-canvas] Canvas initialized successfully');
 
-                // Auto-enable compact mode on narrow viewports (toolbar labels would overflow)
-                if (canvasEntry && typeof canvasEntry.installToolbarCompactMode === 'function') {
-                    canvasEntry.installToolbarCompactMode();
-                } else {
-                    var compactMql = window.matchMedia('(max-width: 480px)');
-                    function updateToolbarCompact(e) {
-                        var tb = document.querySelector('.editor-canvas-toolbar');
-                        if (!tb) return;
-                        tb.classList.toggle('is-compact', e.matches);
-                    }
-                    updateToolbarCompact(compactMql);
-                    compactMql.addEventListener('change', updateToolbarCompact);
-                }
+                installPublicCanvasToolbarCompactMode();
             }
 
             waitForPublicRuntime(startCanvas);

--- a/tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
@@ -95,4 +95,8 @@ test('public canvas init keeps post-init refresh behind a local helper', () => {
     initSrc.indexOf('runPublicCanvasPostInitRefresh({') < initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')"),
     'post-init refresh helper call must remain before post-init logging'
   );
+  assert.ok(
+    initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')") < initSrc.indexOf('installPublicCanvasToolbarCompactMode();'),
+    'successful initialization logging must remain before toolbar compact mode setup'
+  );
 });

--- a/tests/routes/public-canvas-toolbar-compact-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-toolbar-compact-helper-contract.test.cjs
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps toolbar compact mode behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function installPublicCanvasToolbarCompactMode()'),
+    'public canvas init must expose a local toolbar compact mode helper'
+  );
+  assert.ok(
+    initSrc.includes("if (canvasEntry && typeof canvasEntry.installToolbarCompactMode === 'function')"),
+    'toolbar compact helper must delegate to entry wrapper when available'
+  );
+  assert.ok(
+    initSrc.includes('canvasEntry.installToolbarCompactMode();'),
+    'toolbar compact helper must preserve entry wrapper call'
+  );
+  assert.ok(
+    initSrc.includes("var compactMql = window.matchMedia('(max-width: 480px)');"),
+    'toolbar compact helper must preserve compact media query'
+  );
+  assert.ok(
+    initSrc.includes('function updateToolbarCompact(e)'),
+    'toolbar compact helper must preserve compact update callback'
+  );
+  assert.ok(
+    initSrc.includes("var tb = document.querySelector('.editor-canvas-toolbar');"),
+    'toolbar compact helper must preserve toolbar lookup'
+  );
+  assert.ok(
+    initSrc.includes('if (!tb) return;'),
+    'toolbar compact helper must preserve missing toolbar guard'
+  );
+  assert.ok(
+    initSrc.includes("tb.classList.toggle('is-compact', e.matches);"),
+    'toolbar compact helper must preserve compact class toggle'
+  );
+  assert.ok(
+    initSrc.includes('updateToolbarCompact(compactMql);'),
+    'toolbar compact helper must preserve immediate compact sync'
+  );
+  assert.ok(
+    initSrc.includes("compactMql.addEventListener('change', updateToolbarCompact);"),
+    'toolbar compact helper must preserve media query change listener'
+  );
+  assert.ok(
+    initSrc.includes('installPublicCanvasToolbarCompactMode();'),
+    'startCanvas must consume the local toolbar compact mode helper'
+  );
+
+  const startCanvasSrc = initSrc.substring(
+    initSrc.indexOf('function startCanvas()'),
+    initSrc.indexOf('waitForPublicRuntime(startCanvas);')
+  );
+
+  assert.equal(
+    startCanvasSrc.includes("if (canvasEntry && typeof canvasEntry.installToolbarCompactMode === 'function')"),
+    false,
+    'startCanvas should not inline toolbar compact mode delegation'
+  );
+
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function installPublicCanvasToolbarCompactMode()') < initSrc.indexOf('function initPublicCanvas()'),
+    'toolbar compact helper must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf("console.log('[public-canvas] Canvas initialized successfully')") < initSrc.indexOf('installPublicCanvasToolbarCompactMode();'),
+    'toolbar compact mode must remain after successful initialization logging'
+  );
+  assert.ok(
+    initSrc.indexOf('installPublicCanvasToolbarCompactMode();') < initSrc.indexOf('waitForPublicRuntime(startCanvas);'),
+    'toolbar compact mode install must remain inside startCanvas before runtime wait scheduling exits'
+  );
+});


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas toolbar compact mode handling into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming installPublicCanvasToolbarCompactMode().
- Preserve entry-wrapper delegation and fallback matchMedia compact toolbar behavior.
- Add focused contract coverage for the toolbar compact mode helper boundary.

Validation:
- node --test tests/routes/public-canvas-toolbar-compact-helper-contract.test.cjs
- node --test tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
- node --test tests/routes/public-canvas-init-guard-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test