### PR TITLE
refactor(viewer): add public detail helper aliases

### DIFF
--- a/js/viewer/public-viewer-detail-builders.js
+++ b/js/viewer/public-viewer-detail-builders.js
@@ -24,7 +24,7 @@
         }
     }
 
-    function createEditorDetailUIBuilders({ formatI18nText }) {
+    function createPublicViewerDetailUIBuilders({ formatI18nText }) {
         const createInlineIcon = (name, size = '12px') => {
             const icon = document.createElement('span');
             icon.className = 'material-symbols-outlined';
@@ -70,10 +70,14 @@
         };
     }
 
+    const createEditorDetailUIBuilders = createPublicViewerDetailUIBuilders;
+
     installPublicDetailBoundaryFallbacks();
 
+    window.createPublicViewerDetailUIBuilders = createPublicViewerDetailUIBuilders;
     window.createEditorDetailUIBuilders = createEditorDetailUIBuilders;
     window.LoveBudPublicViewerDetailBuilders = {
+        createPublicViewerDetailUIBuilders,
         createEditorDetailUIBuilders,
         createNoopInlineEditBoundary,
         createNoopSidebarStatusBoundary

--- a/js/viewer/public-viewer-detail-tree-meta.js
+++ b/js/viewer/public-viewer-detail-tree-meta.js
@@ -1,5 +1,5 @@
 (function () {
-    function createEditorDetailTreeMetaBoundary(deps) {
+    function createPublicViewerDetailTreeMetaBoundary(deps) {
         const {
             i18n,
             formatI18nText,
@@ -241,8 +241,12 @@
         };
     }
 
+    const createEditorDetailTreeMetaBoundary = createPublicViewerDetailTreeMetaBoundary;
+
+    window.createPublicViewerDetailTreeMetaBoundary = createPublicViewerDetailTreeMetaBoundary;
     window.createEditorDetailTreeMetaBoundary = createEditorDetailTreeMetaBoundary;
     window.LoveBudPublicViewerDetailTreeMeta = {
+        createPublicViewerDetailTreeMetaBoundary,
         createEditorDetailTreeMetaBoundary
     };
 })();

--- a/tests/routes/public-viewer-detail-helper-alias-contract.test.cjs
+++ b/tests/routes/public-viewer-detail-helper-alias-contract.test.cjs
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+const treeMetaSrc = fs.readFileSync('js/viewer/public-viewer-detail-tree-meta.js', 'utf8');
+const buildersSrc = fs.readFileSync('js/viewer/public-viewer-detail-builders.js', 'utf8');
+const detailUiSrc = fs.readFileSync('js/viewer/public-viewer-detail-ui.js', 'utf8');
+
+test('public viewer detail tree meta exposes viewer-named helper with legacy alias', () => {
+  assert.ok(
+    treeMetaSrc.includes('function createPublicViewerDetailTreeMetaBoundary'),
+    'public viewer tree meta helper must use a viewer-named factory'
+  );
+  assert.ok(
+    treeMetaSrc.includes('window.createPublicViewerDetailTreeMetaBoundary = createPublicViewerDetailTreeMetaBoundary'),
+    'public viewer tree meta helper must expose the viewer-named global factory'
+  );
+  assert.ok(
+    treeMetaSrc.includes('const createEditorDetailTreeMetaBoundary = createPublicViewerDetailTreeMetaBoundary'),
+    'legacy editor-named tree meta factory must delegate to the viewer-named factory'
+  );
+  assert.ok(
+    treeMetaSrc.includes('createPublicViewerDetailTreeMetaBoundary,\n        createEditorDetailTreeMetaBoundary'),
+    'public viewer tree meta namespace must expose both viewer and legacy factory aliases'
+  );
+});
+
+test('public viewer detail builders expose viewer-named helper with legacy alias', () => {
+  assert.ok(
+    buildersSrc.includes('function createPublicViewerDetailUIBuilders'),
+    'public viewer detail builders must use a viewer-named factory'
+  );
+  assert.ok(
+    buildersSrc.includes('window.createPublicViewerDetailUIBuilders = createPublicViewerDetailUIBuilders'),
+    'public viewer detail builders must expose the viewer-named global factory'
+  );
+  assert.ok(
+    buildersSrc.includes('const createEditorDetailUIBuilders = createPublicViewerDetailUIBuilders'),
+    'legacy editor-named builder factory must delegate to the viewer-named factory'
+  );
+  assert.ok(
+    buildersSrc.includes('createPublicViewerDetailUIBuilders,\n        createEditorDetailUIBuilders'),
+    'public viewer detail builder namespace must expose both viewer and legacy factory aliases'
+  );
+});
+
+test('public viewer detail UI remains viewer-owned and does not delegate to editor detail UI', () => {
+  assert.ok(
+    detailUiSrc.includes('window.createPublicViewerDetailUI = createPublicViewerDetailUI'),
+    'public viewer detail UI must continue to expose its viewer-owned entrypoint'
+  );
+  assert.ok(
+    detailUiSrc.includes('delegatesToEditorDetailUI: false'),
+    'public viewer detail UI must remain detached from editor detail UI delegation'
+  );
+});


### PR DESCRIPTION
Refs #1711

## Summary
- Add viewer-named factories for public viewer detail tree meta and builder helpers.
- Keep existing editor-named exports available for current script compatibility.
- Add a contract test for the public viewer detail helper export boundary.

## Scope
- js/viewer/public-viewer-detail-tree-meta.js
- js/viewer/public-viewer-detail-builders.js
- tests/routes/public-viewer-detail-helper-alias-contract.test.cjs

## Validation
- PR checks will be used as the merge gate.