### PR TITLE
refactor(editor): require HTTP status helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     const hasConfirmedSessionUser = editorAuthHelpers.hasConfirmedSessionUser || (() => !!getConfirmedSessionUser());
 
-    const getHttpStatus = shellHelpers.getHttpStatus || ((error) => Number(error?.status || error?.statusCode || error?.response?.status || 0));
+    const getHttpStatus = shellHelpers.getHttpStatus;
 
     const createInlineShowToastFallback = shellHelpers.createInlineShowToastFallback ||
         entryFallbacks.createInlineShowToastFallback;
@@ -672,6 +672,11 @@ document.addEventListener('DOMContentLoaded', () => {
             const { showAddMemoryForm, hideAddMemoryForm, addMemoryFromForm } = memoryForm;
 
             log('Binding events...');
+            if (typeof getHttpStatus !== 'function') {
+                reportError('LoveBudEditorShellHelpers.getHttpStatus missing');
+                return;
+            }
+
             if (typeof bindEditorPageEvents === 'function') {
                 bindEditorPageEvents({
                     canEdit,

--- a/tests/contracts/editor-http-status-resolver-contract.test.cjs
+++ b/tests/contracts/editor-http-status-resolver-contract.test.cjs
@@ -16,10 +16,19 @@ test('editor shell helpers expose HTTP status resolver', () => {
   assert.match(shellHelpersSource, /\|\|\s*0/);
 });
 
-test('editor delegates HTTP status resolver with fallback', () => {
-  assert.match(editorSource, /shellHelpers\.getHttpStatus/);
-  assert.match(editorSource, /const getHttpStatus\s*=/);
-  assert.match(editorSource, /Number\(error\?\.status \|\| error\?\.statusCode \|\| error\?\.response\?\.status \|\| 0\)/);
+test('editor delegates HTTP status resolver through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+getHttpStatus\s*=\s*shellHelpers\.getHttpStatus/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+getHttpStatus\s*=\s*shellHelpers\.getHttpStatus\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.getHttpStatus missing/
+  );
 });
 
 test('editor keeps sidebar visibility toggle injection intact', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `getHttpStatus` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.getHttpStatus` boundary
- add an explicit missing-helper guard before binding events using `getHttpStatus`
- update the HTTP status resolver contract to assert required-helper behavior
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
