### PR TITLE
refactor(editor): require shell copy applier

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -223,11 +223,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState;
 
     const editorShellCopyApplier = window.LoveBudEditorShellCopyApplier || {};
-    const createEditorShellCopyApplier = editorShellCopyApplier.createEditorShellCopyApplier || (() => () => {});
     const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell;
 
-    const applyEditorShellCopy = shellHelpers.applyEditorShellCopy ||
-        createEditorShellCopyApplier({ safeI18nText, i18n });
+    const applyEditorShellCopy = shellHelpers.applyEditorShellCopy;
+
+    if (typeof applyEditorShellCopy !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorShellHelpers.applyEditorShellCopy missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     applyEditorShellCopy(safeI18nText, i18n);
 

--- a/tests/contracts/editor-shell-copy-applier-contract.test.cjs
+++ b/tests/contracts/editor-shell-copy-applier-contract.test.cjs
@@ -51,3 +51,42 @@ test('editor.js guards missing createPrepareEditorShell before call and without 
   const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
   assert.doesNotMatch(guardBlock, /reportError\(/);
 });
+
+test('editor.js delegates applyEditorShellCopy through required shell helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+applyEditorShellCopy\s*=\s*shellHelpers\.applyEditorShellCopy/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+applyEditorShellCopy\s*=\s*shellHelpers\.applyEditorShellCopy\s*\|\|/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /createEditorShellCopyApplier\(\{\s*safeI18nText,\s*i18n\s*\}\)/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorShellHelpers\.applyEditorShellCopy missing/
+  );
+  assert.match(
+    editorSource,
+    /applyEditorShellCopy\(safeI18nText,\s*i18n\)/
+  );
+  assert.match(
+    editorSource,
+    /createPrepareEditorShell\(\{\s*applyEditorShellCopy,\s*safeI18nText,\s*i18n,\s*getMyTreesHref\s*\}/
+  );
+});
+
+test('editor.js guards missing applyEditorShellCopy before call and without reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.applyEditorShellCopy missing');
+  const callIndex = editorSource.indexOf('applyEditorShellCopy(safeI18nText, i18n)');
+
+  assert.ok(guardIndex !== -1, 'missing applyEditorShellCopy guard must exist');
+  assert.ok(callIndex !== -1, 'applyEditorShellCopy call must exist');
+  assert.ok(guardIndex < callIndex, 'guard must run before applyEditorShellCopy call');
+
+  const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- remove `createEditorShellCopyApplier` local no-op fallback from `js/editor.js`
- remove `applyEditorShellCopy` local fallback path via `createEditorShellCopyApplier`
- require `LoveBudEditorShellHelpers.applyEditorShellCopy` as the sole boundary
- add explicit missing-helper guard before `applyEditorShellCopy(safeI18nText, i18n)` using bootstrap-level reporting
- keep `createPrepareEditorShell` required boundary intact
- keep `editor-shell-copy-applier.js` unchanged (namespace still holds `createPrepareEditorShell`)

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL