### PR TITLE
refactor(editor): convert canvas topbar template to ESM

### DIFF
--- a/js/editor/templates/editor-canvas-topbar-template.js
+++ b/js/editor/templates/editor-canvas-topbar-template.js
@@ -1,6 +1,5 @@
-(function() {
-    function buildCanvasTopbarTemplate() {
-        return `
+export function buildCanvasTopbarTemplate() {
+    return `
             <div class="editor-canvas-topbar" aria-label="러브트리 캔버스 도구">
                 
                 <div class="editor-canvas-toolbar" role="toolbar" aria-label="트리 화면 조정">
@@ -39,11 +38,10 @@
                     </div>
                 </div>
             </div>
-        `;
-    }
+    `;
+}
 
-    const mount = document.getElementById('editorCanvasTopbarTemplateMount');
-    if (mount) {
-        mount.outerHTML = buildCanvasTopbarTemplate();
-    }
-})();
+const mount = document.getElementById('editorCanvasTopbarTemplateMount');
+if (mount) {
+    mount.outerHTML = buildCanvasTopbarTemplate();
+}

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -80,7 +80,7 @@
     <script src="../js/utils/media.js?v=20260418-1"></script>
     <script type="module" src="../js/editor/templates/editor-add-memory-form-template.js?v=20260531-1494"></script>
     <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
-    <script src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260525-1280"></script>
+    <script type="module" src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260531-1494"></script>
     <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-floating-toolbar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-panel-shell-template.js?v=20260525-1280"></script>

--- a/tests/contracts/editor-template-builder-completion-contract.test.cjs
+++ b/tests/contracts/editor-template-builder-completion-contract.test.cjs
@@ -13,7 +13,7 @@ const TEMPLATE_BUILDERS = [
     path: 'js/editor/templates/editor-canvas-topbar-template.js',
     builder: 'buildCanvasTopbarTemplate',
     mountId: 'editorCanvasTopbarTemplateMount',
-    module: false
+    module: true
   },
   {
     path: 'js/editor/templates/editor-empty-guide-template.js',

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -17,7 +17,8 @@ const TEMPLATE_SCRIPTS = [
 ];
 
 const MODULE_TEMPLATE_SCRIPTS = [
-    'js/editor/templates/editor-add-memory-form-template.js'
+    'js/editor/templates/editor-add-memory-form-template.js',
+    'js/editor/templates/editor-canvas-topbar-template.js'
 ];
 
 function isModuleTemplate(script) {
@@ -175,8 +176,8 @@ test('editor-add-memory-form-template.js defines buildAddMemoryFormTemplate buil
 
 test('editor-canvas-topbar-template.js defines buildCanvasTopbarTemplate builder', () => {
     const content = fs.readFileSync('js/editor/templates/editor-canvas-topbar-template.js', 'utf8');
-    assert.match(content, /function buildCanvasTopbarTemplate\(\)/,
-        'must define buildCanvasTopbarTemplate function');
+    assert.match(content, /export\s+function buildCanvasTopbarTemplate\(\)/,
+        'must define buildCanvasTopbarTemplate as exported function');
     assert.match(content, /mount\.outerHTML\s*=\s*buildCanvasTopbarTemplate\(\)/,
         'must call buildCanvasTopbarTemplate() for mount.outerHTML');
 });
@@ -255,7 +256,13 @@ test('editor-add-memory-form-template.js is loaded as type="module" in editor.ht
         'editor-add-memory-form-template.js must be loaded with type="module"');
 });
 
-test('remaining 8 template scripts are NOT loaded as type="module"', () => {
+test('editor-canvas-topbar-template.js is loaded as type="module" in editor.html', () => {
+    const modulePattern = /<script\s+type="module"\s+src="[^"]*editor-canvas-topbar-template\.js/;
+    assert.match(html, modulePattern,
+        'editor-canvas-topbar-template.js must be loaded with type="module"');
+});
+
+test('remaining 7 template scripts are NOT loaded as type="module"', () => {
     const classicTemplates = TEMPLATE_SCRIPTS.filter(s => !isModuleTemplate(s));
     for (const script of classicTemplates) {
         const scriptTagPattern = new RegExp(`<script\\s+src="[^"]*${script.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);


### PR DESCRIPTION
Refs #1494

## Summary
- convert editor-canvas-topbar-template.js from classic IIFE to ES module
- export buildCanvasTopbarTemplate function
- add type="module" to script tag in editor.html
- update contract tests to include canvas topbar as ESM template
- 7 remaining templates stay as classic IIFE scripts

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-canvas-topbar-template.js
HTML files changed: pages/editor.html (1 line: type="module" added)
Test files changed: tests/contracts/editor-template-load-contract.test.cjs, tests/contracts/editor-template-builder-completion-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS