### PR TITLE
refactor(editor): require refresh memories bridge helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -287,12 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
     });
 
-    const exposeRefreshMemoriesBridge = shellHelpers.exposeRefreshMemoriesBridge || ((options) => {
-        const opts = options || {};
-        const windowRef = opts.windowRef || window;
-        windowRef.refreshMemories = opts.refreshMemories;
-        return windowRef;
-    });
+    const exposeRefreshMemoriesBridge = shellHelpers.exposeRefreshMemoriesBridge;
 
     const resolveSaveStatusTimeFormatter = shellHelpers.resolveSaveStatusTimeFormatter || ((options) => {
         const opts = options || {};
@@ -630,6 +625,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             const refreshMemories = editorDataLoader.createRefreshMemories({ treeId, apiClient: window.apiClient, normalizeMemory, onMemoriesUpdated: handleMemoriesUpdated });
+
+            if (typeof exposeRefreshMemoriesBridge !== 'function') {
+                reportError('LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
+                return;
+            }
+
             exposeRefreshMemoriesBridge({ refreshMemories });
 
             const formatTimeAgo = resolveSaveStatusTimeFormatter({

--- a/tests/contracts/editor-refresh-memories-bridge-contract.test.cjs
+++ b/tests/contracts/editor-refresh-memories-bridge-contract.test.cjs
@@ -18,11 +18,23 @@ test('refresh memories bridge helper keeps testable window hook', () => {
   assert.match(shellHelpersSource, /opts\.refreshMemories/);
 });
 
-test('editor delegates refresh memories bridge with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.exposeRefreshMemoriesBridge/);
-  assert.match(editorSource, /const exposeRefreshMemoriesBridge\s*=/);
-  assert.match(editorSource, /windowRef\.refreshMemories\s*=\s*opts\.refreshMemories/);
-  assert.match(editorSource, /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/);
+test('editor delegates refresh memories bridge through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+exposeRefreshMemoriesBridge\s*=\s*shellHelpers\.exposeRefreshMemoriesBridge/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+exposeRefreshMemoriesBridge\s*=\s*shellHelpers\.exposeRefreshMemoriesBridge\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.exposeRefreshMemoriesBridge missing/
+  );
+  assert.match(
+    editorSource,
+    /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/
+  );
 });
 
 test('editor no longer assigns refresh memories bridge inline', () => {
@@ -35,6 +47,7 @@ test('editor no longer assigns refresh memories bridge inline', () => {
   const block = editorSource.slice(start, end);
   assert.match(block, /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/);
   assert.doesNotMatch(block, /window\.refreshMemories\s*=\s*refreshMemories/);
+  assert.doesNotMatch(block, /windowRef\.refreshMemories\s*=/);
 });
 
 test('editor keeps refresh memories factory invocation intact', () => {
@@ -59,4 +72,13 @@ test('editor keeps handleMemoriesUpdated orchestration intact', () => {
   assert.match(block, /updateSidebarStatus\(\)/);
   assert.match(block, /currentEditingMemory\s*=\s*refreshedEditingMemory/);
   assert.match(block, /updateDetailPanel\(refreshedEditingMemory\)/);
+});
+
+test('editor guards missing refresh memories bridge before exposure', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
+  const exposeIndex = editorSource.indexOf('exposeRefreshMemoriesBridge({ refreshMemories });');
+
+  assert.ok(guardIndex !== -1, 'missing refresh memories bridge guard must exist');
+  assert.ok(exposeIndex !== -1, 'refresh memories bridge exposure must exist');
+  assert.ok(guardIndex < exposeIndex, 'guard must run before refresh memories bridge exposure');
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `exposeRefreshMemoriesBridge` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge` boundary
- add an explicit missing-helper guard before exposing `refreshMemories`
- update the refresh memories bridge contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
