### PR TITLE
refactor(editor): delegate auth start bootstrap

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -94,6 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof renderTreeLoadError !== 'function') { reportEditorBootstrapMissingDependency('LoveBudEditorPageHelpers.renderTreeLoadError missing'); return; }
     const buildTreeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy;
     if (typeof buildTreeLoadErrorCopy !== 'function') { reportEditorBootstrapMissingDependency('LoveBudEditorPageHelpers.buildTreeLoadErrorCopy missing'); return; }
+    const registerEditorAuthStart = editorPageHelpers.registerEditorAuthStart;
+    if (typeof registerEditorAuthStart !== 'function') { reportEditorBootstrapMissingDependency('LoveBudEditorPageHelpers.registerEditorAuthStart missing'); return; }
     const applyEditorShellCopy = shellHelpers.applyEditorShellCopy;
     if (typeof applyEditorShellCopy !== 'function') { reportEditorBootstrapMissingDependency('LoveBudEditorShellHelpers.applyEditorShellCopy missing'); return; }
     applyEditorShellCopy(safeI18nText, i18n);
@@ -495,29 +497,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    var editorStarted = false;
-
-    function tryStartEditor(user) {
-        if (editorStarted) {
-            if (user && (!window.currentTreeMemories || window.currentTreeMemories.length <= 1)) {
-                if (window.refreshMemories) window.refreshMemories();
-            }
-            return;
-        }
-        if (!user) {
-            var cachedUser = readConfirmedAuthCacheFromHelper();
-            if (!cachedUser || !cachedUser.uid) {
-                redirectToEditorLogin();
-                return;
-            }
-        }
-        editorStarted = true;
-        startEditor();
-    }
-
-    if (typeof window.registerOnAuthReady === 'function') {
-        window.registerOnAuthReady(tryStartEditor);
-    } else {
-        window.onAuthReady = tryStartEditor;
-    }
+    registerEditorAuthStart({
+        windowRef: window,
+        startEditor: startEditor,
+        redirectToEditorLogin: redirectToEditorLogin,
+        readConfirmedAuthCache: readConfirmedAuthCacheFromHelper
+    });
 });

--- a/js/editor/editor-page-helpers.js
+++ b/js/editor/editor-page-helpers.js
@@ -143,6 +143,43 @@
     if (addBtn) addBtn.disabled = true;
   }
 
+  function registerEditorAuthStart(options) {
+    var windowRef = options.windowRef;
+    var startEditor = options.startEditor;
+    var redirectToEditorLogin = options.redirectToEditorLogin;
+    var readConfirmedAuthCache = options.readConfirmedAuthCache;
+
+    var editorStarted = false;
+
+    function tryStartEditor(user) {
+      if (editorStarted) {
+        if (user && (!windowRef.currentTreeMemories || windowRef.currentTreeMemories.length <= 1)) {
+          if (windowRef.refreshMemories) windowRef.refreshMemories();
+        }
+        return;
+      }
+
+      if (!user) {
+        var cachedUser = readConfirmedAuthCache();
+        if (!cachedUser || !cachedUser.uid) {
+          redirectToEditorLogin();
+          return;
+        }
+      }
+
+      editorStarted = true;
+      startEditor();
+    }
+
+    if (typeof windowRef.registerOnAuthReady === 'function') {
+      windowRef.registerOnAuthReady(tryStartEditor);
+    } else {
+      windowRef.onAuthReady = tryStartEditor;
+    }
+
+    return tryStartEditor;
+  }
+
   window.LoveBudEditorPageHelpers = {
     getEditorBasePath: getEditorBasePath,
     buildEditorRedirectTarget: buildEditorRedirectTarget,
@@ -151,6 +188,7 @@
     buildMomentDetailHref: buildMomentDetailHref,
     openMomentDetail: openMomentDetail,
     buildTreeLoadErrorCopy: buildTreeLoadErrorCopy,
-    renderTreeLoadError: renderTreeLoadError
+    renderTreeLoadError: renderTreeLoadError,
+    registerEditorAuthStart: registerEditorAuthStart
   };
 })();

--- a/tests/contracts/editor-auth-early-callback-contract.test.cjs
+++ b/tests/contracts/editor-auth-early-callback-contract.test.cjs
@@ -11,17 +11,23 @@ function readRepoFile(relativePath) {
 
 test('auth callbacks preserve editor onAuthReady fallback registered before auth bootstrap loads', () => {
   const editorSource = readRepoFile('js/editor.js');
+  const pageHelpersSource = readRepoFile('js/editor/editor-page-helpers.js');
   const callbacksSource = readRepoFile('js/auth/auth-callbacks.js');
 
   assert.match(
     editorSource,
-    /if\s*\(typeof\s+window\.registerOnAuthReady\s*===\s*['"]function['"]\)/,
-    'Editor must prefer registerOnAuthReady when auth callbacks are already available'
+    /registerEditorAuthStart/,
+    'Editor must delegate auth start to page helpers'
   );
   assert.match(
-    editorSource,
-    /window\.onAuthReady\s*=\s*tryStartEditor/,
-    'Editor currently falls back to window.onAuthReady when loaded before auth callbacks'
+    pageHelpersSource,
+    /if\s*\(typeof\s+windowRef\.registerOnAuthReady\s*===\s*['"]function['"]\)/,
+    'Page helpers must prefer registerOnAuthReady when auth callbacks are already available'
+  );
+  assert.match(
+    pageHelpersSource,
+    /windowRef\.onAuthReady\s*=\s*tryStartEditor/,
+    'Page helpers currently falls back to window.onAuthReady when loaded before auth callbacks'
   );
 
   assert.match(

--- a/tests/contracts/editor-entrypoint-responsibility-contract.test.cjs
+++ b/tests/contracts/editor-entrypoint-responsibility-contract.test.cjs
@@ -23,11 +23,10 @@ test('js/editor.js retains its legacy entrypoint markers', () => {
     // Initialization markers
     assert.ok(js.includes("document.addEventListener('DOMContentLoaded'"), 'should wait for DOMContentLoaded');
     assert.ok(js.includes('const startEditor = async () => {'), 'should have startEditor async function');
-    assert.ok(js.includes('function tryStartEditor(user)'), 'should have tryStartEditor wrapper');
+    assert.ok(js.includes('registerEditorAuthStart'), 'should delegate auth start to page helpers');
 
     // Compatibility glue markers
     assert.ok(js.includes('window.LoveBudEditorDataLoaderFallbacks'), 'should read global fallbacks');
-    assert.ok(js.includes('window.registerOnAuthReady'), 'should hook into auth ready');
 
     // Global exposure (temporary compat)
     assert.ok(js.includes('exposeDetailPanelUpdater'), 'delegates updateDetailPanel global exposure');


### PR DESCRIPTION
Refs #1698

Summary:
- Extract auth start/bootstrap flow from editor.js into editor-page-helpers.js as registerEditorAuthStart.
- Moves editorStarted state management, tryStartEditor definition, auth cache checking, login redirect, and auth-ready registration into the page helpers module.
- Updates 2 contract tests to check for the new delegation pattern.

Validation:
- git diff --check
- node --check js/editor.js
- node --check js/editor/editor-page-helpers.js
- npm run verify (273/273)
- npm test (1616 pass, 0 fail)