### PR TITLE
refactor(editor): convert add memory form template to ESM

### DIFF
--- a/js/editor/templates/editor-add-memory-form-template.js
+++ b/js/editor/templates/editor-add-memory-form-template.js
@@ -1,72 +1,70 @@
-(function() {
-    function buildAddMemoryFormTemplate() {
-        return `
-            <div id="addMemoryForm" class="memory-create-section editor-memory-form-modal" style="display:none;">
-                <div class="editor-memory-form-body">
-                    <div class="editor-modal-eyebrow" id="addMemoryFormEyebrow">첫 순간 시작</div>
-                    <h3 class="headline editor-modal-title" id="addMemoryFormTitle">...</h3>
-                    <p id="addMemoryFormIntro" class="editor-modal-intro">...</p>
-                    <div class="editor-memory-mode-group" id="memoryInputModeGroup" aria-label="순간 입력 방식">
-                        <button type="button" class="editor-memory-mode-chip is-active" id="memoryModeLinkBtn" data-mode="link">
-                            <span class="material-symbols-outlined">smart_display</span>
-                            <span>링크로 시작</span>
-                        </button>
-                        <button type="button" class="editor-memory-mode-chip" id="memoryModeTextBtn" data-mode="text">
-                            <span class="material-symbols-outlined">edit_note</span>
-                            <span>텍스트로 시작</span>
-                        </button>
+export function buildAddMemoryFormTemplate() {
+    return `
+        <div id="addMemoryForm" class="memory-create-section editor-memory-form-modal" style="display:none;">
+            <div class="editor-memory-form-body">
+                <div class="editor-modal-eyebrow" id="addMemoryFormEyebrow">첫 순간 시작</div>
+                <h3 class="headline editor-modal-title" id="addMemoryFormTitle">...</h3>
+                <p id="addMemoryFormIntro" class="editor-modal-intro">...</p>
+                <div class="editor-memory-mode-group" id="memoryInputModeGroup" aria-label="순간 입력 방식">
+                    <button type="button" class="editor-memory-mode-chip is-active" id="memoryModeLinkBtn" data-mode="link">
+                        <span class="material-symbols-outlined">smart_display</span>
+                        <span>링크로 시작</span>
+                    </button>
+                    <button type="button" class="editor-memory-mode-chip" id="memoryModeTextBtn" data-mode="text">
+                        <span class="material-symbols-outlined">edit_note</span>
+                        <span>텍스트로 시작</span>
+                    </button>
+                </div>
+                <div class="editor-form-support-note editor-form-support-note-hidden" id="memoryFormSupportNote" aria-hidden="true">
+                    <span class="material-symbols-outlined">info</span>
+                    <span id="memoryFormSupportNoteText">YouTube 링크가 있으면 대표 장면이 잡히고, 링크가 없어도 제목과 메모만으로 첫 순간을 시작할 수 있어요.</span>
+                </div>
+                <div class="editor-form-field editor-form-field-primary" id="memoryUrlField">
+                    <label id="memoryUrlLabel" class="editor-form-label">...</label>
+                    <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
+                </div>
+                <div class="editor-video-segment-grid" id="memoryVideoSegmentGrid">
+                    <div class="editor-form-field editor-video-segment-field editor-video-segment-field-start" id="memoryStartTimeField">
+                        <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">시작</label>
+                        <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23" class="editor-form-input">
                     </div>
-                    <div class="editor-form-support-note editor-form-support-note-hidden" id="memoryFormSupportNote" aria-hidden="true">
-                        <span class="material-symbols-outlined">info</span>
-                        <span id="memoryFormSupportNoteText">YouTube 링크가 있으면 대표 장면이 잡히고, 링크가 없어도 제목과 메모만으로 첫 순간을 시작할 수 있어요.</span>
+                    <div class="editor-form-field editor-video-segment-field editor-video-segment-field-end" id="memoryEndTimeField">
+                        <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
+                        <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
                     </div>
-                    <div class="editor-form-field editor-form-field-primary" id="memoryUrlField">
-                        <label id="memoryUrlLabel" class="editor-form-label">...</label>
-                        <input type="text" id="memoryUrlInput" placeholder="https://www.youtube.com/watch?v=..." class="editor-form-input">
+                    <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">순간의 시작과 끝 시간을 입력하세요.</p>
+                </div>
+                <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
+                    <div class="memory-link-preview__thumb-wrap">
+                        <img class="memory-link-preview__thumb" id="memoryPreviewThumb" alt="">
+                        <div class="memory-link-preview__play-icon material-symbols-outlined">play_circle</div>
                     </div>
-                    <div class="editor-video-segment-grid" id="memoryVideoSegmentGrid">
-                        <div class="editor-form-field editor-video-segment-field editor-video-segment-field-start" id="memoryStartTimeField">
-                            <label id="memoryStartTimeLabel" for="memoryStartTimeInput" class="editor-form-label">시작</label>
-                            <input type="text" id="memoryStartTimeInput" placeholder="예: 1:23" class="editor-form-input">
-                        </div>
-                        <div class="editor-form-field editor-video-segment-field editor-video-segment-field-end" id="memoryEndTimeField">
-                            <label id="memoryEndTimeLabel" for="memoryEndTimeInput" class="editor-form-label">끝</label>
-                            <input type="text" id="memoryEndTimeInput" placeholder="선택, 예: 1:45" class="editor-form-input">
-                        </div>
-                        <p id="memoryStartTimeHint" class="editor-form-help editor-video-segment-help">순간의 시작과 끝 시간을 입력하세요.</p>
-                    </div>
-                    <div class="memory-link-preview is-hidden" id="memoryLinkPreview" aria-live="polite">
-                        <div class="memory-link-preview__thumb-wrap">
-                            <img class="memory-link-preview__thumb" id="memoryPreviewThumb" alt="">
-                            <div class="memory-link-preview__play-icon material-symbols-outlined">play_circle</div>
-                        </div>
-                        <div class="memory-link-preview__body">
-                            <span class="memory-link-preview__badge" id="memoryPreviewBadge">YouTube</span>
-                            <strong class="memory-link-preview__title" id="memoryPreviewTitle">영상 링크가 확인됐어요</strong>
-                            <p class="memory-link-preview__hint" id="memoryPreviewHint">이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.</p>
-                        </div>
-                    </div>
-                    <div class="editor-form-field editor-form-field-grid">
-                        <div class="editor-form-stack editor-form-stack-compact">
-                            <label id="memoryTitleLabel" class="editor-form-label">...</label>
-                            <input type="text" id="memoryTitleInput" placeholder="..." class="editor-form-input">
-                        </div>
-                        <div class="editor-form-stack editor-form-stack-roomy">
-                            <label id="memoryMemoLabel" class="editor-form-label">...</label>
-                            <textarea id="memoryMemoInput" placeholder="..." rows="5" class="editor-form-textarea"></textarea>
-                        </div>
+                    <div class="memory-link-preview__body">
+                        <span class="memory-link-preview__badge" id="memoryPreviewBadge">YouTube</span>
+                        <strong class="memory-link-preview__title" id="memoryPreviewTitle">영상 링크가 확인됐어요</strong>
+                        <p class="memory-link-preview__hint" id="memoryPreviewHint">이 장면을 트리에 심기 전에 제목과 메모를 다듬어 주세요.</p>
                     </div>
                 </div>
-                <div class="editor-form-actions">
-                    <button id="cancelAddMemory" class="btn-round btn-outline editor-form-action-btn">...</button>
-                    <button id="confirmAddMemory" class="btn-round btn-primary editor-form-action-btn">...</button>
+                <div class="editor-form-field editor-form-field-grid">
+                    <div class="editor-form-stack editor-form-stack-compact">
+                        <label id="memoryTitleLabel" class="editor-form-label">...</label>
+                        <input type="text" id="memoryTitleInput" placeholder="..." class="editor-form-input">
+                    </div>
+                    <div class="editor-form-stack editor-form-stack-roomy">
+                        <label id="memoryMemoLabel" class="editor-form-label">...</label>
+                        <textarea id="memoryMemoInput" placeholder="..." rows="5" class="editor-form-textarea"></textarea>
+                    </div>
                 </div>
             </div>
-        `;
-    }
+            <div class="editor-form-actions">
+                <button id="cancelAddMemory" class="btn-round btn-outline editor-form-action-btn">...</button>
+                <button id="confirmAddMemory" class="btn-round btn-primary editor-form-action-btn">...</button>
+            </div>
+        </div>
+    `;
+}
 
-    const mount = document.getElementById('addMemoryFormTemplateMount');
-    if (mount) {
-        mount.outerHTML = buildAddMemoryFormTemplate();
-    }
-})();
+const mount = document.getElementById('addMemoryFormTemplateMount');
+if (mount) {
+    mount.outerHTML = buildAddMemoryFormTemplate();
+}

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -78,7 +78,7 @@
     <script src="../js/utils/path.js?v=20260418-1"></script>
     <script src="../js/utils/ui.js?v=20260418-1"></script>
     <script src="../js/utils/media.js?v=20260418-1"></script>
-    <script src="../js/editor/templates/editor-add-memory-form-template.js?v=20260525-1280"></script>
+    <script type="module" src="../js/editor/templates/editor-add-memory-form-template.js?v=20260531-1494"></script>
     <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>

--- a/tests/contracts/editor-template-builder-completion-contract.test.cjs
+++ b/tests/contracts/editor-template-builder-completion-contract.test.cjs
@@ -6,47 +6,56 @@ const TEMPLATE_BUILDERS = [
   {
     path: 'js/editor/templates/editor-add-memory-form-template.js',
     builder: 'buildAddMemoryFormTemplate',
-    mountId: 'addMemoryFormTemplateMount'
+    mountId: 'addMemoryFormTemplateMount',
+    module: true
   },
   {
     path: 'js/editor/templates/editor-canvas-topbar-template.js',
     builder: 'buildCanvasTopbarTemplate',
-    mountId: 'editorCanvasTopbarTemplateMount'
+    mountId: 'editorCanvasTopbarTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-empty-guide-template.js',
     builder: 'buildEmptyGuideTemplate',
-    mountId: 'editorEmptyGuideTemplateMount'
+    mountId: 'editorEmptyGuideTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-sidebar-template.js',
     builder: 'buildSidebarTemplate',
-    mountId: 'editorSidebarTemplateMount'
+    mountId: 'editorSidebarTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-floating-toolbar-template.js',
     builder: 'buildFloatingToolbarTemplate',
-    mountId: 'editorFloatingToolbarTemplateMount'
+    mountId: 'editorFloatingToolbarTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-detail-panel-shell-template.js',
     builder: 'buildDetailPanelShellTemplate',
-    mountId: 'editorDetailPanelShellTemplateMount'
+    mountId: 'editorDetailPanelShellTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-detail-empty-state-template.js',
     builder: 'buildDetailEmptyStateTemplate',
-    mountId: 'editorDetailEmptyStateTemplateMount'
+    mountId: 'editorDetailEmptyStateTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-detail-view-mode-template.js',
     builder: 'buildDetailViewModeTemplate',
-    mountId: 'editorDetailViewModeTemplateMount'
+    mountId: 'editorDetailViewModeTemplateMount',
+    module: false
   },
   {
     path: 'js/editor/templates/editor-detail-edit-mode-template.js',
     builder: 'buildDetailEditModeTemplate',
-    mountId: 'editorDetailEditModeTemplateMount'
+    mountId: 'editorDetailEditModeTemplateMount',
+    module: false
   }
 ];
 
@@ -59,16 +68,20 @@ test('all editor templates are tracked in the aggregate builder contract', () =>
 });
 
 test('all editor templates define their local builder function', () => {
-  for (const { path, builder } of TEMPLATE_BUILDERS) {
+  for (const { path, builder, module: isModule } of TEMPLATE_BUILDERS) {
     const content = fs.readFileSync(path, 'utf8');
-    const builderPattern = new RegExp(`function\\s+${escapeRegExp(builder)}\\s*\\(\\)`);
-
-    assert.match(content, builderPattern, `${path} must define ${builder}()`);
+    if (isModule) {
+      const exportBuilderPattern = new RegExp(`export\\s+function\\s+${escapeRegExp(builder)}\\s*\\(\\)`);
+      assert.match(content, exportBuilderPattern, `${path} must define ${builder}() as export`);
+    } else {
+      const builderPattern = new RegExp(`function\\s+${escapeRegExp(builder)}\\s*\\(\\)`);
+      assert.match(content, builderPattern, `${path} must define ${builder}()`);
+    }
   }
 });
 
 test('all editor templates mount through their builder function', () => {
-  for (const { path, builder, mountId } of TEMPLATE_BUILDERS) {
+  for (const { path, builder, mountId, module: isModule } of TEMPLATE_BUILDERS) {
     const content = fs.readFileSync(path, 'utf8');
     const mountPattern = new RegExp(
       `document\\.getElementById\\(['"]${escapeRegExp(mountId)}['"]\\)`
@@ -77,18 +90,39 @@ test('all editor templates mount through their builder function', () => {
       `mount\\.outerHTML\\s*=\\s*${escapeRegExp(builder)}\\(\\)`
     );
 
-    assert.match(content, /^\(function\(\)\s*\{/, `${path} must keep classic IIFE wrapper`);
+    if (isModule) {
+      assert.doesNotMatch(content, /^\(function\(\)\s*\{/, `${path} must not use IIFE wrapper (ESM)`);
+    } else {
+      assert.match(content, /^\(function\(\)\s*\{/, `${path} must keep classic IIFE wrapper`);
+    }
     assert.match(content, mountPattern, `${path} must target #${mountId}`);
     assert.match(content, mountCallPattern, `${path} must mount via ${builder}()`);
   }
 });
 
-test('editor templates do not expose provider globals or module exports yet', () => {
+test('editor templates do not expose window provider globals', () => {
   for (const { path } of TEMPLATE_BUILDERS) {
     const content = fs.readFileSync(path, 'utf8');
 
     assert.doesNotMatch(content, /window\.LoveBudEditor[A-Z]/, `${path} must not set LoveBudEditor globals`);
     assert.doesNotMatch(content, /window\.createEditor[A-Z]/, `${path} must not set createEditor globals`);
-    assert.doesNotMatch(content, /\bexport\s+/, `${path} must not use ESM export before module migration`);
+  }
+});
+
+test('classic templates do not use ESM export', () => {
+  const classicTemplates = TEMPLATE_BUILDERS.filter(t => !t.module);
+  for (const { path } of classicTemplates) {
+    const content = fs.readFileSync(path, 'utf8');
+    assert.doesNotMatch(content, /\bexport\s+/, `${path} must not use ESM export (classic script)`);
+  }
+});
+
+test('ESM templates use export function pattern', () => {
+  const moduleTemplates = TEMPLATE_BUILDERS.filter(t => t.module);
+  assert.ok(moduleTemplates.length > 0, 'at least one template must be ESM');
+  for (const { path, builder } of moduleTemplates) {
+    const content = fs.readFileSync(path, 'utf8');
+    const exportPattern = new RegExp(`export\\s+function\\s+${escapeRegExp(builder)}\\s*\\(`);
+    assert.match(content, exportPattern, `${path} must use export function ${builder}`);
   }
 });

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -16,6 +16,14 @@ const TEMPLATE_SCRIPTS = [
     'js/editor/templates/editor-detail-edit-mode-template.js'
 ];
 
+const MODULE_TEMPLATE_SCRIPTS = [
+    'js/editor/templates/editor-add-memory-form-template.js'
+];
+
+function isModuleTemplate(script) {
+    return MODULE_TEMPLATE_SCRIPTS.includes(script);
+}
+
 // Mount IDs that exist directly in editor.html (top-level)
 const HTML_MOUNT_IDS = [
     'addMemoryFormTemplateMount',
@@ -102,11 +110,19 @@ test('template files use IIFE pattern with mount.outerHTML replacement', () => {
     for (const script of TEMPLATE_SCRIPTS) {
         const filePath = script;
         const content = fs.readFileSync(filePath, 'utf8');
-        assert.match(content, /^\(function\(\)\s*\{/,
-            `template ${script} must start with IIFE pattern`);
-        // Accept both direct template variable and builder function call
-        assert.match(content, /mount\.outerHTML\s*=\s*(template|build\w+Template\(\))/,
-            `template ${script} must use mount.outerHTML = template or builder call`);
+        if (isModuleTemplate(script)) {
+            // Module templates use export function instead of IIFE
+            assert.match(content, /export\s+function\s+build\w+Template\s*\(/,
+                `module template ${script} must use export function builder`);
+            assert.doesNotMatch(content, /^\(function\(\)\s*\{/,
+                `module template ${script} must not use IIFE wrapper`);
+        } else {
+            assert.match(content, /^\(function\(\)\s*\{/,
+                `template ${script} must start with IIFE pattern`);
+        }
+        // All templates: mount.outerHTML = builder call
+        assert.match(content, /mount\.outerHTML\s*=\s*build\w+Template\(\)/,
+            `template ${script} must use mount.outerHTML = buildXxxTemplate()`);
         assert.match(content, /document\.getElementById\(.*TemplateMount/,
             `template ${script} must reference a TemplateMount element`);
     }
@@ -151,8 +167,8 @@ test('no duplicate template script references in editor.html', () => {
 
 test('editor-add-memory-form-template.js defines buildAddMemoryFormTemplate builder', () => {
     const content = fs.readFileSync('js/editor/templates/editor-add-memory-form-template.js', 'utf8');
-    assert.match(content, /function buildAddMemoryFormTemplate\(\)/,
-        'must define buildAddMemoryFormTemplate function');
+    assert.match(content, /export\s+function buildAddMemoryFormTemplate\(\)/,
+        'must define buildAddMemoryFormTemplate as exported function');
     assert.match(content, /mount\.outerHTML\s*=\s*buildAddMemoryFormTemplate\(\)/,
         'must call buildAddMemoryFormTemplate() for mount.outerHTML');
 });
@@ -229,4 +245,23 @@ test('exactly 9 template scripts are loaded in editor.html', () => {
         if (html.indexOf(script) !== -1) count++;
     }
     assert.equal(count, 9, 'editor.html must load exactly 9 template scripts');
+});
+
+// --- 12. Module script type verification in editor.html ---
+
+test('editor-add-memory-form-template.js is loaded as type="module" in editor.html', () => {
+    const modulePattern = /<script\s+type="module"\s+src="[^"]*editor-add-memory-form-template\.js/;
+    assert.match(html, modulePattern,
+        'editor-add-memory-form-template.js must be loaded with type="module"');
+});
+
+test('remaining 8 template scripts are NOT loaded as type="module"', () => {
+    const classicTemplates = TEMPLATE_SCRIPTS.filter(s => !isModuleTemplate(s));
+    for (const script of classicTemplates) {
+        const scriptTagPattern = new RegExp(`<script\\s+src="[^"]*${script.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+        const match = html.match(scriptTagPattern);
+        assert.ok(match, `editor.html must contain script tag for ${script}`);
+        assert.ok(!match[0].includes('type="module"'),
+            `${script} must not be loaded as type="module"`);
+    }
 });


### PR DESCRIPTION
Refs #1494

## Summary
- convert editor-add-memory-form-template.js from classic IIFE to ES module
- export buildAddMemoryFormTemplate function
- add type="module" to script tag in editor.html
- update contract tests to handle ESM/classic template distinction
- 8 remaining templates stay as classic IIFE scripts

## First ESM Migration Smoke
This is the first template ESM conversion. If this passes CI and browser smoke, the remaining 8 templates can be converted one-by-one using the same pattern.

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-add-memory-form-template.js
HTML files changed: pages/editor.html (1 line: type="module" added)
Test files changed: tests/contracts/editor-template-load-contract.test.cjs, tests/contracts/editor-template-builder-completion-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS