### PR TITLE
refactor(editor): isolate detail edit mode template markup

### DIFF
--- a/js/editor/templates/editor-detail-edit-mode-template.js
+++ b/js/editor/templates/editor-detail-edit-mode-template.js
@@ -1,5 +1,6 @@
 (function() {
-    const template = `
+    function buildDetailEditModeTemplate() {
+        return `
                 <div id="detailEditMode" class="editor-hidden-initial">
                     <div class="editor-form-stack editor-form-stack-compact">
                         <label id="editTitleLabel" class="editor-form-label">...</label>
@@ -24,9 +25,11 @@
                         <button id="deleteMemoryBtn" class="editor-delete-link">...</button>
                     </div>
                 </div>
-    `;
+        `;
+    }
+
     const mount = document.getElementById('editorDetailEditModeTemplateMount');
     if (mount) {
-        mount.outerHTML = template;
+        mount.outerHTML = buildDetailEditModeTemplate();
     }
 })();

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -213,6 +213,14 @@ test('editor-detail-view-mode-template.js defines buildDetailViewModeTemplate bu
         'must call buildDetailViewModeTemplate() for mount.outerHTML');
 });
 
+test('editor-detail-edit-mode-template.js defines buildDetailEditModeTemplate builder', () => {
+    const content = fs.readFileSync('js/editor/templates/editor-detail-edit-mode-template.js', 'utf8');
+    assert.match(content, /function buildDetailEditModeTemplate\(\)/,
+        'must define buildDetailEditModeTemplate function');
+    assert.match(content, /mount\.outerHTML\s*=\s*buildDetailEditModeTemplate\(\)/,
+        'must call buildDetailEditModeTemplate() for mount.outerHTML');
+});
+
 // --- 11. Template script count matches expected ---
 
 test('exactly 9 template scripts are loaded in editor.html', () => {


### PR DESCRIPTION
Refs #1494

## Summary
- extract template string into buildDetailEditModeTemplate() function
- keep IIFE + mount.outerHTML mount pattern unchanged
- add targeted test for buildDetailEditModeTemplate function
- no editor.html changes, no script type changes, no window globals added

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-detail-edit-mode-template.js
Test files changed: tests/contracts/editor-template-load-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS