### PR TITLE
refactor(editor): require startup dependency waiter

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -299,17 +299,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const startEditor = async () => {
         const { log, reportError } = createEditorDebugReporter();
 
+        if (typeof createEditorStartupDependencyWaiter !== 'function') {
+            reportError('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
+            return;
+        }
+
         if (typeof markEditorReady !== 'function') {
             reportError('LoveBudEditorShellHelpers.markEditorReady missing');
             return;
         }
 
         log('startEditor sequence initiated');
-
-        if (typeof createEditorStartupDependencyWaiter !== 'function') {
-            reportError('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
-            return;
-        }
 
         const waitForGlobal = createEditorStartupDependencyWaiter({ log, reportError });
 

--- a/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
+++ b/tests/contracts/editor-shell-readiness-helper-contract.test.cjs
@@ -214,6 +214,49 @@ test('editor.js guards missing markEditorReady before startup proceeds', () => {
   assert.ok(guardIndex < waiterIndex, 'markEditorReady guard must run before dependency waiter setup');
 });
 
+test('editor.js guards missing createEditorStartupDependencyWaiter after debug reporter creation', () => {
+  const reporterCall = editorSource.indexOf('createEditorDebugReporter()');
+  const waiterGuard = editorSource.indexOf('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
+
+  assert.ok(reporterCall !== -1, 'createEditorDebugReporter() call must exist');
+  assert.ok(waiterGuard !== -1, 'createEditorStartupDependencyWaiter missing guard must exist');
+  assert.ok(reporterCall < waiterGuard, 'debug reporter must be created before waiter guard');
+});
+
+test('editor.js guards missing createEditorStartupDependencyWaiter before markEditorReady guard', () => {
+  const waiterGuard = editorSource.indexOf('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
+  const markGuard = editorSource.indexOf('LoveBudEditorShellHelpers.markEditorReady missing');
+
+  assert.ok(waiterGuard !== -1, 'createEditorStartupDependencyWaiter missing guard must exist');
+  assert.ok(markGuard !== -1, 'markEditorReady missing guard must exist');
+  assert.ok(waiterGuard < markGuard, 'waiter guard must run before markEditorReady guard');
+});
+
+test('editor.js does not use console.error for createEditorStartupDependencyWaiter missing guard at top level', () => {
+  const topBootSection = editorSource.slice(0, editorSource.indexOf('const startEditor'));
+  const consoleErrorPattern = /console\.error\(.*createEditorStartupDependencyWaiter missing/;
+  assert.doesNotMatch(topBootSection, consoleErrorPattern,
+    'createEditorStartupDependencyWaiter missing must use reportError, not top-level console.error');
+});
+
+test('editor.js maintains waitForGlobal dependency order in startEditor', () => {
+  const startSection = editorSource.slice(editorSource.indexOf('const waitForGlobal'));
+  const waitLines = [
+    "waitForGlobal('createEditorCanvas')",
+    "waitForGlobal('createEditorDetailUI')",
+    "waitForGlobal('createEditorMemoryActions')",
+    "waitForGlobal('createEditorMemoryForm')"
+  ];
+
+  let prevIndex = -1;
+  for (const line of waitLines) {
+    const idx = startSection.indexOf(line);
+    assert.ok(idx !== -1, `Editor must call ${line}`);
+    assert.ok(idx > prevIndex, `Wait order must be preserved: ${line} after previous`);
+    prevIndex = idx;
+  }
+});
+
 test('editor.js guards missing applyEditorEditabilityState before applying editability state', () => {
   const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.applyEditorEditabilityState missing');
   const applyIndex = editorSource.indexOf('applyEditorEditabilityState({ canEdit });');


### PR DESCRIPTION
Refs #1698

## Summary
- require `LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter` immediately after debug reporter creation in `startEditor`
- move the `createEditorStartupDependencyWaiter` missing guard before the `markEditorReady` guard
- keep `createEditorDebugReporter` bootstrap guard unchanged
- preserve `waitForGlobal` construction and dependency wait order (createEditorCanvas → createEditorDetailUI → createEditorMemoryActions → createEditorMemoryForm)
- add contract tests verifying: waiter guard after debug reporter, waiter guard before markEditorReady guard, no top-level console.error fallback, and wait order preservation
- avoid changing canvas, memory, save, auth, API, HTML, or CSS paths

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS