### PR TITLE
refactor(editor): isolate detail empty state template markup

### DIFF
--- a/js/editor/templates/editor-detail-empty-state-template.js
+++ b/js/editor/templates/editor-detail-empty-state-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildDetailEmptyStateTemplate() {
+        return `
                 <div id="detailEmptyState" class="editor-visible-initial">
                     <div class="editor-empty-state-box">
                         <span class="material-symbols-outlined editor-empty-state-icon">sentiment_satisfied</span>
@@ -8,9 +9,11 @@
                         <button type="button" id="detailEmptyStartBtn" class="btn-round btn-primary editor-empty-state-cta" tabindex="-1">첫 순간 심기</button>
                     </div>
                 </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorDetailEmptyStateTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildDetailEmptyStateTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -197,6 +197,14 @@ test('editor-detail-panel-shell-template.js defines buildDetailPanelShellTemplat
         'must call buildDetailPanelShellTemplate() for mount.outerHTML');
 });
 
+test('editor-detail-empty-state-template.js defines buildDetailEmptyStateTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-detail-empty-state-template.js', 'utf8');
+    assert.match(content, /function buildDetailEmptyStateTemplate\(\)/,
+        'must define buildDetailEmptyStateTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildDetailEmptyStateTemplate\(\)/,
+        'must call buildDetailEmptyStateTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildDetailEmptyStateTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildDetailEmptyStateTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-detail-empty-state-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS