### PR TITLE
refactor(editor): require parent id resolver helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -156,12 +156,15 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate || ((selectedNodeId, canonicalRootId) => {
-        if (!selectedNodeId || selectedNodeId === canonicalRootId) {
-            return canonicalRootId === 'root' ? null : canonicalRootId;
-        }
-        return selectedNodeId;
-    });
+    const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate;
+
+    if (typeof resolveParentIdForCreate !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorTreeHelpers.resolveParentIdForCreate missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const getMyTreesHref = editorPageHelpers.getMyTreesHref;
     if (typeof getMyTreesHref !== 'function') {

--- a/tests/contracts/editor-tree-visibility-state-helper-contract.test.cjs
+++ b/tests/contracts/editor-tree-visibility-state-helper-contract.test.cjs
@@ -95,20 +95,38 @@ test('editor.js delegates syncCurrentTreeData through required tree helper', () 
   );
 });
 
-test('editor.js guards missing syncCurrentTreeData and keeps resolveParentIdForCreate fallback', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorTreeHelpers.syncCurrentTreeData missing');
-  const callIndex = editorSource.indexOf('syncCurrentTreeData(tree);');
+test('editor.js delegates resolveParentIdForCreate through required tree helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+resolveParentIdForCreate\s*=\s*editorTreeHelpers\.resolveParentIdForCreate/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+resolveParentIdForCreate\s*=\s*editorTreeHelpers\.resolveParentIdForCreate\s*\|\|/
+  );
+  assert.match(
+    editorSource,
+    /LoveBudEditorTreeHelpers\.resolveParentIdForCreate missing/
+  );
+  // syncCurrentTreeData required boundary is intact
+  assert.match(
+    editorSource,
+    /const\s+syncCurrentTreeData\s*=\s*editorTreeHelpers\.syncCurrentTreeData/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+syncCurrentTreeData\s*=\s*editorTreeHelpers\.syncCurrentTreeData\s*\|\|/
+  );
+});
 
-  assert.ok(guardIndex !== -1, 'missing syncCurrentTreeData guard must exist');
-  assert.ok(callIndex !== -1, 'syncCurrentTreeData call must exist');
-  assert.ok(guardIndex < callIndex, 'guard must run before syncCurrentTreeData call');
+test('editor.js guards missing resolveParentIdForCreate without reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorTreeHelpers.resolveParentIdForCreate missing');
+  const usageIndex = editorSource.indexOf('resolveParentIdForCreate,');
+
+  assert.ok(guardIndex !== -1, 'missing resolveParentIdForCreate guard must exist');
+  assert.ok(usageIndex !== -1, 'resolveParentIdForCreate usage must exist');
+  assert.ok(guardIndex < usageIndex, 'guard must run before resolveParentIdForCreate usage');
 
   const guardBlock = editorSource.slice(guardIndex - 100, guardIndex + 200);
   assert.doesNotMatch(guardBlock, /reportError\(/);
-
-  // resolveParentIdForCreate fallback is still present
-  assert.match(
-    editorSource,
-    /resolveParentIdForCreate\s*=\s*editorTreeHelpers\.resolveParentIdForCreate\s*\|\|/
-  );
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `resolveParentIdForCreate` from `js/editor.js`
- require the existing `LoveBudEditorTreeHelpers.resolveParentIdForCreate` boundary
- add explicit missing-helper guard using bootstrap-level reporting (no `reportError`)
- `syncCurrentTreeData` required boundary remains intact
- memory create/save/update/delete flow unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL