### PR TITLE
test(editor): plan debug reporter required boundary

### DIFF
--- a/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
+++ b/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
@@ -1,0 +1,87 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+
+// --- 1. Current state: local fallback retained ---
+
+test('editor.js currently keeps createEditorDebugReporter local fallback', () => {
+  assert.match(
+    editorSource,
+    /const\s+createEditorDebugReporter\s*=\s*shellHelpers\.createEditorDebugReporter\s*\|\|/
+  );
+});
+
+// --- 2. Shell helper behavior already exists ---
+
+test('editor-shell-helpers.js exports createEditorDebugReporter', () => {
+  assert.match(
+    shellHelpersSource,
+    /createEditorDebugReporter:\s*function\(options\)/
+  );
+});
+
+test('editor-shell-helpers.js createEditorDebugReporter pushes to debugState.logs', () => {
+  assert.match(shellHelpersSource, /debugState\.logs\.push\(entry\)/);
+});
+
+test('editor-shell-helpers.js createEditorDebugReporter pushes to debugState.errors', () => {
+  assert.match(shellHelpersSource, /debugState\.errors\.push\(/);
+});
+
+// --- 3. Missing-helper runtime removal plan guard shape ---
+
+const expectedRuntimeGuard = `
+if (typeof createEditorDebugReporter !== 'function') {
+    const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+    const msg = 'LoveBudEditorShellHelpers.createEditorDebugReporter missing';
+    console.error('[editor-main] ERROR: ' + msg);
+    debugState.errors.push({ msg, error: msg });
+    return;
+}
+`;
+
+test('planned createEditorDebugReporter required path uses typeof guard', () => {
+  assert.match(expectedRuntimeGuard, /typeof createEditorDebugReporter !== 'function'/);
+});
+
+test('planned createEditorDebugReporter required path reports missing helper message', () => {
+  assert.match(expectedRuntimeGuard, /LoveBudEditorShellHelpers\.createEditorDebugReporter missing/);
+});
+
+test('planned createEditorDebugReporter required path uses console.error for bootstrap reporting', () => {
+  assert.match(expectedRuntimeGuard, /console\.error/);
+});
+
+test('planned createEditorDebugReporter required path initializes LoveBudEditorDebug namespace', () => {
+  assert.match(expectedRuntimeGuard, /LoveBudEditorDebug/);
+});
+
+test('planned createEditorDebugReporter required path pushes to debugState.errors', () => {
+  assert.match(expectedRuntimeGuard, /debugState\.errors\.push/);
+});
+
+test('planned createEditorDebugReporter required path returns early on missing helper', () => {
+  assert.match(expectedRuntimeGuard, /return;/);
+});
+
+// --- 4. Forbidden patterns in the planned guard ---
+
+test('planned debug reporter removal must not depend on reportError before reporter exists', () => {
+  assert.doesNotMatch(
+    expectedRuntimeGuard,
+    /reportError\(/,
+    'missing debug reporter guard must not call reportError before createEditorDebugReporter runs'
+  );
+});
+
+// --- 5. Startup dependency waiter remains separate fallback group ---
+
+test('startup dependency waiter remains a separate fallback group', () => {
+  assert.match(
+    editorSource,
+    /const\s+createEditorStartupDependencyWaiter\s*=\s*shellHelpers\.createEditorStartupDependencyWaiter\s*\|\|/
+  );
+});


### PR DESCRIPTION
Refs #1698

## Summary
- add a test/audit contract for the future `createEditorDebugReporter` required-boundary slice
- document the bootstrap-level missing-helper error path needed before `reportError` exists
- assert the current `createEditorDebugReporter` and `createEditorStartupDependencyWaiter` fallbacks remain unchanged
- keep production source, docs, HTML/CSS, canvas, auth, API, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: NONE
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL