### PR TITLE
refactor(canvas): remove world position fallback

### DIFF
--- a/js/editor/editor-canvas.js
+++ b/js/editor/editor-canvas.js
@@ -112,23 +112,14 @@ function createEditorCanvas(deps) {
     }
 
     function getWorldPosition(mem) {
-        if (typeof utils.getWorldPosition === 'function') {
-            return utils.getWorldPosition(mem, {
-                layoutMode: viewportState.layoutMode,
-                viewportState,
-                getCanonicalRootId,
-                getTreeMemories,
-                isRootMemory,
-                getMetrics
-            });
-        }
-        // Fallback
-        if (viewportState.layoutMode === 'structured') {
-            return window.EditorCanvasGeometry.getStructuredWorldPosition(
-                mem, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics
-            );
-        }
-        return window.EditorCanvasGeometry.getWorldPosition(mem, viewportState, getCanonicalRootId, getTreeMemories, isRootMemory, getMetrics);
+        return utils.getWorldPosition(mem, {
+            layoutMode: viewportState.layoutMode,
+            viewportState,
+            getCanonicalRootId,
+            getTreeMemories,
+            isRootMemory,
+            getMetrics
+        });
     }
 
     function calcPosition(mem) {


### PR DESCRIPTION
Refs #1698

## Summary
- remove typeof guard and inline fallback from `getWorldPosition`
- remove `EditorCanvasGeometry.getStructuredWorldPosition`/`getWorldPosition` direct calls from editor-canvas.js
- delegate directly to `utils.getWorldPosition`
- editor-canvas.js: 807 → 798 lines

## Contract Gate
[Editor Entrypoint Contract Gate]
Entrypoint remains classic browser script: YES
pages/editor.html script order changed: NO
Auth/protected-route behavior changed: NO
Selected tree handoff behavior changed: NO
Canvas init behavior changed: NO
Detail panel init behavior changed: NO
Save/update behavior changed: NO
Legacy window globals removed: NO
Runtime files changed: js/editor/editor-canvas.js
Static checks: PASS
Editor browser smoke: PASS
Private payload exposure: NO
Secret exposure: NO
Final judgment: PASS