### PR TITLE
refactor(editor): require text resolver helpers

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -136,15 +136,25 @@ document.addEventListener('DOMContentLoaded', () => {
         buildEditorRedirectTarget
     });
 
-    const createInlineTextResolversFallbacks = resolverFallbacks.createInlineTextResolversFallbacks || (() => ({}));
-    const inlineTextResolvers = editorHelpers.safeI18nText
-        ? editorHelpers
-        : createInlineTextResolversFallbacks();
+    const safeI18nText = editorHelpers.safeI18nText;
+    const resolveHintText = editorHelpers.resolveHintText;
+    const resolveTreeTitleText = editorHelpers.resolveTreeTitleText;
+    const resolveInfoText = editorHelpers.resolveInfoText;
 
-    const safeI18nText = editorHelpers.safeI18nText || inlineTextResolvers.safeI18nText;
-    const resolveHintText = editorHelpers.resolveHintText || inlineTextResolvers.resolveHintText;
-    const resolveTreeTitleText = editorHelpers.resolveTreeTitleText || inlineTextResolvers.resolveTreeTitleText;
-    const resolveInfoText = editorHelpers.resolveInfoText || inlineTextResolvers.resolveInfoText;
+    const missingTextResolvers = [
+        ['LoveBudEditorHelpers.safeI18nText', safeI18nText],
+        ['LoveBudEditorHelpers.resolveHintText', resolveHintText],
+        ['LoveBudEditorHelpers.resolveTreeTitleText', resolveTreeTitleText],
+        ['LoveBudEditorHelpers.resolveInfoText', resolveInfoText]
+    ].filter(([, helper]) => typeof helper !== 'function');
+
+    if (missingTextResolvers.length) {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = missingTextResolvers.map(([name]) => name + ' missing').join('; ');
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const syncCurrentTreeData = editorTreeHelpers.syncCurrentTreeData;
 

--- a/tests/contracts/editor-text-resolvers-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-text-resolvers-required-boundary-contract.test.cjs
@@ -1,0 +1,74 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+const editorHelpersSource = fs.readFileSync('js/editor/editor-helpers.js', 'utf8');
+
+test('editor helpers expose text resolver functions', () => {
+  assert.match(editorHelpersSource, /safeI18nText:\s*safeI18nText/);
+  assert.match(editorHelpersSource, /resolveHintText:\s*resolveHintText/);
+  assert.match(editorHelpersSource, /resolveTreeTitleText:\s*resolveTreeTitleText/);
+  assert.match(editorHelpersSource, /resolveInfoText:\s*resolveInfoText/);
+  assert.match(editorHelpersSource, /function\s+safeI18nText\(i18nFn,\s*key,\s*fallback\)/);
+  assert.match(editorHelpersSource, /function\s+resolveHintText\(i18nFn,\s*rawValue,\s*fallbackKey,\s*fallbackText\)/);
+  assert.match(editorHelpersSource, /function\s+resolveTreeTitleText\(i18nFn,\s*rawTitle\)/);
+  assert.match(editorHelpersSource, /function\s+resolveInfoText\(i18nFn,\s*rawValue,\s*fallbackKey,\s*fallbackText\)/);
+});
+
+test('editor.js delegates all four text resolvers through required helpers', () => {
+  const requiredPattern = [
+    /const\s+safeI18nText\s*=\s*editorHelpers\.safeI18nText/,
+    /const\s+resolveHintText\s*=\s*editorHelpers\.resolveHintText/,
+    /const\s+resolveTreeTitleText\s*=\s*editorHelpers\.resolveTreeTitleText/,
+    /const\s+resolveInfoText\s*=\s*editorHelpers\.resolveInfoText/
+  ];
+
+  requiredPattern.forEach((pattern) => {
+    assert.match(editorSource, pattern);
+  });
+
+  // No fallback via || for any of them
+  const fallbackPatterns = [
+    /const\s+safeI18nText\s*=\s*editorHelpers\.safeI18nText\s*\|\|/,
+    /const\s+resolveHintText\s*=\s*editorHelpers\.resolveHintText\s*\|\|/,
+    /const\s+resolveTreeTitleText\s*=\s*editorHelpers\.resolveTreeTitleText\s*\|\|/,
+    /const\s+resolveInfoText\s*=\s*editorHelpers\.resolveInfoText\s*\|\|/
+  ];
+
+  fallbackPatterns.forEach((pattern) => {
+    assert.doesNotMatch(editorSource, pattern);
+  });
+});
+
+test('editor.js removes createInlineTextResolversFallbacks and inlineTextResolvers adapter', () => {
+  assert.doesNotMatch(editorSource, /createInlineTextResolversFallbacks/);
+  assert.doesNotMatch(editorSource, /inlineTextResolvers/);
+});
+
+test('editor.js adds missing-text-resolvers guard without reportError', () => {
+  assert.match(editorSource, /missingTextResolvers/);
+  // Array entries with helper names
+  assert.match(editorSource, /LoveBudEditorHelpers\.safeI18nText/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.resolveHintText/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.resolveTreeTitleText/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.resolveInfoText/);
+  // Dynamic join creates 'name missing' for each
+  assert.match(editorSource, /name\s*\+\s*' missing'/);
+  assert.match(editorSource, /missingTextResolvers\.map\(/);
+
+  const guardStart = editorSource.indexOf('missingTextResolvers');
+  assert.notEqual(guardStart, -1, 'guard must exist');
+  const guardEnd = editorSource.indexOf('const syncCurrentTreeData', guardStart);
+  assert.notEqual(guardEnd, -1, 'syncCurrentTreeData must follow guard');
+
+  const guardBlock = editorSource.slice(guardStart, guardEnd);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
+});
+
+test('editor.js keeps media resolver fallbacks intact', () => {
+  assert.match(editorSource, /createInlineMediaResolversFallbacks/);
+  assert.match(editorSource, /resolverFallbacks\.createInlineMediaResolversFallbacks\s*\|\|/);
+  assert.match(editorSource, /escapeHtml\s*=\s*editorHelpers\.escapeHtml\s*\|\|/);
+  assert.match(editorSource, /resolveMemoryThumbnail\s*=\s*editorHelpers\.resolveMemoryThumbnail\s*\|\|/);
+});


### PR DESCRIPTION
Refs #1698

## Summary
- remove `createInlineTextResolversFallbacks` adapter and `inlineTextResolvers` conditional from `js/editor.js`
- require `LoveBudEditorHelpers.safeI18nText`, `.resolveHintText`, `.resolveTreeTitleText`, `.resolveInfoText` as sole boundaries
- add combined missing-helper guard using bootstrap-level reporting (no `reportError`)
- keep media resolver fallbacks (`escapeHtml`, `safeUrl`, `resolveMemoryThumbnail`) unchanged
- add new contract test file for text resolvers required boundary

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS/PARTIAL/BLOCKED/NOT_RUN
Editor browser smoke: PASS/PARTIAL/BLOCKED/NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS/PARTIAL/BLOCKED/FAIL