### PR TITLE
refactor(canvas): remove safe viewport fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -247,13 +247,7 @@ function createEditorCanvas(deps) {
     });
 
     function isNodeWithinSafeViewport(pos) {
-        if (typeof utils.isNodeWithinSafeViewport === 'function') {
-            return utils.isNodeWithinSafeViewport(pos, getMetrics);
-        }
-        // Fallback
-        const metrics = getMetrics();
-        const padding = 96;
-        return pos.x >= padding && pos.x <= metrics.width - padding && pos.y >= padding && pos.y <= metrics.height - padding;
+        return utils.isNodeWithinSafeViewport(pos, getMetrics);
     }
 
     function keepSelectionVisible() {


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `isNodeWithinSafeViewport`
- delegate directly to `utils.isNodeWithinSafeViewport`
- editor-canvas.js: 840 → 834 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS