### PR TITLE
refactor(editor): require root helper utilities

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3,60 +3,26 @@ document.addEventListener('DOMContentLoaded', () => {
     const entryFallbacks = window.LoveBudEditorEntryFallbacks || {};
     const shellHelpers = window.LoveBudEditorShellHelpers || {};
 
-    let rootHelperWarningShown = false;
     const rootUtils = window.LoveBudEditorUtils || {};
     const editorHelpers = window.LoveBudEditorHelpers || {};
 
-    const warnRootHelperFallback = () => {
-        if (!rootHelperWarningShown) {
-            console.warn('[editor] LoveBudEditorUtils not loaded, using local fallback for root helpers');
-            rootHelperWarningShown = true;
-        }
-    };
+    const findRootMemory = rootUtils.findRootMemory,
+        getCanonicalRootId = rootUtils.getCanonicalRootId,
+        isRootMemory = rootUtils.isRootMemory;
 
-    const findRootMemory = function(memories) {
-        if (typeof rootUtils.findRootMemory === 'function') {
-            return rootUtils.findRootMemory(memories);
-        }
-        warnRootHelperFallback();
-        if (!Array.isArray(memories)) return null;
-        const parentNullNodes = memories.filter(m => m.parentId === null || m.parentId === undefined);
-        if (parentNullNodes.length === 1) return parentNullNodes[0];
-        if (parentNullNodes.length > 1) {
-            return parentNullNodes.sort((a, b) => {
-                const aTime = a.createdAt || a.timestamp || '9999';
-                const bTime = b.createdAt || b.timestamp || '9999';
-                return new Date(aTime) - new Date(bTime);
-            })[0];
-        }
-        return memories.find(m => m.id === 'root') || null;
-    };
+    const missingRootHelpers = [
+        ['LoveBudEditorUtils.findRootMemory', findRootMemory],
+        ['LoveBudEditorUtils.getCanonicalRootId', getCanonicalRootId],
+        ['LoveBudEditorUtils.isRootMemory', isRootMemory]
+    ].filter(([, helper]) => typeof helper !== 'function');
 
-    const getRootId = function(memories) {
-        if (typeof rootUtils.getRootId === 'function') {
-            return rootUtils.getRootId(memories);
-        }
-        warnRootHelperFallback();
-        const root = findRootMemory(memories);
-        return root ? root.id : 'root';
-    };
-
-    const getCanonicalRootId = function(memories) {
-        if (typeof rootUtils.getCanonicalRootId === 'function') {
-            return rootUtils.getCanonicalRootId(memories);
-        }
-        warnRootHelperFallback();
-        const root = findRootMemory(memories);
-        return root ? root.id : 'root';
-    };
-
-    const isRootMemory = function(mem, rootId) {
-        if (typeof rootUtils.isRootMemory === 'function') {
-            return rootUtils.isRootMemory(mem, rootId);
-        }
-        warnRootHelperFallback();
-        return !!(mem && rootId && mem.id === rootId);
-    };
+    if (missingRootHelpers.length) {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] },
+            msg = missingRootHelpers.map(([name]) => name + ' missing').join('; ');
+        console.error('[editor-main] ERROR: ' + msg);
+        debugState.errors.push({ msg, error: msg });
+        return;
+    }
 
     const editorSaveStatus = window.LoveBudEditorSaveStatus || {};
     const editorPageHelpers = window.LoveBudEditorPageHelpers || {};
@@ -216,13 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    const getYouTubeInputErrorMessage = function(i18n, rawUrl) {
-        if (typeof rootUtils.getYouTubeInputErrorMessage === 'function') {
-            return rootUtils.getYouTubeInputErrorMessage(i18n, rawUrl);
-        }
-        warnRootHelperFallback();
-        return getYouTubeInputErrorMessageFallback(i18n, rawUrl);
-    };
+    const getYouTubeInputErrorMessage = typeof rootUtils.getYouTubeInputErrorMessage === 'function' ? rootUtils.getYouTubeInputErrorMessage : getYouTubeInputErrorMessageFallback;
 
     const renderTreeLoadError = editorPageHelpers.renderTreeLoadError;
 

--- a/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
@@ -1,0 +1,89 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+function scriptSources() {
+  const html = read('pages/editor.html');
+  return Array.from(html.matchAll(/<script\s+[^>]*src=["']([^"']+)["'][^>]*><\/script>/g))
+    .map((match) => match[1]);
+}
+
+function sourceIndex(sources, needle) {
+  return sources.findIndex((src) => src.includes(needle));
+}
+
+test('editor root helpers load before editor utils and editor entry', () => {
+  const sources = scriptSources();
+  const rootHelpers = sourceIndex(sources, 'js/editor/editor-root-helpers.js');
+  const editorUtils = sourceIndex(sources, 'js/editor/editor-utils.js');
+  const editorEntry = sourceIndex(sources, 'js/editor.js');
+
+  assert.notEqual(rootHelpers, -1, 'editor-root-helpers.js must be loaded');
+  assert.notEqual(editorUtils, -1, 'editor-utils.js must be loaded');
+  assert.notEqual(editorEntry, -1, 'editor.js must be loaded');
+  assert.ok(rootHelpers < editorUtils, 'root helpers must load before editor utils');
+  assert.ok(editorUtils < editorEntry, 'editor utils must load before editor entry');
+});
+
+test('root helpers export root utilities and editor utils preserve the namespace', () => {
+  const context = { window: {} };
+  vm.createContext(context);
+
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  assert.equal(typeof context.window.LoveBudEditorUtils.findRootMemory, 'function');
+  assert.equal(typeof context.window.LoveBudEditorUtils.getRootId, 'function');
+  assert.equal(typeof context.window.LoveBudEditorUtils.getCanonicalRootId, 'function');
+  assert.equal(typeof context.window.LoveBudEditorUtils.isRootMemory, 'function');
+
+  const rootFindRootMemory = context.window.LoveBudEditorUtils.findRootMemory;
+  vm.runInContext(read('js/editor/editor-utils.js'), context);
+
+  assert.equal(context.window.LoveBudEditorUtils.findRootMemory, rootFindRootMemory);
+  assert.equal(typeof context.window.LoveBudEditorUtils.getYouTubeInputErrorMessage, 'function');
+
+  const editorUtils = read('js/editor/editor-utils.js');
+  assert.match(editorUtils, /const\s+utils\s*=\s*window\.LoveBudEditorUtils\s*\|\|\s*\{\}/);
+  assert.match(editorUtils, /window\.LoveBudEditorUtils\s*=\s*utils/);
+});
+
+test('editor entry requires preloaded root helper utilities without inline fallbacks', () => {
+  const editor = read('js/editor.js');
+
+  assert.match(editor, /const\s+rootUtils\s*=\s*window\.LoveBudEditorUtils\s*\|\|\s*\{\}/);
+  assert.match(editor, /findRootMemory\s*=\s*rootUtils\.findRootMemory/);
+  assert.match(editor, /getCanonicalRootId\s*=\s*rootUtils\.getCanonicalRootId/);
+  assert.match(editor, /isRootMemory\s*=\s*rootUtils\.isRootMemory/);
+  assert.match(editor, /const\s+missingRootHelpers\s*=\s*\[/);
+  assert.match(editor, /LoveBudEditorUtils\.findRootMemory/);
+  assert.match(editor, /LoveBudEditorUtils\.getCanonicalRootId/);
+  assert.match(editor, /LoveBudEditorUtils\.isRootMemory/);
+  assert.match(editor, /\[editor-main\] ERROR: /);
+
+  assert.doesNotMatch(editor, /rootHelperWarningShown/);
+  assert.doesNotMatch(editor, /warnRootHelperFallback/);
+  assert.doesNotMatch(editor, /LoveBudEditorUtils not loaded, using local fallback for root helpers/);
+  assert.doesNotMatch(editor, /const\s+findRootMemory\s*=\s*function/);
+  assert.doesNotMatch(editor, /const\s+getRootId\s*=\s*function/);
+  assert.doesNotMatch(editor, /const\s+getCanonicalRootId\s*=\s*function/);
+  assert.doesNotMatch(editor, /const\s+isRootMemory\s*=\s*function/);
+});
+
+test('editor entry keeps root helper usage contracts', () => {
+  const editor = read('js/editor.js');
+
+  assert.match(editor, /createInitialMemory[\s\S]*findRootMemory/);
+  assert.match(editor, /canonicalRootId\s*=\s*getCanonicalRootId\(treeMemories\(\)\)/);
+  assert.match(editor, /isRootMemory\(refreshedEditingMemory,\s*canonicalRootId\)/);
+  assert.match(editor, /isRootMemory\(initialSelection,\s*canonicalRootId\)/);
+  assert.match(editor, /memoryActions[\s\S]*isRootMemory[\s\S]*findRootMemory/);
+  assert.match(editor, /detailUI[\s\S]*isRootMemory/);
+  assert.match(editor, /editorCanvas[\s\S]*isRootMemory/);
+});

--- a/tests/contracts/editor-youtube-input-fallback-contract.test.cjs
+++ b/tests/contracts/editor-youtube-input-fallback-contract.test.cjs
@@ -61,15 +61,14 @@ test('editor.js delegates getYouTubeInputErrorMessageFallback through required s
     editorSource,
     /LoveBudEditorShellHelpers\.getYouTubeInputErrorMessageFallback missing/
   );
-  assert.match(editorSource, /if \(typeof rootUtils\.getYouTubeInputErrorMessage === 'function'\)/);
-  assert.match(editorSource, /return rootUtils\.getYouTubeInputErrorMessage\(i18n,\s*rawUrl\)/);
-  assert.match(editorSource, /warnRootHelperFallback\(\)/);
-  assert.match(editorSource, /return getYouTubeInputErrorMessageFallback\(i18n,\s*rawUrl\)/);
+  assert.match(editorSource, /const\s+getYouTubeInputErrorMessage\s*=\s*typeof rootUtils\.getYouTubeInputErrorMessage === 'function'/);
+  assert.match(editorSource, /rootUtils\.getYouTubeInputErrorMessage\s*:\s*getYouTubeInputErrorMessageFallback/);
+  assert.doesNotMatch(editorSource, /warnRootHelperFallback\(\)/);
 });
 
 test('editor.js guards missing getYouTubeInputErrorMessageFallback before wrapper creation and without reportError', () => {
   const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback missing');
-  const wrapperIndex = editorSource.indexOf('const getYouTubeInputErrorMessage = function(i18n, rawUrl)');
+  const wrapperIndex = editorSource.indexOf('const getYouTubeInputErrorMessage = typeof rootUtils.getYouTubeInputErrorMessage');
 
   assert.ok(guardIndex !== -1, 'missing getYouTubeInputErrorMessageFallback guard must exist');
   assert.ok(wrapperIndex !== -1, 'getYouTubeInputErrorMessage wrapper must exist');
@@ -80,14 +79,14 @@ test('editor.js guards missing getYouTubeInputErrorMessageFallback before wrappe
 });
 
 test('editor no longer owns local YouTube validation body inside wrapper', () => {
-  const start = editorSource.indexOf('const getYouTubeInputErrorMessage = function(i18n, rawUrl)');
+  const start = editorSource.indexOf('const getYouTubeInputErrorMessage = typeof rootUtils.getYouTubeInputErrorMessage');
   assert.notEqual(start, -1, 'editor wrapper must exist');
 
   const end = editorSource.indexOf('const renderTreeLoadError', start);
   assert.notEqual(end, -1, 'renderTreeLoadError setup must follow YouTube wrapper');
 
   const block = editorSource.slice(start, end);
-  assert.match(block, /return getYouTubeInputErrorMessageFallback\(i18n,\s*rawUrl\)/);
+  assert.match(block, /getYouTubeInputErrorMessageFallback/);
   assert.doesNotMatch(block, /String\(rawUrl \|\| ''\)\.trim\(\)/);
   assert.doesNotMatch(block, /invalid_youtube_unsupported/);
   assert.doesNotMatch(block, /invalid_youtube_id_length/);


### PR DESCRIPTION
Refs #1698

## Summary
- require preloaded `LoveBudEditorUtils` root helper utilities in `js/editor.js`
- remove inline root helper fallback implementations from the editor entrypoint
- preserve root selection/canonical root behavior through `editor-root-helpers.js`
- keep `editor-utils.js` namespace extension behavior covered by contract tests
- avoid canvas, save, auth API, backend, schema, HTML/CSS behavior changes

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS