### PR TITLE
refactor(editor): isolate detail view mode template markup

### DIFF
--- a/js/editor/templates/editor-detail-view-mode-template.js
+++ b/js/editor/templates/editor-detail-view-mode-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildDetailViewModeTemplate() {
+        return `
                 <div id="detailViewMode" class="editor-hidden-initial">
                     <div class="editor-tree-meta-section" aria-hidden="true">
                         <div class="editor-section-eyebrow" id="detailTreeStatusLabel">현재 트리</div>
@@ -84,10 +85,12 @@
                         </div>
                     </div>
                 </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorDetailViewModeTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildDetailViewModeTemplate();
     }
 })();
 // cache bust

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -205,6 +205,14 @@ test('editor-detail-empty-state-template.js defines buildDetailEmptyStateTemplat
         'must call buildDetailEmptyStateTemplate() for mount.outerHTML');
 });
 
+test('editor-detail-view-mode-template.js defines buildDetailViewModeTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-detail-view-mode-template.js', 'utf8');
+    assert.match(content, /function buildDetailViewModeTemplate\(\)/,
+        'must define buildDetailViewModeTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildDetailViewModeTemplate\(\)/,
+        'must call buildDetailViewModeTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildDetailViewModeTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildDetailViewModeTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-detail-view-mode-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS