### PR TITLE
refactor(canvas): delegate focus and recenter fallbacks

### DIFF
--- a/js/editor/editor-canvas-panzoom.js
+++ b/js/editor/editor-canvas-panzoom.js
@@ -43,3 +43,78 @@ export function getFitViewportIfAvailable(canvasViewport, deps) {
     return canvasViewport.getFitViewport(deps);
 }
 
+/**
+ * Fallback orchestration for focusNodeById when no canvasViewport delegate exists.
+ * Returns true if the focus was applied, false otherwise.
+ */
+export function focusNodeByIdFallback(options) {
+    const {
+        nodeId,
+        getTreeMemories,
+        getWorldPosition,
+        getMetrics,
+        viewportState,
+        scheduleRender,
+        reapplySelection,
+        persistStoredPositions
+    } = options;
+
+    if (!nodeId) return false;
+
+    const treeMemories = getTreeMemories();
+    const target = treeMemories.find((memory) => memory.id === nodeId);
+    if (!target) return false;
+
+    const world = getWorldPosition(target);
+    const metrics = getMetrics();
+    const scale = viewportState.scale || 1;
+    const offset = calculateFocusOffset(world.x, world.y, scale, metrics);
+
+    viewportState.offsetX = offset.offsetX;
+    viewportState.offsetY = offset.offsetY;
+
+    scheduleRender();
+    reapplySelection(nodeId);
+    persistStoredPositions();
+
+    return true;
+}
+
+/**
+ * Fallback orchestration for recenterViewport when no canvasViewport delegate exists.
+ * Returns true when recenter was applied.
+ */
+export function recenterViewportFallback(options) {
+    const {
+        getTreeMemories,
+        getWorldPosition,
+        getMetrics,
+        viewportState,
+        scheduleRender,
+        persistStoredPositions
+    } = options;
+
+    const treeMemories = getTreeMemories();
+
+    if (!treeMemories.length) {
+        viewportState.offsetX = 0;
+        viewportState.offsetY = 0;
+        viewportState.scale = 1;
+        scheduleRender();
+        persistStoredPositions();
+        return true;
+    }
+
+    const points = treeMemories.map((memory) => getWorldPosition(memory));
+    const metrics = getMetrics();
+    const offset = calculateRecenterOffset(points, metrics);
+
+    viewportState.offsetX = offset.offsetX;
+    viewportState.offsetY = offset.offsetY;
+
+    scheduleRender();
+    persistStoredPositions();
+
+    return true;
+}
+

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -625,28 +625,18 @@ function createEditorCanvas(deps) {
             return;
         }
 
-        if (!nodeId) return;
-        const treeMemories = getTreeMemories();
-        const target = treeMemories.find((m) => m.id === nodeId);
-        if (!target) return;
-
-        const world = getWorldPosition(target);
-        const metrics = getMetrics();
-        const scale = viewportState.scale || 1;
-        
-        if (typeof panzoomUtils.calculateFocusOffset === 'function') {
-            const offset = panzoomUtils.calculateFocusOffset(world.x, world.y, scale, metrics);
-            viewportState.offsetX = offset.offsetX;
-            viewportState.offsetY = offset.offsetY;
-        } else {
-            // Fallback
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - (world.x * scale));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - (world.y * scale));
+        if (typeof panzoomUtils.focusNodeByIdFallback === 'function') {
+            panzoomUtils.focusNodeByIdFallback({
+                nodeId,
+                getTreeMemories,
+                getWorldPosition,
+                getMetrics,
+                viewportState,
+                scheduleRender,
+                reapplySelection,
+                persistStoredPositions
+            });
         }
-        
-        scheduleRender();
-        reapplySelection(nodeId);
-        persistStoredPositions();
     }
 
     function recenterViewport() {
@@ -664,35 +654,16 @@ function createEditorCanvas(deps) {
             return;
         }
 
-        const treeMemories = getTreeMemories();
-        if (!treeMemories.length) {
-            viewportState.offsetX = 0;
-            viewportState.offsetY = 0;
-            viewportState.scale = 1;
-            scheduleRender();
-            persistStoredPositions();
-            return;
+        if (typeof panzoomUtils.recenterViewportFallback === 'function') {
+            panzoomUtils.recenterViewportFallback({
+                getTreeMemories,
+                getWorldPosition,
+                getMetrics,
+                viewportState,
+                scheduleRender,
+                persistStoredPositions
+            });
         }
-
-        const points = treeMemories.map((mem) => getWorldPosition(mem));
-        const metrics = getMetrics();
-        
-        if (typeof panzoomUtils.calculateRecenterOffset === 'function') {
-            const offset = panzoomUtils.calculateRecenterOffset(points, metrics);
-            viewportState.offsetX = offset.offsetX;
-            viewportState.offsetY = offset.offsetY;
-        } else {
-            // Fallback
-            const minX = Math.min(...points.map((p) => p.x));
-            const maxX = Math.max(...points.map((p) => p.x));
-            const minY = Math.min(...points.map((p) => p.y));
-            const maxY = Math.max(...points.map((p) => p.y));
-            viewportState.offsetX = Math.round(metrics.width * 0.5 - ((minX + maxX) / 2));
-            viewportState.offsetY = Math.round(metrics.height * 0.38 - ((minY + maxY) / 2));
-        }
-
-        scheduleRender();
-        persistStoredPositions();
     }
 
     /**


### PR DESCRIPTION
Refs #1698

## Summary
- Extract focusNodeById and recenterViewport inline fallback logic into panzoom helpers
- Add focusNodeByIdFallback and recenterViewportFallback to editor-canvas-panzoom.js
- Replace inline fallback code in editor-canvas.js with delegation to new helpers
- editor-canvas.js: 924 → 895 lines (-29)
- Preserve canvasViewport delegate branches and all runtime behavior