### PR TITLE
refactor(editor): require tree load error copy helper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -232,6 +232,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
+    const buildTreeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy;
+
+    if (typeof buildTreeLoadErrorCopy !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy missing';
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
+
     const nextMemoryIdFromMemories = editorTreeHelpers.nextMemoryIdFromMemories;
 
     const markEditorReady = shellHelpers.markEditorReady;
@@ -383,20 +393,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (urlTreeId) {
                     const treeLoadStatus = treeLoadResult.treeLoadStatus || 'not_found';
                     const treeLoadErrorMessage = treeLoadResult.treeLoadErrorMessage || '';
-                    let treeLoadErrorCopy = {
-                        errorTitle: i18n('tree_not_found_title') || '트리를 찾을 수 없어요',
-                        errorDesc: i18n('tree_load_not_found_desc') || '잘못된 링크이거나 접근 권한이 없는 트리입니다.'
-                    };
-
-                    if (typeof editorPageHelpers.buildTreeLoadErrorCopy === 'function') {
-                        treeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy({
-                            treeLoadStatus,
-                            treeLoadErrorMessage,
-                            i18n
-                        });
-                    } else {
-                        reportError('LoveBudEditorPageHelpers.buildTreeLoadErrorCopy missing');
-                    }
+                    const treeLoadErrorCopy = buildTreeLoadErrorCopy({
+                        treeLoadStatus,
+                        treeLoadErrorMessage,
+                        i18n
+                    });
 
                     renderTreeLoadError({
                         canvas,

--- a/tests/contracts/editor-tree-load-error-copy-contract.test.cjs
+++ b/tests/contracts/editor-tree-load-error-copy-contract.test.cjs
@@ -17,8 +17,10 @@ function extractTreeLoadFailureBlock(source) {
   return source.slice(start, end);
 }
 
+// --- 1. Page helper exports buildTreeLoadErrorCopy ---
+
 test('editor page helpers expose tree load error copy helper', () => {
-  assert.match(pageHelpersSource, /function buildTreeLoadErrorCopy\(options\)/);
+  assert.match(pageHelpersSource, /function buildTreeLoadErrorCopy\(/);
   assert.match(pageHelpersSource, /buildTreeLoadErrorCopy:\s*buildTreeLoadErrorCopy/);
 });
 
@@ -43,14 +45,58 @@ test('tree load error copy helper returns title and desc object', () => {
   assert.match(pageHelpersSource, /errorDesc:\s*errorDesc/);
 });
 
-test('editor tree load failure delegates copy creation to page helper', () => {
+// --- 2. editor.js uses required reference without fallback ---
+
+test('editor.js uses buildTreeLoadErrorCopy required reference', () => {
+  assert.match(
+    editorSource,
+    /const\s+buildTreeLoadErrorCopy\s*=\s*editorPageHelpers\.buildTreeLoadErrorCopy/
+  );
+  assert.doesNotMatch(
+    editorSource,
+    /const\s+buildTreeLoadErrorCopy\s*=\s*editorPageHelpers\.buildTreeLoadErrorCopy\s*\|\|/
+  );
+});
+
+test('editor.js has bootstrap guard for missing buildTreeLoadErrorCopy', () => {
+  assert.match(
+    editorSource,
+    /LoveBudEditorPageHelpers\.buildTreeLoadErrorCopy missing/
+  );
+});
+
+test('editor.js buildTreeLoadErrorCopy guard uses console.error pattern', () => {
+  const guardStart = editorSource.indexOf("if (typeof buildTreeLoadErrorCopy !== 'function')");
+  assert.notEqual(guardStart, -1, 'buildTreeLoadErrorCopy guard must exist');
+
+  const guardEnd = editorSource.indexOf('const nextMemoryIdFromMemories', guardStart);
+  assert.notEqual(guardEnd, -1, 'guard end marker must exist after guard');
+
+  const guardBody = editorSource.slice(guardStart, guardEnd);
+
+  assert.match(guardBody, /console\.error/);
+  assert.match(guardBody, /LoveBudEditorDebug/);
+  assert.match(guardBody, /debugState\.errors\.push/);
+  assert.doesNotMatch(guardBody, /reportError\(/);
+});
+
+// --- 3. Tree-load failure block delegates to required helper ---
+
+test('editor tree load failure delegates copy creation to required helper', () => {
   const block = extractTreeLoadFailureBlock(editorSource);
 
-  assert.match(block, /editorPageHelpers\.buildTreeLoadErrorCopy/);
+  assert.match(block, /buildTreeLoadErrorCopy\(\{/);
   assert.match(block, /treeLoadStatus,/);
   assert.match(block, /treeLoadErrorMessage,/);
   assert.match(block, /i18n/);
-  assert.match(block, /LoveBudEditorPageHelpers\.buildTreeLoadErrorCopy missing/);
+});
+
+test('editor tree load failure block no longer has inline fallback or optional check', () => {
+  const block = extractTreeLoadFailureBlock(editorSource);
+
+  assert.doesNotMatch(block, /let\s+treeLoadErrorCopy\s*=\s*\{/);
+  assert.doesNotMatch(block, /typeof editorPageHelpers\.buildTreeLoadErrorCopy/);
+  assert.doesNotMatch(block, /reportError\('LoveBudEditorPageHelpers\.buildTreeLoadErrorCopy missing'\)/);
 });
 
 test('editor no longer owns tree load status copy branching inline', () => {
@@ -63,6 +109,8 @@ test('editor no longer owns tree load status copy branching inline', () => {
   assert.doesNotMatch(block, /treeLoadStatus === 'error'\s*\?/);
 });
 
+// --- 4. Auth redirect and render flow preserved ---
+
 test('editor tree load failure keeps auth redirect and render flow intact', () => {
   const block = extractTreeLoadFailureBlock(editorSource);
 
@@ -74,6 +122,8 @@ test('editor tree load failure keeps auth redirect and render flow intact', () =
   assert.match(block, /errorDesc:\s*treeLoadErrorCopy\.errorDesc/);
   assert.match(block, /markEditorReady\(\)/);
 });
+
+// --- 5. Load order contract preserved ---
 
 test('editor page helpers load before editor entrypoint', () => {
   const pageHelpersIndex = editorHtml.indexOf('js/editor/editor-page-helpers.js');


### PR DESCRIPTION
Refs #1698

## Summary
- require `LoveBudEditorPageHelpers.buildTreeLoadErrorCopy` at editor bootstrap with a console.error guard
- remove the degraded default tree-load copy fallback (let treeLoadErrorCopy = { ... }) from the tree-load failure block in `js/editor.js`
- replace the inline optional check (`typeof editorPageHelpers.buildTreeLoadErrorCopy === 'function'`) with a direct call to the required `buildTreeLoadErrorCopy`
- update the copy contract to verify required reference, bootstrap guard, and absence of fallback patterns
- keep tree-load error copy helper implementation, auth redirect, renderTreeLoadError, and markEditorReady flow unchanged

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS