### PR TITLE
refactor(editor): require detail panel bridge helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -254,12 +254,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return editorNamespace;
     });
 
-    const exposeDetailPanelUpdater = shellHelpers.exposeDetailPanelUpdater || ((options) => {
-        const opts = options || {};
-        const windowRef = opts.windowRef || window;
-        windowRef.updateDetailPanel = opts.updateDetailPanel;
-        return windowRef;
-    });
+    const exposeDetailPanelUpdater = shellHelpers.exposeDetailPanelUpdater;
 
     const createSelectedMomentFocusHandler = shellHelpers.createSelectedMomentFocusHandler;
 
@@ -563,6 +558,11 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             const { setDetailEmptyState, updateFocusSelectedBtn, updateSidebarStatus: updateSidebarStatusBase, updateDetailPanel } = detailUI;
+            if (typeof exposeDetailPanelUpdater !== 'function') {
+                reportError('LoveBudEditorShellHelpers.exposeDetailPanelUpdater missing');
+                return;
+            }
+
             exposeDetailPanelUpdater({ updateDetailPanel });
 
             const sidebarUIHelper = window.LoveBudEditorSidebarUI || {};

--- a/tests/contracts/editor-detail-panel-bridge-contract.test.cjs
+++ b/tests/contracts/editor-detail-panel-bridge-contract.test.cjs
@@ -18,24 +18,46 @@ test('detail panel bridge helper keeps testable window hook', () => {
   assert.match(shellHelpersSource, /opts\.updateDetailPanel/);
 });
 
-test('editor delegates detail panel bridge with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.exposeDetailPanelUpdater/);
-  assert.match(editorSource, /const exposeDetailPanelUpdater\s*=/);
-  assert.match(editorSource, /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}\)/);
-  assert.match(editorSource, /windowRef\.updateDetailPanel\s*=\s*opts\.updateDetailPanel/);
-});
+test('editor delegates detail panel bridge through required shell helper', () => {
+    assert.match(
+      editorSource,
+      /const\s+exposeDetailPanelUpdater\s*=\s*shellHelpers\.exposeDetailPanelUpdater/
+    );
+    assert.doesNotMatch(
+      editorSource,
+      /const\s+exposeDetailPanelUpdater\s*=\s*shellHelpers\.exposeDetailPanelUpdater\s*\|\|/
+    );
+    assert.match(
+      editorSource,
+      /LoveBudEditorShellHelpers\.exposeDetailPanelUpdater missing/
+    );
+    assert.match(
+      editorSource,
+      /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}\)/
+    );
+  });
 
 test('editor no longer assigns detail panel bridge inline', () => {
-  const start = editorSource.indexOf('const { setDetailEmptyState, updateFocusSelectedBtn');
-  assert.notEqual(start, -1, 'detailUI destructuring must exist');
+    const start = editorSource.indexOf('const { setDetailEmptyState, updateFocusSelectedBtn');
+    assert.notEqual(start, -1, 'detailUI destructuring must exist');
 
-  const end = editorSource.indexOf('const sidebarUIHelper =', start);
-  assert.notEqual(end, -1, 'sidebar helper setup must follow detail bridge setup');
+    const end = editorSource.indexOf('const sidebarUIHelper =', start);
+    assert.notEqual(end, -1, 'sidebar helper setup must follow detail bridge setup');
 
-  const block = editorSource.slice(start, end);
-  assert.match(block, /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}\)/);
-  assert.doesNotMatch(block, /window\.updateDetailPanel\s*=\s*updateDetailPanel/);
-});
+    const block = editorSource.slice(start, end);
+    assert.match(block, /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}/);
+    assert.doesNotMatch(block, /window\.updateDetailPanel\s*=\s*updateDetailPanel/);
+    assert.doesNotMatch(block, /windowRef\.updateDetailPanel\s*=/);
+  });
+
+test('editor guards missing detail panel bridge before exposure', () => {
+    const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.exposeDetailPanelUpdater missing');
+    const exposeIndex = editorSource.indexOf('exposeDetailPanelUpdater({ updateDetailPanel });');
+
+    assert.ok(guardIndex !== -1, 'missing detail panel bridge guard must exist');
+    assert.ok(exposeIndex !== -1, 'detail panel bridge exposure must exist');
+    assert.ok(guardIndex < exposeIndex, 'guard must run before detail panel bridge exposure');
+  });
 
 test('editor keeps detail panel destructuring and canvas injection intact', () => {
   assert.match(

--- a/tests/contracts/editor-empty-guide-bridge-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-bridge-contract.test.cjs
@@ -43,9 +43,9 @@ test('editor keeps empty guide updater creation and event binding intact', () =>
   assert.match(editorSource, /updateCanvasEmptyGuide\(\)/);
 });
 
-test('editor detail panel bridge is delegated to shell helper in this slice', () => {
-  assert.match(editorSource, /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}\)/);
-  assert.match(editorSource, /windowRef\.updateDetailPanel\s*=\s*opts\.updateDetailPanel/);
+test('editor detail panel bridge is delegated to required shell helper in this slice', () => {
+  assert.match(editorSource, /exposeDetailPanelUpdater\(\{\s*updateDetailPanel\s*\}/);
+  assert.match(editorSource, /LoveBudEditorShellHelpers\.exposeDetailPanelUpdater missing/);
 });
 
 test('editor shell helpers load before editor entrypoint', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `exposeDetailPanelUpdater` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.exposeDetailPanelUpdater` boundary
- add an explicit missing-helper guard before exposing `updateDetailPanel`
- update the detail panel bridge contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS