### PR TITLE
refactor(editor): extract entry dependency resolution

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1,274 +1,127 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const dataLoaderFallbacks = window.LoveBudEditorDataLoaderFallbacks || {};
-    const entryFallbacks = window.LoveBudEditorEntryFallbacks || {};
-    const shellHelpers = window.LoveBudEditorShellHelpers || {};
+    const entryDependencies = window.LoveBudEditorEntryDependencies || {};
+    const resolveEditorEntryDependencies = entryDependencies.resolveEditorEntryDependencies;
 
-    const rootUtils = window.LoveBudEditorUtils || {};
-    const editorHelpers = window.LoveBudEditorHelpers || {};
-
-    const findRootMemory = rootUtils.findRootMemory,
-        getCanonicalRootId = rootUtils.getCanonicalRootId,
-        isRootMemory = rootUtils.isRootMemory;
-
-    const missingRootHelpers = [
-        ['LoveBudEditorUtils.findRootMemory', findRootMemory],
-        ['LoveBudEditorUtils.getCanonicalRootId', getCanonicalRootId],
-        ['LoveBudEditorUtils.isRootMemory', isRootMemory]
-    ].filter(([, helper]) => typeof helper !== 'function');
-
-    if (missingRootHelpers.length) {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] },
-            msg = missingRootHelpers.map(([name]) => name + ' missing').join('; ');
+    if (typeof resolveEditorEntryDependencies !== 'function') {
+        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
+        const msg = 'LoveBudEditorEntryDependencies.resolveEditorEntryDependencies missing';
         console.error('[editor-main] ERROR: ' + msg);
         debugState.errors.push({ msg, error: msg });
         return;
     }
 
-    const editorSaveStatus = window.LoveBudEditorSaveStatus || {};
-    const editorPageHelpers = window.LoveBudEditorPageHelpers || {};
-    const editorTreeHelpers = window.LoveBudEditorTreeHelpers || {};
+    const entryDependenciesResult = resolveEditorEntryDependencies({
+        windowRef: window,
+        URLSearchParamsRef: URLSearchParams
+    });
+
+    if (entryDependenciesResult.status === 'stopped') return;
+
+    const deps = entryDependenciesResult.deps;
+    const dataLoaderFallbacks = window.LoveBudEditorDataLoaderFallbacks || deps.dataLoaderFallbacks;
+    const entryFallbacks = window.LoveBudEditorEntryFallbacks || deps.entryFallbacks;
+    const shellHelpers = window.LoveBudEditorShellHelpers || deps.shellHelpers;
+    const rootUtils = window.LoveBudEditorUtils || {};
+    const editorHelpers = deps.editorHelpers;
+    const editorSaveStatus = deps.editorSaveStatus;
+    const editorPageHelpers = deps.editorPageHelpers;
+    const editorTreeHelpers = deps.editorTreeHelpers;
     const editorSelectionUI = window.LoveBudEditorSelectionUI || {};
-    const editorBindings = window.LoveBudEditorBindings || {};
-    const editorPageEventBindings = window.LoveBudEditorPageEventBindings || {};
-    const bindEditorPageEvents = editorPageEventBindings.bindEditorPageEvents;
-    const editorDataLoader = window.LoveBudEditorDataLoader || {};
-    const editorInitialLoadFlow = window.LoveBudEditorInitialLoadFlow || {};
-    const runEditorInitialLoadFlow = editorInitialLoadFlow.runEditorInitialLoadFlow;
-    const editorRefreshSaveRuntime = window.LoveBudEditorRefreshSaveRuntime || {},
-        createEditorRefreshSaveRuntime = editorRefreshSaveRuntime.createEditorRefreshSaveRuntime;
-    const editorStartupContext = window.LoveBudEditorStartupContext || {};
-    const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
+    const editorBindings = deps.editorBindings;
+    const editorPageEventBindings = window.LoveBudEditorPageEventBindings || deps.editorPageEventBindings;
+    const editorDataLoader = deps.editorDataLoader;
+    const editorInitialLoadFlow = deps.editorInitialLoadFlow;
+    const editorRefreshSaveRuntime = window.LoveBudEditorRefreshSaveRuntime || deps.editorRefreshSaveRuntime;
+    const editorStartupContext = deps.editorStartupContext;
     const editorAuthHelpers = window.LoveBudEditorAuthHelpers || {};
+    const editorShellCopyApplier = window.LoveBudEditorShellCopyApplier || deps.editorShellCopyApplier;
+    const editorDomRefsBuilder = window.LoveBudEditorDomRefsBuilder || deps.editorDomRefsBuilder;
+    const bindEditorPageEvents = editorPageEventBindings.bindEditorPageEvents;
+    const runEditorInitialLoadFlow = editorInitialLoadFlow.runEditorInitialLoadFlow;
+    const createEditorRefreshSaveRuntime = editorRefreshSaveRuntime.createEditorRefreshSaveRuntime;
+    const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
+    const getConfirmedSessionUser = deps.getConfirmedSessionUser;
     const readConfirmedAuthCacheFromHelper = () => (
         window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
     );
-    const getConfirmedSessionUser = function() {
-        try {
-            if (window.LoveBudProtectedRoute) {
-                var state = window.LoveBudProtectedRoute.getAuthState();
-                if (state.ready && state.user) return state.user;
-            }
-            if (window.getConfirmedAuthUser) return window.getConfirmedAuthUser();
-        } catch (e) {}
-        return readConfirmedAuthCacheFromHelper();
-    };
-    const hasConfirmedSessionUser = editorAuthHelpers.hasConfirmedSessionUser || (() => !!getConfirmedSessionUser());
-
     const getHttpStatus = shellHelpers.getHttpStatus;
-
     const createInlineShowToastFallback = shellHelpers.createInlineShowToastFallback;
-    if (typeof createInlineShowToastFallback !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.createInlineShowToastFallback missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
-    const showToast = editorHelpers.createToast
-        ? editorHelpers.createToast({ warningKey: '__editorToastWarningShown' })
-        : createInlineShowToastFallback();
-
+    if (typeof createInlineShowToastFallback !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.createInlineShowToastFallback missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
+    const showToast = deps.showToast;
     const getI18n = shellHelpers.getI18n;
-    if (typeof getI18n !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.getI18n missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
+    if (typeof getI18n !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.getI18n missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const i18n = getI18n();
-
     const getEditorBasePath = shellHelpers.getEditorBasePath;
-    if (typeof getEditorBasePath !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.getEditorBasePath missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof getEditorBasePath !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.getEditorBasePath missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const buildEditorRedirectTargetHelper = shellHelpers.buildEditorRedirectTarget;
-    if (typeof buildEditorRedirectTargetHelper !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.buildEditorRedirectTarget missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-    const buildEditorRedirectTarget = () => buildEditorRedirectTargetHelper.call(shellHelpers);
-
+    if (typeof buildEditorRedirectTargetHelper !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.buildEditorRedirectTarget missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
+    const buildEditorRedirectTarget = buildEditorRedirectTargetHelper.call(shellHelpers);
     const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin;
-
-    if (typeof redirectToEditorLogin !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorPageHelpers.redirectToEditorLogin missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof redirectToEditorLogin !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorPageHelpers.redirectToEditorLogin missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const safeI18nText = editorHelpers.safeI18nText;
     const resolveHintText = editorHelpers.resolveHintText;
     const resolveTreeTitleText = editorHelpers.resolveTreeTitleText;
     const resolveInfoText = editorHelpers.resolveInfoText;
-
     const missingTextResolvers = [
         ['LoveBudEditorHelpers.safeI18nText', safeI18nText],
         ['LoveBudEditorHelpers.resolveHintText', resolveHintText],
         ['LoveBudEditorHelpers.resolveTreeTitleText', resolveTreeTitleText],
         ['LoveBudEditorHelpers.resolveInfoText', resolveInfoText]
     ].filter(([, helper]) => typeof helper !== 'function');
-
-    if (missingTextResolvers.length) {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = missingTextResolvers.map(([name]) => name + ' missing').join('; ');
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (missingTextResolvers.length) { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = missingTextResolvers.map(([name]) => name + ' missing').join('; '); console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const syncCurrentTreeData = editorTreeHelpers.syncCurrentTreeData;
-
-    if (typeof syncCurrentTreeData !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorTreeHelpers.syncCurrentTreeData missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof syncCurrentTreeData !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorTreeHelpers.syncCurrentTreeData missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate;
-
-    if (typeof resolveParentIdForCreate !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorTreeHelpers.resolveParentIdForCreate missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof resolveParentIdForCreate !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorTreeHelpers.resolveParentIdForCreate missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const getMyTreesHref = editorPageHelpers.getMyTreesHref;
-    if (typeof getMyTreesHref !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorPageHelpers.getMyTreesHref missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
+    if (typeof getMyTreesHref !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorPageHelpers.getMyTreesHref missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const escapeHtml = editorHelpers.escapeHtml;
     const safeUrl = editorHelpers.safeUrl;
     const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail;
-
     const missingMediaResolvers = [
         ['LoveBudEditorHelpers.escapeHtml', escapeHtml],
         ['LoveBudEditorHelpers.safeUrl', safeUrl],
         ['LoveBudEditorHelpers.resolveMemoryThumbnail', resolveMemoryThumbnail]
     ].filter(([, helper]) => typeof helper !== 'function');
-
-    if (missingMediaResolvers.length) {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = missingMediaResolvers.map(([name]) => name + ' missing').join('; ');
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (missingMediaResolvers.length) { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = missingMediaResolvers.map(([name]) => name + ' missing').join('; '); console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const getYouTubeInputErrorMessageFallback = shellHelpers.getYouTubeInputErrorMessageFallback;
-
-    if (typeof getYouTubeInputErrorMessageFallback !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof getYouTubeInputErrorMessageFallback !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const getYouTubeInputErrorMessage = typeof rootUtils.getYouTubeInputErrorMessage === 'function' ? rootUtils.getYouTubeInputErrorMessage : getYouTubeInputErrorMessageFallback;
-
     const renderTreeLoadError = editorPageHelpers.renderTreeLoadError;
-
-    if (typeof renderTreeLoadError !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorPageHelpers.renderTreeLoadError missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof renderTreeLoadError !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorPageHelpers.renderTreeLoadError missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const buildTreeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy;
-
-    if (typeof buildTreeLoadErrorCopy !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
-    const nextMemoryIdFromMemories = editorTreeHelpers.nextMemoryIdFromMemories;
-
-    const markEditorReady = shellHelpers.markEditorReady;
-
-    const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState;
-
-    const editorShellCopyApplier = window.LoveBudEditorShellCopyApplier || {};
-    const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell;
-
+    if (typeof buildTreeLoadErrorCopy !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const applyEditorShellCopy = shellHelpers.applyEditorShellCopy;
-
-    if (typeof applyEditorShellCopy !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.applyEditorShellCopy missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof applyEditorShellCopy !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.applyEditorShellCopy missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     applyEditorShellCopy(safeI18nText, i18n);
-
-    const editorDomRefsBuilder = window.LoveBudEditorDomRefsBuilder || {};
-    const createEditorDomRefs = editorDomRefsBuilder.createEditorDomRefs;
-
-    if (typeof createPrepareEditorShell !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellCopyApplier.createPrepareEditorShell missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell;
+    if (typeof createPrepareEditorShell !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellCopyApplier.createPrepareEditorShell missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const prepareEditorShell = createPrepareEditorShell({ applyEditorShellCopy, safeI18nText, i18n, getMyTreesHref });
-
+    const nextMemoryIdFromMemories = editorTreeHelpers.nextMemoryIdFromMemories;
+    const markEditorReady = shellHelpers.markEditorReady;
+    const applyEditorEditabilityState = shellHelpers.applyEditorEditabilityState;
+    const createEditorDomRefs = editorDomRefsBuilder.createEditorDomRefs;
     const createEditorDebugReporter = shellHelpers.createEditorDebugReporter;
-
-    if (typeof createEditorDebugReporter !== 'function') {
-        const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] };
-        const msg = 'LoveBudEditorShellHelpers.createEditorDebugReporter missing';
-        console.error('[editor-main] ERROR: ' + msg);
-        debugState.errors.push({ msg, error: msg });
-        return;
-    }
-
+    if (typeof createEditorDebugReporter !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.createEditorDebugReporter missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const createEditorStartupDependencyWaiter = shellHelpers.createEditorStartupDependencyWaiter;
-
     const exposeCanvasEmptyGuideUpdater = shellHelpers.exposeCanvasEmptyGuideUpdater;
-
     const exposeDetailPanelUpdater = shellHelpers.exposeDetailPanelUpdater;
-
     const createSelectedMomentFocusHandler = shellHelpers.createSelectedMomentFocusHandler;
-
     const createSidebarTreeActionsUpdater = shellHelpers.createSidebarTreeActionsUpdater;
-
     const createMemoryActionsReadinessWrapper = shellHelpers.createMemoryActionsReadinessWrapper;
-
     const createCurrentMomentDetailOpener = shellHelpers.createCurrentMomentDetailOpener;
-
     const createSaveStatusOrchestrationFallback = shellHelpers.createSaveStatusOrchestrationFallback;
-
     const exposeRefreshMemoriesBridge = shellHelpers.exposeRefreshMemoriesBridge;
-
     const resolveSaveStatusTimeFormatter = shellHelpers.resolveSaveStatusTimeFormatter;
+    const findRootMemory = rootUtils.findRootMemory;
+    const getCanonicalRootId = rootUtils.getCanonicalRootId;
+    const isRootMemory = rootUtils.isRootMemory;
+    const missingRootHelpers = [
+        ['LoveBudEditorUtils.findRootMemory', findRootMemory],
+        ['LoveBudEditorUtils.getCanonicalRootId', getCanonicalRootId],
+        ['LoveBudEditorUtils.isRootMemory', isRootMemory]
+    ].filter(([, helper]) => typeof helper !== 'function');
+    if (missingRootHelpers.length) { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = missingRootHelpers.map(([name]) => name + ' missing').join('; '); console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
 
     const startEditor = async () => {
         const { log, reportError } = createEditorDebugReporter();

--- a/js/editor/editor-entry-dependencies.js
+++ b/js/editor/editor-entry-dependencies.js
@@ -1,0 +1,212 @@
+(function() {
+    'use strict';
+
+    function bootstrapError(windowRef, message) {
+        const debugState = windowRef.LoveBudEditorDebug = windowRef.LoveBudEditorDebug || { logs: [], errors: [] };
+        console.error('[editor-main] ERROR: ' + message);
+        debugState.errors.push({ msg: message, error: message });
+        return { status: 'stopped' };
+    }
+
+    function stopMissing(windowRef, name) {
+        return bootstrapError(windowRef, name + ' missing');
+    }
+
+    function stopMissingList(windowRef, missingHelpers) {
+        return bootstrapError(windowRef, missingHelpers.map(([name]) => name + ' missing').join('; '));
+    }
+
+    function resolveEditorEntryDependencies(options) {
+        const opts = options || {};
+        const windowRef = opts.windowRef || window;
+
+        const dataLoaderFallbacks = windowRef.LoveBudEditorDataLoaderFallbacks || {};
+        const entryFallbacks = windowRef.LoveBudEditorEntryFallbacks || {};
+        const shellHelpers = windowRef.LoveBudEditorShellHelpers || {};
+        const rootUtils = windowRef.LoveBudEditorUtils || {};
+        const editorHelpers = windowRef.LoveBudEditorHelpers || {};
+        const editorSaveStatus = windowRef.LoveBudEditorSaveStatus || {};
+        const editorPageHelpers = windowRef.LoveBudEditorPageHelpers || {};
+        const editorTreeHelpers = windowRef.LoveBudEditorTreeHelpers || {};
+        const editorSelectionUI = windowRef.LoveBudEditorSelectionUI || {};
+        const editorBindings = windowRef.LoveBudEditorBindings || {};
+        const editorPageEventBindings = windowRef.LoveBudEditorPageEventBindings || {};
+        const editorDataLoader = windowRef.LoveBudEditorDataLoader || {};
+        const editorInitialLoadFlow = windowRef.LoveBudEditorInitialLoadFlow || {};
+        const editorRefreshSaveRuntime = windowRef.LoveBudEditorRefreshSaveRuntime || {};
+        const editorStartupContext = windowRef.LoveBudEditorStartupContext || {};
+        const editorAuthHelpers = windowRef.LoveBudEditorAuthHelpers || {};
+        const editorShellCopyApplier = windowRef.LoveBudEditorShellCopyApplier || {};
+        const editorDomRefsBuilder = windowRef.LoveBudEditorDomRefsBuilder || {};
+
+        const findRootMemory = rootUtils.findRootMemory,
+            getCanonicalRootId = rootUtils.getCanonicalRootId,
+            isRootMemory = rootUtils.isRootMemory;
+
+        const missingRootHelpers = [
+            ['LoveBudEditorUtils.findRootMemory', findRootMemory],
+            ['LoveBudEditorUtils.getCanonicalRootId', getCanonicalRootId],
+            ['LoveBudEditorUtils.isRootMemory', isRootMemory]
+        ].filter(([, helper]) => typeof helper !== 'function');
+
+        if (missingRootHelpers.length) return stopMissingList(windowRef, missingRootHelpers);
+
+        const createInlineShowToastFallback = shellHelpers.createInlineShowToastFallback;
+        if (typeof createInlineShowToastFallback !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.createInlineShowToastFallback');
+
+        const showToast = editorHelpers.createToast
+            ? editorHelpers.createToast({ warningKey: '__editorToastWarningShown' })
+            : createInlineShowToastFallback();
+
+        const getI18n = shellHelpers.getI18n;
+        if (typeof getI18n !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.getI18n');
+        const i18n = getI18n();
+
+        const getEditorBasePath = shellHelpers.getEditorBasePath;
+        if (typeof getEditorBasePath !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.getEditorBasePath');
+
+        const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin;
+        if (typeof redirectToEditorLogin !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.redirectToEditorLogin');
+
+        const safeI18nText = editorHelpers.safeI18nText;
+        const resolveHintText = editorHelpers.resolveHintText;
+        const resolveTreeTitleText = editorHelpers.resolveTreeTitleText;
+        const resolveInfoText = editorHelpers.resolveInfoText;
+        const missingTextResolvers = [
+            ['LoveBudEditorHelpers.safeI18nText', safeI18nText],
+            ['LoveBudEditorHelpers.resolveHintText', resolveHintText],
+            ['LoveBudEditorHelpers.resolveTreeTitleText', resolveTreeTitleText],
+            ['LoveBudEditorHelpers.resolveInfoText', resolveInfoText]
+        ].filter(([, helper]) => typeof helper !== 'function');
+        if (missingTextResolvers.length) return stopMissingList(windowRef, missingTextResolvers);
+
+        const syncCurrentTreeData = editorTreeHelpers.syncCurrentTreeData;
+        if (typeof syncCurrentTreeData !== 'function') return stopMissing(windowRef, 'LoveBudEditorTreeHelpers.syncCurrentTreeData');
+
+        const resolveParentIdForCreate = editorTreeHelpers.resolveParentIdForCreate;
+        if (typeof resolveParentIdForCreate !== 'function') return stopMissing(windowRef, 'LoveBudEditorTreeHelpers.resolveParentIdForCreate');
+
+        const getMyTreesHref = editorPageHelpers.getMyTreesHref;
+        if (typeof getMyTreesHref !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.getMyTreesHref');
+
+        const escapeHtml = editorHelpers.escapeHtml;
+        const resolveMemoryThumbnail = editorHelpers.resolveMemoryThumbnail;
+        const missingMediaResolvers = [
+            ['LoveBudEditorHelpers.escapeHtml', escapeHtml],
+            ['LoveBudEditorHelpers.safeUrl', editorHelpers.safeUrl],
+            ['LoveBudEditorHelpers.resolveMemoryThumbnail', resolveMemoryThumbnail]
+        ].filter(([, helper]) => typeof helper !== 'function');
+        if (missingMediaResolvers.length) return stopMissingList(windowRef, missingMediaResolvers);
+
+        const getYouTubeInputErrorMessageFallback = shellHelpers.getYouTubeInputErrorMessageFallback;
+        if (typeof getYouTubeInputErrorMessageFallback !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.getYouTubeInputErrorMessageFallback');
+        const getYouTubeInputErrorMessage = typeof rootUtils.getYouTubeInputErrorMessage === 'function' ? rootUtils.getYouTubeInputErrorMessage : getYouTubeInputErrorMessageFallback;
+
+        const renderTreeLoadError = editorPageHelpers.renderTreeLoadError;
+        if (typeof renderTreeLoadError !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.renderTreeLoadError');
+
+        const buildTreeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy;
+        if (typeof buildTreeLoadErrorCopy !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy');
+
+        const applyEditorShellCopy = shellHelpers.applyEditorShellCopy;
+        if (typeof applyEditorShellCopy !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.applyEditorShellCopy');
+
+        const createPrepareEditorShell = editorShellCopyApplier.createPrepareEditorShell;
+        if (typeof createPrepareEditorShell !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellCopyApplier.createPrepareEditorShell');
+
+        const createEditorDebugReporter = shellHelpers.createEditorDebugReporter;
+        if (typeof createEditorDebugReporter !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.createEditorDebugReporter');
+
+        const readConfirmedAuthCacheFromHelper = () => (
+            windowRef.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
+        );
+        const getConfirmedSessionUser = function() {
+            try {
+                if (windowRef.LoveBudProtectedRoute) {
+                    var state = windowRef.LoveBudProtectedRoute.getAuthState();
+                    if (state.ready && state.user) return state.user;
+                }
+                if (windowRef.getConfirmedAuthUser) return windowRef.getConfirmedAuthUser();
+            } catch (e) {}
+            return readConfirmedAuthCacheFromHelper();
+        };
+
+        return {
+            status: 'ready',
+            deps: {
+                dataLoaderFallbacks,
+                entryFallbacks,
+                shellHelpers,
+                rootUtils,
+                editorHelpers,
+                editorSaveStatus,
+                editorPageHelpers,
+                editorTreeHelpers,
+                editorSelectionUI,
+                editorBindings,
+                editorPageEventBindings,
+                bindEditorPageEvents: editorPageEventBindings.bindEditorPageEvents,
+                editorDataLoader,
+                editorInitialLoadFlow,
+                runEditorInitialLoadFlow: editorInitialLoadFlow.runEditorInitialLoadFlow,
+                editorRefreshSaveRuntime,
+                createEditorRefreshSaveRuntime: editorRefreshSaveRuntime.createEditorRefreshSaveRuntime,
+                editorStartupContext,
+                createEditorStartupContext: editorStartupContext.createEditorStartupContext,
+                editorAuthHelpers,
+                editorShellCopyApplier,
+                editorDomRefsBuilder,
+                getConfirmedSessionUser,
+                hasConfirmedSessionUser: editorAuthHelpers.hasConfirmedSessionUser || (() => !!getConfirmedSessionUser()),
+                getHttpStatus: shellHelpers.getHttpStatus,
+                showToast,
+                i18n,
+                getEditorBasePath,
+                redirectToEditorLogin,
+                safeI18nText,
+                resolveHintText,
+                resolveTreeTitleText,
+                resolveInfoText,
+                syncCurrentTreeData,
+                resolveParentIdForCreate,
+                escapeHtml,
+                resolveMemoryThumbnail,
+                getYouTubeInputErrorMessage,
+                renderTreeLoadError,
+                buildTreeLoadErrorCopy,
+                applyEditorShellCopy,
+                createPrepareEditorShell,
+                nextMemoryIdFromMemories: editorTreeHelpers.nextMemoryIdFromMemories,
+                markEditorReady: shellHelpers.markEditorReady,
+                applyEditorEditabilityState: shellHelpers.applyEditorEditabilityState,
+                createEditorDomRefs: editorDomRefsBuilder.createEditorDomRefs,
+                createEditorDebugReporter,
+                createEditorStartupDependencyWaiter: shellHelpers.createEditorStartupDependencyWaiter,
+                exposeCanvasEmptyGuideUpdater: shellHelpers.exposeCanvasEmptyGuideUpdater,
+                exposeDetailPanelUpdater: shellHelpers.exposeDetailPanelUpdater,
+                createSelectedMomentFocusHandler: shellHelpers.createSelectedMomentFocusHandler,
+                createSidebarTreeActionsUpdater: shellHelpers.createSidebarTreeActionsUpdater,
+                createMemoryActionsReadinessWrapper: shellHelpers.createMemoryActionsReadinessWrapper,
+                createCurrentMomentDetailOpener: shellHelpers.createCurrentMomentDetailOpener,
+                createSaveStatusOrchestrationFallback: shellHelpers.createSaveStatusOrchestrationFallback,
+                exposeRefreshMemoriesBridge: shellHelpers.exposeRefreshMemoriesBridge,
+                resolveSaveStatusTimeFormatter: shellHelpers.resolveSaveStatusTimeFormatter,
+                findRootMemory,
+                getCanonicalRootId,
+                isRootMemory
+            }
+        };
+    }
+
+    if (typeof window !== 'undefined') {
+        window.LoveBudEditorEntryDependencies = Object.freeze({
+            resolveEditorEntryDependencies
+        });
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            resolveEditorEntryDependencies
+        };
+    }
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -167,6 +167,7 @@
     <script src="../js/editor/editor-page-event-bindings.js?v=20260530-1698"></script>
     <script src="../js/editor/editor-initial-load-flow.js?v=20260531-1698"></script>
     <script src="../js/editor/editor-refresh-save-runtime.js?v=20260531-1698"></script>
+    <script src="../js/editor/editor-entry-dependencies.js?v=20260531-1698"></script>
 
     <script src="../js/editor.js?v=20260502-1"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -1,0 +1,99 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+function scriptSources() {
+  return Array.from(read('pages/editor.html').matchAll(/<script\s+[^>]*src=["']([^"']+)["'][^>]*><\/script>/g))
+    .map((match) => match[1]);
+}
+
+function sourceIndex(sources, needle) {
+  return sources.findIndex((src) => src.includes(needle));
+}
+
+test('editor entry dependencies helper loads before editor entry', () => {
+  const sources = scriptSources();
+  const dependencyHelper = sourceIndex(sources, 'js/editor/editor-entry-dependencies.js');
+  const editorEntry = sourceIndex(sources, 'js/editor.js');
+
+  assert.notEqual(dependencyHelper, -1, 'editor-entry-dependencies.js must be loaded');
+  assert.notEqual(editorEntry, -1, 'editor.js must be loaded');
+  assert.ok(dependencyHelper < editorEntry, 'entry dependencies helper must load before editor.js');
+});
+
+test('editor entry dependencies helper exports resolveEditorEntryDependencies', () => {
+  const context = { window: {}, console: { error() {} }, Object };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-entry-dependencies.js'), context);
+
+  assert.equal(
+    typeof context.window.LoveBudEditorEntryDependencies.resolveEditorEntryDependencies,
+    'function'
+  );
+  assert.equal(Object.isFrozen(context.window.LoveBudEditorEntryDependencies), true);
+});
+
+test('editor entry delegates dependency resolution to helper', () => {
+  const editor = read('js/editor.js');
+
+  assert.match(editor, /window\.LoveBudEditorEntryDependencies/);
+  assert.match(editor, /resolveEditorEntryDependencies\s*=\s*entryDependencies\.resolveEditorEntryDependencies/);
+  assert.match(editor, /LoveBudEditorEntryDependencies\.resolveEditorEntryDependencies missing/);
+  assert.match(editor, /resolveEditorEntryDependencies\(\{\s*windowRef:\s*window,\s*URLSearchParamsRef:\s*URLSearchParams\s*\}\)/);
+  assert.match(editor, /entryDependenciesResult\.status\s*===\s*'stopped'/);
+  assert.match(editor, /const\s+deps\s*=\s*entryDependenciesResult\.deps/);
+  assert.match(editor, /const\s+createEditorDebugReporter\s*=\s*shellHelpers\.createEditorDebugReporter/);
+  assert.match(editor, /const\s+findRootMemory\s*=\s*rootUtils\.findRootMemory/);
+  assert.match(editor, /const\s+getCanonicalRootId\s*=\s*rootUtils\.getCanonicalRootId/);
+  assert.match(editor, /const\s+isRootMemory\s*=\s*rootUtils\.isRootMemory/);
+  assert.match(editor, /const\s+\{\s*log,\s*reportError\s*\}\s*=\s*createEditorDebugReporter\(\)/);
+  assert.match(editor, /prepareEditorShell\(\)/);
+
+  assert.match(editor, /const\s+missingTextResolvers\s*=\s*\[/);
+  assert.match(editor, /const\s+missingMediaResolvers\s*=\s*\[/);
+  assert.match(editor, /const\s+missingRootHelpers\s*=\s*\[/);
+  assert.match(editor, /LoveBudEditorPageHelpers\.renderTreeLoadError missing/);
+  assert.match(editor, /LoveBudEditorPageHelpers\.buildTreeLoadErrorCopy missing/);
+  assert.match(editor, /LoveBudEditorShellHelpers\.applyEditorShellCopy missing/);
+  assert.match(editor, /LoveBudEditorShellCopyApplier\.createPrepareEditorShell missing/);
+});
+
+test('entry dependencies helper preserves bootstrap missing-helper messages', () => {
+  const helper = read('js/editor/editor-entry-dependencies.js');
+
+  const messages = [
+    'LoveBudEditorUtils.findRootMemory',
+    'LoveBudEditorHelpers.safeI18nText',
+    'LoveBudEditorHelpers.escapeHtml',
+    'LoveBudEditorPageHelpers.renderTreeLoadError',
+    'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy',
+    'LoveBudEditorShellHelpers.applyEditorShellCopy',
+    'LoveBudEditorShellCopyApplier.createPrepareEditorShell',
+    'LoveBudEditorShellHelpers.createEditorDebugReporter'
+  ];
+
+  for (const message of messages) {
+    assert.match(helper, new RegExp(message.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  assert.match(helper, /console\.error\('\[editor-main\] ERROR: ' \+ message\)/);
+  assert.match(helper, /debugState\.errors\.push\(\{ msg: message, error: message \}\)/);
+});
+
+test('entry dependencies helper preserves shell copy side effect before prepare shell return', () => {
+  const editor = read('js/editor.js');
+  const applyIndex = editor.indexOf('applyEditorShellCopy(safeI18nText, i18n);');
+  const prepareIndex = editor.indexOf('const prepareEditorShell = createPrepareEditorShell');
+
+  assert.notEqual(applyIndex, -1, 'applyEditorShellCopy side effect must remain');
+  assert.notEqual(prepareIndex, -1, 'prepareEditorShell creation must remain');
+  assert.ok(applyIndex < prepareIndex, 'shell copy must apply before prepareEditorShell is returned');
+});

--- a/tests/contracts/editor-script-order-contract.test.cjs
+++ b/tests/contracts/editor-script-order-contract.test.cjs
@@ -65,6 +65,7 @@ test('editor helper scripts load before the editor entry script', () => {
     'js/editor/editor-data-loader.js',
     'js/editor/editor-data-loader-fallbacks.js',
     'js/editor/editor-refresh-save-runtime.js',
+    'js/editor/editor-entry-dependencies.js',
   ];
 
   for (const helper of helpers) {


### PR DESCRIPTION
Refs #1698

## Summary
- extract editor entry dependency resolution from `js/editor.js`
- preserve existing bootstrap missing-helper guard behavior
- keep `startEditor` runtime flow in the editor entrypoint
- reduce editor entrypoint dependency/guard responsibility
- avoid canvas, memory action/form internals, save/update/delete behavior, auth API, backend, schema, HTML/CSS behavior changes

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: YES
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor.js, js/editor/editor-entry-dependencies.js
Static checks: PASS
Editor browser smoke: NOT_RUN
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS