### PR TITLE
refactor(editor): require my trees href helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -154,7 +154,14 @@ document.addEventListener('DOMContentLoaded', () => {
         return selectedNodeId;
     });
 
-    const getMyTreesHref = editorPageHelpers.getMyTreesHref || (() => getEditorBasePath() + 'my-trees');
+    const getMyTreesHref = editorPageHelpers.getMyTreesHref;
+    if (typeof getMyTreesHref !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorPageHelpers.getMyTreesHref missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
     const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
 
     const escapeHtml = editorHelpers.escapeHtml || ((value) => {

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const test = require('node:test');
 
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const pageHelpersSource = fs.readFileSync('js/editor/editor-page-helpers.js', 'utf8');
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const editorHtmlSource = fs.readFileSync('pages/editor.html', 'utf8');
 
@@ -124,4 +125,42 @@ test('editor html loads shell helpers before editor entrypoint for core utilitie
   assert.notEqual(shellHelpersIndex, -1, 'editor-shell-helpers.js script must exist');
   assert.notEqual(editorIndex, -1, 'editor.js script must exist');
   assert.ok(shellHelpersIndex < editorIndex, 'editor-shell-helpers.js must load before editor.js');
+});
+
+test('editor page helpers expose getMyTreesHref', () => {
+  assert.match(pageHelpersSource, /function\s+getMyTreesHref\s*\(\)/);
+  assert.match(pageHelpersSource, /getMyTreesHref:\s*getMyTreesHref/);
+});
+
+test('editor entrypoint requires getMyTreesHref page helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+getMyTreesHref\s*=\s*editorPageHelpers\.getMyTreesHref/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+getMyTreesHref\s*=\s*editorPageHelpers\.getMyTreesHref\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorPageHelpers\.getMyTreesHref missing/
+  );
+
+  // Guard must not use reportError
+  const guardStart = editorSource.indexOf('LoveBudEditorPageHelpers.getMyTreesHref missing');
+  assert.notEqual(guardStart, -1, 'getMyTreesHref missing guard must exist');
+  const guardEnd = editorSource.indexOf('const createInlineMediaResolversFallbacks =', guardStart);
+  assert.notEqual(guardEnd, -1, 'next fallback block must follow getMyTreesHref guard');
+  const guardBlock = editorSource.slice(guardStart, guardEnd);
+  assert.doesNotMatch(guardBlock, /reportError/);
+
+  // check parameter passing is intact
+  assert.match(
+    editorSource,
+    /entryFallbacks\.createInlineRenderTreeLoadErrorFallback\(\{\s*getMyTreesHref\s*\}\)/
+  );
+  assert.match(
+    editorSource,
+    /createPrepareEditorShell\(\{\s*applyEditorShellCopy,\s*safeI18nText,\s*i18n,\s*getMyTreesHref\s*\}\)/
+  );
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `getMyTreesHref` from `js/editor.js`
- require the existing `LoveBudEditorPageHelpers.getMyTreesHref` boundary
- add an explicit bootstrap-level missing-helper guard before invoking `getMyTreesHref`
- update the core utilities contract to assert required-helper behavior for `getMyTreesHref`
- keep canvas, auth, API, data loading, memory actions, save/update/delete, and persistence paths unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS
