### PR TITLE
refactor(editor): require media resolver helpers

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     const dataLoaderFallbacks = window.LoveBudEditorDataLoaderFallbacks || {};
     const entryFallbacks = window.LoveBudEditorEntryFallbacks || {};
-    const resolverFallbacks = window.LoveBudEditorResolverFallbacks || {};
     const shellHelpers = window.LoveBudEditorShellHelpers || {};
 
     let rootHelperWarningShown = false;
@@ -184,24 +183,23 @@ document.addEventListener('DOMContentLoaded', () => {
         debugState.errors.push({ msg, error: msg });
         return;
     }
-    const createInlineMediaResolversFallbacks = resolverFallbacks.createInlineMediaResolversFallbacks || (() => ({}));
+    const escapeHtml = editorHelpers.escapeHtml;
+    const safeUrl = editorHelpers.safeUrl;
+    const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail;
 
-    const escapeHtml = editorHelpers.escapeHtml || ((value) => {
-        var sec = window.LoveBudSecurity;
-        if (sec) return sec.escapeHtml(value);
-        return String(value ?? '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    });
+    const missingMediaResolvers = [
+        ['LoveBudEditorHelpers.escapeHtml', escapeHtml],
+        ['LoveBudEditorHelpers.safeUrl', safeUrl],
+        ['LoveBudEditorHelpers.resolveMemoryThumbnail', resolveMemoryThumbnail]
+    ].filter(([, helper]) => typeof helper !== 'function');
 
-    const inlineMediaResolvers = editorHelpers.safeUrl
-        ? editorHelpers
-        : createInlineMediaResolversFallbacks();
-
-    const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail || inlineMediaResolvers.resolveMemoryThumbnail;
+    if (missingMediaResolvers.length) {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = missingMediaResolvers.map(([name]) => name + ' missing').join('; ');
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const getYouTubeInputErrorMessageFallback = shellHelpers.getYouTubeInputErrorMessageFallback;
 

--- a/tests/contracts/editor-shell-core-utilities-contract.test.cjs
+++ b/tests/contracts/editor-shell-core-utilities-contract.test.cjs
@@ -149,7 +149,7 @@ test('editor entrypoint requires getMyTreesHref page helper', () => {
   // Guard must not use reportError
   const guardStart = editorSource.indexOf('LoveBudEditorPageHelpers.getMyTreesHref missing');
   assert.notEqual(guardStart, -1, 'getMyTreesHref missing guard must exist');
-  const guardEnd = editorSource.indexOf('const createInlineMediaResolversFallbacks =', guardStart);
+  const guardEnd = editorSource.indexOf('const getYouTubeInputErrorMessageFallback =', guardStart);
   assert.notEqual(guardEnd, -1, 'next fallback block must follow getMyTreesHref guard');
   const guardBlock = editorSource.slice(guardStart, guardEnd);
   assert.doesNotMatch(guardBlock, /reportError/);

--- a/tests/contracts/editor-text-resolvers-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-text-resolvers-required-boundary-contract.test.cjs
@@ -66,9 +66,40 @@ test('editor.js adds missing-text-resolvers guard without reportError', () => {
   assert.doesNotMatch(guardBlock, /reportError\(/);
 });
 
-test('editor.js keeps media resolver fallbacks intact', () => {
-  assert.match(editorSource, /createInlineMediaResolversFallbacks/);
-  assert.match(editorSource, /resolverFallbacks\.createInlineMediaResolversFallbacks\s*\|\|/);
-  assert.match(editorSource, /escapeHtml\s*=\s*editorHelpers\.escapeHtml\s*\|\|/);
-  assert.match(editorSource, /resolveMemoryThumbnail\s*=\s*editorHelpers\.resolveMemoryThumbnail\s*\|\|/);
+test('editor.js requires media resolver helpers through required boundaries', () => {
+  // Three media resolvers now required via direct assignment
+  assert.match(editorSource, /const\s+escapeHtml\s*=\s*editorHelpers\.escapeHtml\b[^|]/);
+  assert.match(editorSource, /const\s+safeUrl\s*=\s*editorHelpers\.safeUrl\b[^|]/);
+  assert.match(editorSource, /const\s+resolveMemoryThumbnail\s*=\s*editorHelpers\.resolveMemoryThumbnail\b[^|]/);
+
+  // No more fallback via ||
+  assert.doesNotMatch(editorSource, /escapeHtml\s*=\s*editorHelpers\.escapeHtml\s*\|\|/);
+  assert.doesNotMatch(editorSource, /resolveMemoryThumbnail\s*=\s*editorHelpers\.resolveMemoryThumbnail\s*\|\|/);
+
+  // Adapter pattern removed
+  assert.doesNotMatch(editorSource, /createInlineMediaResolversFallbacks/);
+  assert.doesNotMatch(editorSource, /resolverFallbacks\.createInlineMediaResolversFallbacks/);
+  assert.doesNotMatch(editorSource, /inlineMediaResolvers/);
+
+  // Missing-helper guard exists
+  assert.match(editorSource, /missingMediaResolvers/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.escapeHtml/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.safeUrl/);
+  assert.match(editorSource, /LoveBudEditorHelpers\.resolveMemoryThumbnail/);
+
+  // Guard does not use reportError
+  const guardStart = editorSource.indexOf('missingMediaResolvers');
+  assert.notEqual(guardStart, -1, 'guard must exist');
+  const guardEnd = editorSource.indexOf('const getYouTubeInputErrorMessageFallback', guardStart);
+  assert.notEqual(guardEnd, -1, 'getYouTubeInputErrorMessageFallback must follow guard');
+  const guardBlock = editorSource.slice(guardStart, guardEnd);
+  assert.doesNotMatch(guardBlock, /reportError\(/);
+});
+
+test('editor.js keeps text resolver required boundaries intact', () => {
+  assert.match(editorSource, /const\s+safeI18nText\s*=\s*editorHelpers\.safeI18nText/);
+  assert.match(editorSource, /const\s+resolveHintText\s*=\s*editorHelpers\.resolveHintText/);
+  assert.match(editorSource, /const\s+resolveTreeTitleText\s*=\s*editorHelpers\.resolveTreeTitleText/);
+  assert.match(editorSource, /const\s+resolveInfoText\s*=\s*editorHelpers\.resolveInfoText/);
+  assert.match(editorSource, /missingTextResolvers/);
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove the local inline fallback for `escapeHtml`, `safeUrl`, `resolveMemoryThumbnail` from `js/editor.js`
- remove the `createInlineMediaResolversFallbacks` adapter and `inlineMediaResolvers` conditional branch
- remove orphaned `resolverFallbacks` declaration
- require the existing `LoveBudEditorHelpers.escapeHtml`, `LoveBudEditorHelpers.safeUrl`, `LoveBudEditorHelpers.resolveMemoryThumbnail` boundaries
- add a combined missing-helper guard before applying media resolvers
- update shell readiness helper contracts to assert required-helper behavior for media resolvers
- keep text resolver required boundaries intact

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS