### PR TITLE
refactor(viewer): delegate public canvas node click handling

### DIFF
--- a/js/viewer/public-canvas-init.js
+++ b/js/viewer/public-canvas-init.js
@@ -424,6 +424,23 @@
         return false;
     }
 
+    function createPublicCanvasNodeClickHandler(ctx) {
+        return function(el, data) {
+            if (!data) return;
+            ctx.selectionState.selectMemory(data);
+            document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
+            if (el) el.classList.add('selected');
+            ctx.updateDetailPanel(data);
+            ctx.updateFocusSelectedBtn();
+            ctx.setDetailEmptyState(false);
+
+            var editorCanvas = typeof ctx.getEditorCanvas === 'function' ? ctx.getEditorCanvas() : null;
+            if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
+                editorCanvas.updateAffordance();
+            }
+        };
+    }
+
     function setupPublicRoute() {
         var canvasEntry = window.LoveBudPublicViewerCanvasEntry;
         if (canvasEntry && typeof canvasEntry.setupPublicRoute === 'function') {
@@ -527,18 +544,14 @@
                 }
 
                 // Create canvas instance
-                var onPublicCanvasNodeClick = function(el, data) {
-                    if (!data) return;
-                    selectionState.selectMemory(data);
-                    document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });
-                    if (el) el.classList.add('selected');
-                    updateDetailPanel(data);
-                    updateFocusSelectedBtn();
-                    setDetailEmptyState(false);
-                    if (editorCanvas && typeof editorCanvas.updateAffordance === 'function') {
-                        editorCanvas.updateAffordance();
-                    }
-                };
+                var editorCanvas;
+                var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({
+                    selectionState: selectionState,
+                    updateDetailPanel: updateDetailPanel,
+                    updateFocusSelectedBtn: updateFocusSelectedBtn,
+                    setDetailEmptyState: setDetailEmptyState,
+                    getEditorCanvas: function() { return editorCanvas; }
+                });
 
                 var canvasOptions = createPublicCanvasOptions({
                     canvas: canvas,
@@ -553,7 +566,7 @@
                     onNodeClick: onPublicCanvasNodeClick
                 });
 
-                var editorCanvas = createPublicEditorCanvas(canvasOptions);
+                editorCanvas = createPublicEditorCanvas(canvasOptions);
 
                 installPublicCanvasReadOnlyState(canvas, editorCanvas);
 

--- a/tests/routes/public-canvas-creation-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-creation-helper-contract.test.cjs
@@ -30,7 +30,7 @@ test('public canvas init keeps canvas creation behind a local helper', () => {
     'canvas creation helper must return the created editor canvas'
   );
   assert.ok(
-    initSrc.includes('var editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    initSrc.includes('editorCanvas = createPublicEditorCanvas(canvasOptions);'),
     'startCanvas must consume the local canvas creation helper'
   );
   assert.equal(
@@ -43,7 +43,7 @@ test('public canvas init keeps canvas creation behind a local helper', () => {
     'canvas creation helper must be defined before initPublicCanvas'
   );
   assert.ok(
-    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'canvas must be created before read-only state installation'
   );
   assert.ok(

--- a/tests/routes/public-canvas-node-click-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-node-click-helper-contract.test.cjs
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+test('public canvas init keeps node click handling behind a local helper', () => {
+  const initSrc = fs.readFileSync('js/viewer/public-canvas-init.js', 'utf8');
+
+  assert.ok(
+    initSrc.includes('function createPublicCanvasNodeClickHandler(ctx)'),
+    'public canvas init must expose a local node click handler factory'
+  );
+  assert.ok(
+    initSrc.includes('return function(el, data)'),
+    'node click helper must return an event handler'
+  );
+  assert.ok(
+    initSrc.includes('if (!data) return;'),
+    'node click helper must preserve missing data guard'
+  );
+  assert.ok(
+    initSrc.includes('ctx.selectionState.selectMemory(data);'),
+    'node click helper must preserve selection update'
+  );
+  assert.ok(
+    initSrc.includes("document.querySelectorAll('.memory-node').forEach(function(n) { n.classList.remove('selected'); });"),
+    'node click helper must preserve selected class reset'
+  );
+  assert.ok(
+    initSrc.includes("if (el) el.classList.add('selected');"),
+    'node click helper must preserve clicked element selected class'
+  );
+  assert.ok(
+    initSrc.includes('ctx.updateDetailPanel(data);'),
+    'node click helper must preserve detail panel update'
+  );
+  assert.ok(
+    initSrc.includes('ctx.updateFocusSelectedBtn();'),
+    'node click helper must preserve focus button update'
+  );
+  assert.ok(
+    initSrc.includes('ctx.setDetailEmptyState(false);'),
+    'node click helper must preserve detail empty state update'
+  );
+  assert.ok(
+    initSrc.includes("var editorCanvas = typeof ctx.getEditorCanvas === 'function' ? ctx.getEditorCanvas() : null;"),
+    'node click helper must lazily resolve editorCanvas'
+  );
+  assert.ok(
+    initSrc.includes("if (editorCanvas && typeof editorCanvas.updateAffordance === 'function')"),
+    'node click helper must preserve updateAffordance guard'
+  );
+  assert.ok(
+    initSrc.includes('editorCanvas.updateAffordance();'),
+    'node click helper must preserve updateAffordance call'
+  );
+  assert.ok(
+    initSrc.includes('var editorCanvas;'),
+    'startCanvas must declare editorCanvas before creating the node click handler'
+  );
+  assert.ok(
+    initSrc.includes('var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({'),
+    'startCanvas must consume the local node click handler factory'
+  );
+  assert.ok(
+    initSrc.includes('getEditorCanvas: function() { return editorCanvas; }'),
+    'startCanvas must provide a lazy editorCanvas getter'
+  );
+  assert.ok(
+    initSrc.includes('editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    'startCanvas must assign editorCanvas after canvasOptions creation'
+  );
+
+  const startCanvasSrc = initSrc.substring(
+    initSrc.indexOf('function startCanvas()'),
+    initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({')
+  );
+
+  assert.equal(
+    startCanvasSrc.includes('var onPublicCanvasNodeClick = function(el, data)'),
+    false,
+    'startCanvas should not inline node click handler'
+  );
+
+  assert.ok(
+    initSrc.includes("var MARKER = 'LoveBudPublicCanvasInitLoaded';"),
+    'public canvas init marker must remain unchanged'
+  );
+  assert.equal(
+    initSrc.includes('LoveBudPublicCanvasInitLoaded_setupPublicRoute'),
+    false,
+    'marker must not contain contract-test strings'
+  );
+  assert.equal(
+    initSrc.includes('var _seq'),
+    false,
+    'source must not contain test-only sequence variables'
+  );
+  assert.ok(
+    initSrc.indexOf('function createPublicCanvasNodeClickHandler(ctx)') < initSrc.indexOf('function initPublicCanvas()'),
+    'node click handler factory must be defined before initPublicCanvas'
+  );
+  assert.ok(
+    initSrc.indexOf('var editorCanvas;') < initSrc.indexOf('var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({'),
+    'editorCanvas declaration must remain before handler creation'
+  );
+  assert.ok(
+    initSrc.indexOf('var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({') < initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({'),
+    'node click handler must remain before canvas options creation'
+  );
+  assert.ok(
+    initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({') < initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    'editorCanvas assignment must remain after canvas options creation'
+  );
+});

--- a/tests/routes/public-canvas-options-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-options-helper-contract.test.cjs
@@ -101,15 +101,15 @@ test('public canvas init keeps canvas options behind a local helper', () => {
     'canvas options helper must be defined before initPublicCanvas'
   );
   assert.ok(
-    initSrc.indexOf('var onPublicCanvasNodeClick = function(el, data)') < initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({'),
-    'canvas options must remain after public canvas click handler'
+    initSrc.indexOf('var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({') < initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({'),
+    'node click handler must remain before canvas options creation'
   );
   assert.ok(
-    initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({') < initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);'),
-    'canvas options must remain before editor canvas creation'
+    initSrc.indexOf('var canvasOptions = createPublicCanvasOptions({') < initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);'),
+    'canvas options must remain before editor canvas assignment'
   );
   assert.ok(
-    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'editor canvas creation must remain before read-only state install'
   );
 });

--- a/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
+++ b/tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
@@ -29,7 +29,7 @@ test('public canvas init keeps read-only editor state install behind a local hel
     initSrc.includes('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'startCanvas must consume the local read-only state helper'
   );
-  const startCanvasSrc = initSrc.substring(initSrc.indexOf('function startCanvas()'), initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);'));
+  const startCanvasSrc = initSrc.substring(initSrc.indexOf('function startCanvas()'), initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);'));
   assert.equal(
     startCanvasSrc.includes("if (canvasEntry && typeof canvasEntry.installPublicEditorReadOnlyState === 'function')"),
     false,
@@ -54,7 +54,7 @@ test('public canvas init keeps read-only editor state install behind a local hel
     'read-only state helper must be defined before initPublicCanvas'
   );
   assert.ok(
-    initSrc.indexOf('var editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
+    initSrc.indexOf('editorCanvas = createPublicEditorCanvas(canvasOptions);') < initSrc.indexOf('installPublicCanvasReadOnlyState(canvas, editorCanvas);'),
     'read-only state install must remain after editor canvas creation'
   );
   assert.ok(

--- a/tests/routes/public-canvas-route-dependency-contract.test.cjs
+++ b/tests/routes/public-canvas-route-dependency-contract.test.cjs
@@ -428,7 +428,7 @@ test('public canvas init delegates metrics/profile setup through entry wrapper',
   );
   assert.ok(initSrc.includes('function waitForModules'), 'public canvas init must keep waitForModules local');
   assert.ok(initSrc.includes('function startCanvas'), 'public canvas init must keep startCanvas local');
-  assert.ok(initSrc.includes('var onPublicCanvasNodeClick = function(el, data)'), 'public canvas init must keep node click flow local');
+  assert.ok(initSrc.includes('var onPublicCanvasNodeClick = createPublicCanvasNodeClickHandler({'), 'public canvas init must keep node click flow local');
   assert.ok(initSrc.includes('editorCanvas.initCanvas();'), 'public canvas init must keep editorCanvas init call local');
   assert.ok(initSrc.includes('appendPublicLoadFailureState'), 'public canvas init must delegate load failure appending through entry wrapper');
   assert.ok(initSrc.includes('canvasEntry.appendPublicLoadFailureState'), 'public canvas init must call delegated load failure append helper');


### PR DESCRIPTION
Refs #1711

Summary:
- Extract public canvas node click handling into a local helper in public-canvas-init.js.
- Keep startCanvas focused on orchestration by consuming createPublicCanvasNodeClickHandler(ctx).
- Preserve selection, selected class sync, detail refresh, focus button refresh, empty state update, and updateAffordance behavior.
- Add focused contract coverage for the node click handler boundary.

Validation:
- node --test tests/routes/public-canvas-node-click-helper-contract.test.cjs
- node --test tests/routes/public-canvas-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-toolbar-compact-helper-contract.test.cjs
- node --test tests/routes/public-canvas-post-init-refresh-helper-contract.test.cjs
- node --test tests/routes/public-canvas-init-guard-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-detail-options-helper-contract.test.cjs
- node --test tests/routes/public-canvas-selection-state-helper-contract.test.cjs
- node --test tests/routes/public-canvas-readonly-actions-helper-contract.test.cjs
- node --test tests/routes/public-canvas-memory-helpers-contract.test.cjs
- node --test tests/routes/public-canvas-empty-guide-helper-contract.test.cjs
- node --test tests/routes/public-canvas-config-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-profile-helper-contract.test.cjs
- node --test tests/routes/public-canvas-load-failure-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-wait-helper-contract.test.cjs
- node --test tests/routes/public-canvas-result-extraction-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-ready-helper-contract.test.cjs
- node --test tests/routes/public-canvas-missing-route-helper-contract.test.cjs
- node --test tests/routes/public-canvas-route-setup-helper-contract.test.cjs
- node --test tests/routes/public-canvas-bridge-normalization-contract.test.cjs
- node --test tests/routes/public-canvas-target-lookup-contract.test.cjs
- node --test tests/routes/public-canvas-creation-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-readiness-helper-contract.test.cjs
- node --test tests/routes/public-canvas-runtime-boundary-contract.test.cjs
- node --test tests/routes/public-canvas-route-dependency-contract.test.cjs
- npm run verify
- npm test