### PR TITLE
refactor(editor): require next memory id helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    const createInlineNextMemoryIdFallback = dataLoaderFallbacks.createInlineNextMemoryIdFallback || ((options) => () => 'm1');
+    const nextMemoryIdFromMemories = editorTreeHelpers.nextMemoryIdFromMemories;
     const createInlineFormatTimeAgoFallback = entryFallbacks.createInlineFormatTimeAgoFallback;
 
     const markEditorReady = shellHelpers.markEditorReady;
@@ -465,9 +465,12 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             const createInitialMemory = () => editorTreeHelpers.createInitialMemory({ getTreeMemories: () => treeMemories(), findRootMemory, canonicalRootId, treeId, i18n });
 
-            const nextMemoryId = editorTreeHelpers.nextMemoryIdFromMemories
-                ? () => editorTreeHelpers.nextMemoryIdFromMemories(treeMemories())
-                : createInlineNextMemoryIdFallback({ treeMemories });
+            if (typeof nextMemoryIdFromMemories !== 'function') {
+                reportError('LoveBudEditorTreeHelpers.nextMemoryIdFromMemories missing');
+                return;
+            }
+
+            const nextMemoryId = () => nextMemoryIdFromMemories(treeMemories());
 
             const emptyGuideUIHelper = window.LoveBudEditorEmptyGuideUI || {};
             const updateCanvasEmptyGuide = emptyGuideUIHelper.createCanvasEmptyGuideUpdater

--- a/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+
+const editorSource = fs.readFileSync('js/editor.js', 'utf8');
+const treeHelpersSource = fs.readFileSync('js/editor/editor-tree-helpers.js', 'utf8');
+
+test('editor tree helpers expose nextMemoryIdFromMemories', () => {
+  assert.match(treeHelpersSource, /treeHelpers\.nextMemoryIdFromMemories/);
+  assert.match(treeHelpersSource, /function nextMemoryIdFromMemories\(memories\)/);
+});
+
+test('editor.js requires nextMemoryIdFromMemories through required tree helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+nextMemoryIdFromMemories\s*=\s*editorTreeHelpers\.nextMemoryIdFromMemories/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+nextMemoryIdFromMemories\s*=\s*editorTreeHelpers\.nextMemoryIdFromMemories\s*\|\|/
+  );
+});
+
+test('editor.js removes createInlineNextMemoryIdFallback', () => {
+  assert.doesNotMatch(editorSource, /createInlineNextMemoryIdFallback/);
+  assert.doesNotMatch(editorSource, /dataLoaderFallbacks\.createInlineNextMemoryIdFallback/);
+});
+
+test('editor.js guards missing nextMemoryIdFromMemories with reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorTreeHelpers.nextMemoryIdFromMemories missing');
+  const guardReportStart = editorSource.indexOf('reportError(', guardIndex - 50);
+  const guardReportEnd = editorSource.indexOf(')', guardReportStart) + 1;
+  const guardReportExpr = editorSource.slice(guardReportStart, guardReportEnd);
+
+  assert.ok(guardIndex !== -1, 'missing nextMemoryIdFromMemories guard must exist');
+  assert.ok(guardReportStart !== -1, 'guard must use reportError');
+  assert.match(guardReportExpr, /reportError\(['"]LoveBudEditorTreeHelpers\.nextMemoryIdFromMemories missing['"]\)/);
+});
+
+test('editor.js delegates nextMemoryId through required tree helper', () => {
+  assert.match(
+    editorSource,
+    /const\s+nextMemoryId\s*=\s*\(\s*\)\s*=>\s*nextMemoryIdFromMemories\(treeMemories\(\)\)/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /createInlineNextMemoryIdFallback\(\{/
+  );
+});
+
+test('editor.js keeps createInlineFormatTimeAgoFallback and redirectToEditorLogin fallbacks intact', () => {
+  assert.match(editorSource, /createInlineFormatTimeAgoFallback/);
+  assert.match(editorSource, /redirectToEditorLogin/);
+});

--- a/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
+++ b/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
@@ -60,7 +60,7 @@ test('editor.js renderTreeLoadError guard does not use reportError', () => {
   const guardStart = editorSource.indexOf("if (typeof renderTreeLoadError !== 'function')");
   assert.notEqual(guardStart, -1, 'renderTreeLoadError guard must exist');
 
-  const guardEnd = editorSource.indexOf("const createInlineNextMemoryIdFallback", guardStart);
+  const guardEnd = editorSource.indexOf("const nextMemoryIdFromMemories", guardStart);
   assert.notEqual(guardEnd, -1, 'guard end marker must exist after guard');
 
   const guardBody = editorSource.slice(guardStart, guardEnd);


### PR DESCRIPTION
Refs #1698

## Summary
- remove the `createInlineNextMemoryIdFallback` local fallback from `js/editor.js`
- require `LoveBudEditorTreeHelpers.nextMemoryIdFromMemories` boundary with top-level reference
- add a guard with `reportError` inside `startEditor` (where `treeMemories()` is already available)
- simplify `nextMemoryId` from conditional fallback to direct required call
- keep `createInlineFormatTimeAgoFallback` and `redirectToEditorLogin` fallbacks unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS