### PR TITLE
refactor(editor): require i18n shell helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -94,7 +94,14 @@ document.addEventListener('DOMContentLoaded', () => {
         ? editorHelpers.createToast({ warningKey: '__editorToastWarningShown' })
         : createInlineShowToastFallback();
 
-    const getI18n = shellHelpers.getI18n || (() => window.t || ((k) => k));
+    const getI18n = shellHelpers.getI18n;
+    if (typeof getI18n !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellHelpers.getI18n missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
     const i18n = getI18n();
 
     const getEditorBasePath = shellHelpers.getEditorBasePath || (() =>

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -45,7 +45,27 @@ test('buildEditorRedirectTarget preserves editor redirect composition', () => {
 });
 
 test('editor entrypoint keeps core utility fallback resolution intact', () => {
-  assert.match(editorSource, /shellHelpers\.getI18n \|\|/);
+  assert.match(
+    editorSource,
+    /const\s+getI18n\s*=\s*shellHelpers\.getI18n/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+getI18n\s*=\s*shellHelpers\.getI18n\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.getI18n missing/
+  );
+
+  // Guard must not use reportError
+  const guardStart = editorSource.indexOf('LoveBudEditorShellHelpers.getI18n missing');
+  assert.notEqual(guardStart, -1, 'getI18n missing guard must exist');
+  const guardEnd = editorSource.indexOf('const i18n = getI18n();', guardStart);
+  assert.notEqual(guardEnd, -1, 'i18n initialization must exist after guard');
+  const guardBlock = editorSource.slice(guardStart, guardEnd);
+  assert.doesNotMatch(guardBlock, /reportError/);
+
   assert.match(editorSource, /const i18n\s*=\s*getI18n\(\)/);
 
   assert.match(editorSource, /shellHelpers\.getEditorBasePath \|\|/);


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `getI18n` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.getI18n` boundary
- add an explicit bootstrap-level missing-helper guard before invoking `getI18n`
- update the core utilities contract to assert required-helper behavior for `getI18n`
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
