### PR TITLE
refactor(editor): convert empty guide template to ESM

### DIFF
--- a/js/editor/templates/editor-empty-guide-template.js
+++ b/js/editor/templates/editor-empty-guide-template.js
@@ -1,6 +1,5 @@
-(function() {
-    function buildEmptyGuideTemplate() {
-        return `
+export function buildEmptyGuideTemplate() {
+    return `
                         <div id="canvasEmptyGuide" class="editor-canvas-empty-guide editor-canvas-empty-guide-hidden" aria-live="polite">
                 <div class="editor-canvas-empty-guide__eyebrow" id="canvasEmptyGuideEyebrow">시작하기</div>
                 <h3 class="editor-canvas-empty-guide__title" id="canvasEmptyGuideTitle">이 트리의 첫 순간을 기록해볼까요?</h3>
@@ -21,11 +20,10 @@
                 </div>
                 <p class="editor-canvas-empty-guide__hint" id="canvasEmptyGuideHint">붙여넣는 순간 바로 생성돼요.</p>
             </div>
-        `;
-    }
+    `;
+}
 
-    const mount = document.getElementById('editorEmptyGuideTemplateMount');
-    if (mount) {
-        mount.outerHTML = buildEmptyGuideTemplate();
-    }
-})();
+const mount = document.getElementById('editorEmptyGuideTemplateMount');
+if (mount) {
+    mount.outerHTML = buildEmptyGuideTemplate();
+}

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -81,7 +81,7 @@
     <script type="module" src="../js/editor/templates/editor-add-memory-form-template.js?v=20260531-1494"></script>
     <script src="../js/editor/templates/editor-sidebar-template.js?v=20260525-1280"></script>
     <script type="module" src="../js/editor/templates/editor-canvas-topbar-template.js?v=20260531-1494"></script>
-    <script src="../js/editor/templates/editor-empty-guide-template.js?v=20260525-1280"></script>
+    <script type="module" src="../js/editor/templates/editor-empty-guide-template.js?v=20260531-1494"></script>
     <script src="../js/editor/templates/editor-floating-toolbar-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-panel-shell-template.js?v=20260525-1280"></script>
     <script src="../js/editor/templates/editor-detail-empty-state-template.js?v=20260525-1280"></script>

--- a/tests/contracts/editor-template-builder-completion-contract.test.cjs
+++ b/tests/contracts/editor-template-builder-completion-contract.test.cjs
@@ -19,7 +19,7 @@ const TEMPLATE_BUILDERS = [
     path: 'js/editor/templates/editor-empty-guide-template.js',
     builder: 'buildEmptyGuideTemplate',
     mountId: 'editorEmptyGuideTemplateMount',
-    module: false
+    module: true
   },
   {
     path: 'js/editor/templates/editor-sidebar-template.js',

--- a/tests/contracts/editor-template-load-contract.test.cjs
+++ b/tests/contracts/editor-template-load-contract.test.cjs
@@ -18,7 +18,8 @@ const TEMPLATE_SCRIPTS = [
 
 const MODULE_TEMPLATE_SCRIPTS = [
     'js/editor/templates/editor-add-memory-form-template.js',
-    'js/editor/templates/editor-canvas-topbar-template.js'
+    'js/editor/templates/editor-canvas-topbar-template.js',
+    'js/editor/templates/editor-empty-guide-template.js'
 ];
 
 function isModuleTemplate(script) {
@@ -184,8 +185,8 @@ test('editor-canvas-topbar-template.js defines buildCanvasTopbarTemplate builder
 
 test('editor-empty-guide-template.js defines buildEmptyGuideTemplate builder', () => {
     const content = fs.readFileSync('js/editor/templates/editor-empty-guide-template.js', 'utf8');
-    assert.match(content, /function buildEmptyGuideTemplate\(\)/,
-        'must define buildEmptyGuideTemplate function');
+    assert.match(content, /export\s+function buildEmptyGuideTemplate\(\)/,
+        'must define buildEmptyGuideTemplate as exported function');
     assert.match(content, /mount\.outerHTML\s*=\s*buildEmptyGuideTemplate\(\)/,
         'must call buildEmptyGuideTemplate() for mount.outerHTML');
 });
@@ -262,7 +263,13 @@ test('editor-canvas-topbar-template.js is loaded as type="module" in editor.html
         'editor-canvas-topbar-template.js must be loaded with type="module"');
 });
 
-test('remaining 7 template scripts are NOT loaded as type="module"', () => {
+test('editor-empty-guide-template.js is loaded as type="module" in editor.html', () => {
+    const modulePattern = /<script\s+type="module"\s+src="[^"]*editor-empty-guide-template\.js/;
+    assert.match(html, modulePattern,
+        'editor-empty-guide-template.js must be loaded with type="module"');
+});
+
+test('remaining 6 template scripts are NOT loaded as type="module"', () => {
     const classicTemplates = TEMPLATE_SCRIPTS.filter(s => !isModuleTemplate(s));
     for (const script of classicTemplates) {
         const scriptTagPattern = new RegExp(`<script\\s+src="[^"]*${script.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);


### PR DESCRIPTION
Refs #1494

## Summary
- convert editor-empty-guide-template.js from classic IIFE to ES module
- export buildEmptyGuideTemplate function
- add type="module" to script tag in editor.html
- update contract tests to include empty-guide as ESM template
- 6 remaining templates stay as classic IIFE scripts

## Contract Gate
[Editor Entrypoint Contract Gate]
Runtime files changed: js/editor/templates/editor-empty-guide-template.js
HTML files changed: pages/editor.html (1 line: type="module" added)
Test files changed: tests/contracts/editor-template-load-contract.test.cjs, tests/contracts/editor-template-builder-completion-contract.test.cjs
Static checks: PASS
Full tests: PASS
Final judgment: PASS