### PR TITLE
refactor(editor): require save status fallback factory helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -259,23 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const createCurrentMomentDetailOpener = shellHelpers.createCurrentMomentDetailOpener;
 
-    const createSaveStatusOrchestrationFallback = shellHelpers.createSaveStatusOrchestrationFallback || ((options) => {
-        const opts = options || {};
-        const consoleRef = opts.consoleRef || console;
-
-        return function createEditorSaveStatusOrchestrationFallback() {
-            consoleRef.warn('[editor] LoveBudEditorSaveStatusOrchestration not loaded, using minimal fallback');
-
-            let saveStatusData = { status: 'saved', lastSaved: null, timer: null };
-
-            return {
-                saveStatusData,
-                updateSaveStatus: (status, message) => {
-                    saveStatusData.status = status;
-                }
-            };
-        };
-    });
+    const createSaveStatusOrchestrationFallback = shellHelpers.createSaveStatusOrchestrationFallback;
 
     const exposeRefreshMemoriesBridge = shellHelpers.exposeRefreshMemoriesBridge;
 
@@ -639,8 +623,16 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             const saveStatusOrchestrationHelper = window.LoveBudEditorSaveStatusOrchestration || {};
-            const createEditorSaveStatusOrchestration = saveStatusOrchestrationHelper.createEditorSaveStatusOrchestration
-                || createSaveStatusOrchestrationFallback();
+            let createEditorSaveStatusOrchestration = saveStatusOrchestrationHelper.createEditorSaveStatusOrchestration;
+
+            if (typeof createEditorSaveStatusOrchestration !== 'function') {
+                if (typeof createSaveStatusOrchestrationFallback !== 'function') {
+                    reportError('LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
+                    return;
+                }
+
+                createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();
+            }
 
             const { saveStatusData, updateSaveStatus } = createEditorSaveStatusOrchestration({ editorSaveStatus, i18n, formatTimeAgo });
 

--- a/tests/contracts/editor-save-status-fallback-factory-contract.test.cjs
+++ b/tests/contracts/editor-save-status-fallback-factory-contract.test.cjs
@@ -24,13 +24,34 @@ test('save status fallback preserves minimal updateSaveStatus behavior', () => {
   assert.match(shellHelpersSource, /saveStatusData\.status\s*=\s*status/);
 });
 
-test('editor delegates save status fallback while preserving primary orchestration priority', () => {
-  assert.match(editorSource, /shellHelpers\.createSaveStatusOrchestrationFallback/);
-  assert.match(editorSource, /const createSaveStatusOrchestrationFallback\s*=/);
-  assert.match(editorSource, /const saveStatusOrchestrationHelper\s*=\s*window\.LoveBudEditorSaveStatusOrchestration\s*\|\|\s*\{\}/);
+test('editor delegates save status fallback through required shell helper while preserving primary orchestration priority', () => {
   assert.match(
     editorSource,
-    /const createEditorSaveStatusOrchestration\s*=\s*saveStatusOrchestrationHelper\.createEditorSaveStatusOrchestration\s*\|\|\s*createSaveStatusOrchestrationFallback\(\)/
+    /const\s+createSaveStatusOrchestrationFallback\s*=\s*shellHelpers\.createSaveStatusOrchestrationFallback/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+createSaveStatusOrchestrationFallback\s*=\s*shellHelpers\.createSaveStatusOrchestrationFallback\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /const\s+saveStatusOrchestrationHelper\s*=\s*window\.LoveBudEditorSaveStatusOrchestration\s*\|\|\s*\{\}/
+  );
+  assert.match(
+    editorSource,
+    /let\s+createEditorSaveStatusOrchestration\s*=\s*saveStatusOrchestrationHelper\.createEditorSaveStatusOrchestration/
+  );
+  assert.match(
+    editorSource,
+    /typeof\s+createEditorSaveStatusOrchestration\s*!==\s*'function'/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createSaveStatusOrchestrationFallback missing/
+  );
+  assert.match(
+    editorSource,
+    /createEditorSaveStatusOrchestration\s*=\s*createSaveStatusOrchestrationFallback\(\)/
   );
 });
 
@@ -43,8 +64,18 @@ test('editor no longer owns inline save status fallback body', () => {
 
   const block = editorSource.slice(start, end);
   assert.match(block, /createSaveStatusOrchestrationFallback\(\)/);
+  assert.match(block, /LoveBudEditorShellHelpers\.createSaveStatusOrchestrationFallback missing/);
   assert.doesNotMatch(block, /console\.warn\('\[editor\] LoveBudEditorSaveStatusOrchestration not loaded, using minimal fallback'\)/);
   assert.doesNotMatch(block, /let saveStatusData\s*=\s*\{\s*status:\s*'saved',\s*lastSaved:\s*null,\s*timer:\s*null\s*\}/);
+});
+
+test('editor guards missing save status fallback factory before fallback creation', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
+  const fallbackIndex = editorSource.indexOf('createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();');
+
+  assert.ok(guardIndex !== -1, 'missing save status fallback factory guard must exist');
+  assert.ok(fallbackIndex !== -1, 'fallback factory assignment must exist');
+  assert.ok(guardIndex < fallbackIndex, 'guard must run before fallback factory assignment');
 });
 
 test('editor keeps save status orchestration invocation intact', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback body for `createSaveStatusOrchestrationFallback` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback` boundary only when the primary save-status orchestration module is unavailable
- preserve primary `LoveBudEditorSaveStatusOrchestration.createEditorSaveStatusOrchestration` priority
- update the save-status fallback factory contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS