### PR TITLE
refactor(editor): isolate canvas topbar template markup

### DIFF
--- a/js/editor/templates/editor-canvas-topbar-template.js
+++ b/js/editor/templates/editor-canvas-topbar-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildCanvasTopbarTemplate() {
+        return `
             <div class="editor-canvas-topbar" aria-label="러브트리 캔버스 도구">
                 
                 <div class="editor-canvas-toolbar" role="toolbar" aria-label="트리 화면 조정">
@@ -38,9 +39,11 @@
                     </div>
                 </div>
             </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorCanvasTopbarTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildCanvasTopbarTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -147,7 +147,7 @@ test('no duplicate template script references in editor.html', () => {
     }
 });
 
-// --- 10. Add-memory form template uses builder function ---
+// --- 10. Templates with builder functions ---
 
 test('editor-add-memory-form-template.js defines buildAddMemoryFormTemplate builder', () => {
     const content = fs.readFileSync('js/editor/templates/editor-add-memory-form-template.js', 'utf8');
@@ -155,6 +155,14 @@ test('editor-add-memory-form-template.js defines buildAddMemoryFormTemplate buil
         'must define buildAddMemoryFormTemplate function');
     assert.match(content, /mount\.outerHTML\s*=\s*buildAddMemoryFormTemplate\(\)/,
         'must call buildAddMemoryFormTemplate() for mount.outerHTML');
+});
+
+test('editor-canvas-topbar-template.js defines buildCanvasTopbarTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-canvas-topbar-template.js', 'utf8');
+    assert.match(content, /function buildCanvasTopbarTemplate\(\)/,
+        'must define buildCanvasTopbarTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildCanvasTopbarTemplate\(\)/,
+        'must call buildCanvasTopbarTemplate() for mount.outerHTML');
 });
 
 // --- 11. Template script count matches expected ---


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildCanvasTopbarTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildCanvasTopbarTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-canvas-topbar-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS