### PR TITLE
refactor(canvas): remove affordance renderer fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -293,28 +293,13 @@ function createEditorCanvas(deps) {
 
     function renderAffordanceForMemory(mem) {
         if (!mem) return;
-        const canonicalRootId = getCanonicalRootId();
-        
-        if (typeof renderUtils.renderAffordancesForMemory === 'function') {
-            renderUtils.renderAffordancesForMemory(mem, {
-                growthAffordance,
-                branchPorts,
-                getTreeMemories,
-                canonicalRootId,
-                isRootMemory
-            });
-            return;
-        }
-
-        // Fallback
-        const drawableMemories = getTreeMemories().filter((node) => !isRootMemory(node, canonicalRootId));
-        clearGrowthAffordance();
-        growthAffordance.renderGrowthAffordance(mem, {
-            isFirstStep: drawableMemories.length <= 1,
-            isStartMoment: mem.parentId === canonicalRootId
+        renderUtils.renderAffordancesForMemory(mem, {
+            growthAffordance,
+            branchPorts,
+            getTreeMemories,
+            canonicalRootId: getCanonicalRootId(),
+            isRootMemory
         });
-        branchPorts.renderPortsForNode(mem);
-        branchPorts.showPortsForMemory(mem);
     }
 
     function renderAffordanceForHoveredMemory(mem) {


### PR DESCRIPTION
Refs #1698

## Summary
- remove inline fallback body from `renderAffordanceForMemory`
- delegate directly to `renderUtils.renderAffordancesForMemory`
- remove typeof guard (exported function is always available)
- preserve mem null guard and `getCanonicalRootId()` call
- `clearGrowthAffordance` function retained (used elsewhere)
- editor-canvas.js: 881 → 866 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS