### PR TITLE
refactor(canvas): remove initial visible fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -418,20 +418,7 @@ function createEditorCanvas(deps) {
     }
 
     function findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId) {
-        if (typeof utils.findInitialVisibleMemory === 'function') {
-            return utils.findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId);
-        }
-        // Fallback
-        const rootMemory = treeMemories.find(function(m) {
-            return m && (m.parentId === null || m.parentId === undefined);
-        });
-        if (rootMemory) {
-            var firstChild = drawableMemories.find(function(m) {
-                return m && m.parentId === rootMemory.id;
-            });
-            if (firstChild) return firstChild;
-        }
-        return drawableMemories[0] || null;
+        return utils.findInitialVisibleMemory(drawableMemories, treeMemories, canonicalRootId);
     }
 
     let _rafPending = false;


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `findInitialVisibleMemory`
- delegate directly to `utils.findInitialVisibleMemory`
- editor-canvas.js: 834 → 821 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS