### PR TITLE
refactor(canvas): delegate viewport controls fallback

### DIFF
--- a/js/editor/editor-canvas-ui-helpers.js
+++ b/js/editor/editor-canvas-ui-helpers.js
@@ -192,6 +192,46 @@ export function bindZoomControls(zoomInBtn, zoomOutBtn, onZoom) {
 }
 
 /**
+ * Fallback orchestration for binding all viewport control buttons
+ * when the external canvasViewport.bindControls delegate is unavailable.
+ * @param {Object} options
+ * @param {Object} options.viewportState - Viewport state (controlsBound flag).
+ * @param {Function} options.getSelectedMemoryId - Returns currently selected memory ID.
+ * @param {Function} options.focusNodeById - Focuses on a node by ID.
+ * @param {Function} options.recenterViewport - Recenters the viewport.
+ * @param {Function} options.zoomBy - Zooms by a factor.
+ * @returns {boolean} True if controls were bound, false if already bound.
+ */
+export function bindViewportControlsFallback(options) {
+    const {
+        viewportState,
+        getSelectedMemoryId,
+        focusNodeById,
+        recenterViewport,
+        zoomBy
+    } = options;
+
+    if (viewportState.controlsBound) return false;
+    viewportState.controlsBound = true;
+
+    const buttons = getViewportControlButtons();
+    const { focusBtn, recenterBtn, zoomInBtn, zoomOutBtn } = buttons;
+
+    bindViewportControlPropagationGuards(buttons);
+
+    bindFocusSelectedControl(
+        focusBtn,
+        getSelectedMemoryId,
+        focusNodeById
+    );
+
+    bindRecenterControl(recenterBtn, recenterViewport);
+    bindZoomControls(zoomInBtn, zoomOutBtn, zoomBy);
+
+    return true;
+}
+
+/**
  * Binds keyboard shortcuts (Enter, Space) on a node element to trigger selection.
  * @param {HTMLElement} nodeEl - The memory node element.
  * @param {Function} onSelect - Callback to trigger when a shortcut is pressed.

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -683,23 +683,15 @@ function createEditorCanvas(deps) {
             return;
         }
 
-        if (viewportState.controlsBound) return;
-        viewportState.controlsBound = true;
-
-        const buttons = uiHelpers.getViewportControlButtons();
-        const { focusBtn, recenterBtn, zoomInBtn, zoomOutBtn } = buttons;
-
-        uiHelpers.bindViewportControlPropagationGuards(buttons);
-
-        uiHelpers.bindFocusSelectedControl(
-            focusBtn,
-            () => selectionUtils.getSelectedMemoryId(document),
-            focusNodeById
-        );
-
-        uiHelpers.bindRecenterControl(recenterBtn, recenterViewport);
-
-        uiHelpers.bindZoomControls(zoomInBtn, zoomOutBtn, zoomBy);
+        if (typeof uiHelpers.bindViewportControlsFallback === 'function') {
+            uiHelpers.bindViewportControlsFallback({
+                viewportState,
+                getSelectedMemoryId: () => selectionUtils.getSelectedMemoryId(document),
+                focusNodeById,
+                recenterViewport,
+                zoomBy
+            });
+        }
     }
 
     function bindLayoutModeToggle() {


### PR DESCRIPTION
Refs #1698

## Summary
- add `bindViewportControlsFallback` orchestration helper to `editor-canvas-ui-helpers.js`
- replace inline viewport controls binding body in `bindViewportControls` with helper call
- preserve `canvasViewport.bindControls` delegate branch
- preserve `controlsBound` guard, propagation guards, and button binding order
- editor-canvas.js: 889 → 881 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js, js/editor/editor-canvas-ui-helpers.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS