### PR TITLE
refactor(editor): require selected focus helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -261,20 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return windowRef;
     });
 
-    const createSelectedMomentFocusHandler = shellHelpers.createSelectedMomentFocusHandler || ((options) => {
-        const opts = options || {};
-        const getEditorCanvas = opts.getEditorCanvas || (() => null);
-        const getSelectedNodeId = opts.getSelectedNodeId || (() => null);
-
-        return function focusSelectedMoment() {
-            const editorCanvas = getEditorCanvas();
-            const selectedNodeId = getSelectedNodeId();
-
-            if (editorCanvas && typeof editorCanvas.focusNodeById === 'function' && selectedNodeId) {
-                editorCanvas.focusNodeById(selectedNodeId);
-            }
-        };
-    });
+    const createSelectedMomentFocusHandler = shellHelpers.createSelectedMomentFocusHandler;
 
     const createSidebarTreeActionsUpdater = shellHelpers.createSidebarTreeActionsUpdater || ((options) => {
         const opts = options || {};
@@ -569,6 +556,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     editorCanvas.updateAffordance();
                 }
             };
+
+            if (typeof createSelectedMomentFocusHandler !== 'function') {
+                reportError('LoveBudEditorShellHelpers.createSelectedMomentFocusHandler missing');
+                return;
+            }
 
             const focusSelectedMoment = createSelectedMomentFocusHandler({
                 getEditorCanvas: () => editorCanvas,

--- a/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
+++ b/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
@@ -22,12 +22,27 @@ test('editor shell helpers expose interaction helper boundaries', () => {
   }
 });
 
-test('editor entrypoint resolves interaction helpers through shell helper boundary', () => {
-  for (const helperName of interactionHelpers) {
+test('editor entrypoint resolves selected moment focus through required shell helper boundary', () => {
+  assert.match(
+    editorSource,
+    /const\s+createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler\s*\|\|/
+  );
+});
+
+const fallbackInteractionHelpers = [
+  'createSidebarTreeActionsUpdater',
+  'createCurrentMomentDetailOpener'
+];
+
+test('editor entrypoint keeps remaining interaction helper fallbacks intact', () => {
+  for (const helperName of fallbackInteractionHelpers) {
     assert.match(
       editorSource,
-      new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`),
-      `${helperName} should resolve through shellHelpers before local fallback`
+      new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`)
     );
   }
 });

--- a/tests/contracts/editor-selected-moment-focus-contract.test.cjs
+++ b/tests/contracts/editor-selected-moment-focus-contract.test.cjs
@@ -19,9 +19,10 @@ test('selected moment focus helper preserves focusNodeById guard', () => {
   assert.match(shellHelpersSource, /editorCanvas\.focusNodeById\(selectedNodeId\)/);
 });
 
-test('editor delegates selected moment focus handler with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.createSelectedMomentFocusHandler/);
-  assert.match(editorSource, /const createSelectedMomentFocusHandler\s*=/);
+test('editor delegates selected moment focus handler through required shell helper', () => {
+  assert.match(editorSource, /const createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler/);
+  assert.doesNotMatch(editorSource, /createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler\s*\|\|/);
+  assert.match(editorSource, /LoveBudEditorShellHelpers\.createSelectedMomentFocusHandler missing/);
   assert.match(editorSource, /const focusSelectedMoment\s*=\s*createSelectedMomentFocusHandler\(\{/);
   assert.match(editorSource, /getEditorCanvas:\s*\(\)\s*=>\s*editorCanvas/);
   assert.match(editorSource, /getSelectedNodeId:\s*\(\)\s*=>\s*selectedNodeId/);


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createSelectedMomentFocusHandler` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.createSelectedMomentFocusHandler` boundary
- add an explicit missing-helper guard before creating `focusSelectedMoment`
- keep sidebar tree actions and current moment detail opener fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
