### PR TITLE
refactor(canvas): remove growth clear fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -395,14 +395,7 @@ function createEditorCanvas(deps) {
             hoverAffordanceTimer = null;
         }
 
-        if (typeof renderUtils.clearGrowthAffordances === 'function') {
-            renderUtils.clearGrowthAffordances(growthAffordance, branchPorts);
-            return;
-        }
-
-        // Fallback
-        if (growthAffordance) growthAffordance.clearGrowthAffordance();
-        if (branchPorts) branchPorts.clearPorts();
+        renderUtils.clearGrowthAffordances(growthAffordance, branchPorts);
     }
 
     function openAddMomentFromCanvas() {

--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -358,18 +358,7 @@ function createEditorCanvas(deps) {
     }
 
     function createNodeElement(mem, pos) {
-        if (typeof renderUtils.createNodeElement === 'function') {
-            return renderUtils.createNodeElement(mem, pos, canvasNode, {
-                resolveMemoryThumbnail: resolveMemoryThumbnail,
-                NODE_HALF: NODE_HALF,
-                scale: viewportState.scale || 1
-            });
-        }
-        // Fallback
-        if (typeof canvasNode.createNodeElement !== "function") {
-            throw new Error("LoveBudEditorCanvasNode.createNodeElement is required");
-        }
-        return canvasNode.createNodeElement(mem, pos, {
+        return renderUtils.createNodeElement(mem, pos, canvasNode, {
             resolveMemoryThumbnail: resolveMemoryThumbnail,
             NODE_HALF: NODE_HALF,
             scale: viewportState.scale || 1
@@ -377,15 +366,7 @@ function createEditorCanvas(deps) {
     }
 
     function attachNodeInfo(nodeEl, mem) {
-        if (typeof renderUtils.attachNodeInfo === 'function') {
-            renderUtils.attachNodeInfo(canvas, nodeEl, mem, canvasNode);
-            return;
-        }
-        // Fallback
-        if (typeof canvasNode.appendNodeInfo === 'function') {
-            canvasNode.appendNodeInfo(nodeEl, mem);
-        }
-        canvas.appendChild(nodeEl);
+        renderUtils.attachNodeInfo(canvas, nodeEl, mem, canvasNode);
     }
 
     function attachNodeBehavior(nodeEl, mem) {


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `clearGrowthAffordance`
- delegate directly to `renderUtils.clearGrowthAffordances`
- preserve hoverAffordanceMemoryId/timer cleanup
- editor-canvas.js: 847 → 840 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS