### PR TITLE
refactor(editor): require memory actions readiness wrapper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -265,22 +265,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const createSidebarTreeActionsUpdater = shellHelpers.createSidebarTreeActionsUpdater;
 
-    const createMemoryActionsReadinessWrapper = shellHelpers.createMemoryActionsReadinessWrapper || ((options) => {
-        const opts = options || {};
-        const getMemoryActions = opts.getMemoryActions || (() => null);
-        const consoleRef = opts.consoleRef || console;
-
-        return async function updateSelectedMemoryFields(...args) {
-            const memoryActions = getMemoryActions();
-
-            if (!memoryActions || typeof memoryActions.updateSelectedMemoryFields !== 'function') {
-                consoleRef.warn('[editor] updateSelectedMemoryFields called before memory actions are ready');
-                return false;
-            }
-
-            return memoryActions.updateSelectedMemoryFields(...args);
-        };
-    });
+    const createMemoryActionsReadinessWrapper = shellHelpers.createMemoryActionsReadinessWrapper;
 
     const createCurrentMomentDetailOpener = shellHelpers.createCurrentMomentDetailOpener;
 
@@ -457,6 +442,12 @@ document.addEventListener('DOMContentLoaded', () => {
             let editorCanvas = null;
 
             let memoryActions = null;
+
+            if (typeof createMemoryActionsReadinessWrapper !== 'function') {
+                reportError('LoveBudEditorShellHelpers.createMemoryActionsReadinessWrapper missing');
+                return;
+            }
+
             const updateSelectedMemoryFields = createMemoryActionsReadinessWrapper({
                 getMemoryActions: () => memoryActions
             });

--- a/tests/contracts/editor-memory-actions-readiness-wrapper-contract.test.cjs
+++ b/tests/contracts/editor-memory-actions-readiness-wrapper-contract.test.cjs
@@ -24,11 +24,27 @@ test('memory actions readiness wrapper preserves argument forwarding', () => {
   assert.match(shellHelpersSource, /memoryActions\.updateSelectedMemoryFields\.apply\(memoryActions,\s*args\)/);
 });
 
-test('editor delegates memory actions readiness wrapper with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.createMemoryActionsReadinessWrapper/);
-  assert.match(editorSource, /const createMemoryActionsReadinessWrapper\s*=/);
-  assert.match(editorSource, /const updateSelectedMemoryFields\s*=\s*createMemoryActionsReadinessWrapper\(\{/);
-  assert.match(editorSource, /getMemoryActions:\s*\(\)\s*=>\s*memoryActions/);
+test('editor delegates memory actions readiness wrapper through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+createMemoryActionsReadinessWrapper\s*=\s*shellHelpers\.createMemoryActionsReadinessWrapper/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+createMemoryActionsReadinessWrapper\s*=\s*shellHelpers\.createMemoryActionsReadinessWrapper\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createMemoryActionsReadinessWrapper missing/
+  );
+  assert.match(
+    editorSource,
+    /const\s+updateSelectedMemoryFields\s*=\s*createMemoryActionsReadinessWrapper\(\{/
+  );
+  assert.match(
+    editorSource,
+    /getMemoryActions:\s*\(\)\s*=>\s*memoryActions/
+  );
 });
 
 test('editor no longer owns inline memory actions readiness wrapper near memoryActions declaration', () => {
@@ -53,4 +69,13 @@ test('editor keeps detail UI updateSelectedMemoryFields injection intact', () =>
 test('editor keeps memory actions creation and assignment intact', () => {
   assert.match(editorSource, /memoryActions\s*=\s*window\.createEditorMemoryActions\(\{/);
   assert.match(editorSource, /const \{\s*enterEditMode,\s*exitEditMode,\s*saveMemoryEdit,\s*deleteMemory\s*\}\s*=\s*memoryActions/);
+});
+
+test('editor guards missing memory actions readiness wrapper before creation', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.createMemoryActionsReadinessWrapper missing');
+  const createIndex = editorSource.indexOf('const updateSelectedMemoryFields = createMemoryActionsReadinessWrapper({');
+
+  assert.ok(guardIndex !== -1, 'missing wrapper guard must exist');
+  assert.ok(createIndex !== -1, 'updateSelectedMemoryFields creation must exist');
+  assert.ok(guardIndex < createIndex, 'guard must run before updateSelectedMemoryFields creation');
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createMemoryActionsReadinessWrapper` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.createMemoryActionsReadinessWrapper` boundary
- add an explicit missing-helper guard before creating `updateSelectedMemoryFields`
- update the memory actions readiness wrapper contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions creation, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
