### PR TITLE
refactor(editor): require current tree sync helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -146,12 +146,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const resolveTreeTitleText = editorHelpers.resolveTreeTitleText || inlineTextResolvers.resolveTreeTitleText;
     const resolveInfoText = editorHelpers.resolveInfoText || inlineTextResolvers.resolveInfoText;
 
-    const syncCurrentTreeData = editorTreeHelpers.syncCurrentTreeData || ((tree) => {
-        window.currentTreeData = {
-            ...tree,
-            visibility: tree.visibility || 'public'
-        };
-    });
+    const syncCurrentTreeData = editorTreeHelpers.syncCurrentTreeData;
+
+    if (typeof syncCurrentTreeData !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorTreeHelpers.syncCurrentTreeData missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate || ((selectedNodeId, canonicalRootId) => {
         if (!selectedNodeId || selectedNodeId === canonicalRootId) {

--- a/tests/contracts/editor-tree-visibility-state-helper-contract.test.cjs
+++ b/tests/contracts/editor-tree-visibility-state-helper-contract.test.cjs
@@ -71,3 +71,44 @@ test('editor tree helpers load before editor entrypoint', () => {
   assert.notEqual(editorJsIndex, -1, 'editor.js must be loaded');
   assert.ok(treeHelpersIndex < editorJsIndex, 'editor-tree-helpers.js must load before editor.js');
 });
+
+test('editor tree helpers expose syncCurrentTreeData', () => {
+  assert.match(treeHelpersSource, /syncCurrentTreeData/);
+  assert.match(treeHelpersSource, /treeHelpers\.syncCurrentTreeData/);
+  assert.match(treeHelpersSource, /function syncCurrentTreeData\(tree\)/);
+  assert.match(treeHelpersSource, /window\.currentTreeData\s*=\s*\{/);
+  assert.match(treeHelpersSource, /visibility:\s*tree\s*&&\s*tree\.visibility/);
+});
+
+test('editor.js delegates syncCurrentTreeData through required tree helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+syncCurrentTreeData\s*=\s*editorTreeHelpers\.syncCurrentTreeData/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+syncCurrentTreeData\s*=\s*editorTreeHelpers\.syncCurrentTreeData\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorTreeHelpers\.syncCurrentTreeData missing/
+  );
+});
+
+test('editor.js guards missing syncCurrentTreeData and keeps resolveParentIdForCreate fallback', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorTreeHelpers.syncCurrentTreeData missing');
+  const callIndex = editorSource.indexOf('syncCurrentTreeData(tree);');
+
+  assert.ok(guardIndex !== -1, 'missing syncCurrentTreeData guard must exist');
+  assert.ok(callIndex !== -1, 'syncCurrentTreeData call must exist');
+  assert.ok(guardIndex < callIndex, 'guard must run before syncCurrentTreeData call');
+
+  const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
+
+  // resolveParentIdForCreate fallback is still present
+  assert.match(
+    editorSource,
+    /resolveParentIdForCreate\s*=\s*editorTreeHelpers\.resolveParentIdForCreate\s*\|\|/
+  );
+});


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `syncCurrentTreeData` from `js/editor.js`
- require the existing `LoveBudEditorTreeHelpers.syncCurrentTreeData` boundary
- add explicit missing-helper guard using bootstrap-level reporting (no `reportError`)
- keep `resolveParentIdForCreate` local fallback unchanged
- add tree helper contract tests for `syncCurrentTreeData` required pattern, guard, and `resolveParentIdForCreate` fallback preservation

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL