### PR TITLE
refactor(editor): inline auth session deps aliases

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -43,8 +43,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const runEditorInitialLoadFlow = deps.runEditorInitialLoadFlow;
     const createEditorRefreshSaveRuntime = deps.createEditorRefreshSaveRuntime;
     const createEditorStartupContext = deps.createEditorStartupContext;
-    const getConfirmedSessionUser = deps.getConfirmedSessionUser;
-    const readConfirmedAuthCache = deps.readConfirmedAuthCache;
     const showToast = deps.showToast;
     const i18n = deps.i18n;
     const getEditorBasePath = deps.getEditorBasePath;
@@ -229,7 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 i18n,
                 apiClient: window.apiClient,
                 createDefaultTreeTitle: () => safeI18nText(i18n, 'default_tree_title', '러브트리'),
-                getConfirmedSessionUser,
+                getConfirmedSessionUser: deps.getConfirmedSessionUser,
                 showToast,
                 redirectToEditorLogin,
                 buildTreeLoadErrorCopy,
@@ -620,6 +618,6 @@ document.addEventListener('DOMContentLoaded', () => {
         windowRef: window,
         startEditor: startEditor,
         redirectToEditorLogin: redirectToEditorLogin,
-        readConfirmedAuthCache: readConfirmedAuthCache
+        readConfirmedAuthCache: deps.readConfirmedAuthCache
     });
 });

--- a/tests/contracts/editor-post-bootstrap-alias-inventory-contract.test.cjs
+++ b/tests/contracts/editor-post-bootstrap-alias-inventory-contract.test.cjs
@@ -40,8 +40,6 @@ test('direct deps function aliases remain inventoried', () => {
   const editor = read('js/editor.js');
 
   const expectedDirectAliases = [
-    'const getConfirmedSessionUser = deps.getConfirmedSessionUser;',
-    'const readConfirmedAuthCache = deps.readConfirmedAuthCache;',
     'const showToast = deps.showToast;',
     'const i18n = deps.i18n;',
     'const getEditorBasePath = deps.getEditorBasePath;',
@@ -160,7 +158,9 @@ test('remaining helper method aliases: none — all 20 helper method aliases hav
     'const escapeHtml = deps.escapeHtml;',
     'const findRootMemory = deps.findRootMemory;',
     'const getCanonicalRootId = deps.getCanonicalRootId;',
-    'const isRootMemory = deps.isRootMemory;'
+    'const isRootMemory = deps.isRootMemory;',
+    'const getConfirmedSessionUser = deps.getConfirmedSessionUser;',
+    'const readConfirmedAuthCache = deps.readConfirmedAuthCache;'
   ];
 
   for (const alias of forbiddenLocalAliases) {
@@ -169,6 +169,8 @@ test('remaining helper method aliases: none — all 20 helper method aliases hav
 
   // Verify direct deps usage for the last cleaned up alias
   assert.ok(editor.includes('deps.registerEditorAuthStart'), 'editor should use deps.registerEditorAuthStart directly');
+  assert.ok(editor.includes('deps.getConfirmedSessionUser'), 'editor should use deps.getConfirmedSessionUser directly');
+  assert.ok(editor.includes('deps.readConfirmedAuthCache'), 'editor should use deps.readConfirmedAuthCache directly');
 });
 
 test('resolver-owned duplicate bootstrap guards remain removed after cleanup', () => {

--- a/tests/contracts/editor-unused-fallback-namespace-reads-contract.test.cjs
+++ b/tests/contracts/editor-unused-fallback-namespace-reads-contract.test.cjs
@@ -20,8 +20,8 @@ test('entry dependency resolver still owns fallback namespace resolution', () =>
 test('editor still consumes resolved dependency outputs that remain active', () => {
   assert.match(editorSource, /const\s+deps\s*=\s*entryDependenciesResult\.deps/);
   assert.match(editorSource, /const\s+editorDataLoader\s*=\s*deps\.editorDataLoader/);
-  assert.match(editorSource, /const\s+getConfirmedSessionUser\s*=\s*deps\.getConfirmedSessionUser/);
-  assert.match(editorSource, /const\s+readConfirmedAuthCache\s*=\s*deps\.readConfirmedAuthCache/);
+  assert.match(editorSource, /getConfirmedSessionUser:\s*deps\.getConfirmedSessionUser/);
+  assert.match(editorSource, /readConfirmedAuthCache:\s*deps\.readConfirmedAuthCache/);
 });
 
 test('unused fallback namespace cleanup avoids runtime behavior changes', () => {

--- a/tests/routes/editor-auth-helper-callsite.test.cjs
+++ b/tests/routes/editor-auth-helper-callsite.test.cjs
@@ -13,8 +13,8 @@ test('editor auth cache reader is resolved from entry dependencies', () => {
   const editor = read('js/editor.js');
   const deps = read('js/editor/editor-entry-dependencies.js');
 
-  // editor.js should get readConfirmedAuthCache from deps
-  assert.match(editor, /const\s+readConfirmedAuthCache\s*=\s*deps\.readConfirmedAuthCache/);
+  // editor.js should get readConfirmedAuthCache from deps at call site
+  assert.match(editor, /deps\.registerEditorAuthStart\(\{[\s\S]*readConfirmedAuthCache:\s*deps\.readConfirmedAuthCache/);
 
   // editor-entry-dependencies.js should expose readConfirmedAuthCache
   assert.match(deps, /readConfirmedAuthCache:\s*readConfirmedAuthCacheFromHelper/);


### PR DESCRIPTION
Refs #1698

**Changes:**
- `js/editor.js`: Removed 2 auth session aliases (`getConfirmedSessionUser`, `readConfirmedAuthCache`), inlined direct `deps.*` usage at 2 call sites
- `tests/contracts/editor-post-bootstrap-alias-inventory-contract.test.cjs`: Added direct deps usage assertions for the 2 cleaned up aliases
- `tests/contracts/editor-unused-fallback-namespace-reads-contract.test.cjs`: Updated assertions from alias patterns to call-site direct deps usage
- `tests/routes/editor-auth-helper-callsite.test.cjs`: Updated assertion from alias pattern to call-site direct deps usage

**Progress:**
- Direct deps function aliases: 20 → 18
- Namespace deps aliases: 14 (unchanged)
- #1698 remains OPEN for remaining cleanup

**Verification:**
- `npm run verify`: 272/272 pass
- `npm test`: 1848/1849 pass (1 existing skip)
