### PR TITLE
refactor(editor): isolate sidebar template markup

### DIFF
--- a/js/editor/templates/editor-sidebar-template.js
+++ b/js/editor/templates/editor-sidebar-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildSidebarTemplate() {
+        return `
         <aside class="sidebar reveal-fade">
             <div class="editor-sidebar-back-wrap">
                 <a id="backToMyTreesLink" href="my-trees" class="editor-sidebar-back-link">
@@ -33,9 +34,11 @@
                 </div>
             </section>
         </aside>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorSidebarTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildSidebarTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -173,6 +173,14 @@ test('editor-empty-guide-template.js defines buildEmptyGuideTemplate builder', (
         'must call buildEmptyGuideTemplate() for mount.outerHTML');
 });
 
+test('editor-sidebar-template.js defines buildSidebarTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-sidebar-template.js', 'utf8');
+    assert.match(content, /function buildSidebarTemplate\(\)/,
+        'must define buildSidebarTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildSidebarTemplate\(\)/,
+        'must call buildSidebarTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildSidebarTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildSidebarTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-sidebar-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS