### PR TITLE
refactor(editor): require empty guide bridge helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -247,12 +247,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
     });
 
-    const exposeCanvasEmptyGuideUpdater = shellHelpers.exposeCanvasEmptyGuideUpdater || ((options) => {
-        const opts = options || {};
-        const editorNamespace = opts.editorNamespace || (window.LoveBudEditor = window.LoveBudEditor || {});
-        editorNamespace.updateCanvasEmptyGuide = opts.updateCanvasEmptyGuide;
-        return editorNamespace;
-    });
+    const exposeCanvasEmptyGuideUpdater = shellHelpers.exposeCanvasEmptyGuideUpdater;
 
     const exposeDetailPanelUpdater = shellHelpers.exposeDetailPanelUpdater;
 
@@ -463,6 +458,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 };
             
             // Bridge this back to LoveBudEditor so canvas can call it
+            if (typeof exposeCanvasEmptyGuideUpdater !== 'function') {
+                reportError('LoveBudEditorShellHelpers.exposeCanvasEmptyGuideUpdater missing');
+                return;
+            }
+
             exposeCanvasEmptyGuideUpdater({ updateCanvasEmptyGuide });
 
             const selectNode = (el, data) => {

--- a/tests/contracts/editor-empty-guide-bridge-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-bridge-contract.test.cjs
@@ -18,11 +18,23 @@ test('canvas empty guide bridge helper keeps testable namespace hook', () => {
   assert.match(shellHelpersSource, /opts\.updateCanvasEmptyGuide/);
 });
 
-test('editor delegates canvas empty guide bridge with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.exposeCanvasEmptyGuideUpdater/);
-  assert.match(editorSource, /const exposeCanvasEmptyGuideUpdater\s*=/);
-  assert.match(editorSource, /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}\)/);
-  assert.match(editorSource, /editorNamespace\.updateCanvasEmptyGuide\s*=\s*opts\.updateCanvasEmptyGuide/);
+test('editor delegates canvas empty guide bridge through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+exposeCanvasEmptyGuideUpdater\s*=\s*shellHelpers\.exposeCanvasEmptyGuideUpdater/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+exposeCanvasEmptyGuideUpdater\s*=\s*shellHelpers\.exposeCanvasEmptyGuideUpdater\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.exposeCanvasEmptyGuideUpdater missing/
+  );
+  assert.match(
+    editorSource,
+    /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}\)/
+  );
 });
 
 test('editor no longer assigns canvas empty guide bridge inline', () => {
@@ -33,8 +45,18 @@ test('editor no longer assigns canvas empty guide bridge inline', () => {
   assert.notEqual(end, -1, 'selectNode must follow empty guide bridge setup');
 
   const block = editorSource.slice(start, end);
-  assert.match(block, /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}\)/);
+  assert.match(block, /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}/);
   assert.doesNotMatch(block, /window\.LoveBudEditor\.updateCanvasEmptyGuide\s*=\s*updateCanvasEmptyGuide/);
+  assert.doesNotMatch(block, /editorNamespace\.updateCanvasEmptyGuide\s*=/);
+});
+
+test('editor guards missing canvas empty guide bridge before exposure', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.exposeCanvasEmptyGuideUpdater missing');
+  const exposeIndex = editorSource.indexOf('exposeCanvasEmptyGuideUpdater({ updateCanvasEmptyGuide });');
+
+  assert.ok(guardIndex !== -1, 'missing canvas empty guide bridge guard must exist');
+  assert.ok(exposeIndex !== -1, 'canvas empty guide bridge exposure must exist');
+  assert.ok(guardIndex < exposeIndex, 'guard must run before canvas empty guide bridge exposure');
 });
 
 test('editor keeps empty guide updater creation and event binding intact', () => {

--- a/tests/contracts/editor-empty-guide-updater-delegation-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-updater-delegation-contract.test.cjs
@@ -35,10 +35,10 @@ test('editor entrypoint no longer owns canvas empty guide dom toggle implementat
 });
 
 test('editor keeps global updateCanvasEmptyGuide bridge and call sites', () => {
-  assert.match(editorSource, /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}\)/);
+  assert.match(editorSource, /exposeCanvasEmptyGuideUpdater\(\{\s*updateCanvasEmptyGuide\s*\}/);
   assert.match(editorSource, /updateCanvasEmptyGuide\(\);/);
   assert.match(editorSource, /updateSidebarStatus\(\);/);
-  assert.match(editorSource, /editorNamespace\.updateCanvasEmptyGuide\s*=\s*opts\.updateCanvasEmptyGuide/);
+  assert.match(editorSource, /LoveBudEditorShellHelpers\.exposeCanvasEmptyGuideUpdater missing/);
 });
 
 test('editor reuses one empty guide ui helper binding reference', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `exposeCanvasEmptyGuideUpdater` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.exposeCanvasEmptyGuideUpdater` boundary
- add an explicit missing-helper guard before exposing `updateCanvasEmptyGuide`
- update the empty guide bridge contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS