### PR TITLE
refactor(editor): require base path shell helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -104,8 +104,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const i18n = getI18n();
 
-    const getEditorBasePath = shellHelpers.getEditorBasePath || (() =>
-        window.location.pathname.indexOf('/pages/') !== -1 ? '' : 'pages/');
+    const getEditorBasePath = shellHelpers.getEditorBasePath;
+    if (typeof getEditorBasePath !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellHelpers.getEditorBasePath missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const buildEditorRedirectTarget = shellHelpers.buildEditorRedirectTarget || (() =>
         getEditorBasePath() + 'editor' + (window.location.search || ''));

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -45,6 +45,7 @@ test('buildEditorRedirectTarget preserves editor redirect composition', () => {
 });
 
 test('editor entrypoint keeps core utility fallback resolution intact', () => {
+  // getI18n
   assert.match(
     editorSource,
     /const\s+getI18n\s*=\s*shellHelpers\.getI18n/
@@ -58,17 +59,37 @@ test('editor entrypoint keeps core utility fallback resolution intact', () => {
     /LoveBudEditorShellHelpers\.getI18n missing/
   );
 
-  // Guard must not use reportError
-  const guardStart = editorSource.indexOf('LoveBudEditorShellHelpers.getI18n missing');
-  assert.notEqual(guardStart, -1, 'getI18n missing guard must exist');
-  const guardEnd = editorSource.indexOf('const i18n = getI18n();', guardStart);
-  assert.notEqual(guardEnd, -1, 'i18n initialization must exist after guard');
-  const guardBlock = editorSource.slice(guardStart, guardEnd);
-  assert.doesNotMatch(guardBlock, /reportError/);
+  const i18nGuardStart = editorSource.indexOf('LoveBudEditorShellHelpers.getI18n missing');
+  assert.notEqual(i18nGuardStart, -1, 'getI18n missing guard must exist');
+  const i18nGuardEnd = editorSource.indexOf('const i18n = getI18n();', i18nGuardStart);
+  assert.notEqual(i18nGuardEnd, -1, 'i18n initialization must exist after guard');
+  const i18nGuardBlock = editorSource.slice(i18nGuardStart, i18nGuardEnd);
+  assert.doesNotMatch(i18nGuardBlock, /reportError/);
 
   assert.match(editorSource, /const i18n\s*=\s*getI18n\(\)/);
 
-  assert.match(editorSource, /shellHelpers\.getEditorBasePath \|\|/);
+  // getEditorBasePath
+  assert.match(
+    editorSource,
+    /const\s+getEditorBasePath\s*=\s*shellHelpers\.getEditorBasePath/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+getEditorBasePath\s*=\s*shellHelpers\.getEditorBasePath\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.getEditorBasePath missing/
+  );
+
+  const bpGuardStart = editorSource.indexOf('LoveBudEditorShellHelpers.getEditorBasePath missing');
+  assert.notEqual(bpGuardStart, -1, 'getEditorBasePath missing guard must exist');
+  const bpGuardEnd = editorSource.indexOf('const buildEditorRedirectTarget =', bpGuardStart);
+  assert.notEqual(bpGuardEnd, -1, 'buildEditorRedirectTarget must exist after base path guard');
+  const bpGuardBlock = editorSource.slice(bpGuardStart, bpGuardEnd);
+  assert.doesNotMatch(bpGuardBlock, /reportError/);
+
+  // buildEditorRedirectTarget (fallback still active)
   assert.match(editorSource, /shellHelpers\.buildEditorRedirectTarget \|\|/);
 });
 


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `getEditorBasePath` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.getEditorBasePath` boundary
- add an explicit bootstrap-level missing-helper guard before invoking `getEditorBasePath`
- update the core utilities contract to assert required-helper behavior for `getEditorBasePath`
- keep buildEditorRedirectTarget fallback, canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
