### PR TITLE
refactor(editor): require mark ready helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -177,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
     const createInlineFormatTimeAgoFallback = entryFallbacks.createInlineFormatTimeAgoFallback;
 
-    const markEditorReady = shellHelpers.markEditorReady || (() => document.body?.classList.remove('editor-preload'));
+    const markEditorReady = shellHelpers.markEditorReady;
 
     const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState || ((options) => {
         const opts = options || {};
@@ -267,6 +267,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const startEditor = async () => {
         const { log, reportError } = createEditorDebugReporter();
+
+        if (typeof markEditorReady !== 'function') {
+            reportError('LoveBudEditorShellHelpers.markEditorReady missing');
+            return;
+        }
 
         log('startEditor sequence initiated');
 

--- a/tests/contracts/editor-ready-marker-contract.test.cjs
+++ b/tests/contracts/editor-ready-marker-contract.test.cjs
@@ -18,7 +18,8 @@ test('markEditorReady removes editor preload class through classList', () => {
 
 test('editor delegates ready marker to shell helper with fallback', () => {
   assert.match(editorSource, /shellHelpers\.markEditorReady/);
-  assert.match(editorSource, /document\.body\?\.classList\.remove\('editor-preload'\)/);
+  assert.doesNotMatch(editorSource, /document\.body\?\.classList\.remove\('editor-preload'\)/);
+  assert.match(editorSource, /LoveBudEditorShellHelpers\.markEditorReady missing/);
 });
 
 test('editor ready marker call sites remain intact', () => {

--- a/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
+++ b/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
@@ -144,8 +144,19 @@ test('createEditorStartupDependencyWaiter calls reportError and returns false wh
 
 // --- 6. editor.js still keeps local fallbacks (test-only, not removing) ---
 
-test('editor.js still keeps markEditorReady local fallback', () => {
-  assert.match(editorSource, /shellHelpers\.markEditorReady\s*\|\|/);
+test('editor.js delegates markEditorReady through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+markEditorReady\s*=\s*shellHelpers\.markEditorReady/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+markEditorReady\s*=\s*shellHelpers\.markEditorReady\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.markEditorReady missing/
+  );
 });
 
 test('editor.js still keeps applyEditorEditabilityState local fallback', () => {
@@ -176,6 +187,18 @@ test('editor.js calls applyEditorEditabilityState with canEdit', () => {
 
 test('editor.js calls markEditorReady in startup completion', () => {
   assert.match(editorSource, /markEditorReady\(\)/);
+});
+
+test('editor.js guards missing markEditorReady before startup proceeds', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.markEditorReady missing');
+  const logIndex = editorSource.indexOf("log('startEditor sequence initiated')");
+  const waiterIndex = editorSource.indexOf('const waitForGlobal = createEditorStartupDependencyWaiter({ log, reportError });');
+
+  assert.ok(guardIndex !== -1, 'missing markEditorReady guard must exist');
+  assert.ok(logIndex !== -1, 'startup log must exist');
+  assert.ok(waiterIndex !== -1, 'dependency waiter setup must exist');
+  assert.ok(guardIndex < logIndex, 'markEditorReady guard must run before startup log');
+  assert.ok(guardIndex < waiterIndex, 'markEditorReady guard must run before dependency waiter setup');
 });
 
 // --- 8. VM-based runtime behavior tests ---


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `markEditorReady` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.markEditorReady` boundary
- add an explicit missing-helper guard before startup proceeds
- update shell readiness helper contracts to assert required-helper behavior for `markEditorReady`
- keep `applyEditorEditabilityState`, `createEditorDebugReporter`, and `createEditorStartupDependencyWaiter` fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS