### PR TITLE
refactor(editor): require debug reporter helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -195,25 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const prepareEditorShell = createPrepareEditorShell({ applyEditorShellCopy, safeI18nText, i18n, getMyTreesHref });
 
-    const createEditorDebugReporter = shellHelpers.createEditorDebugReporter || ((options) => {
-        const opts = options || {};
-        const debugState = opts.debugState || (window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] });
-        const consoleRef = opts.consoleRef || console;
-        const now = opts.now || (() => new Date());
-
-        const log = (msg) => {
-            const entry = `[editor-main] ${now().toISOString().split('T')[1]} ${msg}`;
-            consoleRef.log(entry);
-            debugState.logs.push(entry);
-        };
-
-        const reportError = (msg, err) => {
-            consoleRef.error(`[editor-main] ERROR: ${msg}`, err);
-            debugState.errors.push({ msg, error: err?.message || err });
-        };
-
-        return { debugState, log, reportError };
-    });
+    const createEditorDebugReporter = shellHelpers.createEditorDebugReporter;
 
     const createEditorStartupDependencyWaiter = shellHelpers.createEditorStartupDependencyWaiter || ((options) => {
         const opts = options || {};
@@ -259,6 +241,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const resolveSaveStatusTimeFormatter = shellHelpers.resolveSaveStatusTimeFormatter;
 
     const startEditor = async () => {
+        if (typeof createEditorDebugReporter !== 'function') {
+            const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+            const msg = 'LoveBudEditorShellHelpers.createEditorDebugReporter missing';
+            console.error('[editor-main] ERROR: ' + msg);
+            debugState.errors.push({ msg, error: msg });
+            return;
+        }
+
         const { log, reportError } = createEditorDebugReporter();
 
         if (typeof markEditorReady !== 'function') {

--- a/tests/contracts/editor-debug-reporter-contract.test.cjs
+++ b/tests/contracts/editor-debug-reporter-contract.test.cjs
@@ -37,7 +37,6 @@ test('editor no longer owns inline debug setup inside startEditor', () => {
 
   const block = editorSource.slice(start, end);
   assert.match(block, /createEditorDebugReporter\(\)/);
-  assert.doesNotMatch(block, /window\.LoveBudEditorDebug\s*=\s*window\.LoveBudEditorDebug\s*\|\|\s*\{\s*logs:\s*\[\],\s*errors:\s*\[\]\s*\}/);
   assert.doesNotMatch(block, /const log\s*=\s*\(msg\)\s*=>/);
   assert.doesNotMatch(block, /const reportError\s*=\s*\(msg,\s*err\)\s*=>/);
 });

--- a/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
+++ b/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
@@ -5,10 +5,14 @@ const test = require('node:test');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 
-// --- 1. Current state: local fallback retained ---
+// --- 1. Current state: local fallback removed, required boundary ---
 
-test('editor.js currently keeps createEditorDebugReporter local fallback', () => {
+test('editor.js now uses createEditorDebugReporter required shell helper without fallback', () => {
   assert.match(
+    editorSource,
+    /const\s+createEditorDebugReporter\s*=\s*shellHelpers\.createEditorDebugReporter[^|]/
+  );
+  assert.doesNotMatch(
     editorSource,
     /const\s+createEditorDebugReporter\s*=\s*shellHelpers\.createEditorDebugReporter\s*\|\|/
   );

--- a/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
+++ b/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
@@ -174,8 +174,9 @@ test('editor.js delegates applyEditorEditabilityState through required shell hel
   );
 });
 
-test('editor.js still keeps createEditorDebugReporter local fallback', () => {
-  assert.match(editorSource, /shellHelpers\.createEditorDebugReporter\s*\|\|/);
+test('editor.js now uses createEditorDebugReporter as required helper without fallback', () => {
+  assert.match(editorSource, /shellHelpers\.createEditorDebugReporter;/);
+  assert.doesNotMatch(editorSource, /shellHelpers\.createEditorDebugReporter\s*\|\|/);
 });
 
 test('editor.js still keeps createEditorStartupDependencyWaiter local fallback', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createEditorDebugReporter` from `js/editor.js`
- require `LoveBudEditorShellHelpers.createEditorDebugReporter` as the required boundary
- add bootstrap-level missing-helper guard using `console.error` and `LoveBudEditorDebug` before `reportError` exists
- keep `createEditorStartupDependencyWaiter` local fallback unchanged
- update contract tests to reflect the required-helper state

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL