### PR TITLE
refactor(editor): extract initial load flow

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -66,6 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorPageEventBindings = window.LoveBudEditorPageEventBindings || {};
     const bindEditorPageEvents = editorPageEventBindings.bindEditorPageEvents;
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
+    const editorInitialLoadFlow = window.LoveBudEditorInitialLoadFlow || {};
+    const runEditorInitialLoadFlow = editorInitialLoadFlow.runEditorInitialLoadFlow;
     const editorStartupContext = window.LoveBudEditorStartupContext || {};
     const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
@@ -319,6 +321,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        if (typeof runEditorInitialLoadFlow !== 'function') {
+            reportError('LoveBudEditorInitialLoadFlow.runEditorInitialLoadFlow missing');
+            return;
+        }
+
         log('startEditor sequence initiated');
 
         const waitForGlobal = createEditorStartupDependencyWaiter({ log, reportError });
@@ -364,87 +371,38 @@ document.addEventListener('DOMContentLoaded', () => {
             // Expose canEdit for modules that read it after DOMContentLoaded
             applyEditorEditabilityState({ canEdit });
 
-            const cache = window.LoveBudCache || null;
-            let MEMORIES_CACHE_KEY = 'memories_default';
             let isLocalSaveMode = false;
 
-            const loadInitialTree = editorDataLoader.loadInitialEditorTree;
-            if (typeof loadInitialTree !== 'function') {
-                reportError('LoveBudEditorDataLoader.loadInitialEditorTree missing');
-                return;
-            }
-            
-            log('Loading initial tree data...');
-            const treeLoadResult = await loadInitialTree({
+            const initialLoadResult = await runEditorInitialLoadFlow({
                 urlTreeId,
+                canvas,
+                addBtn,
+                cache: window.LoveBudCache || null,
+                i18n,
                 apiClient: window.apiClient,
                 createDefaultTreeTitle: () => safeI18nText(i18n, 'default_tree_title', '러브트리'),
-                getConfirmedSessionUser
-            });
-
-            let tree = treeLoadResult.tree || null;
-            if (!tree) {
-                log('Tree not found or auth required');
-                if (treeLoadResult.authRequired) {
-                    showToast(i18n('need_login'), 'error');
-                    redirectToEditorLogin(2000);
-                    return;
-                }
-                if (urlTreeId) {
-                    const treeLoadStatus = treeLoadResult.treeLoadStatus || 'not_found';
-                    const treeLoadErrorMessage = treeLoadResult.treeLoadErrorMessage || '';
-                    const treeLoadErrorCopy = buildTreeLoadErrorCopy({
-                        treeLoadStatus,
-                        treeLoadErrorMessage,
-                        i18n
-                    });
-
-                    renderTreeLoadError({
-                        canvas,
-                        addBtn,
-                        errorTitle: treeLoadErrorCopy.errorTitle,
-                        errorDesc: treeLoadErrorCopy.errorDesc,
-                        i18n,
-                        escapeHtml,
-                        setDetailEmptyState: null
-                    });
-                    markEditorReady();
-                    return;
-                }
-                markEditorReady();
-                return;
-            }
-
-            syncCurrentTreeData(tree);
-            const treeId = tree.id || null;
-            MEMORIES_CACHE_KEY = 'memories_' + (treeId || 'default');
-            log(`Tree loaded: ${treeId}`);
-
-            if (typeof editorDataLoader.createNormalizeMemory !== 'function') {
-                reportError('LoveBudEditorDataLoader.createNormalizeMemory missing');
-                return;
-            }
-            const normalizeMemory = editorDataLoader.createNormalizeMemory({ sharedNormalize: window.LoveBudNormalize?.normalizeMemory });
-
-            if (typeof editorDataLoader.loadEditorMemories !== 'function') {
-                reportError('LoveBudEditorDataLoader.loadEditorMemories missing');
-                return;
-            }
-            
-            log('Loading editor memories...');
-            await editorDataLoader.loadEditorMemories({
-                treeId,
-                cache,
-                cacheKey: MEMORIES_CACHE_KEY,
-                apiClient: window.apiClient,
+                getConfirmedSessionUser,
                 showToast,
-                i18n,
-                normalizeMemory
+                redirectToEditorLogin,
+                buildTreeLoadErrorCopy,
+                renderTreeLoadError,
+                markEditorReady,
+                syncCurrentTreeData,
+                editorDataLoader,
+                sharedNormalize: window.LoveBudNormalize?.normalizeMemory,
+                escapeHtml,
+                log,
+                reportError
             });
-            
-            const treeMemories = () => (window.currentTreeMemories || []).map(normalizeMemory).filter(Boolean);
-            const memoriesCount = treeMemories().length;
-            log(`Memories loaded: ${memoriesCount}`);
+
+            if (initialLoadResult.status === 'stopped') {
+                return;
+            }
+
+            const tree = initialLoadResult.tree;
+            const treeId = initialLoadResult.treeId;
+            const normalizeMemory = initialLoadResult.normalizeMemory;
+            const treeMemories = initialLoadResult.treeMemories;
             
             const canonicalRootId = getCanonicalRootId(treeMemories());
             let selectedNodeId = canonicalRootId;

--- a/js/editor/editor-initial-load-flow.js
+++ b/js/editor/editor-initial-load-flow.js
@@ -1,0 +1,109 @@
+(function() {
+    'use strict';
+
+    async function runEditorInitialLoadFlow(options) {
+        const opts = options || {};
+        const editorDataLoader = opts.editorDataLoader || {};
+        const log = typeof opts.log === 'function' ? opts.log : function() {};
+        const reportError = typeof opts.reportError === 'function' ? opts.reportError : function() {};
+        const cache = opts.cache || null;
+        let cacheKey = 'memories_default';
+
+        const loadInitialTree = editorDataLoader.loadInitialEditorTree;
+        if (typeof loadInitialTree !== 'function') {
+            reportError('LoveBudEditorDataLoader.loadInitialEditorTree missing');
+            return { status: 'stopped' };
+        }
+
+        log('Loading initial tree data...');
+        const treeLoadResult = await loadInitialTree({
+            urlTreeId: opts.urlTreeId,
+            apiClient: opts.apiClient,
+            createDefaultTreeTitle: opts.createDefaultTreeTitle,
+            getConfirmedSessionUser: opts.getConfirmedSessionUser
+        });
+
+        const tree = treeLoadResult.tree || null;
+        if (!tree) {
+            log('Tree not found or auth required');
+            if (treeLoadResult.authRequired) {
+                opts.showToast(opts.i18n('need_login'), 'error');
+                opts.redirectToEditorLogin(2000);
+                return { status: 'stopped' };
+            }
+
+            if (opts.urlTreeId) {
+                const treeLoadStatus = treeLoadResult.treeLoadStatus || 'not_found';
+                const treeLoadErrorMessage = treeLoadResult.treeLoadErrorMessage || '';
+                const treeLoadErrorCopy = opts.buildTreeLoadErrorCopy({
+                    treeLoadStatus,
+                    treeLoadErrorMessage,
+                    i18n: opts.i18n
+                });
+
+                opts.renderTreeLoadError({
+                    canvas: opts.canvas,
+                    addBtn: opts.addBtn,
+                    errorTitle: treeLoadErrorCopy.errorTitle,
+                    errorDesc: treeLoadErrorCopy.errorDesc,
+                    i18n: opts.i18n,
+                    escapeHtml: opts.escapeHtml,
+                    setDetailEmptyState: null
+                });
+                opts.markEditorReady();
+                return { status: 'stopped' };
+            }
+
+            opts.markEditorReady();
+            return { status: 'stopped' };
+        }
+
+        opts.syncCurrentTreeData(tree);
+        const treeId = tree.id || null;
+        cacheKey = 'memories_' + (treeId || 'default');
+        log(`Tree loaded: ${treeId}`);
+
+        if (typeof editorDataLoader.createNormalizeMemory !== 'function') {
+            reportError('LoveBudEditorDataLoader.createNormalizeMemory missing');
+            return { status: 'stopped' };
+        }
+        const normalizeMemory = editorDataLoader.createNormalizeMemory({
+            sharedNormalize: opts.sharedNormalize
+        });
+
+        if (typeof editorDataLoader.loadEditorMemories !== 'function') {
+            reportError('LoveBudEditorDataLoader.loadEditorMemories missing');
+            return { status: 'stopped' };
+        }
+
+        log('Loading editor memories...');
+        await editorDataLoader.loadEditorMemories({
+            treeId,
+            cache,
+            cacheKey,
+            apiClient: opts.apiClient,
+            showToast: opts.showToast,
+            i18n: opts.i18n,
+            normalizeMemory
+        });
+
+        const treeMemories = () => (window.currentTreeMemories || []).map(normalizeMemory).filter(Boolean);
+        const memoriesCount = treeMemories().length;
+        log(`Memories loaded: ${memoriesCount}`);
+
+        return {
+            status: 'ready',
+            tree,
+            treeId,
+            cache,
+            cacheKey,
+            normalizeMemory,
+            treeMemories,
+            memoriesCount
+        };
+    }
+
+    window.LoveBudEditorInitialLoadFlow = Object.freeze({
+        runEditorInitialLoadFlow
+    });
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -165,6 +165,7 @@
     <script src="../js/editor/editor-startup-context.js?v=20260530-1698"></script>
     <script src="../js/editor/editor-save-status-orchestration.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-page-event-bindings.js?v=20260530-1698"></script>
+    <script src="../js/editor/editor-initial-load-flow.js?v=20260531-1698"></script>
 
     <script src="../js/editor.js?v=20260502-1"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>

--- a/tests/contracts/editor-editability-shell-state-contract.test.cjs
+++ b/tests/contracts/editor-editability-shell-state-contract.test.cjs
@@ -30,8 +30,8 @@ test('editor no longer applies editability state inline in start flow', () => {
   const start = editorSource.indexOf('createEditorStartupContext({');
   assert.notEqual(start, -1, 'createEditorStartupContext call must exist in start flow');
 
-  const end = editorSource.indexOf('const cache = window.LoveBudCache || null;', start);
-  assert.notEqual(end, -1, 'cache setup must follow editability state setup');
+  const end = editorSource.indexOf('const initialLoadResult = await runEditorInitialLoadFlow({', start);
+  assert.notEqual(end, -1, 'initial load flow setup must follow editability state setup');
 
   const block = editorSource.slice(start, end);
   assert.match(block, /applyEditorEditabilityState\(\{\s*canEdit\s*\}/);

--- a/tests/contracts/editor-entrypoint-responsibility-contract.test.cjs
+++ b/tests/contracts/editor-entrypoint-responsibility-contract.test.cjs
@@ -41,6 +41,7 @@ test('js/editor.js retains its legacy entrypoint markers', () => {
 
 test('js/editor.js contains specific responsibility areas (Audit candidates)', () => {
     const js = fs.readFileSync('js/editor.js', 'utf8');
+    const initialLoadFlow = fs.readFileSync('js/editor/editor-initial-load-flow.js', 'utf8');
 
     // 1. Bootstrapping / Shell Copy
     assert.ok(!js.includes('const createEditorShellCopyApplier = ({ safeI18nText, i18n }) => {'), 'EXTRACTED: shell copy applier should not be inline');
@@ -50,8 +51,11 @@ test('js/editor.js contains specific responsibility areas (Audit candidates)', (
     assert.ok(js.includes('window.LoveBudEditorShellCopyApplier'), 'must use shell copy applier namespace');
 
     // 2. Data Loading Orchestration
-    assert.ok(js.includes('loadInitialEditorTree'), 'Candidate: initial tree loading');
-    assert.ok(js.includes('loadEditorMemories'), 'Candidate: editor memories loading');
+    assert.ok(!js.includes('const loadInitialTree = editorDataLoader.loadInitialEditorTree'), 'EXTRACTED: initial tree loading should not be inline');
+    assert.ok(!js.includes('await editorDataLoader.loadEditorMemories'), 'EXTRACTED: editor memories loading should not be inline');
+    assert.ok(js.includes('runEditorInitialLoadFlow'), 'must delegate initial tree/memory load flow');
+    assert.ok(initialLoadFlow.includes('loadInitialEditorTree'), 'initial load helper owns initial tree loading');
+    assert.ok(initialLoadFlow.includes('loadEditorMemories'), 'initial load helper owns editor memories loading');
 
     // 3. UI Orchestration / Detail flow
     assert.ok(js.includes('updateCanvasEmptyGuide'), 'Candidate: empty guide logic');

--- a/tests/contracts/editor-ready-marker-contract.test.cjs
+++ b/tests/contracts/editor-ready-marker-contract.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const initialLoadFlowSource = fs.readFileSync('js/editor/editor-initial-load-flow.js', 'utf8');
 const editorHtml = fs.readFileSync('pages/editor.html', 'utf8');
 
 test('editor shell helpers expose markEditorReady helper', () => {
@@ -23,7 +24,7 @@ test('editor delegates ready marker to shell helper with fallback', () => {
 });
 
 test('editor ready marker call sites remain intact', () => {
-  const matches = editorSource.match(/markEditorReady\(\)/g) || [];
+  const matches = (editorSource + initialLoadFlowSource).match(/markEditorReady\(\)/g) || [];
   assert.ok(matches.length >= 2, 'existing markEditorReady call sites should remain');
 });
 

--- a/tests/contracts/editor-tree-load-error-copy-contract.test.cjs
+++ b/tests/contracts/editor-tree-load-error-copy-contract.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const pageHelpersSource = fs.readFileSync('js/editor/editor-page-helpers.js', 'utf8');
+const initialLoadFlowSource = fs.readFileSync('js/editor/editor-initial-load-flow.js', 'utf8');
 const editorHtml = fs.readFileSync('pages/editor.html', 'utf8');
 
 function extractTreeLoadFailureBlock(source) {
@@ -11,7 +12,7 @@ function extractTreeLoadFailureBlock(source) {
   const start = source.indexOf(marker);
   assert.notEqual(start, -1, 'tree load failure block must exist');
 
-  const end = source.indexOf('            syncCurrentTreeData(tree);', start);
+  const end = source.indexOf('        opts.syncCurrentTreeData(tree);', start);
   assert.notEqual(end, -1, 'syncCurrentTreeData marker must follow tree load failure block');
 
   return source.slice(start, end);
@@ -83,7 +84,7 @@ test('editor.js buildTreeLoadErrorCopy guard uses console.error pattern', () => 
 // --- 3. Tree-load failure block delegates to required helper ---
 
 test('editor tree load failure delegates copy creation to required helper', () => {
-  const block = extractTreeLoadFailureBlock(editorSource);
+  const block = extractTreeLoadFailureBlock(initialLoadFlowSource);
 
   assert.match(block, /buildTreeLoadErrorCopy\(\{/);
   assert.match(block, /treeLoadStatus,/);
@@ -92,7 +93,7 @@ test('editor tree load failure delegates copy creation to required helper', () =
 });
 
 test('editor tree load failure block no longer has inline fallback or optional check', () => {
-  const block = extractTreeLoadFailureBlock(editorSource);
+  const block = extractTreeLoadFailureBlock(initialLoadFlowSource);
 
   assert.doesNotMatch(block, /let\s+treeLoadErrorCopy\s*=\s*\{/);
   assert.doesNotMatch(block, /typeof editorPageHelpers\.buildTreeLoadErrorCopy/);
@@ -100,7 +101,7 @@ test('editor tree load failure block no longer has inline fallback or optional c
 });
 
 test('editor no longer owns tree load status copy branching inline', () => {
-  const block = extractTreeLoadFailureBlock(editorSource);
+  const block = extractTreeLoadFailureBlock(initialLoadFlowSource);
 
   assert.doesNotMatch(block, /const errorTitle\s*=/);
   assert.doesNotMatch(block, /const errorDesc\s*=/);
@@ -112,24 +113,27 @@ test('editor no longer owns tree load status copy branching inline', () => {
 // --- 4. Auth redirect and render flow preserved ---
 
 test('editor tree load failure keeps auth redirect and render flow intact', () => {
-  const block = extractTreeLoadFailureBlock(editorSource);
+  const block = extractTreeLoadFailureBlock(initialLoadFlowSource);
 
   assert.match(block, /if \(treeLoadResult\.authRequired\)/);
-  assert.match(block, /showToast\(i18n\('need_login'\), 'error'\)/);
-  assert.match(block, /redirectToEditorLogin\(2000\)/);
-  assert.match(block, /renderTreeLoadError\(\{/);
+  assert.match(block, /opts\.showToast\(opts\.i18n\('need_login'\), 'error'\)/);
+  assert.match(block, /opts\.redirectToEditorLogin\(2000\)/);
+  assert.match(block, /opts\.renderTreeLoadError\(\{/);
   assert.match(block, /errorTitle:\s*treeLoadErrorCopy\.errorTitle/);
   assert.match(block, /errorDesc:\s*treeLoadErrorCopy\.errorDesc/);
-  assert.match(block, /markEditorReady\(\)/);
+  assert.match(block, /opts\.markEditorReady\(\)/);
 });
 
 // --- 5. Load order contract preserved ---
 
 test('editor page helpers load before editor entrypoint', () => {
   const pageHelpersIndex = editorHtml.indexOf('js/editor/editor-page-helpers.js');
+  const initialLoadFlowIndex = editorHtml.indexOf('js/editor/editor-initial-load-flow.js');
   const editorJsIndex = editorHtml.indexOf('js/editor.js');
 
   assert.notEqual(pageHelpersIndex, -1, 'editor-page-helpers.js must be loaded');
+  assert.notEqual(initialLoadFlowIndex, -1, 'editor-initial-load-flow.js must be loaded');
   assert.notEqual(editorJsIndex, -1, 'editor.js must be loaded');
   assert.ok(pageHelpersIndex < editorJsIndex, 'editor-page-helpers.js must load before editor.js');
+  assert.ok(initialLoadFlowIndex < editorJsIndex, 'editor-initial-load-flow.js must load before editor.js');
 });

--- a/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
+++ b/tests/contracts/editor-tree-load-error-renderer-contract.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const pageHelpersSource = fs.readFileSync('js/editor/editor-page-helpers.js', 'utf8');
+const initialLoadFlowSource = fs.readFileSync('js/editor/editor-initial-load-flow.js', 'utf8');
 
 // --- 1. Page helper exports renderTreeLoadError ---
 
@@ -73,17 +74,17 @@ test('editor.js renderTreeLoadError guard does not use reportError', () => {
 
 // --- 4. Render call options structure preserved ---
 
-test('editor.js renderTreeLoadError call preserves options keys', () => {
-  const callStart = editorSource.indexOf('renderTreeLoadError({');
+test('initial load flow renderTreeLoadError call preserves options keys', () => {
+  const callStart = initialLoadFlowSource.indexOf('opts.renderTreeLoadError({');
   assert.notEqual(callStart, -1, 'renderTreeLoadError call must exist');
-  const callEnd = editorSource.indexOf('});', callStart);
-  const callBody = editorSource.slice(callStart, callEnd + 3);
+  const callEnd = initialLoadFlowSource.indexOf('});', callStart);
+  const callBody = initialLoadFlowSource.slice(callStart, callEnd + 3);
 
-  assert.match(callBody, /canvas,/);
-  assert.match(callBody, /addBtn,/);
+  assert.match(callBody, /canvas:/);
+  assert.match(callBody, /addBtn:/);
   assert.match(callBody, /errorTitle:/);
   assert.match(callBody, /errorDesc:/);
-  assert.match(callBody, /i18n,/);
-  assert.match(callBody, /escapeHtml,/);
+  assert.match(callBody, /i18n:/);
+  assert.match(callBody, /escapeHtml:/);
   assert.match(callBody, /setDetailEmptyState:/);
 });

--- a/tests/contracts/modal-owner-public-guard-contract.test.cjs
+++ b/tests/contracts/modal-owner-public-guard-contract.test.cjs
@@ -42,7 +42,7 @@ test('Modal owner writes preserve tree owner write boundary', () => {
   assert.match(ownerWrites, /def require_tree_owner/);
   assert.match(ownerWrites, /fetch_tree_for_owner_check/);
   assert.match(ownerWrites, /tree\.get\("owner_id"\)/);
-  assert.match(ownerWrites, /WHERE id = %s\n\s+AND owner_id = %s/);
+  assert.match(ownerWrites, /WHERE id = %s\r?\n\s+AND owner_id = %s/);
   assert.match(ownerWrites, /DELETE FROM trees WHERE id = %s AND owner_id = %s/);
 });
 
@@ -52,7 +52,7 @@ test('Modal owner writes preserve memory owner precheck and write boundary', () 
   assert.match(ownerWrites, /def require_memory_owner/);
   assert.match(ownerWrites, /t\.owner_id AS tree_owner_id/);
   assert.match(ownerWrites, /memory\.get\("tree_owner_id"\)/);
-  assert.match(ownerWrites, /EXISTS \(\n\s+SELECT 1\n\s+FROM trees t\n\s+WHERE t\.id = memories\.tree_id\n\s+AND t\.owner_id = %s/);
+  assert.match(ownerWrites, /EXISTS \(\r?\n\s+SELECT 1\r?\n\s+FROM trees t\r?\n\s+WHERE t\.id = memories\.tree_id\r?\n\s+AND t\.owner_id = %s/);
 });
 
 test('Modal owner writes preserve private storage entitlement guard', () => {


### PR DESCRIPTION
Refs #1698

## Summary
- extract initial editor tree/memory load flow from `js/editor.js`
- preserve auth redirect, tree-load error render, memory load, and readiness behavior
- reduce editor entrypoint orchestration responsibility
- avoid canvas, save, auth API, backend, schema, HTML/CSS behavior changes
- keep test-only CRLF/LF regex tolerance update after revert check failed `npm test`

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: YES
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js, js/editor/editor-initial-load-flow.js
Static checks: PASS
Editor browser smoke: PARTIAL (PR Preview loads and unauthenticated auth redirect observed; authenticated existing-tree, missing/private error render, and memory/canvas states blocked by missing browser verification credential entrypoint)
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS