### PR TITLE
refactor(editor): consolidate start dependency guards

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -129,22 +129,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const startEditor = async () => {
         const { log, reportError } = createEditorDebugReporter();
 
-        if (typeof createEditorStartupDependencyWaiter !== 'function') {
-            reportError('LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing');
-            return;
-        }
+        const ensureStartEditorDependency = (dependency, message) => {
+            if (typeof dependency === 'function') return true;
+            reportError(message);
+            return false;
+        };
 
-        if (typeof markEditorReady !== 'function') {
-            reportError('LoveBudEditorShellHelpers.markEditorReady missing');
-            return;
-        }
+        if (!ensureStartEditorDependency(createEditorStartupDependencyWaiter, 'LoveBudEditorShellHelpers.createEditorStartupDependencyWaiter missing')) return;
 
-        if (typeof runEditorInitialLoadFlow !== 'function') {
-            reportError('LoveBudEditorInitialLoadFlow.runEditorInitialLoadFlow missing');
-            return;
-        }
+        if (!ensureStartEditorDependency(markEditorReady, 'LoveBudEditorShellHelpers.markEditorReady missing')) return;
 
-        if (typeof createEditorRefreshSaveRuntime !== 'function') { reportError('LoveBudEditorRefreshSaveRuntime.createEditorRefreshSaveRuntime missing'); return; }
+        if (!ensureStartEditorDependency(runEditorInitialLoadFlow, 'LoveBudEditorInitialLoadFlow.runEditorInitialLoadFlow missing')) return;
+
+        if (!ensureStartEditorDependency(createEditorRefreshSaveRuntime, 'LoveBudEditorRefreshSaveRuntime.createEditorRefreshSaveRuntime missing')) return;
 
         log('startEditor sequence initiated');
 
@@ -155,15 +152,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!await waitForGlobal('createEditorMemoryActions')) return;
         if (!await waitForGlobal('createEditorMemoryForm')) return;
 
-        if (typeof createEditorDomRefs !== 'function') {
-            reportError('LoveBudEditorDomRefsBuilder.createEditorDomRefs missing');
-            return;
-        }
+        if (!ensureStartEditorDependency(createEditorDomRefs, 'LoveBudEditorDomRefsBuilder.createEditorDomRefs missing')) return;
 
-        if (typeof createEditorStartupContext !== 'function') {
-            reportError('LoveBudEditorStartupContext.createEditorStartupContext missing');
-            return;
-        }
+        if (!ensureStartEditorDependency(createEditorStartupContext, 'LoveBudEditorStartupContext.createEditorStartupContext missing')) return;
 
         try {
             const {
@@ -183,10 +174,7 @@ document.addEventListener('DOMContentLoaded', () => {
             prepareEditorShell();
             log('Editor shell mounted');
 
-            if (typeof applyEditorEditabilityState !== 'function') {
-                reportError('LoveBudEditorShellHelpers.applyEditorEditabilityState missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(applyEditorEditabilityState, 'LoveBudEditorShellHelpers.applyEditorEditabilityState missing')) return;
 
             // Expose canEdit for modules that read it after DOMContentLoaded
             applyEditorEditabilityState({ canEdit });
@@ -231,25 +219,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
             let memoryActions = null;
 
-            if (typeof createMemoryActionsReadinessWrapper !== 'function') {
-                reportError('LoveBudEditorShellHelpers.createMemoryActionsReadinessWrapper missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(createMemoryActionsReadinessWrapper, 'LoveBudEditorShellHelpers.createMemoryActionsReadinessWrapper missing')) return;
 
             const updateSelectedMemoryFields = createMemoryActionsReadinessWrapper({
                 getMemoryActions: () => memoryActions
             });
 
-            if (typeof editorTreeHelpers.createInitialMemory !== 'function') {
-                reportError('LoveBudEditorTreeHelpers.createInitialMemory missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(editorTreeHelpers.createInitialMemory, 'LoveBudEditorTreeHelpers.createInitialMemory missing')) return;
             const createInitialMemory = () => editorTreeHelpers.createInitialMemory({ getTreeMemories: () => treeMemories(), findRootMemory, canonicalRootId, treeId, i18n });
 
-            if (typeof nextMemoryIdFromMemories !== 'function') {
-                reportError('LoveBudEditorTreeHelpers.nextMemoryIdFromMemories missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(nextMemoryIdFromMemories, 'LoveBudEditorTreeHelpers.nextMemoryIdFromMemories missing')) return;
 
             const nextMemoryId = () => nextMemoryIdFromMemories(treeMemories());
 
@@ -264,10 +243,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 };
             
             // Bridge this back to LoveBudEditor so canvas can call it
-            if (typeof exposeCanvasEmptyGuideUpdater !== 'function') {
-                reportError('LoveBudEditorShellHelpers.exposeCanvasEmptyGuideUpdater missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(exposeCanvasEmptyGuideUpdater, 'LoveBudEditorShellHelpers.exposeCanvasEmptyGuideUpdater missing')) return;
 
             exposeCanvasEmptyGuideUpdater({ updateCanvasEmptyGuide });
 
@@ -295,20 +271,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             };
 
-            if (typeof createSelectedMomentFocusHandler !== 'function') {
-                reportError('LoveBudEditorShellHelpers.createSelectedMomentFocusHandler missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(createSelectedMomentFocusHandler, 'LoveBudEditorShellHelpers.createSelectedMomentFocusHandler missing')) return;
 
             const focusSelectedMoment = createSelectedMomentFocusHandler({
                 getEditorCanvas: () => editorCanvas,
                 getSelectedNodeId: () => selectedNodeId
             });
 
-            if (typeof createCurrentMomentDetailOpener !== 'function') {
-                reportError('LoveBudEditorShellHelpers.createCurrentMomentDetailOpener missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(createCurrentMomentDetailOpener, 'LoveBudEditorShellHelpers.createCurrentMomentDetailOpener missing')) return;
 
             const openCurrentMomentDetail = createCurrentMomentDetailOpener({
                 getCurrentEditingMemory: () => currentEditingMemory,
@@ -364,18 +334,12 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             const { setDetailEmptyState, updateFocusSelectedBtn, updateSidebarStatus: updateSidebarStatusBase, updateDetailPanel } = detailUI;
-            if (typeof exposeDetailPanelUpdater !== 'function') {
-                reportError('LoveBudEditorShellHelpers.exposeDetailPanelUpdater missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(exposeDetailPanelUpdater, 'LoveBudEditorShellHelpers.exposeDetailPanelUpdater missing')) return;
 
             exposeDetailPanelUpdater({ updateDetailPanel });
 
             const sidebarUIHelper = window.LoveBudEditorSidebarUI || {};
-            if (typeof createSidebarTreeActionsUpdater !== 'function') {
-                reportError('LoveBudEditorShellHelpers.createSidebarTreeActionsUpdater missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(createSidebarTreeActionsUpdater, 'LoveBudEditorShellHelpers.createSidebarTreeActionsUpdater missing')) return;
 
             const updateSidebarTreeActions = createSidebarTreeActionsUpdater({
                 sidebarUIHelper,
@@ -485,10 +449,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const { showAddMemoryForm, hideAddMemoryForm, addMemoryFromForm } = memoryForm;
 
             log('Binding events...');
-            if (typeof getHttpStatus !== 'function') {
-                reportError('LoveBudEditorShellHelpers.getHttpStatus missing');
-                return;
-            }
+            if (!ensureStartEditorDependency(getHttpStatus, 'LoveBudEditorShellHelpers.getHttpStatus missing')) return;
 
             if (typeof bindEditorPageEvents === 'function') {
                 bindEditorPageEvents({

--- a/tests/contracts/editor-dom-refs-fallback-removal-contract.test.cjs
+++ b/tests/contracts/editor-dom-refs-fallback-removal-contract.test.cjs
@@ -39,7 +39,7 @@ test('editor entrypoint uses dom refs builder without inline fallback', () => {
 });
 
 test('editor entrypoint reports missing dom refs builder before calling it', () => {
-  const guardIndex = editorSource.indexOf("typeof createEditorDomRefs !== 'function'");
+  const guardIndex = editorSource.indexOf("ensureStartEditorDependency(createEditorDomRefs,");
   const startupContextCallIndex = editorSource.indexOf('createEditorStartupContext({');
 
   assert.notEqual(guardIndex, -1, 'missing createEditorDomRefs guard must exist');
@@ -48,7 +48,7 @@ test('editor entrypoint reports missing dom refs builder before calling it', () 
 
   assert.match(
     editorSource,
-    /reportError\('LoveBudEditorDomRefsBuilder\.createEditorDomRefs missing'\)/
+    /ensureStartEditorDependency\(createEditorDomRefs,\s*'LoveBudEditorDomRefsBuilder\.createEditorDomRefs missing'\)/
   );
 });
 

--- a/tests/contracts/editor-dom-refs-selector-registry-contract.test.cjs
+++ b/tests/contracts/editor-dom-refs-selector-registry-contract.test.cjs
@@ -51,8 +51,7 @@ test('selector registry defines all ids consumed by dom refs builder', () => {
 
 test('editor entrypoint still delegates initial refs through dom refs builder', () => {
   assert.match(editorSource, /const createEditorDomRefs\s*=\s*editorDomRefsBuilder\.createEditorDomRefs/);
-  assert.match(editorSource, /typeof createEditorDomRefs !== 'function'/);
-  assert.match(editorSource, /LoveBudEditorDomRefsBuilder\.createEditorDomRefs missing/);
+  assert.match(editorSource, /ensureStartEditorDependency\(createEditorDomRefs,\s*'LoveBudEditorDomRefsBuilder\.createEditorDomRefs missing'\)/);
   assert.match(editorSource, /createEditorStartupContext\(\{\s*createEditorDomRefs,/);
   assert.match(editorSource, /locationRef:\s*window\.location/);
   assert.match(editorSource, /URLSearchParamsRef:\s*URLSearchParams/);

--- a/tests/contracts/editor-memory-actions-readiness-wrapper-contract.test.cjs
+++ b/tests/contracts/editor-memory-actions-readiness-wrapper-contract.test.cjs
@@ -51,7 +51,7 @@ test('editor no longer owns inline memory actions readiness wrapper near memoryA
   const start = editorSource.indexOf('let memoryActions = null;');
   assert.notEqual(start, -1, 'memoryActions declaration must exist');
 
-  const end = editorSource.indexOf("if (typeof editorTreeHelpers.createInitialMemory !== 'function')", start);
+  const end = editorSource.indexOf("ensureStartEditorDependency(editorTreeHelpers.createInitialMemory,", start);
   assert.notEqual(end, -1, 'createInitialMemory guard must follow memory actions readiness setup');
 
   const block = editorSource.slice(start, end);

--- a/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-next-memory-id-required-boundary-contract.test.cjs
@@ -27,14 +27,10 @@ test('editor.js removes createInlineNextMemoryIdFallback', () => {
 });
 
 test('editor.js guards missing nextMemoryIdFromMemories with reportError', () => {
-  const guardIndex = editorSource.indexOf('LoveBudEditorTreeHelpers.nextMemoryIdFromMemories missing');
-  const guardReportStart = editorSource.indexOf('reportError(', guardIndex - 50);
-  const guardReportEnd = editorSource.indexOf(')', guardReportStart) + 1;
-  const guardReportExpr = editorSource.slice(guardReportStart, guardReportEnd);
-
-  assert.ok(guardIndex !== -1, 'missing nextMemoryIdFromMemories guard must exist');
-  assert.ok(guardReportStart !== -1, 'guard must use reportError');
-  assert.match(guardReportExpr, /reportError\(['"]LoveBudEditorTreeHelpers\.nextMemoryIdFromMemories missing['"]\)/);
+  assert.match(
+    editorSource,
+    /ensureStartEditorDependency\(nextMemoryIdFromMemories,\s*'LoveBudEditorTreeHelpers\.nextMemoryIdFromMemories missing'\)/
+  );
 });
 
 test('editor.js delegates nextMemoryId through required tree helper', () => {


### PR DESCRIPTION
Refs #1698

Summary:
- Extract repeated missing dependency guard pattern in startEditor into a local ensureStartEditorDependency(dependency, message) helper.
- Consolidates 16 guard blocks that shared the same typeof check, reportError call, and return pattern.
- Updates 4 contract tests to check for the new helper call pattern.

Validation:
- git diff --check
- node --check js/editor.js
- npm run verify (273/273)
- npm test (1616 pass, 0 fail)