### PR TITLE
refactor(editor): preserve redirect target wrapper

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof getEditorBasePath !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.getEditorBasePath missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const buildEditorRedirectTargetHelper = shellHelpers.buildEditorRedirectTarget;
     if (typeof buildEditorRedirectTargetHelper !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorShellHelpers.buildEditorRedirectTarget missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
-    const buildEditorRedirectTarget = buildEditorRedirectTargetHelper.call(shellHelpers);
+    const buildEditorRedirectTarget = () => buildEditorRedirectTargetHelper.call(shellHelpers);
     const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin;
     if (typeof redirectToEditorLogin !== 'function') { const debugState = window.LoveBudEditorDebug = window.LoveBudEditorDebug || { logs: [], errors: [] }; const msg = 'LoveBudEditorPageHelpers.redirectToEditorLogin missing'; console.error('[editor-main] ERROR: ' + msg); debugState.errors.push({ msg, error: msg }); return; }
     const safeI18nText = editorHelpers.safeI18nText;


### PR DESCRIPTION
Refs #1698

Summary:
- Wrap buildEditorRedirectTarget in an arrow function to preserve lazy evaluation.
- Ensures redirect target is computed at call time rather than at initialization.
- Single line change in js/editor.js.

Validation:
- git diff --check
- node --check js/editor.js
- npm run verify (273/273)
- npm test (1616 pass, 0 fail)