### PR TITLE
docs(editor): refresh helper fallback audit

### DIFF
--- a/docs/engineering/EDITOR_HELPER_FALLBACK_AUDIT_1698.md
+++ b/docs/engineering/EDITOR_HELPER_FALLBACK_AUDIT_1698.md
@@ -1,12 +1,30 @@
 # Editor Helper Fallback Audit for #1698
 
-**Status:** Active audit  
-**Owner:** CTO / Engineering Lead  
-**Related issue:** #1698  
-**Reference main SHA:** `fb52f42f66ec92d70286ffe07cb26de32a710cab`  
+**Status:** Active audit — refreshed after helper-boundary cleanup through PR #1900
+**Owner:** CTO / Engineering Lead
+**Related issue:** #1698
+**Reference main SHA:** `8ee12e1403e1d9d3a2cbb496ab9e6db0003975bf`
 **Audited file:** `js/editor.js`
 
-This audit reviews the remaining helper fallback boundaries in `js/editor.js` after the event-binding and startup-context slices landed.
+This audit reviews the remaining helper fallback boundaries in `js/editor.js` after the event-binding, startup-context, and helper-boundary slices landed.
+
+---
+
+## Completed helper-boundary slices through PR #1900
+
+The following editor entrypoint local fallback bodies have been removed from `js/editor.js` and now resolve through `window.LoveBudEditorShellHelpers` required boundaries:
+
+| Helper | PR | Current state |
+| --- | --- | --- |
+| `createSelectedMomentFocusHandler` | #1891 | Required shell helper |
+| `createSidebarTreeActionsUpdater` | #1892 | Required shell helper |
+| `createCurrentMomentDetailOpener` | #1894 | Required shell helper |
+| `createMemoryActionsReadinessWrapper` | #1895 | Required shell helper |
+| `exposeRefreshMemoriesBridge` | #1896 | Required shell helper |
+| `exposeDetailPanelUpdater` | #1897 | Required shell helper |
+| `exposeCanvasEmptyGuideUpdater` | #1898 | Required shell helper |
+| `createSaveStatusOrchestrationFallback` | #1899 | Required shell helper, with primary orchestration priority preserved |
+| `resolveSaveStatusTimeFormatter` | #1900 | Required shell helper, with formatter priority preserved |
 
 ---
 
@@ -20,9 +38,9 @@ This audit reviews the remaining helper fallback boundaries in `js/editor.js` af
 | Shell/core fallbacks | `getHttpStatus`, `getI18n`, `getEditorBasePath`, `buildEditorRedirectTarget`, redirect fallback | Hold. Mostly safe but still protects startup and login redirect behavior. |
 | Text/media resolver fallbacks | `safeI18nText`, `resolveHintText`, `resolveTreeTitleText`, `resolveInfoText`, `escapeHtml`, `resolveMemoryThumbnail` | Hold. Some paths depend on `LoveBudSecurity` and resolver fallback bundles. |
 | Shell state/readiness fallbacks | `markEditorReady`, `applyEditorEditabilityState`, `createEditorDebugReporter`, dependency waiter | Hold. Too close to startup diagnostics and page readiness. |
-| Global bridge fallbacks | `exposeCanvasEmptyGuideUpdater`, `exposeDetailPanelUpdater`, `exposeRefreshMemoriesBridge` | Hold. These expose legacy globals used by canvas/detail/refresh flows. |
-| Interaction helper fallbacks | selected-moment focus, sidebar tree actions, current-moment detail opener | Possible later, but only with contract-first coverage. |
-| Save status fallback | `createSaveStatusOrchestrationFallback`, `resolveSaveStatusTimeFormatter` | Hold. Touches save UI state and fallback behavior. |
+| Global bridge fallbacks | `exposeCanvasEmptyGuideUpdater`, `exposeDetailPanelUpdater`, `exposeRefreshMemoriesBridge` | Completed through #1896-#1898. Keep browser smoke recommended. |
+| Interaction helper fallbacks | selected-moment focus, sidebar tree actions, current-moment detail opener | Completed through #1891, #1892, and #1894, with #1893 test-first coverage for detail opener. |
+| Save status fallback | `createSaveStatusOrchestrationFallback`, `resolveSaveStatusTimeFormatter` | Completed through #1899-#1900. Primary save-status orchestration and formatter priority preserved. |
 | Data-loader fallback | `createInlineNextMemoryIdFallback` | Hold. Used only when helper is missing, but still affects memory creation IDs. |
 
 ---
@@ -47,12 +65,10 @@ markEditorReady fallback
 applyEditorEditabilityState fallback
 debug reporter fallback
 startup dependency waiter fallback
-canvas/detail/refresh bridge fallbacks
-save status orchestration fallback
 next memory id fallback
 ```
 
-These areas connect to root selection, auth redirect, i18n/copy, page readiness, canvas bridge behavior, save status, or memory creation behavior.
+These areas connect to root selection, auth redirect, i18n/copy, page readiness, or memory creation behavior.
 
 ---
 
@@ -77,13 +93,14 @@ Even here, the safer path is:
 
 ## 5. Current recommendation
 
-Do not remove fallbacks in the next PR.
+Do not remove additional runtime fallbacks in the next PR without either authenticated editor browser smoke or test-first contract coverage for the exact fallback group.
 
-Next best options:
+The next best options are:
 
 1. Run authenticated Editor browser smoke for current `main`.
-2. If browser smoke is unavailable, create a test-first helper contract for a small non-persistence helper.
-3. Keep runtime wiring changes separate from helper-contract PRs.
+2. If browser smoke is unavailable, add test-first contracts for one remaining small fallback group before any runtime removal.
+3. Keep root/auth/redirect/resolver/readiness/data-loader fallback changes separate.
+4. Avoid mixing documentation refresh, runtime fallback removal, and canvas refactors in one PR.
 
 The next PR should not touch:
 


### PR DESCRIPTION
Refs #1698

## Summary
- refresh `EDITOR_HELPER_FALLBACK_AUDIT_1698.md` after the #1896-#1900 helper-boundary slices
- mark completed bridge/save-status required-boundary conversions
- keep remaining root/auth/resolver/readiness/startup fallback groups in hold or test-first status
- document that browser smoke remains recommended before any further runtime fallback removal

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: NONE
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS