### PR TITLE
refactor(viewer): drop normalize utility from public view

### DIFF
--- a/pages/view.html
+++ b/pages/view.html
@@ -36,7 +36,6 @@
         <div id="editorDetailPanelShellTemplateMount"></div>
     </div>
 
-    <script src="../js/utils/normalize.js?v=20260422-1"></script>
     <script src="../js/utils/path.js?v=20260418-1"></script>
     <script src="../js/utils/ui.js?v=20260418-1"></script>
     <script src="../js/utils/media.js?v=20260418-1"></script>

--- a/tests/routes/public-view-normalize-utils-route-contract.test.cjs
+++ b/tests/routes/public-view-normalize-utils-route-contract.test.cjs
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+
+function getScriptSrcs() {
+  const html = fs.readFileSync('pages/view.html', 'utf8');
+  return [...html.matchAll(/<script(?:\s+type="module")?\s+src="([^"]+)"/g)]
+    .map((match) => String(match[1] || '').split('?')[0]);
+}
+
+function hasScript(scripts, needle) {
+  return scripts.some((src) => src.includes(needle));
+}
+
+test('public view does not load shared normalize utility prelude', () => {
+  const scripts = getScriptSrcs();
+
+  assert.equal(
+    hasScript(scripts, 'js/utils/normalize.js'),
+    false,
+    'view.html must not load utils/normalize.js on the public viewer route'
+  );
+  assert.ok(
+    hasScript(scripts, 'js/viewer/public-canvas-bridge.js'),
+    'public viewer must keep the public canvas bridge that owns route-specific normalization'
+  );
+});
+
+test('public canvas bridge owns public viewer normalization locally', () => {
+  const bridgeSrc = fs.readFileSync('js/viewer/public-canvas-bridge.js', 'utf8');
+
+  assert.ok(
+    bridgeSrc.includes('function normalizeForCanvas'),
+    'public canvas bridge must expose normalizeForCanvas for route-specific normalization'
+  );
+  assert.ok(
+    bridgeSrc.includes('window.currentTreeData = treeData'),
+    'public canvas bridge must still set currentTreeData for the shared canvas runtime'
+  );
+  assert.ok(
+    bridgeSrc.includes('window.currentTreeMemories = normalizedMemories'),
+    'public canvas bridge must still set currentTreeMemories for the shared canvas runtime'
+  );
+  assert.equal(
+    bridgeSrc.includes('LoveBudNormalize'),
+    false,
+    'public canvas bridge must not depend on the shared LoveBudNormalize utility for public viewer normalization'
+  );
+});


### PR DESCRIPTION
Refs #1711

## Summary
- Remove `utils/normalize.js` from the public viewer route.
- Add a focused route contract confirming the public viewer does not load the shared normalize utility.
- Guard that public canvas bridge keeps owning route-specific normalization.

## Scope
- `pages/view.html`
- `tests/routes/public-view-normalize-utils-route-contract.test.cjs`

## Validation
- PR checks will be used as the merge gate.