### PR TITLE
refactor(editor): require current moment detail opener helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -282,40 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
     });
 
-    const createCurrentMomentDetailOpener = shellHelpers.createCurrentMomentDetailOpener || ((options) => {
-        const opts = options || {};
-        const getCurrentEditingMemory = opts.getCurrentEditingMemory || (() => null);
-        const getTreeMemories = opts.getTreeMemories || (() => []);
-        const getSelectedNodeId = opts.getSelectedNodeId || (() => null);
-        const createInitialMemory = opts.createInitialMemory || (() => null);
-        const getTreeId = opts.getTreeId || (() => null);
-        const editorPageHelpers = opts.editorPageHelpers || {};
-        const getEditorBasePath = opts.getEditorBasePath;
-        const locationRef = opts.locationRef || window.location;
-        const reportError = opts.reportError || (() => {});
-
-        return function openCurrentMomentDetail() {
-            const selectedNodeId = getSelectedNodeId();
-            const treeMemories = getTreeMemories();
-            const activeMemory = getCurrentEditingMemory()
-                || treeMemories.find((memory) => memory.id === selectedNodeId)
-                || createInitialMemory();
-            const treeId = getTreeId();
-
-            if (!activeMemory || !activeMemory.id || !treeId) return;
-
-            if (typeof editorPageHelpers.openMomentDetail === 'function') {
-                editorPageHelpers.openMomentDetail({
-                    memoryId: activeMemory.id,
-                    treeId,
-                    getEditorBasePath,
-                    locationRef
-                });
-            } else {
-                reportError('LoveBudEditorPageHelpers.openMomentDetail missing');
-            }
-        };
-    });
+    const createCurrentMomentDetailOpener = shellHelpers.createCurrentMomentDetailOpener;
 
     const createSaveStatusOrchestrationFallback = shellHelpers.createSaveStatusOrchestrationFallback || ((options) => {
         const opts = options || {};
@@ -550,6 +517,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 getEditorCanvas: () => editorCanvas,
                 getSelectedNodeId: () => selectedNodeId
             });
+
+            if (typeof createCurrentMomentDetailOpener !== 'function') {
+                reportError('LoveBudEditorShellHelpers.createCurrentMomentDetailOpener missing');
+                return;
+            }
 
             const openCurrentMomentDetail = createCurrentMomentDetailOpener({
                 getCurrentEditingMemory: () => currentEditingMemory,

--- a/tests/contracts/editor-current-moment-detail-opener-contract.test.cjs
+++ b/tests/contracts/editor-current-moment-detail-opener-contract.test.cjs
@@ -162,10 +162,18 @@ test('current moment detail opener reports missing page helper instead of routin
   assert.deepEqual(errors, ['LoveBudEditorPageHelpers.openMomentDetail missing']);
 });
 
-test('editor entrypoint keeps current moment detail opener fallback before runtime removal slice', () => {
+test('editor entrypoint delegates current moment detail opener through required shell helper', () => {
   assert.match(
     editorSource,
+    /const\s+createCurrentMomentDetailOpener\s*=\s*shellHelpers\.createCurrentMomentDetailOpener/
+  );
+  assert.doesNotMatch(
+    editorSource,
     /const\s+createCurrentMomentDetailOpener\s*=\s*shellHelpers\.createCurrentMomentDetailOpener\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createCurrentMomentDetailOpener missing/
   );
   assert.match(
     editorSource,

--- a/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
+++ b/tests/contracts/editor-interaction-helper-boundary-contract.test.cjs
@@ -24,7 +24,8 @@ test('editor shell helpers expose interaction helper boundaries', () => {
 
 const requiredInteractionHelpers = [
   'createSelectedMomentFocusHandler',
-  'createSidebarTreeActionsUpdater'
+  'createSidebarTreeActionsUpdater',
+  'createCurrentMomentDetailOpener'
 ];
 
 test('editor entrypoint resolves required interaction helpers through shell helper boundary', () => {
@@ -40,13 +41,9 @@ test('editor entrypoint resolves required interaction helpers through shell help
   }
 });
 
-const fallbackInteractionHelpers = [
-  'createCurrentMomentDetailOpener'
-];
-
-test('editor entrypoint keeps remaining interaction helper fallback intact', () => {
-  for (const helperName of fallbackInteractionHelpers) {
-    assert.match(
+test('editor entrypoint has no remaining interaction helper local fallbacks', () => {
+  for (const helperName of interactionHelpers) {
+    assert.doesNotMatch(
       editorSource,
       new RegExp(`const\\s+${helperName}\\s*=\\s*shellHelpers\\.${helperName}\\s*\\|\\|`)
     );
@@ -61,6 +58,17 @@ test('editor entrypoint guards missing sidebar tree actions helper before creati
   assert.match(
     editorSource,
     /const\s+updateSidebarTreeActions\s*=\s*createSidebarTreeActionsUpdater\(\{/
+  );
+});
+
+test('editor entrypoint guards missing current moment detail opener before creation', () => {
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createCurrentMomentDetailOpener missing/
+  );
+  assert.match(
+    editorSource,
+    /const\s+openCurrentMomentDetail\s*=\s*createCurrentMomentDetailOpener\(\{/
   );
 });
 


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createCurrentMomentDetailOpener` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.createCurrentMomentDetailOpener` boundary
- add an explicit missing-helper guard before creating `openCurrentMomentDetail`
- update interaction helper boundary contracts now that all three interaction helpers are required
- keep canvas, auth, API, data loading, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
