### PR TITLE
feat(product): add manual LoveBud Scout draft MVP

### DIFF
--- a/css/scout/scout-draft.css
+++ b/css/scout/scout-draft.css
@@ -1,0 +1,472 @@
+/**
+ * LoveBud Scout Draft CSS
+ * Phase 1: Manual draft entrypoint styles
+ * v20260605-1
+ */
+
+:root {
+    --scout-modal-bg: rgba(255, 255, 255, 0.98);
+    --scout-modal-border: rgba(237, 223, 214, 0.9);
+    --scout-input-bg: rgba(255, 255, 255, 0.9);
+    --scout-input-border: rgba(229, 212, 201, 0.8);
+    --scout-input-focus-border: var(--color-rose-400);
+    --scout-error-color: var(--color-rose-500);
+    --scout-preview-bg: rgba(255, 251, 247, 0.98);
+}
+
+/* Modal overlay */
+.scout-draft-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(15, 12, 10, 0.6);
+    backdrop-filter: blur(4px);
+    animation: scout-fade-in 0.2s ease-out;
+}
+
+.scout-draft-modal-overlay.is-open {
+    display: flex;
+}
+
+@keyframes scout-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Modal content */
+.scout-draft-modal {
+    width: 100%;
+    max-width: 560px;
+    max-height: 90vh;
+    overflow-y: auto;
+    background: var(--scout-modal-bg);
+    border: 1px solid var(--scout-modal-border);
+    border-radius: 24px;
+    box-shadow: var(--shadow-xl);
+    animation: scout-slide-up 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes scout-slide-up {
+    from {
+        opacity: 0;
+        transform: translateY(20px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Header */
+.scout-draft-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px;
+    border-bottom: 1px solid var(--scout-modal-border);
+}
+
+.scout-draft-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-brown-900);
+}
+
+.scout-draft-close-btn {
+    width: 36px;
+    height: 36px;
+    border: none;
+    background: transparent;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--color-brown-500);
+    transition: background 0.15s, color 0.15s;
+}
+
+.scout-draft-close-btn:hover {
+    background: rgba(229, 212, 201, 0.5);
+    color: var(--color-brown-700);
+}
+
+.scout-draft-close-btn:focus-visible {
+    outline: 2px solid var(--color-rose-400);
+    outline-offset: 2px;
+}
+
+/* Form */
+.scout-draft-form {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.scout-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scout-field label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-brown-700);
+}
+
+.scout-field .field-hint {
+    font-size: 0.75rem;
+    color: var(--color-brown-400);
+    margin-top: 4px;
+}
+
+.scout-input,
+.scout-textarea {
+    width: 100%;
+    padding: 12px 16px;
+    font-size: 0.9375rem;
+    font-family: inherit;
+    color: var(--color-brown-900);
+    background: var(--scout-input-bg);
+    border: 1px solid var(--scout-input-border);
+    border-radius: 12px;
+    box-sizing: border-box;
+    transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+}
+
+.scout-input::placeholder,
+.scout-textarea::placeholder {
+    color: var(--color-brown-300);
+}
+
+.scout-input:hover,
+.scout-textarea:hover {
+    border-color: rgba(229, 212, 201, 1);
+}
+
+.scout-input:focus,
+.scout-textarea:focus {
+    outline: none;
+    border-color: var(--scout-input-focus-border);
+    box-shadow: 0 0 0 3px rgba(249, 168, 149, 0.25);
+    background: #fff;
+}
+
+.scout-input.has-error,
+.scout-textarea.has-error {
+    border-color: var(--scout-error-color);
+}
+
+.scout-input.has-error:focus,
+.scout-textarea.has-error:focus {
+    box-shadow: 0 0 0 3px rgba(244, 114, 82, 0.2);
+}
+
+.scout-textarea {
+    min-height: 100px;
+    resize: vertical;
+    line-height: 1.6;
+}
+
+.scout-error {
+    display: none;
+    font-size: 0.75rem;
+    color: var(--scout-error-color);
+    margin-top: 4px;
+}
+
+/* Actions */
+.scout-draft-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    padding-top: 8px;
+    margin-top: 8px;
+    border-top: 1px solid var(--scout-modal-border);
+}
+
+.scout-btn {
+    padding: 12px 24px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    font-family: inherit;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.scout-btn-primary {
+    background: linear-gradient(135deg, var(--color-rose-400), var(--color-rose-500));
+    color: #fff;
+    box-shadow: 0 4px 14px rgba(244, 114, 82, 0.3);
+}
+
+.scout-btn-primary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(244, 114, 82, 0.4);
+}
+
+.scout-btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.scout-btn-outline {
+    background: transparent;
+    color: var(--color-brown-600);
+    border: 1px solid var(--scout-input-border);
+}
+
+.scout-btn-outline:hover:not(:disabled) {
+    background: rgba(229, 212, 201, 0.5);
+    border-color: rgba(229, 212, 201, 1);
+}
+
+.scout-btn-secondary {
+    background: var(--color-cream-100);
+    color: var(--color-brown-600);
+}
+
+.scout-btn-secondary:hover:not(:disabled) {
+    background: var(--color-cream-200);
+}
+
+/* Preview overlay */
+.scout-preview-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(15, 12, 10, 0.7);
+    backdrop-filter: blur(6px);
+    opacity: 0;
+    transition: opacity 0.2s ease-out;
+}
+
+.scout-preview-content {
+    width: 100%;
+    max-width: 480px;
+    max-height: 85vh;
+    overflow-y: auto;
+    background: var(--scout-preview-bg);
+    border: 1px solid var(--scout-modal-border);
+    border-radius: 20px;
+    box-shadow: var(--shadow-xl);
+    transform: scale(0.95);
+    transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.scout-preview-overlay[style*="opacity: 1"] .scout-preview-content {
+    transform: scale(1);
+}
+
+.scout-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--scout-modal-border);
+}
+
+.scout-preview-header h3 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--color-brown-900);
+}
+
+.scout-preview-close {
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--color-brown-500);
+    font-size: 1.5rem;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s;
+}
+
+.scout-preview-close:hover {
+    background: rgba(229, 212, 201, 0.5);
+    color: var(--color-brown-700);
+}
+
+.scout-preview-body {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.preview-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.preview-field label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-brown-400);
+}
+
+.preview-field span {
+    font-size: 0.9375rem;
+    color: var(--color-brown-800);
+    line-height: 1.5;
+}
+
+.preview-field a {
+    color: var(--color-rose-500);
+    text-decoration: none;
+    word-break: break-all;
+}
+
+.preview-field a:hover {
+    text-decoration: underline;
+}
+
+.scout-preview-footer {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    padding: 16px 20px;
+    border-top: 1px solid var(--scout-modal-border);
+}
+
+/* Trigger button (for adding to editor toolbar, etc.) */
+.scout-draft-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    font-family: inherit;
+    color: var(--color-brown-700);
+    background: linear-gradient(135deg, rgba(249, 240, 232, 0.9), rgba(255, 248, 243, 0.9));
+    border: 1px solid rgba(237, 223, 214, 0.8);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.15s;
+    box-shadow: var(--shadow-sm);
+}
+
+.scout-draft-trigger:hover {
+    background: linear-gradient(135deg, rgba(249, 240, 232, 1), rgba(255, 248, 243, 1));
+    border-color: rgba(237, 223, 214, 1);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.scout-draft-trigger:focus-visible {
+    outline: 2px solid var(--color-rose-400);
+    outline-offset: 2px;
+}
+
+.scout-draft-trigger-icon {
+    font-size: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .scout-draft-modal {
+        max-width: 100%;
+        border-radius: 20px 20px 0 0;
+        max-height: 85vh;
+    }
+
+    .scout-draft-header {
+        padding: 16px 20px;
+    }
+
+    .scout-draft-form {
+        padding: 20px;
+        gap: 16px;
+    }
+
+    .scout-draft-actions {
+        flex-direction: column-reverse;
+    }
+
+    .scout-btn {
+        width: 100%;
+    }
+
+    .scout-preview-content {
+        max-width: 100%;
+        border-radius: 16px 16px 0 0;
+    }
+}
+
+/* Dark mode adjustments (if needed) */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --scout-modal-bg: rgba(25, 20, 18, 0.98);
+        --scout-modal-border: rgba(90, 70, 60, 0.5);
+        --scout-input-bg: rgba(35, 30, 28, 0.9);
+        --scout-input-border: rgba(90, 70, 60, 0.5);
+        --scout-preview-bg: rgba(30, 25, 22, 0.98);
+    }
+
+    .scout-field label {
+        color: var(--color-cream-100);
+    }
+
+    .scout-input,
+    .scout-textarea {
+        color: var(--color-cream-100);
+    }
+
+    .scout-input::placeholder,
+    .scout-textarea::placeholder {
+        color: var(--color-brown-400);
+    }
+
+    .preview-field span {
+        color: var(--color-cream-100);
+    }
+
+    .preview-field label {
+        color: var(--color-brown-500);
+    }
+
+    .scout-draft-trigger {
+        color: var(--color-cream-100);
+        background: linear-gradient(135deg, rgba(60, 45, 40, 0.9), rgba(50, 38, 34, 0.9));
+        border-color: rgba(90, 70, 60, 0.6);
+    }
+
+    .scout-draft-trigger:hover {
+        background: linear-gradient(135deg, rgba(70, 52, 46, 1), rgba(58, 44, 39, 1));
+        border-color: rgba(110, 85, 75, 1);
+    }
+
+    .scout-btn-outline {
+        color: var(--color-cream-200);
+        border-color: rgba(90, 70, 60, 0.5);
+    }
+
+    .scout-btn-outline:hover:not(:disabled) {
+        background: rgba(90, 70, 60, 0.3);
+        border-color: rgba(110, 85, 75, 1);
+    }
+}

--- a/js/editor/editor-floating-toolbar-dropdown.js
+++ b/js/editor/editor-floating-toolbar-dropdown.js
@@ -76,7 +76,7 @@
 
   /**
    * Bind dropdown events: more button click, document click-outside,
-   * and secondary action dispatch (delete, share, focus).
+   * and secondary action dispatch (delete, share, focus, scout).
    */
   function bindDropdownEvents(ctx) {
     var dropdown = ctx.dropdown;
@@ -84,6 +84,7 @@
     var deleteAction = ctx.deleteAction;
     var shareAction = ctx.shareAction;
     var focusAction = ctx.focusAction;
+    var scoutAction = ctx.scoutAction;
 
     // More button: toggle dropdown
     if (moreBtn) {
@@ -148,6 +149,24 @@
         var focusBtn = document.getElementById('focusSelectedBtn');
         if (focusBtn) {
           focusBtn.click();
+        }
+      });
+    }
+
+    // Secondary action: Scout draft (manual entry)
+    if (scoutAction) {
+      scoutAction.addEventListener('click', function (e) {
+        e.stopPropagation();
+        hideDropdown(dropdown, moreBtn);
+        if (window.LoveBudScoutDraftUI && window.LoveBudScoutDraftUI.open) {
+          // Get the currently selected node ID from the context
+          // ctx.selectedNode might be a function (getSelectedNodeEl) or an element
+          var selectedNodeEl = ctx.selectedNode;
+          if (typeof selectedNodeEl === 'function') {
+            selectedNodeEl = selectedNodeEl();
+          }
+          var selectedId = selectedNodeEl ? (selectedNodeEl.dataset.id || selectedNodeEl.getAttribute('data-id')) : null;
+          window.LoveBudScoutDraftUI.open(selectedId);
         }
       });
     }

--- a/js/editor/editor-floating-toolbar-elements.js
+++ b/js/editor/editor-floating-toolbar-elements.js
@@ -38,7 +38,8 @@
       forkBtn: byId(ids.forkBtn),
       deleteAction: byId(ids.deleteAction),
       shareAction: byId(ids.shareAction),
-      focusAction: byId(ids.focusAction)
+      focusAction: byId(ids.focusAction),
+      scoutAction: byId(ids.scoutAction)
     };
 
     if (!elements.editBtn || !elements.continueBtn || !elements.viewBtn) return null;

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -30,6 +30,7 @@
   const DELETE_ACTION_ID = 'ftbDeleteAction';
   const SHARE_ACTION_ID = 'ftbShareAction';
   const FOCUS_ACTION_ID = 'ftbFocusAction';
+  const SCOUT_ACTION_ID = 'ftbScoutAction';
   const SELECTED_CLASS = 'selected';
   const NODE_SELECTOR = '.memory-node';
   const IS_VISIBLE_CLASS = 'is-visible';
@@ -70,7 +71,8 @@
         forkBtn: FORK_BTN_ID,
         deleteAction: DELETE_ACTION_ID,
         shareAction: SHARE_ACTION_ID,
-        focusAction: FOCUS_ACTION_ID
+        focusAction: FOCUS_ACTION_ID,
+        scoutAction: SCOUT_ACTION_ID
       })
       : null;
 
@@ -89,6 +91,7 @@
     var deleteAction = elements.deleteAction;
     var shareAction = elements.shareAction;
     var focusAction = elements.focusAction;
+    var scoutAction = elements.scoutAction;
 
     // Prevent double-init
     if (toolbar.dataset.ftbInitialized === '1') return;
@@ -238,7 +241,9 @@
         moreBtn: moreBtn,
         deleteAction: deleteAction,
         shareAction: shareAction,
-        focusAction: focusAction
+        focusAction: focusAction,
+        scoutAction: scoutAction,
+        selectedNode: getSelectedNodeEl()
       });
     }
 

--- a/js/editor/templates/editor-floating-toolbar-template.js
+++ b/js/editor/templates/editor-floating-toolbar-template.js
@@ -34,6 +34,10 @@ export function buildFloatingToolbarTemplate() {
         </button>
         <!-- Secondary actions dropdown for "..." button -->
         <div id="ftbDropdown" class="editor-ftb-dropdown is-hidden" role="menu" aria-label="추가 행동" style="display:none;">
+            <button type="button" class="editor-ftb-dropdown-item" id="ftbScoutAction" role="menuitem" data-action="scout">
+                <span class="material-symbols-outlined" aria-hidden="true">scanner</span>
+                <span data-i18n="scout_trigger_label">Scout로 순간 저장</span>
+            </button>
             <button type="button" class="editor-ftb-dropdown-item" id="ftbDeleteAction" role="menuitem" data-action="delete">
                 <span class="material-symbols-outlined" aria-hidden="true">delete</span>
                 <span>순간 삭제</span>

--- a/js/i18n/i18n-index.js
+++ b/js/i18n/i18n-index.js
@@ -19,7 +19,8 @@
     window.i18nDetail,
     window.i18nEditor,
     window.i18nMyTrees,
-    window.i18nIndex
+    window.i18nIndex,
+    window.i18nScout
   ];
 
   dictModules.forEach(function(module) {

--- a/js/i18n/i18n-scout.js
+++ b/js/i18n/i18n-scout.js
@@ -1,0 +1,143 @@
+/**
+ * LoveBud - i18n Scout Dictionary
+ * Phase 1: Manual draft entrypoint
+ * v20260605-1
+ */
+
+(function() {
+    'use strict';
+
+    window.i18nScout = {
+        // Modal title
+        'scout_draft_title': {
+            ko: 'Scout 드래프트',
+            en: 'Scout Draft'
+        },
+
+        // Form fields
+        'scout_source_url_label': {
+            ko: '출처 링크',
+            en: 'Source URL'
+        },
+        'scout_source_url_placeholder': {
+            ko: '공개 링크를 붙여넣으세요 (http:// 또는 https://)',
+            en: 'Paste a public link (http:// or https://)'
+        },
+        'scout_source_url_hint': {
+            ko: 'YouTube, 기사, 블로그 등 공개된 페이지 링크를 입력하세요.',
+            en: 'Enter a public page link (YouTube, article, blog, etc.).'
+        },
+        'scout_excerpt_label': {
+            ko: '발췌 / 요약',
+            en: 'Excerpt / Summary'
+        },
+        'scout_excerpt_placeholder': {
+            ko: '인상 깊었던 구절이나 핵심 내용을 적어보세요 (선택)',
+            en: 'Write a memorable passage or key points (optional)'
+        },
+        'scout_excerpt_hint': {
+            ko: '원문에서 발췌한 텍스트나 직접 요약한 내용을 남겨두면 나중에 다시 보기 좋습니다.',
+            en: 'Save an excerpt or your own summary for later reference.'
+        },
+        'scout_memo_label': {
+            ko: '내 메모',
+            en: 'My Note'
+        },
+        'scout_memo_placeholder': {
+            ko: '이 순간이 왜 의미있는지, 어떤 감정이 들었는지 자유롭게 적어보세요 (선택)',
+            en: 'Why this moment matters, how you felt — write freely (optional)'
+        },
+        'scout_memo_hint': {
+            ko: '나만의 감정 기록을 남겨두세요.',
+            en: 'Leave your personal emotional note.'
+        },
+        'scout_emotion_tags_label': {
+            ko: '감정 태그',
+            en: 'Emotion Tags'
+        },
+        'scout_emotion_tags_placeholder': {
+            ko: '감동, 행복, 그리움, 설렘... (쉼표로 구분, 최대 4개)',
+            en: 'moving, happy, longing, excitement... (comma separated, max 4)'
+        },
+        'scout_emotion_tags_hint': {
+            ko: '태그는 최대 4개까지, 각각 20자 이하로 입력 가능합니다.',
+            en: 'Up to 4 tags, each 20 characters max.'
+        },
+
+        // Buttons
+        'scout_preview_btn': {
+            ko: '미리보기',
+            en: 'Preview'
+        },
+        'scout_save_btn': {
+            ko: '러브트리에 저장',
+            en: 'Save to LoveTree'
+        },
+        'scout_cancel_btn': {
+            ko: '취소',
+            en: 'Cancel'
+        },
+
+        // Preview
+        'scout_preview_title': {
+            ko: '저장 미리보기',
+            en: 'Save Preview'
+        },
+        'scout_preview_title_label': {
+            ko: '제목',
+            en: 'Title'
+        },
+        'scout_preview_source_label': {
+            ko: '출처',
+            en: 'Source'
+        },
+        'scout_preview_excerpt_label': {
+            ko: '발췌 / 메모',
+            en: 'Excerpt / Note'
+        },
+        'scout_preview_tags_label': {
+            ko: '감정 태그',
+            en: 'Emotion Tags'
+        },
+        'scout_preview_edit': {
+            ko: '수정',
+            en: 'Edit'
+        },
+        'scout_preview_confirm': {
+            ko: '확인 및 저장',
+            en: 'Confirm & Save'
+        },
+
+        // Toasts / Messages
+        'scout_draft_saved': {
+            ko: 'Scout 드래프트가 저장되었습니다.',
+            en: 'Scout draft saved.'
+        },
+        'scout_draft_save_failed': {
+            ko: '저장에 실패했습니다. 다시 시도해 주세요.',
+            en: 'Failed to save. Please try again.'
+        },
+        'scout_invalid_url': {
+            ko: '올바른 URL을 입력해 주세요.',
+            en: 'Please enter a valid URL.'
+        },
+        'scout_tag_too_long': {
+            ko: '감정 태그는 20자 이하로 입력해 주세요.',
+            en: 'Emotion tags must be 20 characters or less.'
+        },
+        'scout_no_tree_context': {
+            ko: '트리 컨텍스트가 없습니다. 편집기에서 다시 시도해 주세요.',
+            en: 'No tree context. Please try from the editor.'
+        },
+
+        // Trigger button (for editor toolbar, etc.)
+        'scout_trigger_label': {
+            ko: 'Scout로 순간 저장',
+            en: 'Save Moment with Scout'
+        },
+        'scout_trigger_tooltip': {
+            ko: '직접 링크와 메모로 순간을 저장합니다 (AI 없이)',
+            en: 'Save a moment manually with link and note (no AI)'
+        }
+    };
+})();

--- a/js/scout/scout-draft-ui.js
+++ b/js/scout/scout-draft-ui.js
@@ -1,0 +1,385 @@
+/**
+ * LoveBud Scout Draft UI Module
+ * Phase 1: Manual draft entrypoint UI
+ * v20260605-1
+ *
+ * Provides the UI for:
+ * - Public source URL input
+ * - Excerpt/summary textarea
+ * - Memo textarea
+ * - Emotion tags input
+ * - Save/preview actions
+ */
+
+(function() {
+    'use strict';
+
+    function isScoutUIDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_SCOUT_DEBUG === true;
+    }
+
+    function scoutUIDebugLog() {
+        if (!isScoutUIDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
+    const ScoutDraft = window.LoveBudScoutDraft;
+    const i18n = window.t || function(key) { return key; };
+
+    function createScoutDraftUI(deps) {
+        const {
+            treeId,
+            getSelectedNodeId,
+            getCanonicalRootId,
+            resolveParentIdForCreate,
+            showToast,
+            i18n: localI18n,
+            onDraftSave,
+            onDraftCancel
+        } = deps || {};
+
+        const t = localI18n || i18n;
+
+        // DOM refs
+        let refs = {};
+        let isOpen = false;
+        let escHandler = null;
+        let outsideClickHandler = null;
+
+        function getRefs() {
+            return {
+                modal: document.getElementById('scoutDraftModal'),
+                sourceUrlInput: document.getElementById('scoutSourceUrlInput'),
+                excerptTextarea: document.getElementById('scoutExcerptTextarea'),
+                memoTextarea: document.getElementById('scoutMemoTextarea'),
+                emotionTagsInput: document.getElementById('scoutEmotionTagsInput'),
+                saveBtn: document.getElementById('scoutDraftSaveBtn'),
+                cancelBtn: document.getElementById('scoutDraftCancelBtn'),
+                closeBtn: document.getElementById('scoutDraftCloseBtn'),
+                sourceUrlError: document.getElementById('scoutSourceUrlError'),
+                previewBtn: document.getElementById('scoutDraftPreviewBtn')
+            };
+        }
+
+        function setError(field, message) {
+            const errorEl = refs[field + 'Error'];
+            if (errorEl) {
+                errorEl.textContent = message;
+                errorEl.style.display = message ? 'block' : 'none';
+            }
+            const inputEl = refs[field + 'Input'] || refs[field + 'Textarea'];
+            if (inputEl) {
+                inputEl.classList.toggle('has-error', !!message);
+            }
+        }
+
+        function clearAllErrors() {
+            ['sourceUrl', 'excerpt', 'memo', 'emotionTags'].forEach(field => {
+                setError(field, '');
+            });
+        }
+
+        function resetForm() {
+            refs.sourceUrlInput.value = '';
+            refs.excerptTextarea.value = '';
+            refs.memoTextarea.value = '';
+            refs.emotionTagsInput.value = '';
+            clearAllErrors();
+        }
+
+        function openModal() {
+            refs = getRefs();
+            if (!refs.modal) {
+                scoutUIDebugLog('[ScoutDraftUI] Modal not found in DOM');
+                return false;
+            }
+            resetForm();
+            refs.modal.style.display = 'flex';
+            refs.modal.classList.add('is-open');
+            isOpen = true;
+
+            // Focus first input
+            setTimeout(() => {
+                if (refs.sourceUrlInput) refs.sourceUrlInput.focus();
+            }, 50);
+
+            // ESC handler
+            escHandler = (e) => {
+                if (e.key === 'Escape') {
+                    e.stopPropagation();
+                    closeModal();
+                }
+            };
+            document.addEventListener('keydown', escHandler);
+
+            // Outside click handler
+            outsideClickHandler = (e) => {
+                if (refs.modal.contains(e.target)) return;
+                if (e.target.closest('[data-scout-draft-trigger]')) return;
+                closeModal();
+            };
+            setTimeout(() => document.addEventListener('click', outsideClickHandler, true), 0);
+
+            // Bind save
+            if (refs.saveBtn) {
+                refs.saveBtn.onclick = handleSave;
+            }
+
+            // Bind cancel/close
+            const closeHandler = () => closeModal();
+            if (refs.cancelBtn) refs.cancelBtn.onclick = closeHandler;
+            if (refs.closeBtn) refs.closeBtn.onclick = closeHandler;
+
+            // Real-time validation on source URL
+            if (refs.sourceUrlInput) {
+                refs.sourceUrlInput.addEventListener('input', () => {
+                    const result = ScoutDraft.validateSourceUrl(refs.sourceUrlInput.value);
+                    setError('sourceUrl', result.ok ? '' : result.message);
+                });
+            }
+
+            scoutUIDebugLog('[ScoutDraftUI] Modal opened');
+            return true;
+        }
+
+        function closeModal() {
+            if (!refs.modal || !isOpen) return;
+            refs.modal.style.display = 'none';
+            refs.modal.classList.remove('is-open');
+            isOpen = false;
+
+            if (escHandler) {
+                document.removeEventListener('keydown', escHandler);
+                escHandler = null;
+            }
+            if (outsideClickHandler) {
+                document.removeEventListener('click', outsideClickHandler, true);
+                outsideClickHandler = null;
+            }
+
+            if (onDraftCancel) onDraftCancel();
+
+            scoutUIDebugLog('[ScoutDraftUI] Modal closed');
+        }
+
+        function handleSave() {
+            const sourceUrl = refs.sourceUrlInput?.value || '';
+            const excerpt = refs.excerptTextarea?.value || '';
+            const memo = refs.memoTextarea?.value || '';
+            const emotionTagsInput = refs.emotionTagsInput?.value || '';
+            const emotionTags = ScoutDraft.parseEmotionTagsInput(emotionTagsInput);
+
+            clearAllErrors();
+
+            // Build draft
+            const draftResult = ScoutDraft.buildScoutDraft({
+                sourceUrl,
+                excerpt,
+                memo,
+                emotionTags,
+                treeId: treeId || null
+            });
+
+            if (!draftResult.ok) {
+                setError(draftResult.field || 'sourceUrl', draftResult.message);
+                showToast?.(draftResult.message, 'error');
+                return;
+            }
+
+            // Convert to memory payload
+            const payloadResult = ScoutDraft.convertDraftToMemoryPayload(
+                draftResult.data,
+                resolveParentIdForCreate,
+                getSelectedNodeId,
+                getCanonicalRootId,
+                t
+            );
+
+            if (!payloadResult.ok) {
+                showToast?.(payloadResult.message, 'error');
+                return;
+            }
+
+            // Close modal and trigger save callback
+            closeModal();
+
+            if (onDraftSave) {
+                onDraftSave(payloadResult.data, draftResult.data);
+            } else {
+                // Default: show success toast
+                showToast?.(t('save_saved') || '저장됨', 'success');
+            }
+
+            scoutUIDebugLog('[ScoutDraftUI] Draft saved', payloadResult.data);
+        }
+
+        function handlePreview() {
+            const sourceUrl = refs.sourceUrlInput?.value || '';
+            const excerpt = refs.excerptTextarea?.value || '';
+            const memo = refs.memoTextarea?.value || '';
+            const emotionTagsInput = refs.emotionTagsInput?.value || '';
+            const emotionTags = ScoutDraft.parseEmotionTagsInput(emotionTagsInput);
+
+            clearAllErrors();
+
+            const draftResult = ScoutDraft.buildScoutDraft({
+                sourceUrl,
+                excerpt,
+                memo,
+                emotionTags,
+                treeId: treeId || null
+            });
+
+            if (!draftResult.ok) {
+                setError(draftResult.field || 'sourceUrl', draftResult.message);
+                return;
+            }
+
+            // Show preview - could open a small preview panel
+            const payloadResult = ScoutDraft.convertDraftToMemoryPayload(
+                draftResult.data,
+                resolveParentIdForCreate,
+                getSelectedNodeId,
+                getCanonicalRootId,
+                t
+            );
+
+            if (payloadResult.ok) {
+                showPreview(payloadResult.data);
+            }
+        }
+
+        function showPreview(payload) {
+            // Create preview overlay using safe DOM node assembly (no innerHTML)
+            const overlay = document.createElement('div');
+            overlay.className = 'scout-preview-overlay';
+            overlay.id = 'scoutPreviewOverlay';
+
+            const content = document.createElement('div');
+            content.className = 'scout-preview-content';
+
+            // Header
+            const header = document.createElement('div');
+            header.className = 'scout-preview-header';
+
+            const h3 = document.createElement('h3');
+            h3.textContent = t('scout_preview_title') || '저장 미리보기';
+            header.appendChild(h3);
+
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.className = 'scout-preview-close';
+            closeBtn.id = 'scoutPreviewCloseBtn';
+            closeBtn.setAttribute('aria-label', '닫기');
+            closeBtn.textContent = '×';
+            header.appendChild(closeBtn);
+
+            content.appendChild(header);
+
+            // Body
+            const body = document.createElement('div');
+            body.className = 'scout-preview-body';
+
+            function createField(labelText, valueText) {
+                const field = document.createElement('div');
+                field.className = 'preview-field';
+
+                const label = document.createElement('label');
+                label.textContent = labelText;
+                field.appendChild(label);
+
+                const span = document.createElement('span');
+                span.textContent = valueText || '—';
+                field.appendChild(span);
+
+                return field;
+            }
+
+            body.appendChild(createField(t('scout_preview_title_label') || '제목', payload.title));
+            body.appendChild(createField(t('scout_preview_source_label') || '출처', payload.sourceUrl || '—'));
+
+            // Source URL as link if present
+            if (payload.sourceUrl) {
+                const sourceField = body.lastElementChild;
+                const span = sourceField.querySelector('span');
+                const link = document.createElement('a');
+                link.href = payload.sourceUrl;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = payload.sourceUrl;
+                span.textContent = '';
+                span.appendChild(link);
+            }
+
+            body.appendChild(createField(t('scout_preview_excerpt_label') || '발췌', payload.memo));
+            body.appendChild(createField(t('scout_preview_tags_label') || '감정 태그',
+                payload.emotionTags && payload.emotionTags.length ? payload.emotionTags.join(', ') : '—'));
+
+            content.appendChild(body);
+
+            // Footer
+            const footer = document.createElement('div');
+            footer.className = 'scout-preview-footer';
+
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.className = 'btn-round btn-outline';
+            editBtn.id = 'scoutPreviewEditBtn';
+            editBtn.textContent = t('scout_preview_edit') || '수정';
+            footer.appendChild(editBtn);
+
+            const confirmBtn = document.createElement('button');
+            confirmBtn.type = 'button';
+            confirmBtn.className = 'btn-round btn-primary';
+            confirmBtn.id = 'scoutPreviewConfirmBtn';
+            confirmBtn.textContent = t('save') || '저장';
+            footer.appendChild(confirmBtn);
+
+            content.appendChild(footer);
+            overlay.appendChild(content);
+
+            // Remove existing preview
+            const existing = document.getElementById('scoutPreviewOverlay');
+            if (existing) existing.remove();
+
+            document.body.appendChild(overlay);
+
+            const closePreview = () => {
+                overlay.style.opacity = '0';
+                setTimeout(() => overlay.remove(), 200);
+            };
+
+            // Event listeners - buttons already created above with IDs
+            const closeBtnEl = document.getElementById('scoutPreviewCloseBtn');
+            const editBtnEl = document.getElementById('scoutPreviewEditBtn');
+            const confirmBtnEl = document.getElementById('scoutPreviewConfirmBtn');
+
+            closeBtnEl?.addEventListener('click', closePreview);
+            editBtnEl?.addEventListener('click', closePreview);
+            confirmBtnEl?.addEventListener('click', () => {
+                closePreview();
+                if (onDraftSave) onDraftSave(payload, draftResult.data);
+            });
+
+            overlay.addEventListener('click', (e) => {
+                if (e.target === overlay) closePreview();
+            });
+
+            // Animate in
+            requestAnimationFrame(() => {
+                overlay.style.opacity = '1';
+            });
+        }
+
+        // Public API
+        return {
+            open: openModal,
+            close: closeModal,
+            isOpen: () => isOpen
+        };
+    }
+
+    window.LoveBudScoutDraftUI = {
+        createScoutDraftUI
+    };
+})();

--- a/js/scout/scout-draft.js
+++ b/js/scout/scout-draft.js
@@ -1,0 +1,218 @@
+/**
+ * LoveBud Scout Draft Module
+ * Phase 1: Manual draft entrypoint (no AI/fetch/auto-extraction)
+ * v20260605-1
+ *
+ * Allows user to manually provide:
+ * - Public source URL
+ * - Excerpt/summary/memo text
+ * - Optional emotion tags
+ * - Prepares draft data for save-to-LoveTree flow
+ */
+
+(function() {
+    'use strict';
+
+    function isScoutDebugEnabled() {
+        return window.LOVEBUD_DEBUG === true || window.LOVEBUD_SCOUT_DEBUG === true;
+    }
+
+    function scoutDebugLog() {
+        if (!isScoutDebugEnabled() || !window.console || typeof console.log !== 'function') return;
+        console.log.apply(console, arguments);
+    }
+
+    function scoutDebugWarn(message) {
+        if (!isScoutDebugEnabled() || !window.console || typeof console.warn !== 'function') return;
+        console.warn(message);
+    }
+
+    /**
+     * Validates a public source URL.
+     * Accepts HTTP/HTTPS URLs. Does not fetch or validate content.
+     */
+    function validateSourceUrl(rawUrl) {
+        if (!rawUrl) return { ok: true, value: '' };
+        const trimmed = String(rawUrl).trim();
+        if (!trimmed) return { ok: true, value: '' };
+        try {
+            const url = new URL(trimmed);
+            if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+                return { ok: false, message: '지원하지 않는 프로토콜입니다. http:// 또는 https:// 로 시작하는 링크를 입력해 주세요.' };
+            }
+            return { ok: true, value: trimmed };
+        } catch (e) {
+            return { ok: false, message: '올바른 URL 형식이 아닙니다.' };
+        }
+    }
+
+    /**
+     * Validates excerpt/summary text.
+     * Optional field - can be empty.
+     */
+    function validateExcerpt(text) {
+        if (!text) return { ok: true, value: '' };
+        const trimmed = String(text).trim();
+        return { ok: true, value: trimmed };
+    }
+
+    /**
+     * Validates memo text.
+     * Optional field - can be empty.
+     */
+    function validateMemo(text) {
+        if (!text) return { ok: true, value: '' };
+        const trimmed = String(text).trim();
+        return { ok: true, value: trimmed };
+    }
+
+    /**
+     * Validates emotion tags.
+     * Optional - array of strings, max 4 tags, each max 20 chars.
+     */
+    function validateEmotionTags(tags) {
+        if (!tags || !Array.isArray(tags)) return { ok: true, value: [] };
+        const filtered = tags
+            .map(t => String(t).trim())
+            .filter(t => t.length > 0)
+            .slice(0, 4);
+        const tooLong = filtered.some(t => t.length > 20);
+        if (tooLong) {
+            return { ok: false, message: '감정 태그는 20자 이하로 입력해 주세요.' };
+        }
+        return { ok: true, value: filtered };
+    }
+
+    /**
+     * Builds a Scout draft object from form inputs.
+     * This is the core data structure for Phase 1.
+     */
+    function buildScoutDraft(options) {
+        const {
+            sourceUrl,
+            excerpt,
+            memo,
+            emotionTags,
+            treeId
+        } = options || {};
+
+        const sourceUrlResult = validateSourceUrl(sourceUrl);
+        if (!sourceUrlResult.ok) return { ok: false, message: sourceUrlResult.message, field: 'sourceUrl' };
+
+        const excerptResult = validateExcerpt(excerpt);
+        if (!excerptResult.ok) return { ok: false, message: excerptResult.message, field: 'excerpt' };
+
+        const memoResult = validateMemo(memo);
+        if (!memoResult.ok) return { ok: false, message: memoResult.message, field: 'memo' };
+
+        const emotionTagsResult = validateEmotionTags(emotionTags);
+        if (!emotionTagsResult.ok) return { ok: false, message: emotionTagsResult.message, field: 'emotionTags' };
+
+        const draft = {
+            // Scout-specific metadata
+            scoutVersion: 1,
+            sourceUrl: sourceUrlResult.value,
+            excerpt: excerptResult.value,
+            memo: memoResult.value,
+            emotionTags: emotionTagsResult.value,
+            createdAt: new Date().toISOString(),
+
+            // Tree context for save flow
+            treeId: treeId || null,
+
+            // Ready for memory payload conversion
+            readyForSave: true
+        };
+
+        return { ok: true, data: draft };
+    }
+
+    /**
+     * Converts a Scout draft to a memory payload format compatible with editor.
+     * This enables the save-to-LoveTree flow.
+     */
+    function convertDraftToMemoryPayload(draft, resolveParentIdForCreate, getSelectedNodeId, getCanonicalRootId, i18n) {
+        if (!draft || !draft.readyForSave) {
+            return { ok: false, message: '유효하지 않은 드래프트입니다.' };
+        }
+
+        const parentId = resolveParentIdForCreate
+            ? resolveParentIdForCreate(getSelectedNodeId?.(), getCanonicalRootId?.())
+            : (getCanonicalRootId?.() || '');
+
+        // Build title from excerpt or source URL
+        let title = '';
+        if (draft.excerpt) {
+            // Use first 50 chars of excerpt as title
+            title = draft.excerpt.slice(0, 50).trim();
+            if (draft.excerpt.length > 50) title += '…';
+        } else if (draft.sourceUrl) {
+            // Fallback: domain from URL
+            try {
+                const url = new URL(draft.sourceUrl);
+                title = url.hostname.replace('www.', '') + ' 순간';
+            } catch (e) {
+                title = '수동 저장 순간';
+            }
+        } else {
+            title = '새 순간';
+        }
+
+        // Build memo: combine excerpt and memo
+        let fullMemo = '';
+        if (draft.excerpt) fullMemo += draft.excerpt;
+        if (draft.memo) {
+            if (fullMemo) fullMemo += '\n\n';
+            fullMemo += draft.memo;
+        }
+
+        const payload = {
+            treeId: draft.treeId,
+            title: title,
+            memo: fullMemo,
+            timestamp: draft.createdAt.split('T')[0].replace(/-/g, '.'),
+            sourceUrl: draft.sourceUrl,
+            sourceType: 'scout',
+            emotionTags: draft.emotionTags || [],
+            parentId: parentId,
+            thumbnail: '',
+            artist: '',
+            source: 'Scout',
+            visibility: 'public'
+        };
+
+        return { ok: true, data: payload };
+    }
+
+    /**
+     * Parses emotion tags from comma-separated string input.
+     */
+    function parseEmotionTagsInput(input) {
+        if (!input) return [];
+        return String(input)
+            .split(',')
+            .map(t => t.trim())
+            .filter(t => t.length > 0);
+    }
+
+    /**
+     * Formats emotion tags array for display in input.
+     */
+    function formatEmotionTagsInput(tags) {
+        if (!Array.isArray(tags)) return '';
+        return tags.join(', ');
+    }
+
+    window.LoveBudScoutDraft = {
+        validateSourceUrl,
+        validateExcerpt,
+        validateMemo,
+        validateEmotionTags,
+        buildScoutDraft,
+        convertDraftToMemoryPayload,
+        parseEmotionTagsInput,
+        formatEmotionTagsInput
+    };
+
+    scoutDebugLog('[LoveBudScoutDraft] Module loaded');
+})();

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -175,6 +175,11 @@
     <script src="../js/editor/editor-refresh-save-runtime.js?v=20260531-1698"></script>
     <script src="../js/editor/editor-entry-dependencies.js?v=20260531-1698"></script>
 
+    <!-- Scout Draft (Manual Entry) -->
+    <link rel="stylesheet" href="../css/scout/scout-draft.css?v=20260605-1" />
+    <script src="../js/scout/scout-draft.js?v=20260605-1"></script>
+    <script src="../js/scout/scout-draft-ui.js?v=20260605-1"></script>
+
     <script src="../js/editor.js?v=20260502-1"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
@@ -187,6 +192,7 @@
     <script src="../js/i18n/i18n-search.js?v=20260421-1"></script>
     <script src="../js/i18n/i18n-detail.js?v=20260421-5"></script>
     <script src="../js/i18n/i18n-editor.js?v=20260504-633"></script>
+    <script src="../js/i18n/i18n-scout.js?v=20260605-1"></script>
     <script>
       window.i18nEditor = Object.assign(window.i18nEditor || {}, {
         editor_sidebar_public_tree: { ko: "공개", en: "Public" },


### PR DESCRIPTION
Refs #1882

Closes #2202

## Summary

Adds the Phase 1 manual LoveBud Scout Draft MVP.

This implementation provides a frontend-first manual entry flow that lets users create a Scout draft from a user-provided public source URL, optional excerpt/summary text, memo, and emotion tags. The draft is converted into a save-ready payload through the onDraftSave callback.

## Scope

- Adds Scout Draft i18n copy
- Adds Scout draft validation and payload mapping logic
- Adds Scout modal UI and preview flow
- Adds Scout styling
- Adds Scout action to the editor floating toolbar dropdown
- Wires the Scout action through existing floating toolbar modules
- Keeps AI, automatic fetch, metadata extraction, crawling, and backend/schema changes out of scope

## Safety

- No AI provider integration
- No external URL fetching
- No crawling or scraping
- No API keys or provider environment variables
- No backend/schema migration
- Preview rendering uses safe DOM assembly with createElement, textContent, and appendChild
- No DOM XSS guardrail allowlist exception remains

## Validation

- npm test: 1847 passed
- npm run lint: passed, with only pre-existing unrelated warnings