### PR TITLE
refactor(editor): require prepare shell helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const editorShellCopyApplier = window.LoveBudEditorShellCopyApplier || {};
     const createEditorShellCopyApplier = editorShellCopyApplier.createEditorShellCopyApplier || (() => () => {});
-    const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell || (() => () => {});
+    const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell;
 
     const applyEditorShellCopy = shellHelpers.applyEditorShellCopy ||
         createEditorShellCopyApplier({ safeI18nText, i18n });
@@ -233,6 +233,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const editorDomRefsBuilder = window.LoveBudEditorDomRefsBuilder || {};
     const createEditorDomRefs = editorDomRefsBuilder.createEditorDomRefs;
+
+    if (typeof createPrepareEditorShell !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellCopyApplier.createPrepareEditorShell missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const prepareEditorShell = createPrepareEditorShell({ applyEditorShellCopy, safeI18nText, i18n, getMyTreesHref });
 

--- a/tests/contracts/editor-shell-copy-applier-contract.test.cjs
+++ b/tests/contracts/editor-shell-copy-applier-contract.test.cjs
@@ -22,3 +22,32 @@ test('editor.html loads editor-shell-copy-applier.js before editor.js', () => {
     assert.notEqual(editorJsIndex, -1, 'editor.js must be loaded');
     assert.ok(applierIndex < editorJsIndex, 'applier must load before editor.js');
 });
+
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+
+test('editor.js delegates createPrepareEditorShell through required shell copy applier', () => {
+  assert.match(
+    editorSource,
+    /const\s+createPrepareEditorShell\s*=\s*editorShellCopyApplier\.createPrepareEditorShell/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+createPrepareEditorShell\s*=\s*editorShellCopyApplier\.createPrepareEditorShell\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellCopyApplier\.createPrepareEditorShell missing/
+  );
+});
+
+test('editor.js guards missing createPrepareEditorShell before call and without reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellCopyApplier.createPrepareEditorShell missing');
+  const callIndex = editorSource.indexOf('createPrepareEditorShell({ applyEditorShellCopy, safeI18nText, i18n, getMyTreesHref })');
+
+  assert.ok(guardIndex !== -1, 'missing createPrepareEditorShell guard must exist');
+  assert.ok(callIndex !== -1, 'createPrepareEditorShell call must exist');
+  assert.ok(guardIndex < callIndex, 'guard must run before createPrepareEditorShell call');
+
+  const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local no-op fallback for `createPrepareEditorShell` from `js/editor.js`
- require the existing `LoveBudEditorShellCopyApplier.createPrepareEditorShell` boundary
- add an explicit missing-helper guard before the `createPrepareEditorShell({...})` call, using bootstrap-level reporting (before `createEditorDebugReporter` section)
- update editor shell copy applier contracts to assert required-helper behavior for `createPrepareEditorShell`
- keep `createEditorShellCopyApplier` and `applyEditorShellCopy` fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL