### PR TITLE
refactor(editor): require editability state helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -179,14 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const markEditorReady = shellHelpers.markEditorReady;
 
-    const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState || ((options) => {
-        const opts = options || {};
-        const nextCanEdit = opts.canEdit !== false;
-        window.LoveBudEditor = window.LoveBudEditor || {};
-        window.LoveBudEditor.canEdit = nextCanEdit;
-        document.body?.classList?.toggle('editor-readonly', !nextCanEdit);
-        return window.LoveBudEditor;
-    });
+    const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState;
 
     const editorShellCopyApplier = window.LoveBudEditorShellCopyApplier || {};
     const createEditorShellCopyApplier = editorShellCopyApplier.createEditorShellCopyApplier || (() => () => {});
@@ -309,6 +302,11 @@ document.addEventListener('DOMContentLoaded', () => {
             log('DOM refs and URL params prepared');
             prepareEditorShell();
             log('Editor shell mounted');
+
+            if (typeof applyEditorEditabilityState !== 'function') {
+                reportError('LoveBudEditorShellHelpers.applyEditorEditabilityState missing');
+                return;
+            }
 
             // Expose canEdit for modules that read it after DOMContentLoaded
             applyEditorEditabilityState({ canEdit });

--- a/tests/contracts/editor-editability-shell-state-contract.test.cjs
+++ b/tests/contracts/editor-editability-shell-state-contract.test.cjs
@@ -21,8 +21,9 @@ test('editor delegates editability shell state with fallback', () => {
   assert.match(editorSource, /shellHelpers\.applyEditorEditabilityState/);
   assert.match(editorSource, /const applyEditorEditabilityState\s*=/);
   assert.match(editorSource, /applyEditorEditabilityState\(\{\s*canEdit\s*\}\)/);
-  assert.match(editorSource, /window\.LoveBudEditor\.canEdit\s*=\s*nextCanEdit/);
-  assert.match(editorSource, /classList\?\.toggle\('editor-readonly',\s*!nextCanEdit\)/);
+  assert.doesNotMatch(editorSource, /window\.LoveBudEditor\.canEdit\s*=\s*nextCanEdit/);
+  assert.doesNotMatch(editorSource, /classList\?\.toggle\('editor-readonly',\s*!nextCanEdit\)/);
+  assert.match(editorSource, /LoveBudEditorShellHelpers\.applyEditorEditabilityState missing/);
 });
 
 test('editor no longer applies editability state inline in start flow', () => {

--- a/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
+++ b/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
@@ -159,8 +159,19 @@ test('editor.js delegates markEditorReady through required shell helper', () => 
   );
 });
 
-test('editor.js still keeps applyEditorEditabilityState local fallback', () => {
-  assert.match(editorSource, /shellHelpers\.applyEditorEditabilityState\s*\|\|/);
+test('editor.js delegates applyEditorEditabilityState through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+applyEditorEditabilityState\s*=\s*shellHelpers\.applyEditorEditabilityState/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+applyEditorEditabilityState\s*=\s*shellHelpers\.applyEditorEditabilityState\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.applyEditorEditabilityState missing/
+  );
 });
 
 test('editor.js still keeps createEditorDebugReporter local fallback', () => {
@@ -199,6 +210,15 @@ test('editor.js guards missing markEditorReady before startup proceeds', () => {
   assert.ok(waiterIndex !== -1, 'dependency waiter setup must exist');
   assert.ok(guardIndex < logIndex, 'markEditorReady guard must run before startup log');
   assert.ok(guardIndex < waiterIndex, 'markEditorReady guard must run before dependency waiter setup');
+});
+
+test('editor.js guards missing applyEditorEditabilityState before applying editability state', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.applyEditorEditabilityState missing');
+  const applyIndex = editorSource.indexOf('applyEditorEditabilityState({ canEdit });');
+
+  assert.ok(guardIndex !== -1, 'missing applyEditorEditabilityState guard must exist');
+  assert.ok(applyIndex !== -1, 'applyEditorEditabilityState call must exist');
+  assert.ok(guardIndex < applyIndex, 'guard must run before editability state application');
 });
 
 // --- 8. VM-based runtime behavior tests ---


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `applyEditorEditabilityState` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.applyEditorEditabilityState` boundary
- add an explicit missing-helper guard before applying editor editability state
- update shell readiness helper contracts to assert required-helper behavior for `applyEditorEditabilityState`
- keep `createEditorDebugReporter` and `createEditorStartupDependencyWaiter` fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS