### PR TITLE
test(editor): cover interaction helper boundary

### DIFF
--- a/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
+++ b/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+const editorHtmlSource = fs.readFileSync('pages/editor.html', 'utf8');
+
+const interactionHelpers = [
+  'createSelectedMomentFocusHandler',
+  'createSidebarTreeActionsUpdater',
+  'createCurrentMomentDetailOpener'
+];
+
+test('editor shell helpers expose interaction helper boundaries', () => {
+  for (const helperName of interactionHelpers) {
+    assert.match(
+      shellHelpersSource,
+      new RegExp(`${helperName}:\\s*function\\s*\\(`),
+      `${helperName} must be exported from LoveBudEditorShellHelpers`
+    );
+  }
+});
+
+test('editor entrypoint resolves interaction helpers through shell helper boundary', () => {
+  for (const helperName of interactionHelpers) {
+    assert.match(
+      editorSource,
+      new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`),
+      `${helperName} should resolve through shellHelpers before local fallback`
+    );
+  }
+});
+
+test('editor html loads shell helpers before editor entrypoint for interaction helpers', () => {
+  const shellHelpersIndex = editorHtmlSource.indexOf('js/editor/editor-shell-helpers.js');
+  const editorIndex = editorHtmlSource.indexOf('js/editor.js');
+
+  assert.notEqual(shellHelpersIndex, -1, 'editor-shell-helpers.js script must exist');
+  assert.notEqual(editorIndex, -1, 'editor.js script must exist');
+  assert.ok(shellHelpersIndex < editorIndex, 'editor-shell-helpers.js must load before editor.js');
+});
+
+test('interaction helper boundary contract avoids canvas auth data and persistence modules', () => {
+  const combinedBoundaryText = interactionHelpers
+    .map((helperName) => {
+      const start = shellHelpersSource.indexOf(`${helperName}: function`);
+      assert.notEqual(start, -1, `${helperName} must exist`);
+      const nextExport = shellHelpersSource.indexOf('\n        ', start + helperName.length + 1);
+      return nextExport === -1 ? shellHelpersSource.slice(start) : shellHelpersSource.slice(start, nextExport);
+    })
+    .join('\n');
+
+  assert.doesNotMatch(combinedBoundaryText, /createEditorCanvas/);
+  assert.doesNotMatch(combinedBoundaryText, /initCanvas/);
+  assert.doesNotMatch(combinedBoundaryText, /createEditorMemoryActions/);
+  assert.doesNotMatch(combinedBoundaryText, /createEditorMemoryForm/);
+  assert.doesNotMatch(combinedBoundaryText, /registerOnAuthReady/);
+  assert.doesNotMatch(combinedBoundaryText, /LoveBudProtectedRoute/);
+  assert.doesNotMatch(combinedBoundaryText, /apiClient/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- add a contract test for the existing interaction helper boundary in `editor-shell-helpers.js`
- verify `createSelectedMomentFocusHandler`, `createSidebarTreeActionsUpdater`, and `createCurrentMomentDetailOpener` resolve through the shell helper boundary
- keep runtime source, HTML, CSS, API/backend/schema/auth/public viewer, and canvas code unchanged

## Verification
- not run locally; test-only PR created through GitHub contents API
- PR checks should be used as the remote verification source