### PR TITLE
refactor(canvas): delegate layout mode switching

### DIFF
--- a/js/editor/editor-canvas-layout-transition.js
+++ b/js/editor/editor-canvas-layout-transition.js
@@ -79,12 +79,92 @@
         initFn();
     }
 
+    function createLayoutModeSwitcher(options) {
+        var viewportState = options.viewportState;
+        var loadStoredLayout = options.loadStoredLayout;
+        var persistLayoutModeLocal = options.persistLayoutMode;
+        var persistStoredPositionsLocal = options.persistStoredPositions;
+        var fitViewportToTreeLocal = options.fitViewportToTree;
+        var initCanvasLocal = options.initCanvas;
+        var updateLayoutToggleUILocal = options.updateLayoutToggleUI;
+        var getSavedFreePositions = options.getSavedFreePositions;
+        var setSavedFreePositions = options.setSavedFreePositions;
+        var getStoredFreePositions = options.getStoredFreePositions;
+        var setStoredFreePositions = options.setStoredFreePositions;
+
+        function switchToFreeMode() {
+            viewportState.layoutMode = 'free';
+            persistLayoutModeLocal('free');
+            viewportState.initialViewportApplied = false;
+
+            var saved = getSavedFreePositions();
+            if (saved) {
+                viewportState.positions = { ...saved };
+                setSavedFreePositions(null);
+            }
+
+            var stored = getStoredFreePositions();
+            if (stored && Object.keys(viewportState.positions).length === 0) {
+                viewportState.positions = { ...stored };
+            }
+
+            if (Object.keys(viewportState.positions).length === 0) {
+                var loaded = loadStoredLayout();
+                if (loaded.positions && Object.keys(loaded.positions).length > 0) {
+                    viewportState.positions = { ...loaded.positions };
+                }
+            }
+
+            fitViewportToTreeLocal();
+            applyLayoutModeClasses('free');
+            updateLayoutToggleUILocal();
+            initCanvasLocal();
+            persistStoredPositionsLocal();
+        }
+
+        function switchToStructuredMode() {
+            setSavedFreePositions({ ...viewportState.positions });
+            viewportState.layoutMode = 'structured';
+            viewportState.initialViewportApplied = false;
+            persistLayoutModeLocal('structured');
+
+            fitViewportToTreeLocal();
+            applyLayoutModeClasses('structured');
+            updateLayoutToggleUILocal();
+            initCanvasLocal();
+        }
+
+        function setLayoutMode(mode) {
+            if (mode === 'structured') {
+                switchToStructuredMode();
+            } else {
+                switchToFreeMode();
+            }
+        }
+
+        function toggleLayoutMode() {
+            if (viewportState.layoutMode === 'structured') {
+                switchToFreeMode();
+            } else {
+                switchToStructuredMode();
+            }
+        }
+
+        return {
+            switchToFreeMode: switchToFreeMode,
+            switchToStructuredMode: switchToStructuredMode,
+            setLayoutMode: setLayoutMode,
+            toggleLayoutMode: toggleLayoutMode
+        };
+    }
+
     window.LoveBudEditorCanvasLayoutTransition = {
         applyLayoutModeClasses: applyLayoutModeClasses,
         fitViewportToTree: fitViewportToTree,
         initCanvas: initCanvas,
         persistLayoutMode: persistLayoutMode,
         persistStoredPositions: persistStoredPositions,
-        updateLayoutToggleUI: updateLayoutToggleUI
+        updateLayoutToggleUI: updateLayoutToggleUI,
+        createLayoutModeSwitcher: createLayoutModeSwitcher
     };
 })();

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -39,22 +39,6 @@ function createEditorCanvas(deps) {
 
     let savedFreePositions = null;
     let storedFreePositions = null;
-
-    const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher === 'function'
-        ? layoutTransition.createLayoutModeSwitcher({
-            viewportState,
-            loadStoredLayout,
-            persistLayoutMode,
-            persistStoredPositions,
-            fitViewportToTree,
-            initCanvas,
-            updateLayoutToggleUI,
-            getSavedFreePositions: () => savedFreePositions,
-            setSavedFreePositions: (value) => { savedFreePositions = value; },
-            getStoredFreePositions: () => storedFreePositions,
-            setStoredFreePositions: (value) => { storedFreePositions = value; }
-        })
-        : null;
     let hoverAffordanceTimer = null;
     let hoverAffordanceMemoryId = null;
 
@@ -209,96 +193,19 @@ function createEditorCanvas(deps) {
     }
 
     function switchToFreeMode() {
-        if (layoutModeSwitcher) {
-            layoutModeSwitcher.switchToFreeMode();
-            return;
-        }
-        viewportState.layoutMode = 'free';
-        if (typeof layoutTransition.persistLayoutMode === 'function') {
-            layoutTransition.persistLayoutMode(persistLayoutMode, 'free');
-        } else {
-            persistLayoutMode('free');
-        }
-        viewportState.initialViewportApplied = false;
-        if (savedFreePositions) {
-            viewportState.positions = { ...savedFreePositions };
-            savedFreePositions = null;
-        }
-        if (storedFreePositions && Object.keys(viewportState.positions).length === 0) {
-            viewportState.positions = { ...storedFreePositions };
-        }
-        if (Object.keys(viewportState.positions).length === 0) {
-            const stored = loadStoredLayout();
-            if (stored.positions && Object.keys(stored.positions).length > 0) {
-                viewportState.positions = { ...stored.positions };
-            }
-        }
-
-        (typeof layoutTransition.fitViewportToTree === 'function'
-            ? layoutTransition.fitViewportToTree(fitViewportToTree)
-            : fitViewportToTree());
-
-        (typeof layoutTransition.applyLayoutModeClasses === 'function'
-            ? layoutTransition.applyLayoutModeClasses
-            : uiHelpers.applyLayoutModeClasses)('free');
-        updateLayoutToggleUI();
-        (typeof layoutTransition.initCanvas === 'function'
-            ? layoutTransition.initCanvas(initCanvas)
-            : initCanvas());
-        (typeof layoutTransition.persistStoredPositions === 'function'
-            ? layoutTransition.persistStoredPositions(persistStoredPositions)
-            : persistStoredPositions());
+        if (layoutModeSwitcher) { layoutModeSwitcher.switchToFreeMode(); }
     }
 
     function switchToStructuredMode() {
-        if (layoutModeSwitcher) {
-            layoutModeSwitcher.switchToStructuredMode();
-            return;
-        }
-        savedFreePositions = { ...viewportState.positions };
-        viewportState.layoutMode = 'structured';
-        viewportState.initialViewportApplied = false;
-        if (typeof layoutTransition.persistLayoutMode === 'function') {
-            layoutTransition.persistLayoutMode(persistLayoutMode, 'structured');
-        } else {
-            persistLayoutMode('structured');
-        }
-
-        (typeof layoutTransition.fitViewportToTree === 'function'
-            ? layoutTransition.fitViewportToTree(fitViewportToTree)
-            : fitViewportToTree());
-
-        (typeof layoutTransition.applyLayoutModeClasses === 'function'
-            ? layoutTransition.applyLayoutModeClasses
-            : uiHelpers.applyLayoutModeClasses)('structured');
-        updateLayoutToggleUI();
-        (typeof layoutTransition.initCanvas === 'function'
-            ? layoutTransition.initCanvas(initCanvas)
-            : initCanvas());
+        if (layoutModeSwitcher) { layoutModeSwitcher.switchToStructuredMode(); }
     }
 
     function setLayoutMode(mode) {
-        if (layoutModeSwitcher) {
-            layoutModeSwitcher.setLayoutMode(mode);
-            return;
-        }
-        if (mode === 'structured') {
-            switchToStructuredMode();
-        } else {
-            switchToFreeMode();
-        }
+        if (layoutModeSwitcher) { layoutModeSwitcher.setLayoutMode(mode); }
     }
 
     function toggleLayoutMode() {
-        if (layoutModeSwitcher) {
-            layoutModeSwitcher.toggleLayoutMode();
-            return;
-        }
-        if (viewportState.layoutMode === 'structured') {
-            switchToFreeMode();
-        } else {
-            switchToStructuredMode();
-        }
+        if (layoutModeSwitcher) { layoutModeSwitcher.toggleLayoutMode(); }
     }
 
     function updateLayoutToggleUI() {
@@ -684,6 +591,22 @@ function createEditorCanvas(deps) {
             }
         }
     };
+
+    const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher === 'function'
+        ? layoutTransition.createLayoutModeSwitcher({
+            viewportState,
+            loadStoredLayout,
+            persistLayoutMode,
+            persistStoredPositions,
+            fitViewportToTree,
+            initCanvas,
+            updateLayoutToggleUI,
+            getSavedFreePositions: () => savedFreePositions,
+            setSavedFreePositions: (value) => { savedFreePositions = value; },
+            getStoredFreePositions: () => storedFreePositions,
+            setStoredFreePositions: (value) => { storedFreePositions = value; }
+        })
+        : null;
 
     function focusNodeById(nodeId) {
         if (typeof canvasViewport.focusNodeById === 'function') {

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -39,6 +39,22 @@ function createEditorCanvas(deps) {
 
     let savedFreePositions = null;
     let storedFreePositions = null;
+
+    const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher === 'function'
+        ? layoutTransition.createLayoutModeSwitcher({
+            viewportState,
+            loadStoredLayout,
+            persistLayoutMode,
+            persistStoredPositions,
+            fitViewportToTree,
+            initCanvas,
+            updateLayoutToggleUI,
+            getSavedFreePositions: () => savedFreePositions,
+            setSavedFreePositions: (value) => { savedFreePositions = value; },
+            getStoredFreePositions: () => storedFreePositions,
+            setStoredFreePositions: (value) => { storedFreePositions = value; }
+        })
+        : null;
     let hoverAffordanceTimer = null;
     let hoverAffordanceMemoryId = null;
 
@@ -193,6 +209,10 @@ function createEditorCanvas(deps) {
     }
 
     function switchToFreeMode() {
+        if (layoutModeSwitcher) {
+            layoutModeSwitcher.switchToFreeMode();
+            return;
+        }
         viewportState.layoutMode = 'free';
         if (typeof layoutTransition.persistLayoutMode === 'function') {
             layoutTransition.persistLayoutMode(persistLayoutMode, 'free');
@@ -231,6 +251,10 @@ function createEditorCanvas(deps) {
     }
 
     function switchToStructuredMode() {
+        if (layoutModeSwitcher) {
+            layoutModeSwitcher.switchToStructuredMode();
+            return;
+        }
         savedFreePositions = { ...viewportState.positions };
         viewportState.layoutMode = 'structured';
         viewportState.initialViewportApplied = false;
@@ -254,6 +278,10 @@ function createEditorCanvas(deps) {
     }
 
     function setLayoutMode(mode) {
+        if (layoutModeSwitcher) {
+            layoutModeSwitcher.setLayoutMode(mode);
+            return;
+        }
         if (mode === 'structured') {
             switchToStructuredMode();
         } else {
@@ -262,6 +290,10 @@ function createEditorCanvas(deps) {
     }
 
     function toggleLayoutMode() {
+        if (layoutModeSwitcher) {
+            layoutModeSwitcher.toggleLayoutMode();
+            return;
+        }
         if (viewportState.layoutMode === 'structured') {
             switchToFreeMode();
         } else {

--- a/tests/contracts/editor-canvas-layout-mode-transition-contracts.test.cjs
+++ b/tests/contracts/editor-canvas-layout-mode-transition-contracts.test.cjs
@@ -6,10 +6,12 @@ const test = require('node:test');
 const ROOT = path.resolve(__dirname, '..', '..');
 const CANVAS_PATH = path.join(ROOT, 'js/editor/editor-canvas.js');
 const UI_HELPERS_PATH = path.join(ROOT, 'js/editor/editor-canvas-ui-helpers.js');
+const TRANSITION_PATH = path.join(ROOT, 'js/editor/editor-canvas-layout-transition.js');
 const EDITOR_HTML_PATH = path.join(ROOT, 'pages/editor.html');
 
 const canvasSource = fs.readFileSync(CANVAS_PATH, 'utf8');
 const uiHelpersSource = fs.readFileSync(UI_HELPERS_PATH, 'utf8');
+const transitionSource = fs.readFileSync(TRANSITION_PATH, 'utf8');
 const editorHtml = fs.readFileSync(EDITOR_HTML_PATH, 'utf8');
 
 // ---------------------------------------------------------------------------
@@ -57,32 +59,87 @@ test('layout mode transition — updateLayoutToggleUI is defined in editor-canva
 });
 
 // ---------------------------------------------------------------------------
-// 2. Class toggle — applyLayoutModeClasses must be called with correct modes
+// 2. Delegation to layoutModeSwitcher — switch functions delegate to factory
 // ---------------------------------------------------------------------------
 
-test('layout mode transition — switchToFreeMode calls applyLayoutModeClasses("free")', () => {
-  const switchToFreeBlock = canvasSource.slice(
+test('layout mode transition — switchToFreeMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
     canvasSource.indexOf('function switchToFreeMode'),
     canvasSource.indexOf('function switchToStructuredMode')
   );
   assert.match(
-    switchToFreeBlock,
-    /applyLayoutModeClasses[^)]*\)\s*\(\s*['"]free['"]\s*\)/,
-    'switchToFreeMode must call applyLayoutModeClasses("free") (directly or via delegation)'
+    block,
+    /layoutModeSwitcher\.switchToFreeMode\(\)/,
+    'switchToFreeMode must delegate to layoutModeSwitcher.switchToFreeMode()'
   );
 });
 
-test('layout mode transition — switchToStructuredMode calls applyLayoutModeClasses("structured")', () => {
-  const switchToStructuredBlock = canvasSource.slice(
+test('layout mode transition — switchToStructuredMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
     canvasSource.indexOf('function switchToStructuredMode'),
     canvasSource.indexOf('function setLayoutMode')
   );
   assert.match(
-    switchToStructuredBlock,
-    /applyLayoutModeClasses[^)]*\)\s*\(\s*['"]structured['"]\s*\)/,
-    'switchToStructuredMode must call applyLayoutModeClasses("structured") (directly or via delegation)'
+    block,
+    /layoutModeSwitcher\.switchToStructuredMode\(\)/,
+    'switchToStructuredMode must delegate to layoutModeSwitcher.switchToStructuredMode()'
   );
 });
+
+test('layout mode transition — setLayoutMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
+    canvasSource.indexOf('function setLayoutMode'),
+    canvasSource.indexOf('function toggleLayoutMode')
+  );
+  assert.match(
+    block,
+    /layoutModeSwitcher\.setLayoutMode\(mode\)/,
+    'setLayoutMode must delegate to layoutModeSwitcher.setLayoutMode(mode)'
+  );
+});
+
+test('layout mode transition — toggleLayoutMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
+    canvasSource.indexOf('function toggleLayoutMode'),
+    canvasSource.indexOf('function updateLayoutToggleUI')
+  );
+  assert.match(
+    block,
+    /layoutModeSwitcher\.toggleLayoutMode\(\)/,
+    'toggleLayoutMode must delegate to layoutModeSwitcher.toggleLayoutMode()'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. layoutModeSwitcher creation — factory is created after initCanvas
+// ---------------------------------------------------------------------------
+
+test('layout mode transition — layoutModeSwitcher is created using createLayoutModeSwitcher', () => {
+  assert.match(
+    canvasSource,
+    /const layoutModeSwitcher\s*=\s*typeof layoutTransition\.createLayoutModeSwitcher\s*===\s*['"]function['"]/,
+    'layoutModeSwitcher must be created using layoutTransition.createLayoutModeSwitcher'
+  );
+});
+
+test('layout mode transition — layoutModeSwitcher is initialized after initCanvas', () => {
+  const initCanvasIdx = canvasSource.indexOf('const initCanvas = () => {');
+  const layoutModeSwitcherIdx = canvasSource.indexOf('const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher');
+  assert.ok(initCanvasIdx >= 0, 'initCanvas must exist');
+  assert.ok(layoutModeSwitcherIdx >= 0, 'layoutModeSwitcher initialization must exist');
+  assert.ok(layoutModeSwitcherIdx > initCanvasIdx, 'layoutModeSwitcher must be initialized after initCanvas');
+});
+
+test('layout mode transition — layoutModeSwitcher receives required options', () => {
+  assert.match(canvasSource, /viewportState,\s*\n\s*loadStoredLayout/);
+  assert.match(canvasSource, /persistLayoutMode,\s*\n\s*persistStoredPositions/);
+  assert.match(canvasSource, /fitViewportToTree,\s*\n\s*initCanvas/);
+  assert.match(canvasSource, /updateLayoutToggleUI/);
+});
+
+// ---------------------------------------------------------------------------
+// 4. applyLayoutModeClasses handles body classList toggle
+// ---------------------------------------------------------------------------
 
 test('layout mode transition — applyLayoutModeClasses handles body classList toggle', () => {
   assert.match(
@@ -108,98 +165,6 @@ test('layout mode transition — applyLayoutModeClasses handles body classList t
 });
 
 // ---------------------------------------------------------------------------
-// 3. localStorage persistence — must delegate to storageUtils
-// ---------------------------------------------------------------------------
-
-test('layout mode transition — switchToFreeMode persists mode as "free"', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /persistLayoutMode\s*\(\s*['"]free['"]\s*\)/,
-    'switchToFreeMode must persist layout mode as "free"'
-  );
-});
-
-test('layout mode transition — switchToStructuredMode persists mode as "structured"', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    switchToStructuredBlock,
-    /persistLayoutMode\s*\(\s*['"]structured['"]\s*\)/,
-    'switchToStructuredMode must persist layout mode as "structured"'
-  );
-});
-
-test('layout mode transition — switchToFreeMode calls persistStoredPositions', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /persistStoredPositions\s*\(\s*\)/,
-    'switchToFreeMode must call persistStoredPositions()'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 4. Render refresh — fitViewportToTree and initCanvas must be called
-// ---------------------------------------------------------------------------
-
-test('layout mode transition — switchToFreeMode calls fitViewportToTree', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /fitViewportToTree\s*\(\s*\)/,
-    'switchToFreeMode must call fitViewportToTree()'
-  );
-});
-
-test('layout mode transition — switchToStructuredMode calls fitViewportToTree', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    switchToStructuredBlock,
-    /fitViewportToTree\s*\(\s*\)/,
-    'switchToStructuredMode must call fitViewportToTree()'
-  );
-});
-
-test('layout mode transition — switchToFreeMode calls initCanvas', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /initCanvas\s*\(\s*\)/,
-    'switchToFreeMode must call initCanvas()'
-  );
-});
-
-test('layout mode transition — switchToStructuredMode calls initCanvas', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    switchToStructuredBlock,
-    /initCanvas\s*\(\s*\)/,
-    'switchToStructuredMode must call initCanvas()'
-  );
-});
-
-// ---------------------------------------------------------------------------
 // 5. updateLayoutToggleUI delegates to uiHelpers
 // ---------------------------------------------------------------------------
 
@@ -219,57 +184,7 @@ test('layout mode transition — updateLayoutToggleUI delegates to uiHelpers (di
 // 6. setLayoutMode public API — branching logic
 // ---------------------------------------------------------------------------
 
-test('layout mode transition — setLayoutMode routes "structured" to switchToStructuredMode', () => {
-  const setBlock = canvasSource.slice(
-    canvasSource.indexOf('function setLayoutMode'),
-    canvasSource.indexOf('function toggleLayoutMode')
-  );
-  assert.match(
-    setBlock,
-    /mode\s*===\s*['"]structured['"]\s*\)\s*\{[\s\S]*?switchToStructuredMode\s*\(\s*\)/,
-    'setLayoutMode("structured") must call switchToStructuredMode()'
-  );
-});
-
-test('layout mode transition — setLayoutMode routes other values to switchToFreeMode', () => {
-  const setBlock = canvasSource.slice(
-    canvasSource.indexOf('function setLayoutMode'),
-    canvasSource.indexOf('function toggleLayoutMode')
-  );
-  assert.match(
-    setBlock,
-    /else\s*\{[\s\S]*?switchToFreeMode\s*\(\s*\)/,
-    'setLayoutMode(non-"structured") must call switchToFreeMode()'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 7. toggleLayoutMode — branching logic
-// ---------------------------------------------------------------------------
-
-test('layout mode transition — toggleLayoutMode switches based on current layoutMode', () => {
-  const toggleBlock = canvasSource.slice(
-    canvasSource.indexOf('function toggleLayoutMode'),
-    canvasSource.indexOf('function updateLayoutToggleUI')
-  );
-  assert.match(
-    toggleBlock,
-    /viewportState\.layoutMode\s*===\s*['"]structured['"]\s*\)\s*\{[\s\S]*?switchToFreeMode/,
-    'toggleLayoutMode must call switchToFreeMode when current mode is "structured"'
-  );
-  assert.match(
-    toggleBlock,
-    /else\s*\{[\s\S]*?switchToStructuredMode/,
-    'toggleLayoutMode must call switchToStructuredMode when current mode is not "structured"'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 8. setLayoutMode is exposed in createEditorCanvas return
-// ---------------------------------------------------------------------------
-
 test('layout mode transition — setLayoutMode is in the public API returned by createEditorCanvas', () => {
-  // The return block exposes setLayoutMode
   assert.match(
     canvasSource,
     /setLayoutMode\s*,/,
@@ -278,7 +193,7 @@ test('layout mode transition — setLayoutMode is in the public API returned by 
 });
 
 // ---------------------------------------------------------------------------
-// 9. Script order — layout storage helper loaded before canvas
+// 7. Script order — helpers loaded before canvas
 // ---------------------------------------------------------------------------
 
 test('layout mode transition — storage helper loaded before editor-canvas.js in editor.html', () => {
@@ -287,34 +202,6 @@ test('layout mode transition — storage helper loaded before editor-canvas.js i
   assert.ok(storageIdx >= 0, 'editor-canvas-layout-storage.js must be present in editor.html');
   assert.ok(canvasIdx >= 0, 'editor-canvas.js must be present in editor.html');
   assert.ok(storageIdx < canvasIdx, 'storage helper must be loaded before editor-canvas.js');
-});
-
-// ---------------------------------------------------------------------------
-// 10. createEditorCanvas is NOT modified — public API surface unchanged
-// ---------------------------------------------------------------------------
-
-test('layout mode transition — createEditorCanvas function signature is preserved', () => {
-  assert.match(
-    canvasSource,
-    /function createEditorCanvas\s*\(\s*deps\s*\)/,
-    'createEditorCanvas(deps) function signature must be preserved'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 11. Additional stabilization contracts for Stage 53
-// ---------------------------------------------------------------------------
-
-test('layout mode transition — switchToStructuredMode does NOT call persistStoredPositions', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.doesNotMatch(
-    switchToStructuredBlock,
-    /persistStoredPositions/,
-    'switchToStructuredMode must not call persistStoredPositions()'
-  );
 });
 
 test('layout mode transition — transition helper loaded before editor-canvas.js in editor.html', () => {
@@ -326,172 +213,42 @@ test('layout mode transition — transition helper loaded before editor-canvas.j
 });
 
 // ---------------------------------------------------------------------------
-// 12. Render refresh contracts — Stage 55
+// 8. createEditorCanvas is NOT modified — public API surface unchanged
 // ---------------------------------------------------------------------------
 
-test('render refresh — switchToFreeMode calls initCanvas', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /initCanvas\s*\(\s*\)/,
-    'switchToFreeMode must call initCanvas()'
-  );
-});
-
-test('render refresh — switchToStructuredMode calls initCanvas', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    block,
-    /initCanvas\s*\(\s*\)/,
-    'switchToStructuredMode must call initCanvas()'
-  );
-});
-
-test('render refresh — switchToFreeMode calls fitViewportToTree', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /fitViewportToTree\s*\(\s*\)/,
-    'switchToFreeMode must call fitViewportToTree()'
-  );
-});
-
-test('render refresh — switchToStructuredMode calls fitViewportToTree', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    block,
-    /fitViewportToTree\s*\(\s*\)/,
-    'switchToStructuredMode must call fitViewportToTree()'
-  );
-});
-
-test('render refresh — switchToFreeMode calls persistStoredPositions', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /persistStoredPositions\s*\(\s*\)/,
-    'switchToFreeMode must call persistStoredPositions()'
-  );
-});
-
-test('render refresh — switchToStructuredMode does NOT call persistStoredPositions (asymmetry preserved)', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.doesNotMatch(
-    block,
-    /persistStoredPositions/,
-    'switchToStructuredMode must not call persistStoredPositions()'
-  );
-});
-
-test('render refresh — initCanvas is delegated to transition helper with fallback', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.initCanvas/,
-    'initCanvas must be delegated to layoutTransition helper'
-  );
-});
-
-test('render refresh — fitViewportToTree delegated to transition helper with fallback', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.fitViewportToTree/,
-    'fitViewportToTree must be delegated to layoutTransition helper'
-  );
-});
-
-test('render refresh — persistStoredPositions delegated to transition helper with fallback (free-mode only)', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.persistStoredPositions/,
-    'persistStoredPositions must be delegated to layoutTransition helper'
-  );
-});
-
-test('render refresh — initCanvas call order: after class toggle and persistence delegation in switchToFreeMode', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  const classToggleIdx = block.search(/applyLayoutModeClasses/);
-  const initCanvasIdx = block.search(/initCanvas\s*\(\s*\)/);
-  assert.ok(classToggleIdx >= 0, 'applyLayoutModeClasses must appear in switchToFreeMode');
-  assert.ok(initCanvasIdx >= 0, 'initCanvas must appear in switchToFreeMode');
-  assert.ok(classToggleIdx < initCanvasIdx, 'initCanvas must come after class toggle in switchToFreeMode');
-});
-
-test('render refresh — initCanvas call order: after class toggle and persistence delegation in switchToStructuredMode', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  const classToggleIdx = block.search(/applyLayoutModeClasses/);
-  const initCanvasIdx = block.search(/initCanvas\s*\(\s*\)/);
-  assert.ok(classToggleIdx >= 0, 'applyLayoutModeClasses must appear in switchToStructuredMode');
-  assert.ok(initCanvasIdx >= 0, 'initCanvas must appear in switchToStructuredMode');
-  assert.ok(classToggleIdx < initCanvasIdx, 'initCanvas must come after class toggle in switchToStructuredMode');
-});
-
-test('render refresh — setLayoutMode/toggleLayoutMode public API preserved', () => {
-  assert.match(
-    canvasSource,
-    /setLayoutMode\s*,/,
-    'setLayoutMode must be in public API'
-  );
-});
-
-test('render refresh — createEditorCanvas(deps) signature preserved', () => {
+test('layout mode transition — createEditorCanvas function signature is preserved', () => {
   assert.match(
     canvasSource,
     /function createEditorCanvas\s*\(\s*deps\s*\)/,
-    'createEditorCanvas(deps) signature must be preserved'
+    'createEditorCanvas(deps) function signature must be preserved'
   );
 });
 
-test('render refresh — LoveBudEditorCanvasLayoutTransition.persistLayoutMode helper API maintained', () => {
-  const transitionSrc = fs.readFileSync(
-    path.join(ROOT, 'js/editor/editor-canvas-layout-transition.js'),
-    'utf8'
-  );
+// ---------------------------------------------------------------------------
+// 9. Transition helper exports createLayoutModeSwitcher
+// ---------------------------------------------------------------------------
+
+test('layout mode transition — transition helper exports createLayoutModeSwitcher', () => {
   assert.match(
-    transitionSrc,
+    transitionSource,
+    /createLayoutModeSwitcher:\s*createLayoutModeSwitcher/,
+    'createLayoutModeSwitcher must be exported on namespace'
+  );
+});
+
+test('layout mode transition — transition helper exports persistLayoutMode', () => {
+  assert.match(
+    transitionSource,
     /persistLayoutMode:\s*persistLayoutMode/,
     'persistLayoutMode must be exported on namespace'
   );
 });
 
-test('render refresh — script order unchanged: transition helper before canvas.js', () => {
-  const transitionIdx = editorHtml.indexOf('editor-canvas-layout-transition.js');
-  const canvasIdx = editorHtml.indexOf('editor-canvas.js');
-  assert.ok(transitionIdx < canvasIdx, 'transition helper must load before editor-canvas.js');
-});
+// ---------------------------------------------------------------------------
+// 10. updateLayoutToggleUI and uiHelpers fallbacks preserved
+// ---------------------------------------------------------------------------
 
-test('render refresh — helper missing fallback: uiHelpers.applyLayoutModeClasses preserved', () => {
-  assert.match(
-    canvasSource,
-    /uiHelpers\.applyLayoutModeClasses/,
-    'uiHelpers.applyLayoutModeClasses fallback must remain'
-  );
-});
-
-test('render refresh — helper missing fallback: uiHelpers.updateLayoutToggleUI preserved', () => {
+test('layout mode transition — uiHelpers.updateLayoutToggleUI preserved', () => {
   assert.match(
     canvasSource,
     /uiHelpers\.updateLayoutToggleUI/,
@@ -499,282 +256,34 @@ test('render refresh — helper missing fallback: uiHelpers.updateLayoutToggleUI
   );
 });
 
-test('render refresh — helper missing fallback: direct persistLayoutMode call preserved', () => {
+test('layout mode transition — uiHelpers.applyLayoutModeClasses preserved', () => {
   assert.match(
     canvasSource,
-    /else\s*\{[\s\S]*?persistLayoutMode\s*\(\s*['"]free['"]\s*\)/,
-    'direct persistLayoutMode("free") fallback must remain'
-  );
-  assert.match(
-    canvasSource,
-    /else\s*\{[\s\S]*?persistLayoutMode\s*\(\s*['"]structured['"]\s*\)/,
-    'direct persistLayoutMode("structured") fallback must remain'
+    /uiHelpers\.applyLayoutModeClasses/,
+    'uiHelpers.applyLayoutModeClasses fallback must remain'
   );
 });
 
 // ---------------------------------------------------------------------------
-// 13. persistStoredPositions delegation contracts — Stage 57
+// 11. viewportState temporal dead zone — layoutModeSwitcher must come after
 // ---------------------------------------------------------------------------
 
-test('persistStoredPositions delegation — switchToFreeMode calls persistStoredPositions via helper', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /layoutTransition\.persistStoredPositions\s*\(\s*persistStoredPositions\s*\)/,
-    'switchToFreeMode must delegate persistStoredPositions via layoutTransition helper'
-  );
-});
-
-test('persistStoredPositions delegation — switchToFreeMode has fallback to direct persistStoredPositions', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /else\s*\{[\s\S]*?persistStoredPositions\s*\(\s*\)/,
-    'switchToFreeMode must have fallback to direct persistStoredPositions() call'
-  );
-});
-
-test('persistStoredPositions delegation — switchToStructuredMode still does NOT call persistStoredPositions', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.doesNotMatch(
-    block,
-    /persistStoredPositions/,
-    'switchToStructuredMode must not call persistStoredPositions() (asymmetry preserved)'
-  );
-});
-
-test('persistStoredPositions delegation — fitViewportToTree delegation from Stage 56 not broken', () => {
-  const freeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    freeBlock,
-    /layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)/,
-    'Stage 56 fitViewportToTree delegation must remain in switchToFreeMode'
-  );
-  const structuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    structuredBlock,
-    /layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)/,
-    'Stage 56 fitViewportToTree delegation must remain in switchToStructuredMode'
-  );
-});
-
-test('persistStoredPositions delegation — initCanvas is delegated to transition helper', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.initCanvas/,
-    'initCanvas must be delegated to layoutTransition helper'
-  );
-});
-
-test('persistStoredPositions delegation — helper missing fallback: direct persistStoredPositions preserved', () => {
-  assert.match(
-    canvasSource,
-    /else\s*\{[\s\S]*?persistStoredPositions\s*\(\s*\)/,
-    'direct persistStoredPositions() fallback must remain'
-  );
+test('layout mode transition — viewportState is declared before layoutModeSwitcher', () => {
+  const viewportStateIdx = canvasSource.indexOf('const viewportState = {');
+  const layoutModeSwitcherIdx = canvasSource.indexOf('const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher');
+  assert.ok(viewportStateIdx >= 0, 'viewportState must be declared');
+  assert.ok(layoutModeSwitcherIdx >= 0, 'layoutModeSwitcher must be initialized');
+  assert.ok(viewportStateIdx < layoutModeSwitcherIdx, 'viewportState must be declared before layoutModeSwitcher to avoid temporal dead zone');
 });
 
 // ---------------------------------------------------------------------------
-// 14. persistStoredPositions precise fallback contract — Stage 58
+// 12. loadStoredLayout, persistLayoutMode, persistStoredPositions, fitViewportToTree, updateLayoutToggleUI must exist
 // ---------------------------------------------------------------------------
 
-test('persistStoredPositions precise fallback — switchToFreeMode has exact ternary delegation for persistStoredPositions', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /typeof\s+layoutTransition\.persistStoredPositions\s*===\s*['"]function['"]\s*\?[\s\S]*?layoutTransition\.persistStoredPositions\s*\(\s*persistStoredPositions\s*\)[\s\S]*?:[\s\S]*?persistStoredPositions\s*\(\s*\)/,
-    'switchToFreeMode must have precise ternary delegation for persistStoredPositions'
-  );
+test('layout mode transition — required local functions exist', () => {
+  assert.match(canvasSource, /function loadStoredLayout\s*\(\)/);
+  assert.match(canvasSource, /function persistLayoutMode\s*\(mode\)/);
+  assert.match(canvasSource, /function persistStoredPositions\s*\(\)/);
+  assert.match(canvasSource, /function fitViewportToTree\s*\(\)/);
+  assert.match(canvasSource, /function updateLayoutToggleUI\s*\(\)/);
 });
-
-test('persistStoredPositions precise fallback — switchToFreeMode fallback only applies to persistStoredPositions, not persistLayoutMode', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  // Find the persistLayoutMode if/else block - it should contain persistLayoutMode but NOT persistStoredPositions
-  const persistLayoutMatch = switchToFreeBlock.match(
-    /if\s*\(\s*typeof\s+layoutTransition\.persistLayoutMode\s*===\s*['"]function['"]\s*\)\s*\{[\s\S]*?\}[\s\S]*?else\s*\{[\s\S]*?\}/
-  );
-  assert.ok(persistLayoutMatch, 'persistLayoutMode if/else should exist in switchToFreeMode');
-  
-  // Within the persistLayoutMode if/else block, there should be NO persistStoredPositions call
-  const persistLayoutBlock = persistLayoutMatch[0];
-  assert.doesNotMatch(
-    persistLayoutBlock,
-    /persistStoredPositions/,
-    'persistLayoutMode if/else block must not contain persistStoredPositions'
-  );
-});
-
-test('persistStoredPositions precise fallback — switchToStructuredMode has NO persistStoredPositions delegation or fallback', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.doesNotMatch(
-    switchToStructuredBlock,
-    /persistStoredPositions/,
-    'switchToStructuredMode must have NO persistStoredPositions calls at all (asymmetry preserved)'
-  );
-});
-
-test('persistStoredPositions precise fallback — switchToStructuredMode maintains structured-only flow without position removal', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  // Structured mode saves free positions but does NOT persist them
-  assert.match(
-    switchToStructuredBlock,
-    /savedFreePositions\s*=\s*\{\s*\.\.\.viewportState\.positions\s*\}/,
-    'switchToStructuredMode must save free positions to savedFreePositions'
-  );
-  assert.doesNotMatch(
-    switchToStructuredBlock,
-    /removeStoredPositions/,
-    'switchToStructuredMode must not call removeStoredPositions'
-  );
-});
-
-test('persistStoredPositions precise fallback — Stage 56 fitViewportToTree delegation remains intact', () => {
-  const freeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    freeBlock,
-    /typeof\s+layoutTransition\.fitViewportToTree\s*===\s*['"]function['"]\s*\?[\s\S]*?layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)[\s\S]*?:[\s\S]*?fitViewportToTree\s*\(\s*\)/,
-    'Stage 56 fitViewportToTree ternary delegation must remain precise in switchToFreeMode'
-  );
-});
-
-test('persistStoredPositions precise fallback — Stage 56 fitViewportToTree delegation remains in switchToStructuredMode', () => {
-  const structuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    structuredBlock,
-    /typeof\s+layoutTransition\.fitViewportToTree\s*===\s*['"]function['"]\s*\?[\s\S]*?layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)[\s\S]*?:[\s\S]*?fitViewportToTree\s*\(\s*\)/,
-    'Stage 56 fitViewportToTree ternary delegation must remain precise in switchToStructuredMode'
-  );
-});
-
-test('persistStoredPositions precise fallback — helper missing fallback: direct initCanvas preserved', () => {
-  assert.match(
-    canvasSource,
-    /else\s*\{[\s\S]*?initCanvas\s*\(\s*\)/,
-    'direct initCanvas() fallback is handled by ternary directly, but checking its existence'
-  );
-  assert.match(
-    canvasSource,
-    /:\s*initCanvas\s*\(\s*\)/,
-    'initCanvas() must be called as a ternary fallback'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 15. Layout mode init canvas order — Stage 59
-// ---------------------------------------------------------------------------
-
-test('layout mode init canvas order — switchToFreeMode sequence check', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-
-  const idxLayoutMode = block.indexOf("viewportState.layoutMode = 'free'");
-  const idxPersistLayout = block.search(/persistLayoutMode/);
-  const idxRestorePositions = block.indexOf('viewportState.positions = { ...');
-  const idxFitViewport = block.search(/fitViewportToTree/);
-  const idxApplyClasses = block.search(/applyLayoutModeClasses/);
-  const idxUpdateUI = block.search(/updateLayoutToggleUI/);
-  const idxInitCanvas = block.search(/initCanvas\s*\(\s*\)/);
-  const idxPersistPositions = block.search(/persistStoredPositions/);
-
-  assert.ok(idxLayoutMode >= 0, 'layoutMode set to free must exist');
-  assert.ok(idxPersistLayout > idxLayoutMode, 'persistLayoutMode must follow layoutMode assignment');
-  assert.ok(idxRestorePositions > idxPersistLayout, 'positions restoration must follow persistLayoutMode');
-  assert.ok(idxFitViewport > idxRestorePositions, 'fitViewportToTree must follow positions restoration');
-  assert.ok(idxApplyClasses > idxFitViewport, 'applyLayoutModeClasses must follow fitViewportToTree');
-  assert.ok(idxUpdateUI > idxApplyClasses, 'updateLayoutToggleUI must follow applyLayoutModeClasses');
-  assert.ok(idxInitCanvas > idxUpdateUI, 'initCanvas must follow updateLayoutToggleUI');
-  assert.ok(idxPersistPositions > idxInitCanvas, 'persistStoredPositions must follow initCanvas in free mode');
-});
-
-test('layout mode init canvas order — switchToStructuredMode sequence check', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-
-  const idxSavePositions = block.indexOf('savedFreePositions = { ...');
-  const idxLayoutMode = block.indexOf("viewportState.layoutMode = 'structured'");
-  const idxPersistLayout = block.search(/persistLayoutMode/);
-  const idxFitViewport = block.search(/fitViewportToTree/);
-  const idxApplyClasses = block.search(/applyLayoutModeClasses/);
-  const idxUpdateUI = block.search(/updateLayoutToggleUI/);
-  const idxInitCanvas = block.search(/initCanvas\s*\(\s*\)/);
-
-  assert.ok(idxSavePositions >= 0, 'free positions must be saved');
-  assert.ok(idxLayoutMode > idxSavePositions, 'layoutMode set to structured must follow positions saving');
-  assert.ok(idxPersistLayout > idxLayoutMode, 'persistLayoutMode must follow layoutMode assignment');
-  assert.ok(idxFitViewport > idxPersistLayout, 'fitViewportToTree must follow persistLayoutMode');
-  assert.ok(idxApplyClasses > idxFitViewport, 'applyLayoutModeClasses must follow fitViewportToTree');
-  assert.ok(idxUpdateUI > idxApplyClasses, 'updateLayoutToggleUI must follow applyLayoutModeClasses');
-  assert.ok(idxInitCanvas > idxUpdateUI, 'initCanvas must follow updateLayoutToggleUI');
-
-  assert.doesNotMatch(
-    block,
-    /persistStoredPositions/,
-    'switchToStructuredMode must not call persistStoredPositions'
-  );
-});
-
-// ---------------------------------------------------------------------------
-// 16. Layout mode init canvas delegation — Stage 60
-// ---------------------------------------------------------------------------
-
-test('layout mode init canvas delegation — switchToFreeMode has precise ternary delegation', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /typeof\s+layoutTransition\.initCanvas\s*===\s*['"]function['"]\s*\?[\s\S]*?layoutTransition\.initCanvas\s*\(\s*initCanvas\s*\)[\s\S]*?:[\s\S]*?initCanvas\s*\(\s*\)/,
-    'switchToFreeMode must delegate initCanvas precisely with a ternary fallback'
-  );
-});
-
-test('layout mode init canvas delegation — switchToStructuredMode has precise ternary delegation', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    block,
-    /typeof\s+layoutTransition\.initCanvas\s*===\s*['"]function['"]\s*\?[\s\S]*?layoutTransition\.initCanvas\s*\(\s*initCanvas\s*\)[\s\S]*?:[\s\S]*?initCanvas\s*\(\s*\)/,
-    'switchToStructuredMode must delegate initCanvas precisely with a ternary fallback'
-  );
-});
-

--- a/tests/contracts/editor-canvas-layout-transition-contracts.test.cjs
+++ b/tests/contracts/editor-canvas-layout-transition-contracts.test.cjs
@@ -225,7 +225,7 @@ test('layout transition helper — uses IIFE pattern', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 11. persistLayoutMode helper delegation (Stage 54)
+// 11. persistLayoutMode helper delegation
 // ---------------------------------------------------------------------------
 
 test('layout transition helper — persistLayoutMode is exported on namespace', () => {
@@ -244,80 +244,8 @@ test('layout transition helper — persistLayoutMode function is defined', () =>
   );
 });
 
-test('editor-canvas.js — switchToFreeMode delegates persistLayoutMode via transition helper', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /layoutTransition\.persistLayoutMode\s*\(\s*persistLayoutMode\s*,\s*['"]free['"]\s*\)/,
-    'switchToFreeMode must delegate persistence via layoutTransition.persistLayoutMode'
-  );
-});
-
-test('editor-canvas.js — switchToStructuredMode delegates persistLayoutMode via transition helper', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    switchToStructuredBlock,
-    /layoutTransition\.persistLayoutMode\s*\(\s*persistLayoutMode\s*,\s*['"]structured['"]\s*\)/,
-    'switchToStructuredMode must delegate persistence via layoutTransition.persistLayoutMode'
-  );
-});
-
-test('editor-canvas.js — switchToFreeMode has fallback to direct persistLayoutMode', () => {
-  const switchToFreeBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    switchToFreeBlock,
-    /else\s*\{[\s\S]*?persistLayoutMode\s*\(\s*['"]free['"]\s*\)/,
-    'switchToFreeMode must have fallback to direct persistLayoutMode call'
-  );
-});
-
-test('editor-canvas.js — switchToStructuredMode has fallback to direct persistLayoutMode', () => {
-  const switchToStructuredBlock = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    switchToStructuredBlock,
-    /else\s*\{[\s\S]*?persistLayoutMode\s*\(\s*['"]structured['"]\s*\)/,
-    'switchToStructuredMode must have fallback to direct persistLayoutMode call'
-  );
-});
-
-test('editor-canvas.js — persistStoredPositions delegated to transition helper with fallback (free-mode only)', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.persistStoredPositions/,
-    'persistStoredPositions must be delegated to layoutTransition helper'
-  );
-});
-
-test('editor-canvas.js — initCanvas is delegated to transition helper', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.initCanvas/,
-    'initCanvas must be delegated to transition helper'
-  );
-});
-
-test('editor-canvas.js — fitViewportToTree delegated to transition helper with fallback', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.fitViewportToTree/,
-    'fitViewportToTree must be delegated to transition helper'
-  );
-});
-
 // ---------------------------------------------------------------------------
-// 12. fitViewportToTree helper delegation (Stage 56)
+// 12. fitViewportToTree helper delegation
 // ---------------------------------------------------------------------------
 
 test('layout transition helper — fitViewportToTree is exported on namespace', () => {
@@ -336,72 +264,8 @@ test('layout transition helper — fitViewportToTree function is defined', () =>
   );
 });
 
-test('editor-canvas.js — switchToFreeMode delegates fitViewportToTree via transition helper', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)/,
-    'switchToFreeMode must delegate fitViewportToTree via layoutTransition helper'
-  );
-});
-
-test('editor-canvas.js — switchToStructuredMode delegates fitViewportToTree via transition helper', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    block,
-    /layoutTransition\.fitViewportToTree\s*\(\s*fitViewportToTree\s*\)/,
-    'switchToStructuredMode must delegate fitViewportToTree via layoutTransition helper'
-  );
-});
-
-test('editor-canvas.js — switchToFreeMode has fallback to direct fitViewportToTree', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /else\s*\{[\s\S]*?fitViewportToTree\s*\(\s*\)/,
-    'switchToFreeMode must have fallback to direct fitViewportToTree()'
-  );
-});
-
-test('editor-canvas.js — switchToStructuredMode has fallback to direct fitViewportToTree', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.match(
-    block,
-    /else\s*\{[\s\S]*?fitViewportToTree\s*\(\s*\)/,
-    'switchToStructuredMode must have fallback to direct fitViewportToTree()'
-  );
-});
-
-test('editor-canvas.js — initCanvas is delegated to transition helper', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.initCanvas/,
-    'initCanvas must be delegated to layoutTransition helper'
-  );
-});
-
-test('editor-canvas.js — persistStoredPositions still delegated to transition helper with fallback', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.persistStoredPositions/,
-    'persistStoredPositions must be delegated to layoutTransition helper'
-  );
-});
-
 // ---------------------------------------------------------------------------
-// 13. persistStoredPositions helper delegation (Stage 57)
+// 13. persistStoredPositions helper delegation
 // ---------------------------------------------------------------------------
 
 test('layout transition helper — persistStoredPositions is exported on namespace', () => {
@@ -417,50 +281,6 @@ test('layout transition helper — persistStoredPositions function is defined', 
     transitionSource,
     /function\s+persistStoredPositions\s*\(\s*persistFn\s*\)/,
     'persistStoredPositions must be defined with persistFn parameter'
-  );
-});
-
-test('editor-canvas.js — switchToFreeMode delegates persistStoredPositions via transition helper', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /layoutTransition\.persistStoredPositions\s*\(\s*persistStoredPositions\s*\)/,
-    'switchToFreeMode must delegate persistStoredPositions via layoutTransition helper'
-  );
-});
-
-test('editor-canvas.js — switchToFreeMode has fallback to direct persistStoredPositions', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToFreeMode'),
-    canvasSource.indexOf('function switchToStructuredMode')
-  );
-  assert.match(
-    block,
-    /else\s*\{[\s\S]*?persistStoredPositions\s*\(\s*\)/,
-    'switchToFreeMode must have fallback to direct persistStoredPositions()'
-  );
-});
-
-test('editor-canvas.js — switchToStructuredMode still does NOT call persistStoredPositions', () => {
-  const block = canvasSource.slice(
-    canvasSource.indexOf('function switchToStructuredMode'),
-    canvasSource.indexOf('function setLayoutMode')
-  );
-  assert.doesNotMatch(
-    block,
-    /persistStoredPositions/,
-    'switchToStructuredMode must not call persistStoredPositions() (asymmetry preserved)'
-  );
-});
-
-test('editor-canvas.js — initCanvas is delegated to transition helper', () => {
-  assert.match(
-    canvasSource,
-    /layoutTransition\.initCanvas/,
-    'initCanvas must be delegated to layoutTransition helper'
   );
 });
 
@@ -498,4 +318,75 @@ test('layout transition — toggleLayoutMode still exists in editor-canvas.js', 
     /function toggleLayoutMode\s*\(\)/,
     'toggleLayoutMode must remain in editor-canvas.js'
   );
+});
+
+// ---------------------------------------------------------------------------
+// 15. createLayoutModeSwitcher is exported and defined
+// ---------------------------------------------------------------------------
+
+test('layout transition helper — createLayoutModeSwitcher is exported', () => {
+  assert.match(
+    transitionSource,
+    /createLayoutModeSwitcher:\s*createLayoutModeSwitcher/,
+    'createLayoutModeSwitcher must be exported on namespace'
+  );
+});
+
+test('layout transition helper — createLayoutModeSwitcher function is defined', () => {
+  assert.match(
+    transitionSource,
+    /function createLayoutModeSwitcher\s*\(\s*options\s*\)/,
+    'createLayoutModeSwitcher must be defined with options parameter'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 16. layoutModeSwitcher delegation — switch functions delegate to factory
+// ---------------------------------------------------------------------------
+
+test('editor-canvas.js — switchToFreeMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
+    canvasSource.indexOf('function switchToFreeMode'),
+    canvasSource.indexOf('function switchToStructuredMode')
+  );
+  assert.match(
+    block,
+    /layoutModeSwitcher\.switchToFreeMode\(\)/,
+    'switchToFreeMode must delegate to layoutModeSwitcher'
+  );
+});
+
+test('editor-canvas.js — switchToStructuredMode delegates to layoutModeSwitcher', () => {
+  const block = canvasSource.slice(
+    canvasSource.indexOf('function switchToStructuredMode'),
+    canvasSource.indexOf('function setLayoutMode')
+  );
+  assert.match(
+    block,
+    /layoutModeSwitcher\.switchToStructuredMode\(\)/,
+    'switchToStructuredMode must delegate to layoutModeSwitcher'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 17. layoutModeSwitcher is initialized after initCanvas (temporal dead zone fix)
+// ---------------------------------------------------------------------------
+
+test('editor-canvas.js — layoutModeSwitcher is initialized after initCanvas', () => {
+  const initCanvasIdx = canvasSource.indexOf('const initCanvas = () => {');
+  const layoutModeSwitcherIdx = canvasSource.indexOf('const layoutModeSwitcher = typeof layoutTransition.createLayoutModeSwitcher');
+  assert.ok(initCanvasIdx >= 0, 'initCanvas must exist');
+  assert.ok(layoutModeSwitcherIdx >= 0, 'layoutModeSwitcher must exist');
+  assert.ok(layoutModeSwitcherIdx > initCanvasIdx, 'layoutModeSwitcher must be initialized after initCanvas');
+});
+
+// ---------------------------------------------------------------------------
+// 18. factory receives viewportState, loadStoredLayout, etc.
+// ---------------------------------------------------------------------------
+
+test('editor-canvas.js — layoutModeSwitcher receives required options', () => {
+  assert.match(canvasSource, /viewportState,\s*\n\s*loadStoredLayout/);
+  assert.match(canvasSource, /persistLayoutMode,\s*\n\s*persistStoredPositions/);
+  assert.match(canvasSource, /fitViewportToTree,\s*\n\s*initCanvas/);
+  assert.match(canvasSource, /updateLayoutToggleUI/);
 });

--- a/tests/contracts/editor-viewport-controls-contract.test.cjs
+++ b/tests/contracts/editor-viewport-controls-contract.test.cjs
@@ -53,10 +53,14 @@ test('editor canvas viewport module owns fit-safe zoom and focus math', () => {
 
 test('editor layout switching fits the tree instead of centering selected node by default', () => {
   const canvas = read('js/editor/editor-canvas.js');
+  const transition = read('js/editor/editor-canvas-layout-transition.js');
 
   assert.match(canvas, /function\s+fitViewportToTree\s*\(/, 'canvas must expose a layout-switch tree-fit helper');
-  assert.match(canvas, /fitViewportToTree[^)]*\)[\s\S]*applyLayoutModeClasses[^)]*\)\s*\(\s*'free'\s*\)/, 'switching to free mode should fit the tree before rendering');
-  assert.match(canvas, /fitViewportToTree[^)]*\)[\s\S]*applyLayoutModeClasses[^)]*\)\s*\(\s*'structured'\s*\)/, 'switching to structured mode should fit the tree before rendering');
+  // After delegation to layoutModeSwitcher, switchToFreeMode/switchToStructuredMode delegate to factory
+  assert.match(canvas, /layoutModeSwitcher\.switchToFreeMode\(\)/, 'switchToFreeMode must delegate to layoutModeSwitcher');
+  assert.match(canvas, /layoutModeSwitcher\.switchToStructuredMode\(\)/, 'switchToStructuredMode must delegate to layoutModeSwitcher');
+  // The factory ensures fitViewportToTree runs before applyLayoutModeClasses
+  assert.match(transition, /fitViewportToTree[^)]*\)[\s\S]*applyLayoutModeClasses/, 'factory must fit the tree before applying layout classes');
   assert.doesNotMatch(canvas, /function\s+centerViewportOnSelection\s*\(/, 'layout switching must not use selected-node centering by default');
 });
 


### PR DESCRIPTION
Refs #1698

Summary:
- Extract layout mode switching logic from editor-canvas.js into editor-canvas-layout-transition.js as createLayoutModeSwitcher factory.
- Moves switchToFreeMode, switchToStructuredMode, setLayoutMode, and toggleLayoutMode implementations into the layout transition helper.
- Keeps wrapper functions in editor-canvas.js for backward compatibility with existing tests.

Validation:
- git diff --check
- node --check js/editor/editor-canvas.js
- node --check js/editor/editor-canvas-layout-transition.js
- npm run verify (273/273)
- npm test (1618 pass, 0 fail)