### PR TITLE
test(editor): cover page event binding helper contract

### DIFF
--- a/js/editor/editor-page-event-bindings.js
+++ b/js/editor/editor-page-event-bindings.js
@@ -1,0 +1,78 @@
+(function() {
+  'use strict';
+
+  function bindEditorPageEvents(options) {
+    var opts = options || {};
+    var canEdit = opts.canEdit === true;
+    var sidebarUIHelper = opts.sidebarUIHelper || {};
+    var editorBindings = opts.editorBindings || {};
+    var emptyGuideUIHelper = opts.emptyGuideUIHelper || {};
+    var results = {
+      sidebarVisibilityToggle: false,
+      memoryCreateControls: false,
+      detailEmptyStartButton: false,
+      emptyGuideEvents: false,
+      detailActionButtons: false
+    };
+
+    if (canEdit && typeof sidebarUIHelper.bindSidebarVisibilityToggle === 'function') {
+      sidebarUIHelper.bindSidebarVisibilityToggle({
+        getTreeId: opts.getTreeId,
+        updateTreeVisibility: opts.updateTreeVisibility,
+        showToast: opts.showToast,
+        safeI18nText: opts.safeI18nText,
+        i18n: opts.i18n,
+        getHttpStatus: opts.getHttpStatus,
+        updateSidebarStatus: opts.updateSidebarStatus
+      });
+      results.sidebarVisibilityToggle = true;
+    }
+
+    if (canEdit && typeof editorBindings.bindMemoryCreateControlsFromDom === 'function') {
+      editorBindings.bindMemoryCreateControlsFromDom({
+        showAddMemoryForm: opts.showAddMemoryForm,
+        hideAddMemoryForm: opts.hideAddMemoryForm,
+        addMemoryFromForm: opts.addMemoryFromForm,
+        updateSaveStatus: opts.updateSaveStatus,
+        showToast: opts.showToast,
+        i18n: opts.i18n
+      });
+      results.memoryCreateControls = true;
+    }
+
+    if (canEdit && typeof editorBindings.bindDetailEmptyStartButton === 'function') {
+      editorBindings.bindDetailEmptyStartButton({
+        showAddMemoryForm: opts.showAddMemoryForm
+      });
+      results.detailEmptyStartButton = true;
+    }
+
+    if (typeof emptyGuideUIHelper.bindEmptyGuideEvents === 'function') {
+      emptyGuideUIHelper.bindEmptyGuideEvents({
+        getEditorCanvas: opts.getEditorCanvas,
+        showAddMemoryForm: opts.showAddMemoryForm,
+        addMemoryFromForm: opts.addMemoryFromForm,
+        getTreeMemories: opts.getTreeMemories,
+        showToast: opts.showToast,
+        i18n: opts.i18n
+      });
+      results.emptyGuideEvents = true;
+    }
+
+    if (canEdit && typeof editorBindings.bindDetailActionButtons === 'function') {
+      editorBindings.bindDetailActionButtons({
+        enterEditMode: opts.enterEditMode,
+        deleteMemory: opts.deleteMemory,
+        exitEditMode: opts.exitEditMode,
+        saveMemoryEdit: opts.saveMemoryEdit
+      });
+      results.detailActionButtons = true;
+    }
+
+    return results;
+  }
+
+  window.LoveBudEditorPageEventBindings = Object.freeze({
+    bindEditorPageEvents: bindEditorPageEvents
+  });
+})();

--- a/tests/contracts/editor-page-event-bindings-contract.test.cjs
+++ b/tests/contracts/editor-page-event-bindings-contract.test.cjs
@@ -1,0 +1,181 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const helperPath = 'js/editor/editor-page-event-bindings.js';
+const helperSource = fs.readFileSync(helperPath, 'utf8');
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+
+function loadHelper() {
+  const context = {
+    window: {}
+  };
+  vm.runInNewContext(helperSource, context, { filename: helperPath });
+  return context.window.LoveBudEditorPageEventBindings;
+}
+
+function createCalls() {
+  return [];
+}
+
+function record(calls, name) {
+  return (payload) => {
+    calls.push({ name, payload });
+  };
+}
+
+function createBaseOptions(calls, canEdit = true) {
+  const refs = {
+    getTreeId: () => 'tree-1',
+    updateTreeVisibility: () => {},
+    showToast: () => {},
+    safeI18nText: () => '',
+    i18n: () => '',
+    getHttpStatus: () => 200,
+    updateSidebarStatus: () => {},
+    showAddMemoryForm: () => {},
+    hideAddMemoryForm: () => {},
+    addMemoryFromForm: () => {},
+    updateSaveStatus: () => {},
+    getEditorCanvas: () => null,
+    getTreeMemories: () => [],
+    enterEditMode: () => {},
+    deleteMemory: () => {},
+    exitEditMode: () => {},
+    saveMemoryEdit: () => {}
+  };
+
+  return {
+    ...refs,
+    canEdit,
+    sidebarUIHelper: {
+      bindSidebarVisibilityToggle: record(calls, 'bindSidebarVisibilityToggle')
+    },
+    editorBindings: {
+      bindMemoryCreateControlsFromDom: record(calls, 'bindMemoryCreateControlsFromDom'),
+      bindDetailEmptyStartButton: record(calls, 'bindDetailEmptyStartButton'),
+      bindDetailActionButtons: record(calls, 'bindDetailActionButtons')
+    },
+    emptyGuideUIHelper: {
+      bindEmptyGuideEvents: record(calls, 'bindEmptyGuideEvents')
+    },
+    refs
+  };
+}
+
+test('editor page event bindings helper exposes a frozen browser global', () => {
+  const helper = loadHelper();
+
+  assert.equal(typeof helper.bindEditorPageEvents, 'function');
+  assert.equal(Object.isFrozen(helper), true);
+  assert.match(helperSource, /window\.LoveBudEditorPageEventBindings\s*=\s*Object\.freeze\(\{/);
+});
+
+test('editor page event bindings helper has no backend auth api imports or requires', () => {
+  assert.doesNotMatch(helperSource, /require\(/);
+  assert.doesNotMatch(helperSource, /import\s+/);
+  assert.doesNotMatch(helperSource, /apiClient/);
+  assert.doesNotMatch(helperSource, /LoveBudProtectedRoute/);
+  assert.doesNotMatch(helperSource, /registerOnAuthReady/);
+});
+
+test('bindEditorPageEvents calls all editable event binding groups with preserved option references', () => {
+  const helper = loadHelper();
+  const calls = createCalls();
+  const options = createBaseOptions(calls, true);
+  const result = helper.bindEditorPageEvents(options);
+
+  assert.deepEqual(calls.map((call) => call.name), [
+    'bindSidebarVisibilityToggle',
+    'bindMemoryCreateControlsFromDom',
+    'bindDetailEmptyStartButton',
+    'bindEmptyGuideEvents',
+    'bindDetailActionButtons'
+  ]);
+
+  assert.deepEqual(result, {
+    sidebarVisibilityToggle: true,
+    memoryCreateControls: true,
+    detailEmptyStartButton: true,
+    emptyGuideEvents: true,
+    detailActionButtons: true
+  });
+
+  const sidebarPayload = calls.find((call) => call.name === 'bindSidebarVisibilityToggle').payload;
+  assert.equal(sidebarPayload.getTreeId, options.getTreeId);
+  assert.equal(sidebarPayload.updateTreeVisibility, options.updateTreeVisibility);
+  assert.equal(sidebarPayload.showToast, options.showToast);
+  assert.equal(sidebarPayload.safeI18nText, options.safeI18nText);
+  assert.equal(sidebarPayload.i18n, options.i18n);
+  assert.equal(sidebarPayload.getHttpStatus, options.getHttpStatus);
+  assert.equal(sidebarPayload.updateSidebarStatus, options.updateSidebarStatus);
+
+  const createPayload = calls.find((call) => call.name === 'bindMemoryCreateControlsFromDom').payload;
+  assert.equal(createPayload.showAddMemoryForm, options.showAddMemoryForm);
+  assert.equal(createPayload.hideAddMemoryForm, options.hideAddMemoryForm);
+  assert.equal(createPayload.addMemoryFromForm, options.addMemoryFromForm);
+  assert.equal(createPayload.updateSaveStatus, options.updateSaveStatus);
+  assert.equal(createPayload.showToast, options.showToast);
+  assert.equal(createPayload.i18n, options.i18n);
+
+  const emptyStartPayload = calls.find((call) => call.name === 'bindDetailEmptyStartButton').payload;
+  assert.equal(emptyStartPayload.showAddMemoryForm, options.showAddMemoryForm);
+
+  const emptyGuidePayload = calls.find((call) => call.name === 'bindEmptyGuideEvents').payload;
+  assert.equal(emptyGuidePayload.getEditorCanvas, options.getEditorCanvas);
+  assert.equal(emptyGuidePayload.showAddMemoryForm, options.showAddMemoryForm);
+  assert.equal(emptyGuidePayload.addMemoryFromForm, options.addMemoryFromForm);
+  assert.equal(emptyGuidePayload.getTreeMemories, options.getTreeMemories);
+  assert.equal(emptyGuidePayload.showToast, options.showToast);
+  assert.equal(emptyGuidePayload.i18n, options.i18n);
+
+  const detailActionsPayload = calls.find((call) => call.name === 'bindDetailActionButtons').payload;
+  assert.equal(detailActionsPayload.enterEditMode, options.enterEditMode);
+  assert.equal(detailActionsPayload.deleteMemory, options.deleteMemory);
+  assert.equal(detailActionsPayload.exitEditMode, options.exitEditMode);
+  assert.equal(detailActionsPayload.saveMemoryEdit, options.saveMemoryEdit);
+});
+
+test('bindEditorPageEvents skips edit-only binding groups when canEdit is false', () => {
+  const helper = loadHelper();
+  const calls = createCalls();
+  const options = createBaseOptions(calls, false);
+  const result = helper.bindEditorPageEvents(options);
+
+  assert.deepEqual(calls.map((call) => call.name), ['bindEmptyGuideEvents']);
+  assert.deepEqual(result, {
+    sidebarVisibilityToggle: false,
+    memoryCreateControls: false,
+    detailEmptyStartButton: false,
+    emptyGuideEvents: true,
+    detailActionButtons: false
+  });
+});
+
+test('bindEditorPageEvents tolerates missing helper methods without throwing', () => {
+  const helper = loadHelper();
+  const result = helper.bindEditorPageEvents({
+    canEdit: true,
+    sidebarUIHelper: {},
+    editorBindings: {},
+    emptyGuideUIHelper: {}
+  });
+
+  assert.deepEqual(result, {
+    sidebarVisibilityToggle: false,
+    memoryCreateControls: false,
+    detailEmptyStartButton: false,
+    emptyGuideEvents: false,
+    detailActionButtons: false
+  });
+});
+
+test('editor entrypoint still owns local event binding block until follow-up callsite PR', () => {
+  assert.match(editorSource, /sidebarUIHelper\.bindSidebarVisibilityToggle/);
+  assert.match(editorSource, /editorBindings\.bindMemoryCreateControlsFromDom/);
+  assert.match(editorSource, /editorBindings\.bindDetailEmptyStartButton/);
+  assert.match(editorSource, /emptyGuideUIHelper\.bindEmptyGuideEvents/);
+  assert.match(editorSource, /editorBindings\.bindDetailActionButtons/);
+  assert.doesNotMatch(editorSource, /LoveBudEditorPageEventBindings/);
+});

--- a/tests/contracts/editor-page-event-bindings-contract.test.cjs
+++ b/tests/contracts/editor-page-event-bindings-contract.test.cjs
@@ -25,6 +25,14 @@ function record(calls, name) {
   };
 }
 
+function assertBindingResult(result, expected) {
+  assert.equal(result.sidebarVisibilityToggle, expected.sidebarVisibilityToggle);
+  assert.equal(result.memoryCreateControls, expected.memoryCreateControls);
+  assert.equal(result.detailEmptyStartButton, expected.detailEmptyStartButton);
+  assert.equal(result.emptyGuideEvents, expected.emptyGuideEvents);
+  assert.equal(result.detailActionButtons, expected.detailActionButtons);
+}
+
 function createBaseOptions(calls, canEdit = true) {
   const refs = {
     getTreeId: () => 'tree-1',
@@ -94,7 +102,7 @@ test('bindEditorPageEvents calls all editable event binding groups with preserve
     'bindDetailActionButtons'
   ]);
 
-  assert.deepEqual(result, {
+  assertBindingResult(result, {
     sidebarVisibilityToggle: true,
     memoryCreateControls: true,
     detailEmptyStartButton: true,
@@ -144,7 +152,7 @@ test('bindEditorPageEvents skips edit-only binding groups when canEdit is false'
   const result = helper.bindEditorPageEvents(options);
 
   assert.deepEqual(calls.map((call) => call.name), ['bindEmptyGuideEvents']);
-  assert.deepEqual(result, {
+  assertBindingResult(result, {
     sidebarVisibilityToggle: false,
     memoryCreateControls: false,
     detailEmptyStartButton: false,
@@ -162,7 +170,7 @@ test('bindEditorPageEvents tolerates missing helper methods without throwing', (
     emptyGuideUIHelper: {}
   });
 
-  assert.deepEqual(result, {
+  assertBindingResult(result, {
     sidebarVisibilityToggle: false,
     memoryCreateControls: false,
     detailEmptyStartButton: false,


### PR DESCRIPTION
Refs #1698

## Summary
- add `LoveBudEditorPageEventBindings.bindEditorPageEvents` as a browser-global helper
- add contract coverage for editable-only binding gates, empty-guide binding behavior, preserved option references, and frozen global exposure
- keep `js/editor.js` unchanged so the runtime entrypoint is not rewired in this PR

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-page-event-bindings.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS

## Verification
- CI `verify-static`: success
- Browser smoke not run because `js/editor.js` is unchanged and helper is not wired into the entrypoint yet