### PR TITLE
test(editor): cover startup context helper contract

### DIFF
--- a/js/editor/editor-startup-context.js
+++ b/js/editor/editor-startup-context.js
@@ -1,0 +1,35 @@
+(function() {
+  'use strict';
+
+  function createEditorStartupContext(options) {
+    var opts = options || {};
+    var createEditorDomRefs = opts.createEditorDomRefs;
+    var locationRef = opts.locationRef || window.location;
+    var URLSearchParamsRef = opts.URLSearchParamsRef || window.URLSearchParams;
+
+    if (typeof createEditorDomRefs !== 'function') {
+      throw new TypeError('createEditorDomRefs must be a function');
+    }
+
+    var refs = createEditorDomRefs();
+    var search = locationRef && typeof locationRef.search === 'string'
+      ? locationRef.search
+      : '';
+    var params = new URLSearchParamsRef(search);
+    var urlTreeId = params.get('treeId');
+    var canEdit = params.get('readonly') !== '1';
+
+    return {
+      canvas: refs && refs.canvas,
+      svg: refs && refs.svg,
+      detailPanel: refs && refs.detailPanel,
+      addBtn: refs && refs.addBtn,
+      urlTreeId: urlTreeId,
+      canEdit: canEdit
+    };
+  }
+
+  window.LoveBudEditorStartupContext = Object.freeze({
+    createEditorStartupContext: createEditorStartupContext
+  });
+})();

--- a/tests/contracts/editor-startup-context-contract.test.cjs
+++ b/tests/contracts/editor-startup-context-contract.test.cjs
@@ -1,0 +1,114 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const helperPath = 'js/editor/editor-startup-context.js';
+const helperSource = fs.readFileSync(helperPath, 'utf8');
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+
+function loadHelper() {
+  const context = {
+    window: {
+      location: { search: '' },
+      URLSearchParams
+    }
+  };
+  vm.runInNewContext(helperSource, context, { filename: helperPath });
+  return context.window.LoveBudEditorStartupContext;
+}
+
+test('editor startup context helper exposes a frozen browser global', () => {
+  const helper = loadHelper();
+
+  assert.equal(typeof helper.createEditorStartupContext, 'function');
+  assert.equal(Object.isFrozen(helper), true);
+  assert.match(helperSource, /window\.LoveBudEditorStartupContext\s*=\s*Object\.freeze\(\{/);
+});
+
+test('editor startup context helper has no backend auth api imports or lifecycle calls', () => {
+  assert.doesNotMatch(helperSource, /require\(/);
+  assert.doesNotMatch(helperSource, /import\s+/);
+  assert.doesNotMatch(helperSource, /apiClient/);
+  assert.doesNotMatch(helperSource, /registerOnAuthReady/);
+  assert.doesNotMatch(helperSource, /LoveBudProtectedRoute/);
+  assert.doesNotMatch(helperSource, /initCanvas/);
+  assert.doesNotMatch(helperSource, /createEditorCanvas/);
+  assert.doesNotMatch(helperSource, /createEditorMemoryActions/);
+  assert.doesNotMatch(helperSource, /createEditorMemoryForm/);
+});
+
+test('createEditorStartupContext calls createEditorDomRefs once and returns DOM references', () => {
+  const helper = loadHelper();
+  const refs = {
+    canvas: { id: 'canvas' },
+    svg: { id: 'svg' },
+    detailPanel: { id: 'detail' },
+    addBtn: { id: 'add' }
+  };
+  let calls = 0;
+
+  const result = helper.createEditorStartupContext({
+    createEditorDomRefs: () => {
+      calls += 1;
+      return refs;
+    },
+    locationRef: { search: '' },
+    URLSearchParamsRef: URLSearchParams
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.canvas, refs.canvas);
+  assert.equal(result.svg, refs.svg);
+  assert.equal(result.detailPanel, refs.detailPanel);
+  assert.equal(result.addBtn, refs.addBtn);
+});
+
+test('createEditorStartupContext reads urlTreeId from treeId query parameter', () => {
+  const helper = loadHelper();
+  const result = helper.createEditorStartupContext({
+    createEditorDomRefs: () => ({}),
+    locationRef: { search: '?treeId=tree-123&readonly=0' },
+    URLSearchParamsRef: URLSearchParams
+  });
+
+  assert.equal(result.urlTreeId, 'tree-123');
+});
+
+test('createEditorStartupContext derives canEdit from readonly query parameter', () => {
+  const helper = loadHelper();
+
+  const editable = helper.createEditorStartupContext({
+    createEditorDomRefs: () => ({}),
+    locationRef: { search: '?readonly=0' },
+    URLSearchParamsRef: URLSearchParams
+  });
+  const defaultEditable = helper.createEditorStartupContext({
+    createEditorDomRefs: () => ({}),
+    locationRef: { search: '' },
+    URLSearchParamsRef: URLSearchParams
+  });
+  const readOnly = helper.createEditorStartupContext({
+    createEditorDomRefs: () => ({}),
+    locationRef: { search: '?readonly=1' },
+    URLSearchParamsRef: URLSearchParams
+  });
+
+  assert.equal(editable.canEdit, true);
+  assert.equal(defaultEditable.canEdit, true);
+  assert.equal(readOnly.canEdit, false);
+});
+
+test('createEditorStartupContext throws when createEditorDomRefs is missing', () => {
+  const helper = loadHelper();
+
+  assert.throws(() => helper.createEditorStartupContext({}), /createEditorDomRefs must be a function/);
+});
+
+test('editor startup context helper is not wired into editor entrypoint yet', () => {
+  assert.doesNotMatch(editorSource, /LoveBudEditorStartupContext/);
+  assert.match(editorSource, /createEditorDomRefs\(\)/);
+  assert.match(editorSource, /new URLSearchParams\(window\.location\.search\)/);
+  assert.match(editorSource, /urlParams\.get\('treeId'\)/);
+  assert.match(editorSource, /urlParams\.get\('readonly'\) !== '1'/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- add `LoveBudEditorStartupContext.createEditorStartupContext` as a browser-global helper
- add contract coverage for DOM refs, urlTreeId parsing, readonly-derived editability, frozen global exposure, and no backend/auth/API/canvas lifecycle coupling
- keep `js/editor.js` unchanged so the runtime entrypoint is not rewired in this PR

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-startup-context.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS

## Verification
- not run locally; PR created through GitHub contents API
- PR checks should be used as the remote verification source
