### PR TITLE
refactor(editor): require startup dependency waiter helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -197,30 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const createEditorDebugReporter = shellHelpers.createEditorDebugReporter;
 
-    const createEditorStartupDependencyWaiter = shellHelpers.createEditorStartupDependencyWaiter || ((options) => {
-        const opts = options || {};
-        const log = opts.log || (() => {});
-        const reportError = opts.reportError || (() => {});
-        const windowRef = opts.windowRef || window;
-        const wait = opts.wait || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
-        const maxAttempts = opts.maxAttempts || 100;
-        const intervalMs = opts.intervalMs || 50;
-
-        return async function waitForGlobal(name) {
-            log(`Waiting for ${name}...`);
-            let count = 0;
-            while (typeof windowRef[name] !== 'function' && count < maxAttempts) {
-                await wait(intervalMs);
-                count++;
-            }
-            if (typeof windowRef[name] !== 'function') {
-                reportError(`${name} not found after 5s`);
-                return false;
-            }
-            log(`${name} found.`);
-            return true;
-        };
-    });
+    const createEditorStartupDependencyWaiter = shellHelpers.createEditorStartupDependencyWaiter;
 
     const exposeCanvasEmptyGuideUpdater = shellHelpers.exposeCanvasEmptyGuideUpdater;
 
@@ -257,6 +234,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         log('startEditor sequence initiated');
+
+        if (typeof createEditorStartupDependencyWaiter !== 'function') {
+            reportError('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
+            return;
+        }
 
         const waitForGlobal = createEditorStartupDependencyWaiter({ log, reportError });
 

--- a/tests/contracts/editor-debug-reporter-contract.test.cjs
+++ b/tests/contracts/editor-debug-reporter-contract.test.cjs
@@ -42,9 +42,9 @@ test('editor no longer owns inline debug setup inside startEditor', () => {
 });
 
 test('waitForGlobal behavior remains in editor start flow', () => {
-  assert.match(editorSource, /return async function waitForGlobal\(name\)/);
-  assert.match(editorSource, /while\s*\(typeof windowRef\[name\] !== 'function' && count < maxAttempts\)/);
-  assert.match(editorSource, /reportError\(`/);
+  assert.match(shellHelpersSource, /return async function waitForGlobal\(name\)/);
+  assert.match(shellHelpersSource, /while\s*\(typeof windowRef\[name\] !== 'function' && count < maxAttempts\)/);
+  assert.match(editorSource, /createEditorStartupDependencyWaiter\(\{/);
 });
 
 test('editor shell helpers load before editor entrypoint', () => {

--- a/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
+++ b/tests/contracts/editor-debug-reporter-required-plan-contract.test.cjs
@@ -81,11 +81,22 @@ test('planned debug reporter removal must not depend on reportError before repor
   );
 });
 
-// --- 5. Startup dependency waiter remains separate fallback group ---
+// --- 5. Startup dependency waiter now also required ---
 
-test('startup dependency waiter remains a separate fallback group', () => {
+test('editor.js now uses createEditorStartupDependencyWaiter as required helper without fallback', () => {
   assert.match(
     editorSource,
+    /const\s+createEditorStartupDependencyWaiter\s*=\s*shellHelpers\.createEditorStartupDependencyWaiter;/
+  );
+  assert.doesNotMatch(
+    editorSource,
     /const\s+createEditorStartupDependencyWaiter\s*=\s*shellHelpers\.createEditorStartupDependencyWaiter\s*\|\|/
+  );
+});
+
+test('editor.js guards missing createEditorStartupDependencyWaiter before use', () => {
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.createEditorStartupDependencyWaiter missing/
   );
 });

--- a/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
+++ b/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
@@ -179,8 +179,9 @@ test('editor.js now uses createEditorDebugReporter as required helper without fa
   assert.doesNotMatch(editorSource, /shellHelpers\.createEditorDebugReporter\s*\|\|/);
 });
 
-test('editor.js still keeps createEditorStartupDependencyWaiter local fallback', () => {
-  assert.match(editorSource, /shellHelpers\.createEditorStartupDependencyWaiter\s*\|\|/);
+test('editor.js now uses createEditorStartupDependencyWaiter as required helper without fallback', () => {
+  assert.match(editorSource, /shellHelpers\.createEditorStartupDependencyWaiter;/);
+  assert.doesNotMatch(editorSource, /shellHelpers\.createEditorStartupDependencyWaiter\s*\|\|/);
 });
 
 // --- 7. editor.js uses helpers in startup path ---


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `createEditorStartupDependencyWaiter` from `js/editor.js`
- require `LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter` as the required boundary
- add missing-helper guard with `reportError` before using the dependency waiter
- keep `createEditorDebugReporter` required boundary unchanged
- update contract tests to reflect the required-helper state

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL