### PR TITLE
refactor(editor): require sidebar tree actions helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -263,23 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const createSelectedMomentFocusHandler = shellHelpers.createSelectedMomentFocusHandler;
 
-    const createSidebarTreeActionsUpdater = shellHelpers.createSidebarTreeActionsUpdater || ((options) => {
-        const opts = options || {};
-        const sidebarUIHelper = opts.sidebarUIHelper || {};
-        const i18n = opts.i18n;
-        const safeI18nText = opts.safeI18nText;
-        const getTreeId = opts.getTreeId || (() => null);
-
-        return function updateSidebarTreeActions() {
-            if (sidebarUIHelper.updateSidebarTreeActions) {
-                sidebarUIHelper.updateSidebarTreeActions({
-                    i18n,
-                    safeI18nText,
-                    getTreeId
-                });
-            }
-        };
-    });
+    const createSidebarTreeActionsUpdater = shellHelpers.createSidebarTreeActionsUpdater;
 
     const createMemoryActionsReadinessWrapper = shellHelpers.createMemoryActionsReadinessWrapper || ((options) => {
         const opts = options || {};
@@ -624,6 +608,11 @@ document.addEventListener('DOMContentLoaded', () => {
             exposeDetailPanelUpdater({ updateDetailPanel });
 
             const sidebarUIHelper = window.LoveBudEditorSidebarUI || {};
+            if (typeof createSidebarTreeActionsUpdater !== 'function') {
+                reportError('LoveBudEditorShellHelpers.createSidebarTreeActionsUpdater missing');
+                return;
+            }
+
             const updateSidebarTreeActions = createSidebarTreeActionsUpdater({
                 sidebarUIHelper,
                 i18n,

--- a/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
+++ b/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
@@ -22,29 +22,46 @@ test('editor shell helpers expose interaction helper boundaries', () => {
   }
 });
 
-test('editor entrypoint resolves selected moment focus through required shell helper boundary', () => {
-  assert.match(
-    editorSource,
-    /const\s+createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler/
-  );
-  assert.doesNotMatch(
-    editorSource,
-    /const\s+createSelectedMomentFocusHandler\s*=\s*shellHelpers\.createSelectedMomentFocusHandler\s*\|\|/
-  );
+const requiredInteractionHelpers = [
+  'createSelectedMomentFocusHandler',
+  'createSidebarTreeActionsUpdater'
+];
+
+test('editor entrypoint resolves required interaction helpers through shell helper boundary', () => {
+  for (const helperName of requiredInteractionHelpers) {
+    assert.match(
+      editorSource,
+      new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}`)
+    );
+    assert.doesNotMatch(
+      editorSource,
+      new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`)
+    );
+  }
 });
 
 const fallbackInteractionHelpers = [
-  'createSidebarTreeActionsUpdater',
   'createCurrentMomentDetailOpener'
 ];
 
-test('editor entrypoint keeps remaining interaction helper fallbacks intact', () => {
+test('editor entrypoint keeps remaining interaction helper fallback intact', () => {
   for (const helperName of fallbackInteractionHelpers) {
     assert.match(
       editorSource,
       new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`)
     );
   }
+});
+
+test('editor entrypoint guards missing sidebar tree actions helper before creation', () => {
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createSidebarTreeActionsUpdater missing/
+  );
+  assert.match(
+    editorSource,
+    /const\s+updateSidebarTreeActions\s*=\s*createSidebarTreeActionsUpdater\(\{/
+  );
 });
 
 test('editor html loads shell helpers before editor entrypoint for interaction helpers', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createSidebarTreeActionsUpdater` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.createSidebarTreeActionsUpdater` boundary
- add an explicit missing-helper guard before creating `updateSidebarTreeActions`
- keep current moment detail opener fallback unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
