### PR TITLE
refactor(editor): isolate empty guide template markup

### DIFF
--- a/js/editor/templates/editor-empty-guide-template.js
+++ b/js/editor/templates/editor-empty-guide-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildEmptyGuideTemplate() {
+        return `
                         <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
                 <div class="editor-canvas-empty-guide__eyebrow" id="canvasEmptyGuideEyebrow">시작하기</div>
                 <h3 class="editor-canvas-empty-guide__title" id="canvasEmptyGuideTitle">이 트리의 첫 순간을 기록해볼까요?</h3>
@@ -20,9 +21,11 @@
                 </div>
                 <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">붙여넣는 순간 바로 생성돼요.</p>
             </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorEmptyGuideTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildEmptyGuideTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -165,6 +165,14 @@ test('editor-canvas-topbar-template.js defines buildCanvasTopbarTemplate builder
         'must call buildCanvasTopbarTemplate() for mount.outerHTML');
 });
 
+test('editor-empty-guide-template.js defines buildEmptyGuideTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-empty-guide-template.js', 'utf8');
+    assert.match(content, /function buildEmptyGuideTemplate\(\)/,
+        'must define buildEmptyGuideTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildEmptyGuideTemplate\(\)/,
+        'must call buildEmptyGuideTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildEmptyGuideTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildEmptyGuideTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-empty-guide-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS