### PR TITLE
refactor(editor): require redirect target shell helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -113,8 +113,15 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    const buildEditorRedirectTarget = shellHelpers.buildEditorRedirectTarget || (() =>
-        getEditorBasePath() + 'editor' + (window.location.search || ''));
+    const buildEditorRedirectTargetHelper = shellHelpers.buildEditorRedirectTarget;
+    if (typeof buildEditorRedirectTargetHelper !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellHelpers.buildEditorRedirectTarget missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
+    const buildEditorRedirectTarget = () => buildEditorRedirectTargetHelper.call(shellHelpers);
 
     const createInlineRedirectToEditorLoginFallback = entryFallbacks.createInlineRedirectToEditorLoginFallback;
 

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -84,13 +84,37 @@ test('editor entrypoint keeps core utility fallback resolution intact', () => {
 
   const bpGuardStart = editorSource.indexOf('LoveBudEditorShellHelpers.getEditorBasePath missing');
   assert.notEqual(bpGuardStart, -1, 'getEditorBasePath missing guard must exist');
-  const bpGuardEnd = editorSource.indexOf('const buildEditorRedirectTarget =', bpGuardStart);
-  assert.notEqual(bpGuardEnd, -1, 'buildEditorRedirectTarget must exist after base path guard');
+  const bpGuardEnd = editorSource.indexOf('const buildEditorRedirectTargetHelper =', bpGuardStart);
+  assert.notEqual(bpGuardEnd, -1, 'buildEditorRedirectTargetHelper must exist after base path guard');
   const bpGuardBlock = editorSource.slice(bpGuardStart, bpGuardEnd);
   assert.doesNotMatch(bpGuardBlock, /reportError/);
 
-  // buildEditorRedirectTarget (fallback still active)
-  assert.match(editorSource, /shellHelpers\.buildEditorRedirectTarget \|\|/);
+  // buildEditorRedirectTarget
+  assert.match(
+    editorSource,
+    /const\s+buildEditorRedirectTargetHelper\s*=\s*shellHelpers\.buildEditorRedirectTarget/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+buildEditorRedirectTargetHelper\s*=\s*shellHelpers\.buildEditorRedirectTarget\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.buildEditorRedirectTarget missing/
+  );
+
+  const redirectGuardStart = editorSource.indexOf('LoveBudEditorShellHelpers.buildEditorRedirectTarget missing');
+  assert.notEqual(redirectGuardStart, -1, 'buildEditorRedirectTarget missing guard must exist');
+  const redirectGuardEnd = editorSource.indexOf('const buildEditorRedirectTarget =', redirectGuardStart);
+  assert.notEqual(redirectGuardEnd, -1, 'buildEditorRedirectTarget variable must exist after guard');
+  const redirectGuardBlock = editorSource.slice(redirectGuardStart, redirectGuardEnd);
+  assert.doesNotMatch(redirectGuardBlock, /reportError/);
+
+  // check this binding preservation call
+  assert.match(
+    editorSource,
+    /buildEditorRedirectTargetHelper\.call\(\s*shellHelpers\s*\)/
+  );
 });
 
 test('editor html loads shell helpers before editor entrypoint for core utilities', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `buildEditorRedirectTarget` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.buildEditorRedirectTarget` boundary while preserving `shellHelpers` context for correct `this` binding
- add an explicit bootstrap-level missing-helper guard before invoking `buildEditorRedirectTarget`
- update the core utilities contract to assert required-helper behavior and proper `this` binding execution for `buildEditorRedirectTarget`
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
