### PR TITLE
refactor(editor): require save status time formatter helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -263,13 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const exposeRefreshMemoriesBridge = shellHelpers.exposeRefreshMemoriesBridge;
 
-    const resolveSaveStatusTimeFormatter = shellHelpers.resolveSaveStatusTimeFormatter || ((options) => {
-        const opts = options || {};
-        const editorSaveStatus = opts.editorSaveStatus || {};
-        const createInlineFormatTimeAgoFallback = opts.createInlineFormatTimeAgoFallback || (() => () => '');
-
-        return editorSaveStatus.formatTimeAgo || createInlineFormatTimeAgoFallback();
-    });
+    const resolveSaveStatusTimeFormatter = shellHelpers.resolveSaveStatusTimeFormatter;
 
     const startEditor = async () => {
         const { log, reportError } = createEditorDebugReporter();
@@ -616,6 +610,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             exposeRefreshMemoriesBridge({ refreshMemories });
+
+            if (typeof resolveSaveStatusTimeFormatter !== 'function') {
+                reportError('LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
+                return;
+            }
 
             const formatTimeAgo = resolveSaveStatusTimeFormatter({
                 editorSaveStatus,

--- a/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
+++ b/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
@@ -23,11 +23,27 @@ test('save status time formatter resolver preserves primary formatter priority',
   assert.match(block, /return editorSaveStatus\.formatTimeAgo \|\| createInlineFormatTimeAgoFallback\(\)/);
 });
 
-test('editor delegates save status time formatter resolution with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.resolveSaveStatusTimeFormatter/);
-  assert.match(editorSource, /const resolveSaveStatusTimeFormatter\s*=/);
-  assert.match(editorSource, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\{/);
-  assert.match(editorSource, /editorSaveStatus,\s*createInlineFormatTimeAgoFallback/);
+test('editor delegates save status time formatter resolution through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+resolveSaveStatusTimeFormatter\s*=\s*shellHelpers\.resolveSaveStatusTimeFormatter/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+resolveSaveStatusTimeFormatter\s*=\s*shellHelpers\.resolveSaveStatusTimeFormatter\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/
+  );
+  assert.match(
+    editorSource,
+    /const\s+formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\{/
+  );
+  assert.match(
+    editorSource,
+    /editorSaveStatus,\s*createInlineFormatTimeAgoFallback/
+  );
 });
 
 test('editor no longer owns inline save status time formatter resolver', () => {
@@ -39,7 +55,17 @@ test('editor no longer owns inline save status time formatter resolver', () => {
 
   const block = editorSource.slice(start, end);
   assert.match(block, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\{/);
+  assert.match(block, /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/);
   assert.doesNotMatch(block, /const formatTimeAgo\s*=\s*editorSaveStatus\.formatTimeAgo\s*\|\|\s*createInlineFormatTimeAgoFallback\(\)/);
+});
+
+test('editor guards missing save status time formatter before resolution', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
+  const formatIndex = editorSource.indexOf('const formatTimeAgo = resolveSaveStatusTimeFormatter({');
+
+  assert.ok(guardIndex !== -1, 'missing save status time formatter guard must exist');
+  assert.ok(formatIndex !== -1, 'formatTimeAgo resolution must exist');
+  assert.ok(guardIndex < formatIndex, 'guard must run before formatTimeAgo resolution');
 });
 
 test('editor keeps createInlineFormatTimeAgoFallback available and unchanged by boundary', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback body for `resolveSaveStatusTimeFormatter` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter` boundary before resolving `formatTimeAgo`
- preserve `editorSaveStatus.formatTimeAgo` priority and `createInlineFormatTimeAgoFallback` behavior through the shell helper
- update the save-status time formatter contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS