### PR TITLE
refactor(editor): isolate floating toolbar template markup

### DIFF
--- a/js/editor/templates/editor-floating-toolbar-template.js
+++ b/js/editor/templates/editor-floating-toolbar-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildFloatingToolbarTemplate() {
+        return `
             <div id="editorFloatingToolbar" class="editor-floating-toolbar is-hidden" role="toolbar" aria-label="선택한 순간 도구" style="display:none;">
                 <button type="button" class="editor-floating-toolbar-btn" id="ftbEditBtn" aria-label="순간 수정" title="순간 수정">
                     <span class="material-symbols-outlined" aria-hidden="true">edit</span>
@@ -48,9 +49,11 @@
                     <span>선택한 순간 보기</span>
                 </button>
             </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorFloatingToolbarTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildFloatingToolbarTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -181,6 +181,14 @@ test('editor-sidebar-template.js defines buildSidebarTemplate builder', () => {
         'must call buildSidebarTemplate() for mount.outerHTML');
 });
 
+test('editor-floating-toolbar-template.js defines buildFloatingToolbarTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-floating-toolbar-template.js', 'utf8');
+    assert.match(content, /function buildFloatingToolbarTemplate\(\)/,
+        'must define buildFloatingToolbarTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildFloatingToolbarTemplate\(\)/,
+        'must call buildFloatingToolbarTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildFloatingToolbarTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildFloatingToolbarTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-floating-toolbar-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS