### PR TITLE
refactor(canvas): remove calc position fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -132,19 +132,11 @@ function createEditorCanvas(deps) {
     }
 
     function calcPosition(mem) {
-        if (typeof utils.calcPosition === 'function') {
-            return utils.calcPosition(mem, {
-                getWorldPosition: getWorldPosition,
-                canvasViewport,
-                viewportState
-            });
-        }
-        // Fallback
-        const world = getWorldPosition(mem);
-        if (typeof canvasViewport.projectWorldPosition === 'function') {
-            return canvasViewport.projectWorldPosition(world, viewportState);
-        }
-        return { x: world.x + viewportState.offsetX, y: world.y + viewportState.offsetY };
+        return utils.calcPosition(mem, {
+            getWorldPosition: getWorldPosition,
+            canvasViewport,
+            viewportState
+        });
     }
 
     function persistStoredPositions() {

--- a/tests/contracts/editor-viewport-controls-contract.test.cjs
+++ b/tests/contracts/editor-viewport-controls-contract.test.cjs
@@ -70,9 +70,11 @@ test('editor canvas persists scale and keeps node dragging scale-aware', () => {
   const interaction = read('js/editor/editor-canvas-interaction.js');
   const fallbackInteraction = read('js/editor/editor-canvas-interaction-helpers.js');
   const canvasNode = read('js/editor/editor-canvas-node.js');
+  const canvasUtils = read('js/editor/editor-canvas-utils.js');
 
   assert.match(canvas, /scale:\s*storedLayout\.scale \|\| 1/, 'canvas state must initialize viewport scale');
-  assert.match(canvas, /projectWorldPosition\(world,\s*viewportState\)/, 'canvas must render through viewport projection');
+  assert.match(canvas, /utils\.calcPosition\(mem/, 'canvas must delegate position calculation to utils');
+  assert.match(canvasUtils, /projectWorldPosition\(world,\s*viewportState\)/, 'calc position must render through viewport projection');
   assert.match(canvasNode, /nodeEl\.style\.transform = 'scale\(/ , 'node cards must visually scale with viewport (delegated to canvas-node)');
   assert.match(canvas, /function\s+zoomBy\s*\(factor\)/, 'canvas must expose zoom action');
   assert.match(canvas, /persistStoredPositions\(\)/, 'viewport control changes must persist safely');


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `calcPosition`
- delegate directly to `utils.calcPosition`
- update viewport controls contract test to check utils delegation
- editor-canvas.js: 815 → 807 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS