### PR TITLE
refactor(editor): require tree load error renderer

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -205,8 +205,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return getYouTubeInputErrorMessageFallback(i18n, rawUrl);
     };
 
-    const renderTreeLoadError = editorPageHelpers.renderTreeLoadError ||
-        entryFallbacks.createInlineRenderTreeLoadErrorFallback({ getMyTreesHref });
+    const renderTreeLoadError = editorPageHelpers.renderTreeLoadError;
+
+    if (typeof renderTreeLoadError !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorPageHelpers.renderTreeLoadError missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
+
     const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
     const createInlineFormatTimeAgoFallback = entryFallbacks.createInlineFormatTimeAgoFallback;
 

--- a/tests/contracts/editor-script-order-contract.test.cjs
+++ b/tests/contracts/editor-script-order-contract.test.cjs
@@ -154,7 +154,6 @@ test('editor entry delegates entry fallback factories through boundary', () => {
 
   for (const factory of [
     'createInlineRedirectToEditorLoginFallback',
-    'createInlineRenderTreeLoadErrorFallback',
     'createInlineFormatTimeAgoFallback',
   ]) {
     assert.match(boundary, new RegExp(`${factory}\\s*:`), `entry fallback boundary must expose ${factory}`);

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -157,10 +157,6 @@ test('editor entrypoint requires getMyTreesHref page helper', () => {
   // check parameter passing is intact
   assert.match(
     editorSource,
-    /entryFallbacks\.createInlineRenderTreeLoadErrorFallback\(\{\s*getMyTreesHref\s*\}\)/
-  );
-  assert.match(
-    editorSource,
-    /createPrepareEditorShell\(\{\s*applyEditorShellCopy,\s*safeI18nText,\s*i18n,\s*getMyTreesHref\s*\}\)/
+    /createPrepareEditorShell\(\{\s*applyEditorShellCopy,\s*safeI18nText,\s*i18n,\s*getMyTreesHref\s*\}/
   );
 });

--- a/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
+++ b/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
@@ -1,0 +1,89 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+const pageHelpersSource = fs.readFileSync('js/editor/editor-page-helpers.js', 'utf8');
+
+// --- 1. Page helper exports renderTreeLoadError ---
+
+test('editor-page-helpers.js exports renderTreeLoadError', () => {
+  assert.match(pageHelpersSource, /function renderTreeLoadError\(options\)/);
+  assert.match(pageHelpersSource, /renderTreeLoadError:\s*renderTreeLoadError/);
+});
+
+test('editor-page-helpers.js renderTreeLoadError uses canvas, addBtn, errorTitle, errorDesc, i18n, escapeHtml, setDetailEmptyState', () => {
+  const fnStart = pageHelpersSource.indexOf('function renderTreeLoadError(options)');
+  assert.notEqual(fnStart, -1, 'renderTreeLoadError function must exist');
+  const fnEnd = pageHelpersSource.indexOf('function buildTreeLoadErrorCopy', fnStart);
+  const fnBody = pageHelpersSource.slice(fnStart, fnEnd);
+
+  assert.match(fnBody, /canvas/);
+  assert.match(fnBody, /addBtn/);
+  assert.match(fnBody, /errorTitle/);
+  assert.match(fnBody, /errorDesc/);
+  assert.match(fnBody, /i18n/);
+  assert.match(fnBody, /escapeHtml/);
+  assert.match(fnBody, /setDetailEmptyState/);
+});
+
+// --- 2. editor.js uses required pattern without fallback ---
+
+test('editor.js uses renderTreeLoadError required assignment without fallback', () => {
+  assert.match(
+    editorSource,
+    /const\s+renderTreeLoadError\s*=\s*editorPageHelpers\.renderTreeLoadError;/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+renderTreeLoadError\s*=\s*editorPageHelpers\.renderTreeLoadError\s*\|\|/
+  );
+});
+
+test('editor.js no longer references entryFallbacks.createInlineRenderTreeLoadErrorFallback', () => {
+  assert.doesNotMatch(
+    editorSource,
+    /createInlineRenderTreeLoadErrorFallback/
+  );
+});
+
+// --- 3. Bootstrap guard exists and uses console.error ---
+
+test('editor.js guards missing renderTreeLoadError before use', () => {
+  assert.match(
+    editorSource,
+    /LoveBudEditorPageHelpers\.renderTreeLoadError missing/
+  );
+});
+
+test('editor.js renderTreeLoadError guard does not use reportError', () => {
+  const guardStart = editorSource.indexOf("if (typeof renderTreeLoadError !== 'function')");
+  assert.notEqual(guardStart, -1, 'renderTreeLoadError guard must exist');
+
+  const guardEnd = editorSource.indexOf("const createInlineNextMemoryIdFallback", guardStart);
+  assert.notEqual(guardEnd, -1, 'guard end marker must exist after guard');
+
+  const guardBody = editorSource.slice(guardStart, guardEnd);
+
+  assert.match(guardBody, /console\.error/);
+  assert.match(guardBody, /LoveBudEditorDebug/);
+  assert.match(guardBody, /debugState\.errors\.push/);
+  assert.doesNotMatch(guardBody, /reportError\(/);
+});
+
+// --- 4. Render call options structure preserved ---
+
+test('editor.js renderTreeLoadError call preserves options keys', () => {
+  const callStart = editorSource.indexOf('renderTreeLoadError({');
+  assert.notEqual(callStart, -1, 'renderTreeLoadError call must exist');
+  const callEnd = editorSource.indexOf('});', callStart);
+  const callBody = editorSource.slice(callStart, callEnd + 3);
+
+  assert.match(callBody, /canvas,/);
+  assert.match(callBody, /addBtn,/);
+  assert.match(callBody, /errorTitle:/);
+  assert.match(callBody, /errorDesc:/);
+  assert.match(callBody, /i18n,/);
+  assert.match(callBody, /escapeHtml,/);
+  assert.match(callBody, /setDetailEmptyState:/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `renderTreeLoadError` from `js/editor.js`
- require `LoveBudEditorPageHelpers.renderTreeLoadError` as the required boundary
- add bootstrap-level missing-helper guard using `console.error` and `LoveBudEditorDebug` before `reportError` exists (guard placed before `createEditorDebugReporter`)
- `entryFallbacks.createInlineRenderTreeLoadErrorFallback` no longer referenced by editor.js
- keep existing render call options structure intact (canvas, addBtn, errorTitle, errorDesc, i18n, escapeHtml, setDetailEmptyState)
- add contract test for required boundary behavior

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL