### PR TITLE
test(editor): cover current moment detail opener contract

### DIFF
--- a/tests/contracts/editor-current-moment-detail-opener-contract.test.cjs
+++ b/tests/contracts/editor-current-moment-detail-opener-contract.test.cjs
@@ -1,80 +1,174 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const test = require('node:test');
+const vm = require('node:vm');
 
-const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 
-test('editor shell helpers expose current moment detail opener factory', () => {
+function loadShellHelpers() {
+  const context = {
+    window: {
+      location: { href: 'https://example.test/pages/editor.html?treeId=tree-1' }
+    },
+    console
+  };
+  context.window.window = context.window;
+  vm.createContext(context);
+  vm.runInContext(shellHelpersSource, context);
+  return context.window.LoveBudEditorShellHelpers;
+}
+
+test('shell helpers expose current moment detail opener factory contract', () => {
   assert.match(shellHelpersSource, /createCurrentMomentDetailOpener:\s*function\(options\)/);
   assert.match(shellHelpersSource, /var getCurrentEditingMemory\s*=\s*opts\.getCurrentEditingMemory/);
   assert.match(shellHelpersSource, /var getTreeMemories\s*=\s*opts\.getTreeMemories/);
   assert.match(shellHelpersSource, /var getSelectedNodeId\s*=\s*opts\.getSelectedNodeId/);
   assert.match(shellHelpersSource, /var createInitialMemory\s*=\s*opts\.createInitialMemory/);
   assert.match(shellHelpersSource, /var getTreeId\s*=\s*opts\.getTreeId/);
-  assert.match(shellHelpersSource, /return function openCurrentMomentDetail\(\)/);
+  assert.match(shellHelpersSource, /var editorPageHelpers\s*=\s*opts\.editorPageHelpers/);
 });
 
-test('current moment detail opener preserves active memory fallback order', () => {
-  const start = shellHelpersSource.indexOf('createCurrentMomentDetailOpener');
-  assert.notEqual(start, -1, 'factory must exist');
+test('current moment detail opener preserves active memory selection order', () => {
+  const currentIndex = shellHelpersSource.indexOf('getCurrentEditingMemory()');
+  const selectedIndex = shellHelpersSource.indexOf('treeMemories.find');
+  const initialIndex = shellHelpersSource.indexOf('createInitialMemory()');
 
-  const end = shellHelpersSource.lastIndexOf('};');
-  assert.notEqual(end, -1, 'factory must end');
-
-  const block = shellHelpersSource.slice(start, end);
-  const currentIndex = block.indexOf('getCurrentEditingMemory()');
-  const findIndex = block.indexOf('treeMemories.find');
-  const initialIndex = block.indexOf('createInitialMemory()');
-
-  assert.ok(currentIndex !== -1, 'current editing memory fallback must exist');
-  assert.ok(findIndex !== -1, 'selected tree memory lookup must exist');
-  assert.ok(initialIndex !== -1, 'initial memory fallback must exist');
-  assert.ok(currentIndex < findIndex, 'current editing memory must be checked first');
-  assert.ok(findIndex < initialIndex, 'tree memory lookup must be checked before initial fallback');
+  assert.ok(currentIndex !== -1);
+  assert.ok(selectedIndex !== -1);
+  assert.ok(initialIndex !== -1);
+  assert.ok(currentIndex < selectedIndex);
+  assert.ok(selectedIndex < initialIndex);
 });
 
-test('current moment detail opener preserves guards and payload', () => {
-  assert.match(shellHelpersSource, /if \(!activeMemory \|\| !activeMemory\.id \|\| !treeId\) return/);
-  assert.match(shellHelpersSource, /typeof editorPageHelpers\.openMomentDetail === 'function'/);
-  assert.match(shellHelpersSource, /memoryId:\s*activeMemory\.id/);
-  assert.match(shellHelpersSource, /treeId:\s*treeId/);
-  assert.match(shellHelpersSource, /getEditorBasePath:\s*getEditorBasePath/);
-  assert.match(shellHelpersSource, /locationRef:\s*locationRef/);
-  assert.match(shellHelpersSource, /reportError\('LoveBudEditorPageHelpers\.openMomentDetail missing'\)/);
+test('current moment detail opener opens current editing memory first', () => {
+  const shellHelpers = loadShellHelpers();
+  const calls = [];
+
+  const openCurrentMomentDetail = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => ({ id: 'current-1' }),
+    getTreeMemories: () => [{ id: 'selected-1' }],
+    getSelectedNodeId: () => 'selected-1',
+    createInitialMemory: () => ({ id: 'initial-1' }),
+    getTreeId: () => 'tree-1',
+    editorPageHelpers: {
+      openMomentDetail: (payload) => calls.push(payload)
+    },
+    getEditorBasePath: () => 'pages/',
+    locationRef: { href: 'before' },
+    reportError: assert.fail
+  });
+
+  openCurrentMomentDetail();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].memoryId, 'current-1');
+  assert.equal(calls[0].treeId, 'tree-1');
+  assert.equal(typeof calls[0].getEditorBasePath, 'function');
+  assert.deepEqual(calls[0].locationRef, { href: 'before' });
 });
 
-test('editor delegates current moment detail opener with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.createCurrentMomentDetailOpener/);
-  assert.match(editorSource, /const createCurrentMomentDetailOpener\s*=/);
-  assert.match(editorSource, /const openCurrentMomentDetail\s*=\s*createCurrentMomentDetailOpener\(\{/);
-  assert.match(editorSource, /getCurrentEditingMemory:\s*\(\)\s*=>\s*currentEditingMemory/);
-  assert.match(editorSource, /getTreeMemories:\s*\(\)\s*=>\s*treeMemories\(\)/);
-  assert.match(editorSource, /getSelectedNodeId:\s*\(\)\s*=>\s*selectedNodeId/);
-  assert.match(editorSource, /getTreeId:\s*\(\)\s*=>\s*treeId/);
-  assert.match(editorSource, /locationRef:\s*window\.location/);
+test('current moment detail opener falls back to selected tree memory', () => {
+  const shellHelpers = loadShellHelpers();
+  const calls = [];
+
+  const openCurrentMomentDetail = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => null,
+    getTreeMemories: () => [{ id: 'other-1' }, { id: 'selected-1' }],
+    getSelectedNodeId: () => 'selected-1',
+    createInitialMemory: () => ({ id: 'initial-1' }),
+    getTreeId: () => 'tree-1',
+    editorPageHelpers: {
+      openMomentDetail: (payload) => calls.push(payload)
+    }
+  });
+
+  openCurrentMomentDetail();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].memoryId, 'selected-1');
 });
 
-test('editor no longer owns inline current moment detail opener body', () => {
-  const start = editorSource.indexOf('const openCurrentMomentDetail =');
-  assert.notEqual(start, -1, 'openCurrentMomentDetail must exist');
+test('current moment detail opener falls back to initial memory when no current or selected memory exists', () => {
+  const shellHelpers = loadShellHelpers();
+  const calls = [];
 
-  const end = editorSource.indexOf('const updateTreeVisibility =', start);
-  assert.notEqual(end, -1, 'updateTreeVisibility must follow openCurrentMomentDetail');
+  const openCurrentMomentDetail = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => null,
+    getTreeMemories: () => [],
+    getSelectedNodeId: () => 'missing-1',
+    createInitialMemory: () => ({ id: 'initial-1' }),
+    getTreeId: () => 'tree-1',
+    editorPageHelpers: {
+      openMomentDetail: (payload) => calls.push(payload)
+    }
+  });
 
-  const block = editorSource.slice(start, end);
-  assert.match(block, /createCurrentMomentDetailOpener\(\{/);
-  assert.doesNotMatch(block, /currentEditingMemory \|\| treeMemories\(\)\.find/);
-  assert.doesNotMatch(block, /editorPageHelpers\.openMomentDetail\(\{/);
+  openCurrentMomentDetail();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].memoryId, 'initial-1');
 });
 
-test('editor keeps detail UI openCurrentMomentDetail injection intact', () => {
-  assert.match(editorSource, /window\.createEditorDetailUI\(\{/);
-  assert.match(editorSource, /openCurrentMomentDetail/);
-  assert.match(editorSource, /focusSelectedMoment/);
+test('current moment detail opener does not route without active memory or tree id', () => {
+  const shellHelpers = loadShellHelpers();
+  const calls = [];
+
+  const missingMemoryOpener = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => null,
+    getTreeMemories: () => [],
+    getSelectedNodeId: () => null,
+    createInitialMemory: () => null,
+    getTreeId: () => 'tree-1',
+    editorPageHelpers: {
+      openMomentDetail: (payload) => calls.push(payload)
+    }
+  });
+
+  missingMemoryOpener();
+
+  const missingTreeOpener = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => ({ id: 'current-1' }),
+    getTreeMemories: () => [],
+    getSelectedNodeId: () => null,
+    createInitialMemory: () => null,
+    getTreeId: () => null,
+    editorPageHelpers: {
+      openMomentDetail: (payload) => calls.push(payload)
+    }
+  });
+
+  missingTreeOpener();
+
+  assert.equal(calls.length, 0);
 });
 
-test('editor keeps updateTreeVisibility boundary after detail opener', () => {
-  assert.match(editorSource, /const updateTreeVisibility\s*=\s*async\s*\(nextVisibility\)\s*=>/);
-  assert.match(editorSource, /window\.apiClient\.updateTree/);
+test('current moment detail opener reports missing page helper instead of routing', () => {
+  const shellHelpers = loadShellHelpers();
+  const errors = [];
+
+  const openCurrentMomentDetail = shellHelpers.createCurrentMomentDetailOpener({
+    getCurrentEditingMemory: () => ({ id: 'current-1' }),
+    getTreeMemories: () => [],
+    getSelectedNodeId: () => null,
+    createInitialMemory: () => null,
+    getTreeId: () => 'tree-1',
+    editorPageHelpers: {},
+    reportError: (message) => errors.push(message)
+  });
+
+  openCurrentMomentDetail();
+
+  assert.deepEqual(errors, ['LoveBudEditorPageHelpers.openMomentDetail missing']);
+});
+
+test('editor entrypoint keeps current moment detail opener fallback before runtime removal slice', () => {
+  assert.match(
+    editorSource,
+    /const\s+createCurrentMomentDetailOpener\s*=\s*shellHelpers\.createCurrentMomentDetailOpener\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /const\s+openCurrentMomentDetail\s*=\s*createCurrentMomentDetailOpener\(\{/
+  );
 });


### PR DESCRIPTION
Refs #1698

## Summary
- add contract coverage for `LoveBudEditorShellHelpers.createCurrentMomentDetailOpener`
- verify active memory selection order and `openMomentDetail` routing inputs
- keep editor runtime, HTML, CSS, canvas, auth, API, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: NONE
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
