### PR TITLE
refactor(editor): delegate auth cache reader dependency

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -44,9 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const createEditorRefreshSaveRuntime = editorRefreshSaveRuntime.createEditorRefreshSaveRuntime;
     const createEditorStartupContext = editorStartupContext.createEditorStartupContext;
     const getConfirmedSessionUser = deps.getConfirmedSessionUser;
-    const readConfirmedAuthCacheFromHelper = () => (
-        window.LoveBudEditorAuthHelpers?.readConfirmedAuthCache?.() || null
-    );
+    const readConfirmedAuthCache = deps.readConfirmedAuthCache;
     const getHttpStatus = shellHelpers.getHttpStatus;
     const createInlineShowToastFallback = shellHelpers.createInlineShowToastFallback;
     if (typeof createInlineShowToastFallback !== 'function') { reportEditorBootstrapMissingDependency('LoveBudEditorShellHelpers.createInlineShowToastFallback missing'); return; }
@@ -501,6 +499,6 @@ document.addEventListener('DOMContentLoaded', () => {
         windowRef: window,
         startEditor: startEditor,
         redirectToEditorLogin: redirectToEditorLogin,
-        readConfirmedAuthCache: readConfirmedAuthCacheFromHelper
+        readConfirmedAuthCache: readConfirmedAuthCache
     });
 });

--- a/js/editor/editor-entry-dependencies.js
+++ b/js/editor/editor-entry-dependencies.js
@@ -157,6 +157,7 @@
                 editorShellCopyApplier,
                 editorDomRefsBuilder,
                 getConfirmedSessionUser,
+                readConfirmedAuthCache: readConfirmedAuthCacheFromHelper,
                 hasConfirmedSessionUser: editorAuthHelpers.hasConfirmedSessionUser || (() => !!getConfirmedSessionUser()),
                 getHttpStatus: shellHelpers.getHttpStatus,
                 showToast,

--- a/tests/routes/editor-auth-helper-callsite.test.cjs
+++ b/tests/routes/editor-auth-helper-callsite.test.cjs
@@ -9,11 +9,17 @@ function read(file) {
   return fs.readFileSync(path.join(ROOT, file), 'utf8');
 }
 
-test('editor auth cache reader is called through the helper namespace binding', () => {
+test('editor auth cache reader is resolved from entry dependencies', () => {
   const editor = read('js/editor.js');
+  const deps = read('js/editor/editor-entry-dependencies.js');
 
-  assert.match(editor, /const\s+editorAuthHelpers\s*=\s*window\.LoveBudEditorAuthHelpers\s*\|\|\s*\{\}/);
-  assert.match(editor, /readConfirmedAuthCacheFromHelper\s*=\s*\(\)\s*=>\s*\(/);
-  assert.match(editor, /window\.LoveBudEditorAuthHelpers\?\.readConfirmedAuthCache\?\.\(\)/);
-  assert.doesNotMatch(editor, /[^.\w]readConfirmedAuthCache\s*\(/);
+  // editor.js should get readConfirmedAuthCache from deps
+  assert.match(editor, /const\s+readConfirmedAuthCache\s*=\s*deps\.readConfirmedAuthCache/);
+
+  // editor-entry-dependencies.js should expose readConfirmedAuthCache
+  assert.match(deps, /readConfirmedAuthCache:\s*readConfirmedAuthCacheFromHelper/);
+
+  // editor-entry-dependencies.js should define readConfirmedAuthCacheFromHelper internally
+  assert.match(deps, /readConfirmedAuthCacheFromHelper\s*=\s*\(\)\s*=>\s*\(/);
+  assert.match(deps, /windowRef\.LoveBudEditorAuthHelpers\?\.readConfirmedAuthCache\?\.\(\)/);
 });


### PR DESCRIPTION
Refs #1698

## Summary
- Expose  from  deps object
- Remove local  residue from 
- Use deps-provided  in  call
- Update test to verify dependency delegation pattern

## Contract Gate
- Entrypoint remains classic browser script: YES
- pages/editor.html script order changed: NO
- Auth/protected-route behavior changed: NO
- Runtime files changed: js/editor.js
- Static checks: PASS
- Editor browser smoke: NOT_RUN
- Private payload exposure: NO
- Secret exposure: NO
- Final judgment: PASS