### PR TITLE
refactor(editor): isolate add memory template markup

### DIFF
--- a/js/editor/templates/editor-add-memory-form-template.js
+++ b/js/editor/templates/editor-add-memory-form-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildAddMemoryFormTemplate() {
+        return `
             <div id="addMemoryForm" class="memory-create-section editor-memory-form-modal" style="display:none;">
                 <div class="editor-memory-form-body">
                     <div class="editor-modal-eyebrow" id="addMemoryFormEyebrow">첫 순간 시작</div>
@@ -61,9 +62,11 @@
                     <button id="confirmAddMemory" class="btn-round btn-primary editor-form-action-btn">...</button>
                 </div>
             </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('addMemoryFormTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildAddMemoryFormTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -104,8 +104,9 @@ test('template files use IIFE pattern with mount.outerHTML replacement', () => {
         const content = fs.readFileSync(filePath, 'utf8');
         assert.match(content, /^\(function\(\)\s*\{/,
             `template ${script} must start with IIFE pattern`);
-        assert.match(content, /mount\.outerHTML\s*=\s*template/,
-            `template ${script} must use mount.outerHTML = template`);
+        // Accept both direct template variable and builder function call
+        assert.match(content, /mount\.outerHTML\s*=\s*(template|build\w+Template\(\))/,
+            `template ${script} must use mount.outerHTML = template or builder call`);
         assert.match(content, /document\.getElementById\(.*TemplateMount/,
             `template ${script} must reference a TemplateMount element`);
     }
@@ -146,7 +147,17 @@ test('no duplicate template script references in editor.html', () => {
     }
 });
 
-// --- 9. Template script count matches expected ---
+// --- 10. Add-memory form template uses builder function ---
+
+test('editor-add-memory-form-template.js defines buildAddMemoryFormTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-add-memory-form-template.js', 'utf8');
+    assert.match(content, /function buildAddMemoryFormTemplate\(\)/,
+        'must define buildAddMemoryFormTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildAddMemoryFormTemplate\(\)/,
+        'must call buildAddMemoryFormTemplate() for mount.outerHTML');
+});
+
+// --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {
     let count = 0;


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildAddMemoryFormTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- update contract test to accept both direct template and builder call pattern
- add targeted test for buildAddMemoryFormTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-add-memory-form-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS