### PR TITLE
refactor(editor): require YouTube input fallback helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -187,15 +187,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail || inlineMediaResolvers.resolveMemoryThumbnail;
 
-    const getYouTubeInputErrorMessageFallback = shellHelpers.getYouTubeInputErrorMessageFallback || ((i18n, rawUrl) => {
-        const value = String(rawUrl || '').trim();
-        if (!value) return i18n('enter_youtube') || 'YouTube 링크를 입력해 주세요.';
-        if (!/^(https?:\/\/|www\.)/i.test(value)) return i18n('invalid_youtube_format') || '전체 YouTube 링크를 붙여 넣어 주세요.';
-        if (!/(youtube\.com|youtu\.be|youtube\.com\/shorts\/)/i.test(value)) return i18n('invalid_youtube_unsupported') || 'YouTube 링크만 지원합니다. youtube.com 또는 youtu.be 링크를 사용해 주세요.';
-        const match = value.match(/(?:v=|\/|youtu\.be\/|shorts\/)([0-9A-Za-z_-]+)/i);
-        if (match && match[1].length !== 11) return i18n('invalid_youtube_id_length') || '링크가 중간에 잘린 것 같아요. 전체 YouTube 링크를 다시 복사해 주세요.';
-        return i18n('invalid_youtube') || '유효한 YouTube 링크를 입력해 주세요.';
-    });
+    const getYouTubeInputErrorMessageFallback = shellHelpers.getYouTubeInputErrorMessageFallback;
+
+    if (typeof getYouTubeInputErrorMessageFallback !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const getYouTubeInputErrorMessage = function(i18n, rawUrl) {
         if (typeof rootUtils.getYouTubeInputErrorMessage === 'function') {

--- a/tests/contracts/editor-youtube-input-fallback-contract.test.cjs
+++ b/tests/contracts/editor-youtube-input-fallback-contract.test.cjs
@@ -48,13 +48,35 @@ test('YouTube fallback preserves validation order and regex checks', () => {
   assert.match(block, /\(\[0-9A-Za-z_-\]\+\)/);
 });
 
-test('editor delegates local YouTube fallback while keeping rootUtils priority', () => {
-  assert.match(editorSource, /shellHelpers\.getYouTubeInputErrorMessageFallback/);
-  assert.match(editorSource, /const getYouTubeInputErrorMessageFallback\s*=/);
+test('editor.js delegates getYouTubeInputErrorMessageFallback through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+getYouTubeInputErrorMessageFallback\s*=\s*shellHelpers\.getYouTubeInputErrorMessageFallback/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+getYouTubeInputErrorMessageFallback\s*=\s*shellHelpers\.getYouTubeInputErrorMessageFallback\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.getYouTubeInputErrorMessageFallback missing/
+  );
   assert.match(editorSource, /if \(typeof rootUtils\.getYouTubeInputErrorMessage === 'function'\)/);
   assert.match(editorSource, /return rootUtils\.getYouTubeInputErrorMessage\(i18n,\s*rawUrl\)/);
   assert.match(editorSource, /warnRootHelperFallback\(\)/);
   assert.match(editorSource, /return getYouTubeInputErrorMessageFallback\(i18n,\s*rawUrl\)/);
+});
+
+test('editor.js guards missing getYouTubeInputErrorMessageFallback before wrapper creation and without reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback missing');
+  const wrapperIndex = editorSource.indexOf('const getYouTubeInputErrorMessage = function(i18n, rawUrl)');
+
+  assert.ok(guardIndex !== -1, 'missing getYouTubeInputErrorMessageFallback guard must exist');
+  assert.ok(wrapperIndex !== -1, 'getYouTubeInputErrorMessage wrapper must exist');
+  assert.ok(guardIndex < wrapperIndex, 'guard must run before wrapper creation');
+
+  const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
 });
 
 test('editor no longer owns local YouTube validation body inside wrapper', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `getYouTubeInputErrorMessageFallback` from `js/editor.js`
- require the existing `LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback` boundary
- add an explicit missing-helper guard before the wrapper, using bootstrap-level reporting (before `createEditorDebugReporter` section)
- update shell readiness helper contracts to assert required-helper behavior for `getYouTubeInputErrorMessageFallback`
- keep `createEditorDebugReporter` and `createEditorStartupDependencyWaiter` fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL