### PR TITLE
refactor(editor): require login redirect helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -128,12 +128,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const buildEditorRedirectTarget = () => buildEditorRedirectTargetHelper.call(shellHelpers);
 
-    const createInlineRedirectToEditorLoginFallback = entryFallbacks.createInlineRedirectToEditorLoginFallback;
+    const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin;
 
-    const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin || createInlineRedirectToEditorLoginFallback({
-        getEditorBasePath,
-        buildEditorRedirectTarget
-    });
+    if (typeof redirectToEditorLogin !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorPageHelpers.redirectToEditorLogin missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const safeI18nText = editorHelpers.safeI18nText;
     const resolveHintText = editorHelpers.resolveHintText;

--- a/tests/contracts/editor-script-order-contract.test.cjs
+++ b/tests/contracts/editor-script-order-contract.test.cjs
@@ -152,12 +152,10 @@ test('editor entry delegates entry fallback factories through boundary', () => {
 
   assert.match(editor, /window\.LoveBudEditorEntryFallbacks/, 'editor entry must read the entry fallback boundary');
 
-  for (const factory of [
-    'createInlineRedirectToEditorLoginFallback',
-  ]) {
-    assert.match(boundary, new RegExp(`${factory}\\s*:`), `entry fallback boundary must expose ${factory}`);
-    assert.match(editor, new RegExp(`entryFallbacks\\.${factory}`), `editor entry must delegate ${factory}`);
-  }
+  assert.match(boundary, /createInlineRedirectToEditorLoginFallback\s*:/, 'entry fallback boundary must expose createInlineRedirectToEditorLoginFallback');
+  assert.doesNotMatch(editor, /entryFallbacks\.createInlineRedirectToEditorLoginFallback/, 'editor entry no longer delegates createInlineRedirectToEditorLoginFallback through entryFallbacks');
+  assert.match(editor, /redirectToEditorLogin\s*=\s*editorPageHelpers\.redirectToEditorLogin/, 'editor entry requires redirectToEditorLogin from page helpers');
+  assert.match(editor, /LoveBudEditorPageHelpers\.redirectToEditorLogin missing/, 'editor entry guards missing redirectToEditorLogin');
 
   assert.match(editor, /shellHelpers\.createInlineShowToastFallback/, 'editor entry must require toast fallback from shell helpers');
 });


### PR DESCRIPTION
Refs #1698

## Summary
- remove `createInlineRedirectToEditorLoginFallback` fallback wiring from `js/editor.js`
- require `LoveBudEditorPageHelpers.redirectToEditorLogin`
- add bootstrap guard for missing login redirect helper
- keep existing `redirectToEditorLogin(2000)` usage unchanged
- leave `editor-entry-fallbacks.js` unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS