### PR TITLE
refactor(editor): require save status time formatter

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -230,7 +230,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const nextMemoryIdFromMemories = editorTreeHelpers.nextMemoryIdFromMemories;
-    const createInlineFormatTimeAgoFallback = entryFallbacks.createInlineFormatTimeAgoFallback;
 
     const markEditorReady = shellHelpers.markEditorReady;
 
@@ -663,9 +662,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
+            if (typeof editorSaveStatus.formatTimeAgo !== 'function') {
+                reportError('LoveBudEditorSaveStatus.formatTimeAgo missing');
+                return;
+            }
+
             const formatTimeAgo = resolveSaveStatusTimeFormatter({
-                editorSaveStatus,
-                createInlineFormatTimeAgoFallback
+                editorSaveStatus
             });
 
             const saveStatusOrchestrationHelper = window.LoveBudEditorSaveStatusOrchestration || {};

--- a/js/editor/editor-shell-helpers.js
+++ b/js/editor/editor-shell-helpers.js
@@ -63,11 +63,8 @@ window.LoveBudEditorShellHelpers = {
     resolveSaveStatusTimeFormatter: function(options) {
         var opts = options || {};
         var editorSaveStatus = opts.editorSaveStatus || {};
-        var createInlineFormatTimeAgoFallback = opts.createInlineFormatTimeAgoFallback || function() {
-            return function() { return ''; };
-        };
 
-        return editorSaveStatus.formatTimeAgo || createInlineFormatTimeAgoFallback();
+        return editorSaveStatus.formatTimeAgo;
     },
 
     // Toast fallback

--- a/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
@@ -48,7 +48,6 @@ test('editor.js delegates nextMemoryId through required tree helper', () => {
   );
 });
 
-test('editor.js keeps createInlineFormatTimeAgoFallback and redirectToEditorLogin fallbacks intact', () => {
-  assert.match(editorSource, /createInlineFormatTimeAgoFallback/);
+test('editor.js keeps redirectToEditorLogin fallback intact', () => {
   assert.match(editorSource, /redirectToEditorLogin/);
 });

--- a/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
+++ b/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
@@ -9,10 +9,10 @@ const saveStatusOrchestrationSource = fs.readFileSync('js/editor/editor-save-sta
 test('editor shell helpers expose save status time formatter resolver', () => {
   assert.match(shellHelpersSource, /resolveSaveStatusTimeFormatter:\s*function\(options\)/);
   assert.match(shellHelpersSource, /var editorSaveStatus\s*=\s*opts\.editorSaveStatus\s*\|\|\s*\{\}/);
-  assert.match(shellHelpersSource, /var createInlineFormatTimeAgoFallback\s*=\s*opts\.createInlineFormatTimeAgoFallback/);
+  assert.doesNotMatch(shellHelpersSource, /createInlineFormatTimeAgoFallback/);
 });
 
-test('save status time formatter resolver preserves primary formatter priority', () => {
+test('save status time formatter resolver returns editorSaveStatus.formatTimeAgo', () => {
   const start = shellHelpersSource.indexOf('resolveSaveStatusTimeFormatter');
   assert.notEqual(start, -1, 'resolver must exist');
 
@@ -20,7 +20,8 @@ test('save status time formatter resolver preserves primary formatter priority',
   assert.notEqual(end, -1, 'resolver must end');
 
   const block = shellHelpersSource.slice(start, end);
-  assert.match(block, /return editorSaveStatus\.formatTimeAgo \|\| createInlineFormatTimeAgoFallback\(\)/);
+  assert.match(block, /return editorSaveStatus\.formatTimeAgo/);
+  assert.doesNotMatch(block, /createInlineFormatTimeAgoFallback/);
 });
 
 test('editor delegates save status time formatter resolution through required shell helper', () => {
@@ -38,11 +39,15 @@ test('editor delegates save status time formatter resolution through required sh
   );
   assert.match(
     editorSource,
-    /const\s+formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\{/
+    /const\s+formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\s*\{/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /createInlineFormatTimeAgoFallback/
   );
   assert.match(
     editorSource,
-    /editorSaveStatus,\s*createInlineFormatTimeAgoFallback/
+    /LoveBudEditorSaveStatus\.formatTimeAgo missing/
   );
 });
 
@@ -68,9 +73,20 @@ test('editor guards missing save status time formatter before resolution', () =>
   assert.ok(guardIndex < formatIndex, 'guard must run before formatTimeAgo resolution');
 });
 
-test('editor keeps createInlineFormatTimeAgoFallback available and unchanged by boundary', () => {
-  assert.match(editorSource, /createInlineFormatTimeAgoFallback/);
+test('editor.js removes createInlineFormatTimeAgoFallback and requires formatTimeAgo helper', () => {
+  assert.doesNotMatch(editorSource, /createInlineFormatTimeAgoFallback/);
+  assert.doesNotMatch(editorSource, /entryFallbacks\.createInlineFormatTimeAgoFallback/);
+  assert.match(editorSource, /LoveBudEditorSaveStatus\.formatTimeAgo missing/);
   assert.match(editorSource, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter/);
+});
+
+test('editor.js formatTimeAgo guard uses reportError', () => {
+  const guardIndex = editorSource.indexOf('LoveBudEditorSaveStatus.formatTimeAgo missing');
+  assert.ok(guardIndex !== -1, 'missing formatTimeAgo guard must exist');
+  const guardReportStart = editorSource.indexOf('reportError(', guardIndex - 50);
+  assert.ok(guardReportStart !== -1, 'guard must use reportError');
+  const guardReportExpr = editorSource.slice(guardReportStart, editorSource.indexOf(')', guardReportStart) + 1);
+  assert.match(guardReportExpr, /reportError\(['"]LoveBudEditorSaveStatus\.formatTimeAgo missing['"]\)/);
 });
 
 test('editor keeps save status orchestration invocation intact', () => {

--- a/tests/contracts/editor-script-order-contract.test.cjs
+++ b/tests/contracts/editor-script-order-contract.test.cjs
@@ -154,7 +154,6 @@ test('editor entry delegates entry fallback factories through boundary', () => {
 
   for (const factory of [
     'createInlineRedirectToEditorLoginFallback',
-    'createInlineFormatTimeAgoFallback',
   ]) {
     assert.match(boundary, new RegExp(`${factory}\\s*:`), `entry fallback boundary must expose ${factory}`);
     assert.match(editor, new RegExp(`entryFallbacks\\.${factory}`), `editor entry must delegate ${factory}`);


### PR DESCRIPTION
Refs #1698

## Summary
- remove the `createInlineFormatTimeAgoFallback` local fallback from `js/editor.js`
- remove `createInlineFormatTimeAgoFallback` option from `resolveSaveStatusTimeFormatter` in `editor-shell-helpers.js`
- add a guard with `reportError` for `editorSaveStatus.formatTimeAgo` before resolution
- simplify `resolveSaveStatusTimeFormatter` to return `editorSaveStatus.formatTimeAgo` directly
- keep `redirectToEditorLogin` fallback unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js, js/editor/editor-shell-helpers.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS