### PR TITLE
refactor(canvas): remove clear nodes fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -465,13 +465,7 @@ function createEditorCanvas(deps) {
             }
             canvas.style.backgroundPosition = `${viewportState.offsetX}px ${viewportState.offsetY}px`;
 
-            if (typeof renderUtils.clearCanvasNodes === 'function') {
-                renderUtils.clearCanvasNodes(canvas);
-            } else {
-                // Fallback
-                canvas.querySelectorAll('.memory-node').forEach((node) => node.remove());
-                canvas.querySelectorAll('#emptyTreeMessage').forEach((el) => el.remove());
-            }
+            renderUtils.clearCanvasNodes(canvas);
             clearBranches();
             clearGrowthAffordance();
 


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `clearCanvasNodes` call in `initCanvas`
- delegate directly to `renderUtils.clearCanvasNodes`
- editor-canvas.js: 821 → 815 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS