### PR TITLE
refactor(editor): delegate startup context preparation

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -67,6 +67,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorPageEventBindings = window.LoveBudEditorPageEventBindings || {};
     const bindEditorPageEvents = editorPageEventBindings.bindEditorPageEvents;
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
+    const editorStartupContext = window.LoveBudEditorStartupContext || {};
+    const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
     const readConfirmedAuthCacheFromHelper = () => (
         window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
@@ -394,11 +396,24 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        if (typeof createEditorStartupContext !== 'function') {
+            reportError('LoveBudEditorStartupContext.createEditorStartupContext missing');
+            return;
+        }
+
         try {
-            const { canvas, svg, detailPanel, addBtn } = createEditorDomRefs();
-            const urlParams = new URLSearchParams(window.location.search);
-            const urlTreeId = urlParams.get('treeId');
-            const canEdit = urlParams.get('readonly') !== '1';
+            const {
+                canvas,
+                svg,
+                detailPanel,
+                addBtn,
+                urlTreeId,
+                canEdit
+            } = createEditorStartupContext({
+                createEditorDomRefs,
+                locationRef: window.location,
+                URLSearchParamsRef: URLSearchParams
+            });
 
             log('DOM refs and URL params prepared');
             prepareEditorShell();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -162,6 +162,7 @@
     <script src="../js/editor/editor-shell-helpers.js?v=20260422-1"></script>
     <script src="../js/editor/editor-shell-copy-applier.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-dom-refs-builder.js?v=20260522-1276"></script>
+    <script src="../js/editor/editor-startup-context.js?v=20260530-1698"></script>
     <script src="../js/editor/editor-save-status-orchestration.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-page-event-bindings.js?v=20260530-1698"></script>
 

--- a/tests/contracts/editor-dom-refs-fallback-removal-contract.test.cjs
+++ b/tests/contracts/editor-dom-refs-fallback-removal-contract.test.cjs
@@ -40,11 +40,11 @@ test('editor entrypoint uses dom refs builder without inline fallback', () => {
 
 test('editor entrypoint reports missing dom refs builder before calling it', () => {
   const guardIndex = editorSource.indexOf("typeof createEditorDomRefs !== 'function'");
-  const callIndex = editorSource.indexOf('const { canvas, svg, detailPanel, addBtn } = createEditorDomRefs();');
+  const startupContextCallIndex = editorSource.indexOf('createEditorStartupContext({');
 
   assert.notEqual(guardIndex, -1, 'missing createEditorDomRefs guard must exist');
-  assert.notEqual(callIndex, -1, 'createEditorDomRefs call must remain');
-  assert.ok(guardIndex < callIndex, 'missing createEditorDomRefs guard must run before call');
+  assert.notEqual(startupContextCallIndex, -1, 'startup context call must exist');
+  assert.ok(guardIndex < startupContextCallIndex, 'missing createEditorDomRefs guard must run before startup context call');
 
   assert.match(
     editorSource,

--- a/tests/contracts/editor-dom-refs-selector-registry-contract.test.cjs
+++ b/tests/contracts/editor-dom-refs-selector-registry-contract.test.cjs
@@ -53,5 +53,7 @@ test('editor entrypoint still delegates initial refs through dom refs builder', 
   assert.match(editorSource, /const createEditorDomRefs\s*=\s*editorDomRefsBuilder\.createEditorDomRefs/);
   assert.match(editorSource, /typeof createEditorDomRefs !== 'function'/);
   assert.match(editorSource, /LoveBudEditorDomRefsBuilder\.createEditorDomRefs missing/);
-  assert.match(editorSource, /const \{\s*canvas,\s*svg,\s*detailPanel,\s*addBtn\s*\}\s*=\s*createEditorDomRefs\(\)/);
+  assert.match(editorSource, /createEditorStartupContext\(\{\s*createEditorDomRefs,/);
+  assert.match(editorSource, /locationRef:\s*window\.location/);
+  assert.match(editorSource, /URLSearchParamsRef:\s*URLSearchParams/);
 });

--- a/tests/contracts/editor-editability-shell-state-contract.test.cjs
+++ b/tests/contracts/editor-editability-shell-state-contract.test.cjs
@@ -26,14 +26,14 @@ test('editor delegates editability shell state with fallback', () => {
 });
 
 test('editor no longer applies editability state inline in start flow', () => {
-  const start = editorSource.indexOf('const canEdit = urlParams.get');
-  assert.notEqual(start, -1, 'canEdit calculation must exist');
+  const start = editorSource.indexOf('createEditorStartupContext({');
+  assert.notEqual(start, -1, 'createEditorStartupContext call must exist in start flow');
 
   const end = editorSource.indexOf('const cache = window.LoveBudCache || null;', start);
   assert.notEqual(end, -1, 'cache setup must follow editability state setup');
 
   const block = editorSource.slice(start, end);
-  assert.match(block, /applyEditorEditabilityState\(\{\s*canEdit\s*\}\)/);
+  assert.match(block, /applyEditorEditabilityState\(\{\s*canEdit\s*\}/);
   assert.doesNotMatch(block, /window\.LoveBudEditor\s*=\s*window\.LoveBudEditor\s*\|\|\s*\{\}/);
   assert.doesNotMatch(block, /document\.body\.classList\.toggle\('editor-readonly'/);
 });

--- a/tests/contracts/editor-startup-context-contract.test.cjs
+++ b/tests/contracts/editor-startup-context-contract.test.cjs
@@ -105,10 +105,15 @@ test('createEditorStartupContext throws when createEditorDomRefs is missing', ()
   assert.throws(() => helper.createEditorStartupContext({}), /createEditorDomRefs must be a function/);
 });
 
-test('editor startup context helper is not wired into editor entrypoint yet', () => {
-  assert.doesNotMatch(editorSource, /LoveBudEditorStartupContext/);
-  assert.match(editorSource, /createEditorDomRefs\(\)/);
-  assert.match(editorSource, /new URLSearchParams\(window\.location\.search\)/);
-  assert.match(editorSource, /urlParams\.get\('treeId'\)/);
-  assert.match(editorSource, /urlParams\.get\('readonly'\) !== '1'/);
+test('editor entrypoint delegates startup context preparation to helper', () => {
+  assert.match(editorSource, /LoveBudEditorStartupContext/);
+  assert.match(editorSource, /createEditorStartupContext/);
+  assert.match(editorSource, /createEditorStartupContext\(\{/);
+  assert.match(editorSource, /createEditorDomRefs/);
+  assert.match(editorSource, /locationRef:\s*window\.location/);
+  assert.match(editorSource, /URLSearchParamsRef:\s*URLSearchParams/);
+
+  assert.doesNotMatch(editorSource, /new URLSearchParams\(window\.location\.search\)/);
+  assert.doesNotMatch(editorSource, /urlParams\.get\('treeId'\)/);
+  assert.doesNotMatch(editorSource, /urlParams\.get\('readonly'\) !== '1'/);
 });

--- a/tests/contracts/editor-startup-context-script-order-contract.test.cjs
+++ b/tests/contracts/editor-startup-context-script-order-contract.test.cjs
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const editorHtml = fs.readFileSync('pages/editor.html', 'utf8');
+
+function countMatches(source, pattern) {
+  return (source.match(pattern) || []).length;
+}
+
+test('editor startup context helper loads before editor entrypoint', () => {
+  const startupContextScript = '../js/editor/editor-startup-context.js';
+  const editorEntrypointScript = '../js/editor.js';
+
+  const startupContextIndex = editorHtml.indexOf(startupContextScript);
+  const editorEntrypointIndex = editorHtml.indexOf(editorEntrypointScript);
+
+  assert.notEqual(startupContextIndex, -1);
+  assert.notEqual(editorEntrypointIndex, -1);
+  assert.ok(startupContextIndex < editorEntrypointIndex);
+});
+
+test('editor startup context helper loads after dom refs builder', () => {
+  const domRefsScript = '../js/editor/editor-dom-refs-builder.js';
+  const startupContextScript = '../js/editor/editor-startup-context.js';
+  const editorEntrypointScript = '../js/editor.js';
+
+  const domRefsIndex = editorHtml.indexOf(domRefsScript);
+  const startupContextIndex = editorHtml.indexOf(startupContextScript);
+  const editorEntrypointIndex = editorHtml.indexOf(editorEntrypointScript);
+
+  assert.notEqual(domRefsIndex, -1);
+  assert.notEqual(startupContextIndex, -1);
+  assert.notEqual(editorEntrypointIndex, -1);
+  assert.ok(domRefsIndex < startupContextIndex);
+  assert.ok(startupContextIndex < editorEntrypointIndex);
+});
+
+test('editor startup context helper is loaded once', () => {
+  assert.equal(countMatches(editorHtml, /\.\.\/js\/editor\/editor-startup-context\.js/g), 1);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- load `editor-startup-context.js` before `editor.js`
- delegate DOM refs and URL param preparation to `LoveBudEditorStartupContext.createEditorStartupContext`
- keep auth gate, tree/memory loading, canvas init, selected memory state, and save/update paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: YES, startup context helper added before editor.js only
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js, pages/editor.html
Static checks: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PENDING