### PR TITLE
refactor(editor): extract refresh save runtime

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -34,6 +34,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const editorDataLoader = window.LoveBudEditorDataLoader || {};
     const editorInitialLoadFlow = window.LoveBudEditorInitialLoadFlow || {};
     const runEditorInitialLoadFlow = editorInitialLoadFlow.runEditorInitialLoadFlow;
+    const editorRefreshSaveRuntime = window.LoveBudEditorRefreshSaveRuntime || {},
+        createEditorRefreshSaveRuntime = editorRefreshSaveRuntime.createEditorRefreshSaveRuntime;
     const editorStartupContext = window.LoveBudEditorStartupContext || {};
     const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
@@ -285,6 +287,8 @@ document.addEventListener('DOMContentLoaded', () => {
             reportError('LoveBudEditorInitialLoadFlow.runEditorInitialLoadFlow missing');
             return;
         }
+
+        if (typeof createEditorRefreshSaveRuntime !== 'function') { reportError('LoveBudEditorRefreshSaveRuntime.createEditorRefreshSaveRuntime missing'); return; }
 
         log('startEditor sequence initiated');
 
@@ -553,59 +557,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const { calcPosition, drawBranch, drawNode, initCanvas } = editorCanvas;
 
-            const handleMemoriesUpdated = () => {
-                log('Memories updated externally. Rerendering...');
-                initCanvas();
-                updateSidebarStatus();
-                if (currentEditingMemory) {
-                    const refreshedEditingMemory = treeMemories().find((memory) => memory.id === currentEditingMemory.id);
-                    if (refreshedEditingMemory && !isRootMemory(refreshedEditingMemory, canonicalRootId)) {
-                        currentEditingMemory = refreshedEditingMemory;
-                        updateDetailPanel(refreshedEditingMemory);
-                    }
-                }
-            };
-
-            if (typeof editorDataLoader.createRefreshMemories !== 'function') {
-                reportError('LoveBudEditorDataLoader.createRefreshMemories missing');
-                return;
-            }
-            const refreshMemories = editorDataLoader.createRefreshMemories({ treeId, apiClient: window.apiClient, normalizeMemory, onMemoriesUpdated: handleMemoriesUpdated });
-
-            if (typeof exposeRefreshMemoriesBridge !== 'function') {
-                reportError('LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
-                return;
-            }
-
-            exposeRefreshMemoriesBridge({ refreshMemories });
-
-            if (typeof resolveSaveStatusTimeFormatter !== 'function') {
-                reportError('LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
-                return;
-            }
-
-            if (typeof editorSaveStatus.formatTimeAgo !== 'function') {
-                reportError('LoveBudEditorSaveStatus.formatTimeAgo missing');
-                return;
-            }
-
-            const formatTimeAgo = resolveSaveStatusTimeFormatter({
-                editorSaveStatus
+            const refreshSaveRuntime = createEditorRefreshSaveRuntime({
+                log, reportError, editorDataLoader, treeId, apiClient: window.apiClient, normalizeMemory, treeMemories,
+                getCurrentEditingMemory: () => currentEditingMemory, setCurrentEditingMemory: (value) => { currentEditingMemory = value; },
+                isRootMemory, canonicalRootId, updateDetailPanel, updateSidebarStatus, initCanvas, exposeRefreshMemoriesBridge,
+                resolveSaveStatusTimeFormatter, editorSaveStatus, i18n, createSaveStatusOrchestrationFallback, saveStatusOrchestrationHelper: window.LoveBudEditorSaveStatusOrchestration || {}
             });
 
-            const saveStatusOrchestrationHelper = window.LoveBudEditorSaveStatusOrchestration || {};
-            let createEditorSaveStatusOrchestration = saveStatusOrchestrationHelper.createEditorSaveStatusOrchestration;
-
-            if (typeof createEditorSaveStatusOrchestration !== 'function') {
-                if (typeof createSaveStatusOrchestrationFallback !== 'function') {
-                    reportError('LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
-                    return;
-                }
-
-                createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();
-            }
-
-            const { saveStatusData, updateSaveStatus } = createEditorSaveStatusOrchestration({ editorSaveStatus, i18n, formatTimeAgo });
+            if (refreshSaveRuntime.status === 'stopped') return;
+            const { saveStatusData, updateSaveStatus } = refreshSaveRuntime;
 
             log('Initializing Memory Actions...');
             memoryActions = window.createEditorMemoryActions({

--- a/js/editor/editor-refresh-save-runtime.js
+++ b/js/editor/editor-refresh-save-runtime.js
@@ -1,0 +1,112 @@
+(function() {
+    'use strict';
+
+    function stop(reportError, message) {
+        if (typeof reportError === 'function') {
+            reportError(message);
+        }
+        return { status: 'stopped' };
+    }
+
+    function createEditorRefreshSaveRuntime(options) {
+        const opts = options || {};
+        const {
+            log,
+            reportError,
+            editorDataLoader,
+            treeId,
+            apiClient,
+            normalizeMemory,
+            treeMemories,
+            getCurrentEditingMemory,
+            setCurrentEditingMemory,
+            isRootMemory,
+            canonicalRootId,
+            updateDetailPanel,
+            updateSidebarStatus,
+            initCanvas,
+            exposeRefreshMemoriesBridge,
+            resolveSaveStatusTimeFormatter,
+            editorSaveStatus,
+            i18n,
+            createSaveStatusOrchestrationFallback,
+            saveStatusOrchestrationHelper
+        } = opts;
+
+        if (!editorDataLoader || typeof editorDataLoader.createRefreshMemories !== 'function') {
+            return stop(reportError, 'LoveBudEditorDataLoader.createRefreshMemories missing');
+        }
+        if (typeof exposeRefreshMemoriesBridge !== 'function') {
+            return stop(reportError, 'LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
+        }
+        if (typeof resolveSaveStatusTimeFormatter !== 'function') {
+            return stop(reportError, 'LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
+        }
+        if (!editorSaveStatus || typeof editorSaveStatus.formatTimeAgo !== 'function') {
+            return stop(reportError, 'LoveBudEditorSaveStatus.formatTimeAgo missing');
+        }
+
+        const handleMemoriesUpdated = () => {
+            log('Memories updated externally. Rerendering...');
+            initCanvas();
+            updateSidebarStatus();
+
+            const currentEditingMemory = getCurrentEditingMemory();
+            if (currentEditingMemory) {
+                const refreshedEditingMemory = treeMemories().find((memory) => memory.id === currentEditingMemory.id);
+                if (refreshedEditingMemory && !isRootMemory(refreshedEditingMemory, canonicalRootId)) {
+                    setCurrentEditingMemory(refreshedEditingMemory);
+                    updateDetailPanel(refreshedEditingMemory);
+                }
+            }
+        };
+
+        const refreshMemories = editorDataLoader.createRefreshMemories({
+            treeId,
+            apiClient,
+            normalizeMemory,
+            onMemoriesUpdated: handleMemoriesUpdated
+        });
+
+        exposeRefreshMemoriesBridge({ refreshMemories });
+
+        const formatTimeAgo = resolveSaveStatusTimeFormatter({
+            editorSaveStatus
+        });
+
+        let createEditorSaveStatusOrchestration = (saveStatusOrchestrationHelper || {}).createEditorSaveStatusOrchestration;
+
+        if (typeof createEditorSaveStatusOrchestration !== 'function') {
+            if (typeof createSaveStatusOrchestrationFallback !== 'function') {
+                return stop(reportError, 'LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
+            }
+
+            createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();
+        }
+
+        const { saveStatusData, updateSaveStatus } = createEditorSaveStatusOrchestration({
+            editorSaveStatus,
+            i18n,
+            formatTimeAgo
+        });
+
+        return {
+            status: 'ready',
+            refreshMemories,
+            saveStatusData,
+            updateSaveStatus
+        };
+    }
+
+    if (typeof window !== 'undefined') {
+        window.LoveBudEditorRefreshSaveRuntime = Object.freeze({
+            createEditorRefreshSaveRuntime
+        });
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            createEditorRefreshSaveRuntime
+        };
+    }
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -166,6 +166,7 @@
     <script src="../js/editor/editor-save-status-orchestration.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-page-event-bindings.js?v=20260530-1698"></script>
     <script src="../js/editor/editor-initial-load-flow.js?v=20260531-1698"></script>
+    <script src="../js/editor/editor-refresh-save-runtime.js?v=20260531-1698"></script>
 
     <script src="../js/editor.js?v=20260502-1"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>

--- a/tests/contracts/editor-refresh-memories-bridge-contract.test.cjs
+++ b/tests/contracts/editor-refresh-memories-bridge-contract.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
+const refreshSaveRuntimeSource = fs.readFileSync('js/editor/editor-refresh-save-runtime.js', 'utf8');
 
 test('editor shell helpers expose refresh memories bridge helper', () => {
   assert.match(shellHelpersSource, /exposeRefreshMemoriesBridge:\s*function\(options\)/);
@@ -27,56 +28,54 @@ test('editor delegates refresh memories bridge through required shell helper', (
     editorSource,
     /const\s+exposeRefreshMemoriesBridge\s*=\s*shellHelpers\.exposeRefreshMemoriesBridge\s*\|\|/
   );
+  assert.match(refreshSaveRuntimeSource, /LoveBudEditorShellHelpers\.exposeRefreshMemoriesBridge missing/);
   assert.match(
-    editorSource,
-    /LoveBudEditorShellHelpers\.exposeRefreshMemoriesBridge missing/
-  );
-  assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/
   );
 });
 
-test('editor no longer assigns refresh memories bridge inline', () => {
-  const start = editorSource.indexOf('const refreshMemories = editorDataLoader.createRefreshMemories');
+test('refresh save runtime assigns refresh memories bridge without inline window mutation', () => {
+  const start = refreshSaveRuntimeSource.indexOf('const refreshMemories = editorDataLoader.createRefreshMemories');
   assert.notEqual(start, -1, 'refreshMemories creation must exist');
 
-  const end = editorSource.indexOf('const formatTimeAgo =', start);
+  const end = refreshSaveRuntimeSource.indexOf('const formatTimeAgo =', start);
   assert.notEqual(end, -1, 'formatTimeAgo setup must follow refresh bridge setup');
 
-  const block = editorSource.slice(start, end);
+  const block = refreshSaveRuntimeSource.slice(start, end);
   assert.match(block, /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/);
   assert.doesNotMatch(block, /window\.refreshMemories\s*=\s*refreshMemories/);
   assert.doesNotMatch(block, /windowRef\.refreshMemories\s*=/);
+  assert.doesNotMatch(editorSource, /const\s+refreshMemories\s*=\s*editorDataLoader\.createRefreshMemories/);
 });
 
-test('editor keeps refresh memories factory invocation intact', () => {
-  assert.match(editorSource, /if \(typeof editorDataLoader\.createRefreshMemories !== 'function'\)/);
-  assert.match(editorSource, /reportError\('LoveBudEditorDataLoader\.createRefreshMemories missing'\)/);
+test('refresh save runtime keeps refresh memories factory invocation intact', () => {
+  assert.match(refreshSaveRuntimeSource, /typeof editorDataLoader\.createRefreshMemories !== 'function'/);
+  assert.match(refreshSaveRuntimeSource, /LoveBudEditorDataLoader\.createRefreshMemories missing/);
   assert.match(
-    editorSource,
-    /const refreshMemories\s*=\s*editorDataLoader\.createRefreshMemories\(\{\s*treeId,\s*apiClient:\s*window\.apiClient,\s*normalizeMemory,\s*onMemoriesUpdated:\s*handleMemoriesUpdated\s*\}\)/
+    refreshSaveRuntimeSource,
+    /const refreshMemories\s*=\s*editorDataLoader\.createRefreshMemories\(\{\s*treeId,\s*apiClient,\s*normalizeMemory,\s*onMemoriesUpdated:\s*handleMemoriesUpdated\s*\}\)/
   );
 });
 
-test('editor keeps handleMemoriesUpdated orchestration intact', () => {
-  const start = editorSource.indexOf('const handleMemoriesUpdated =');
+test('refresh save runtime keeps handleMemoriesUpdated orchestration intact', () => {
+  const start = refreshSaveRuntimeSource.indexOf('const handleMemoriesUpdated =');
   assert.notEqual(start, -1, 'handleMemoriesUpdated must exist');
 
-  const end = editorSource.indexOf('if (typeof editorDataLoader.createRefreshMemories', start);
+  const end = refreshSaveRuntimeSource.indexOf('const refreshMemories = editorDataLoader.createRefreshMemories', start);
   assert.notEqual(end, -1, 'refresh factory guard must follow handleMemoriesUpdated');
 
-  const block = editorSource.slice(start, end);
+  const block = refreshSaveRuntimeSource.slice(start, end);
   assert.match(block, /log\('Memories updated externally\. Rerendering\.\.\.'\)/);
   assert.match(block, /initCanvas\(\)/);
   assert.match(block, /updateSidebarStatus\(\)/);
-  assert.match(block, /currentEditingMemory\s*=\s*refreshedEditingMemory/);
+  assert.match(block, /setCurrentEditingMemory\(refreshedEditingMemory\)/);
   assert.match(block, /updateDetailPanel\(refreshedEditingMemory\)/);
 });
 
-test('editor guards missing refresh memories bridge before exposure', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
-  const exposeIndex = editorSource.indexOf('exposeRefreshMemoriesBridge({ refreshMemories });');
+test('refresh save runtime guards missing refresh memories bridge before exposure', () => {
+  const guardIndex = refreshSaveRuntimeSource.indexOf('LoveBudEditorShellHelpers.exposeRefreshMemoriesBridge missing');
+  const exposeIndex = refreshSaveRuntimeSource.indexOf('exposeRefreshMemoriesBridge({ refreshMemories });');
 
   assert.ok(guardIndex !== -1, 'missing refresh memories bridge guard must exist');
   assert.ok(exposeIndex !== -1, 'refresh memories bridge exposure must exist');

--- a/tests/contracts/editor-refresh-save-runtime-contract.test.cjs
+++ b/tests/contracts/editor-refresh-save-runtime-contract.test.cjs
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+function scriptSources() {
+  return Array.from(read('pages/editor.html').matchAll(/<script\s+[^>]*src=["']([^"']+)["'][^>]*><\/script>/g))
+    .map((match) => match[1]);
+}
+
+function sourceIndex(sources, needle) {
+  return sources.findIndex((src) => src.includes(needle));
+}
+
+test('editor refresh/save runtime loads before editor entry', () => {
+  const sources = scriptSources();
+  const runtime = sourceIndex(sources, 'js/editor/editor-refresh-save-runtime.js');
+  const editor = sourceIndex(sources, 'js/editor.js');
+
+  assert.notEqual(runtime, -1, 'editor-refresh-save-runtime.js must be loaded');
+  assert.notEqual(editor, -1, 'editor.js must be loaded');
+  assert.ok(runtime < editor, 'editor-refresh-save-runtime.js must load before editor.js');
+});
+
+test('editor refresh/save runtime exports createEditorRefreshSaveRuntime', () => {
+  const context = { window: {}, Object };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-refresh-save-runtime.js'), context);
+
+  assert.equal(
+    typeof context.window.LoveBudEditorRefreshSaveRuntime.createEditorRefreshSaveRuntime,
+    'function'
+  );
+  assert.equal(Object.isFrozen(context.window.LoveBudEditorRefreshSaveRuntime), true);
+});
+
+test('editor entry delegates refresh/save runtime wiring', () => {
+  const editor = read('js/editor.js');
+
+  assert.match(editor, /window\.LoveBudEditorRefreshSaveRuntime/);
+  assert.match(editor, /createEditorRefreshSaveRuntime\s*=\s*editorRefreshSaveRuntime\.createEditorRefreshSaveRuntime/);
+  assert.match(editor, /LoveBudEditorRefreshSaveRuntime\.createEditorRefreshSaveRuntime missing/);
+  assert.match(editor, /createEditorRefreshSaveRuntime\(\{/);
+  assert.match(editor, /getCurrentEditingMemory:\s*\(\)\s*=>\s*currentEditingMemory/);
+  assert.match(editor, /setCurrentEditingMemory:\s*\(value\)\s*=>\s*\{\s*currentEditingMemory\s*=\s*value;\s*\}/);
+  assert.match(editor, /saveStatusOrchestrationHelper:\s*window\.LoveBudEditorSaveStatusOrchestration\s*\|\|\s*\{\}/);
+  assert.match(editor, /const\s+\{\s*saveStatusData,\s*updateSaveStatus\s*\}\s*=\s*refreshSaveRuntime/);
+
+  assert.doesNotMatch(editor, /const\s+handleMemoriesUpdated\s*=\s*\(\)\s*=>/);
+  assert.doesNotMatch(editor, /LoveBudEditorDataLoader\.createRefreshMemories missing/);
+  assert.doesNotMatch(editor, /const\s+refreshMemories\s*=\s*editorDataLoader\.createRefreshMemories/);
+  assert.doesNotMatch(editor, /let\s+createEditorSaveStatusOrchestration\s*=/);
+  assert.doesNotMatch(editor, /createSaveStatusOrchestrationFallback\(\);\s*\n\s*\}\s*\n\s*\n\s*const\s+\{\s*saveStatusData,\s*updateSaveStatus\s*\}\s*=/);
+});
+
+test('refresh/save helper preserves memory refresh bridge behavior', () => {
+  const helper = read('js/editor/editor-refresh-save-runtime.js');
+
+  assert.match(helper, /log\('Memories updated externally\. Rerendering\.\.\.'\)/);
+  assert.match(helper, /initCanvas\(\)/);
+  assert.match(helper, /updateSidebarStatus\(\)/);
+  assert.match(helper, /getCurrentEditingMemory\(\)/);
+  assert.match(helper, /treeMemories\(\)\.find\(\(memory\)\s*=>\s*memory\.id\s*===\s*currentEditingMemory\.id\)/);
+  assert.match(helper, /setCurrentEditingMemory\(refreshedEditingMemory\)/);
+  assert.match(helper, /updateDetailPanel\(refreshedEditingMemory\)/);
+  assert.match(helper, /editorDataLoader\.createRefreshMemories\(\{/);
+  assert.match(helper, /onMemoriesUpdated:\s*handleMemoriesUpdated/);
+  assert.match(helper, /exposeRefreshMemoriesBridge\(\{\s*refreshMemories\s*\}\)/);
+});
+
+test('refresh/save helper preserves save status orchestration behavior', () => {
+  const helper = read('js/editor/editor-refresh-save-runtime.js');
+
+  assert.match(helper, /resolveSaveStatusTimeFormatter\(\{\s*[\s\S]*editorSaveStatus[\s\S]*\}\)/);
+  assert.match(helper, /LoveBudEditorSaveStatus\.formatTimeAgo missing/);
+  assert.match(helper, /createSaveStatusOrchestrationFallback\(\)/);
+  assert.match(helper, /createEditorSaveStatusOrchestration\(\{\s*[\s\S]*editorSaveStatus,\s*[\s\S]*i18n,\s*[\s\S]*formatTimeAgo[\s\S]*\}\)/);
+  assert.match(helper, /return\s+\{\s*[\s\S]*status:\s*'ready'[\s\S]*refreshMemories[\s\S]*saveStatusData[\s\S]*updateSaveStatus[\s\S]*\}/);
+});

--- a/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
@@ -78,10 +78,12 @@ test('editor entry requires preloaded root helper utilities without inline fallb
 
 test('editor entry keeps root helper usage contracts', () => {
   const editor = read('js/editor.js');
+  const refreshSaveRuntime = read('js/editor/editor-refresh-save-runtime.js');
+  const runtimeSources = `${editor}\n${refreshSaveRuntime}`;
 
   assert.match(editor, /createInitialMemory[\s\S]*findRootMemory/);
   assert.match(editor, /canonicalRootId\s*=\s*getCanonicalRootId\(treeMemories\(\)\)/);
-  assert.match(editor, /isRootMemory\(refreshedEditingMemory,\s*canonicalRootId\)/);
+  assert.match(runtimeSources, /isRootMemory\(refreshedEditingMemory,\s*canonicalRootId\)/);
   assert.match(editor, /isRootMemory\(initialSelection,\s*canonicalRootId\)/);
   assert.match(editor, /memoryActions[\s\S]*isRootMemory[\s\S]*findRootMemory/);
   assert.match(editor, /detailUI[\s\S]*isRootMemory/);

--- a/tests/contracts/editor-save-status-fallback-factory-contract.test.cjs
+++ b/tests/contracts/editor-save-status-fallback-factory-contract.test.cjs
@@ -5,6 +5,7 @@ const test = require('node:test');
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
 const saveStatusOrchestrationSource = fs.readFileSync('js/editor/editor-save-status-orchestration.js', 'utf8');
+const refreshSaveRuntimeSource = fs.readFileSync('js/editor/editor-refresh-save-runtime.js', 'utf8');
 
 test('editor shell helpers expose save status orchestration fallback factory', () => {
   assert.match(shellHelpersSource, /createSaveStatusOrchestrationFallback:\s*function\(options\)/);
@@ -35,52 +36,53 @@ test('editor delegates save status fallback through required shell helper while 
   );
   assert.match(
     editorSource,
-    /const\s+saveStatusOrchestrationHelper\s*=\s*window\.LoveBudEditorSaveStatusOrchestration\s*\|\|\s*\{\}/
+    /saveStatusOrchestrationHelper:\s*window\.LoveBudEditorSaveStatusOrchestration\s*\|\|\s*\{\}/
   );
   assert.match(
-    editorSource,
-    /let\s+createEditorSaveStatusOrchestration\s*=\s*saveStatusOrchestrationHelper\.createEditorSaveStatusOrchestration/
+    refreshSaveRuntimeSource,
+    /let\s+createEditorSaveStatusOrchestration\s*=\s*\(saveStatusOrchestrationHelper\s*\|\|\s*\{\}\)\.createEditorSaveStatusOrchestration/
   );
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /typeof\s+createEditorSaveStatusOrchestration\s*!==\s*'function'/
   );
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /LoveBudEditorShellHelpers\.createSaveStatusOrchestrationFallback missing/
   );
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /createEditorSaveStatusOrchestration\s*=\s*createSaveStatusOrchestrationFallback\(\)/
   );
 });
 
-test('editor no longer owns inline save status fallback body', () => {
-  const start = editorSource.indexOf('const saveStatusOrchestrationHelper = window.LoveBudEditorSaveStatusOrchestration || {};');
+test('refresh save runtime owns save status fallback delegation without inline fallback body', () => {
+  const start = refreshSaveRuntimeSource.indexOf('let createEditorSaveStatusOrchestration =');
   assert.notEqual(start, -1, 'save status orchestration helper setup must exist');
 
-  const end = editorSource.indexOf('const { saveStatusData, updateSaveStatus } = createEditorSaveStatusOrchestration', start);
+  const end = refreshSaveRuntimeSource.indexOf('const { saveStatusData, updateSaveStatus } = createEditorSaveStatusOrchestration', start);
   assert.notEqual(end, -1, 'save status destructuring must follow factory resolution');
 
-  const block = editorSource.slice(start, end);
+  const block = refreshSaveRuntimeSource.slice(start, end);
   assert.match(block, /createSaveStatusOrchestrationFallback\(\)/);
   assert.match(block, /LoveBudEditorShellHelpers\.createSaveStatusOrchestrationFallback missing/);
   assert.doesNotMatch(block, /console\.warn\('\[editor\] LoveBudEditorSaveStatusOrchestration not loaded, using minimal fallback'\)/);
   assert.doesNotMatch(block, /let saveStatusData\s*=\s*\{\s*status:\s*'saved',\s*lastSaved:\s*null,\s*timer:\s*null\s*\}/);
+  assert.doesNotMatch(editorSource, /let\s+createEditorSaveStatusOrchestration\s*=/);
 });
 
-test('editor guards missing save status fallback factory before fallback creation', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
-  const fallbackIndex = editorSource.indexOf('createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();');
+test('refresh save runtime guards missing save status fallback factory before fallback creation', () => {
+  const guardIndex = refreshSaveRuntimeSource.indexOf('LoveBudEditorShellHelpers.createSaveStatusOrchestrationFallback missing');
+  const fallbackIndex = refreshSaveRuntimeSource.indexOf('createEditorSaveStatusOrchestration = createSaveStatusOrchestrationFallback();');
 
   assert.ok(guardIndex !== -1, 'missing save status fallback factory guard must exist');
   assert.ok(fallbackIndex !== -1, 'fallback factory assignment must exist');
   assert.ok(guardIndex < fallbackIndex, 'guard must run before fallback factory assignment');
 });
 
-test('editor keeps save status orchestration invocation intact', () => {
+test('refresh save runtime keeps save status orchestration invocation intact', () => {
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /const \{\s*saveStatusData,\s*updateSaveStatus\s*\}\s*=\s*createEditorSaveStatusOrchestration\(\{\s*editorSaveStatus,\s*i18n,\s*formatTimeAgo\s*\}\)/
   );
 });

--- a/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
+++ b/tests/contracts/editor-save-status-time-formatter-resolution-contract.test.cjs
@@ -5,6 +5,7 @@ const test = require('node:test');
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
 const saveStatusOrchestrationSource = fs.readFileSync('js/editor/editor-save-status-orchestration.js', 'utf8');
+const refreshSaveRuntimeSource = fs.readFileSync('js/editor/editor-refresh-save-runtime.js', 'utf8');
 
 test('editor shell helpers expose save status time formatter resolver', () => {
   assert.match(shellHelpersSource, /resolveSaveStatusTimeFormatter:\s*function\(options\)/);
@@ -33,12 +34,9 @@ test('editor delegates save status time formatter resolution through required sh
     editorSource,
     /const\s+resolveSaveStatusTimeFormatter\s*=\s*shellHelpers\.resolveSaveStatusTimeFormatter\s*\|\|/
   );
+  assert.match(refreshSaveRuntimeSource, /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/);
   assert.match(
-    editorSource,
-    /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/
-  );
-  assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /const\s+formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\s*\{/
   );
   assert.doesNotMatch(
@@ -46,27 +44,28 @@ test('editor delegates save status time formatter resolution through required sh
     /createInlineFormatTimeAgoFallback/
   );
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /LoveBudEditorSaveStatus\.formatTimeAgo missing/
   );
 });
 
-test('editor no longer owns inline save status time formatter resolver', () => {
-  const start = editorSource.indexOf('const refreshMemories = editorDataLoader.createRefreshMemories');
+test('refresh save runtime owns save status time formatter resolver without inline fallback', () => {
+  const start = refreshSaveRuntimeSource.indexOf('const refreshMemories = editorDataLoader.createRefreshMemories');
   assert.notEqual(start, -1, 'refreshMemories setup must exist');
 
-  const end = editorSource.indexOf('const saveStatusOrchestrationHelper =', start);
+  const end = refreshSaveRuntimeSource.indexOf('let createEditorSaveStatusOrchestration =', start);
   assert.notEqual(end, -1, 'save status orchestration setup must follow formatTimeAgo setup');
 
-  const block = editorSource.slice(start, end);
+  const block = refreshSaveRuntimeSource.slice(start, end);
   assert.match(block, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter\(\{/);
-  assert.match(block, /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/);
+  assert.match(refreshSaveRuntimeSource, /LoveBudEditorShellHelpers\.resolveSaveStatusTimeFormatter missing/);
   assert.doesNotMatch(block, /const formatTimeAgo\s*=\s*editorSaveStatus\.formatTimeAgo\s*\|\|\s*createInlineFormatTimeAgoFallback\(\)/);
+  assert.doesNotMatch(editorSource, /const\s+formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter/);
 });
 
-test('editor guards missing save status time formatter before resolution', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
-  const formatIndex = editorSource.indexOf('const formatTimeAgo = resolveSaveStatusTimeFormatter({');
+test('refresh save runtime guards missing save status time formatter before resolution', () => {
+  const guardIndex = refreshSaveRuntimeSource.indexOf('LoveBudEditorShellHelpers.resolveSaveStatusTimeFormatter missing');
+  const formatIndex = refreshSaveRuntimeSource.indexOf('const formatTimeAgo = resolveSaveStatusTimeFormatter({');
 
   assert.ok(guardIndex !== -1, 'missing save status time formatter guard must exist');
   assert.ok(formatIndex !== -1, 'formatTimeAgo resolution must exist');
@@ -76,22 +75,22 @@ test('editor guards missing save status time formatter before resolution', () =>
 test('editor.js removes createInlineFormatTimeAgoFallback and requires formatTimeAgo helper', () => {
   assert.doesNotMatch(editorSource, /createInlineFormatTimeAgoFallback/);
   assert.doesNotMatch(editorSource, /entryFallbacks\.createInlineFormatTimeAgoFallback/);
-  assert.match(editorSource, /LoveBudEditorSaveStatus\.formatTimeAgo missing/);
-  assert.match(editorSource, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter/);
+  assert.match(refreshSaveRuntimeSource, /LoveBudEditorSaveStatus\.formatTimeAgo missing/);
+  assert.match(refreshSaveRuntimeSource, /const formatTimeAgo\s*=\s*resolveSaveStatusTimeFormatter/);
 });
 
-test('editor.js formatTimeAgo guard uses reportError', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorSaveStatus.formatTimeAgo missing');
+test('refresh save runtime formatTimeAgo guard uses reportError', () => {
+  const guardIndex = refreshSaveRuntimeSource.indexOf('LoveBudEditorSaveStatus.formatTimeAgo missing');
   assert.ok(guardIndex !== -1, 'missing formatTimeAgo guard must exist');
-  const guardReportStart = editorSource.indexOf('reportError(', guardIndex - 50);
+  const guardReportStart = refreshSaveRuntimeSource.indexOf('reportError', guardIndex - 100);
   assert.ok(guardReportStart !== -1, 'guard must use reportError');
-  const guardReportExpr = editorSource.slice(guardReportStart, editorSource.indexOf(')', guardReportStart) + 1);
-  assert.match(guardReportExpr, /reportError\(['"]LoveBudEditorSaveStatus\.formatTimeAgo missing['"]\)/);
+  const guardReportExpr = refreshSaveRuntimeSource.slice(guardReportStart, refreshSaveRuntimeSource.indexOf(';', guardReportStart) + 1);
+  assert.match(guardReportExpr, /reportError,\s*['"]LoveBudEditorSaveStatus\.formatTimeAgo missing['"]/);
 });
 
-test('editor keeps save status orchestration invocation intact', () => {
+test('refresh save runtime keeps save status orchestration invocation intact', () => {
   assert.match(
-    editorSource,
+    refreshSaveRuntimeSource,
     /const \{\s*saveStatusData,\s*updateSaveStatus\s*\}\s*=\s*createEditorSaveStatusOrchestration\(\{\s*editorSaveStatus,\s*i18n,\s*formatTimeAgo\s*\}\)/
   );
 });

--- a/tests/contracts/editor-script-order-contract.test.cjs
+++ b/tests/contracts/editor-script-order-contract.test.cjs
@@ -64,6 +64,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-auth-helpers.js',
     'js/editor/editor-data-loader.js',
     'js/editor/editor-data-loader-fallbacks.js',
+    'js/editor/editor-refresh-save-runtime.js',
   ];
 
   for (const helper of helpers) {


### PR DESCRIPTION
Refs #1698

## Summary
- extract refresh memories bridge and save status orchestration from `js/editor.js`
- preserve external memory refresh behavior and save status runtime wiring
- reduce editor entrypoint orchestration responsibility
- avoid canvas, memory action/form internals, save/update/delete behavior, auth API, backend, schema, HTML/CSS behavior changes

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: YES
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js, js/editor/editor-refresh-save-runtime.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS