### PR TITLE
fix(product): repair Scout draft toolbar wiring and validation

### DIFF
--- a/js/editor/editor-floating-toolbar-dropdown.js
+++ b/js/editor/editor-floating-toolbar-dropdown.js
@@ -181,6 +181,8 @@
    * @param {HTMLElement} [ctx.deleteAction]
    * @param {HTMLElement} [ctx.shareAction]
    * @param {HTMLElement} [ctx.focusAction]
+   * @param {HTMLElement} [ctx.scoutAction]
+   * @param {Function|HTMLElement} [ctx.selectedNode]
    */
   function bindToolbarDropdown(ctx) {
     if (!ctx) return;
@@ -190,7 +192,9 @@
       moreBtn: ctx.moreBtn,
       deleteAction: ctx.deleteAction,
       shareAction: ctx.shareAction,
-      focusAction: ctx.focusAction
+      focusAction: ctx.focusAction,
+      scoutAction: ctx.scoutAction,
+      selectedNode: ctx.selectedNode
     });
   }
 

--- a/js/editor/editor-floating-toolbar.js
+++ b/js/editor/editor-floating-toolbar.js
@@ -243,7 +243,7 @@
         shareAction: shareAction,
         focusAction: focusAction,
         scoutAction: scoutAction,
-        selectedNode: getSelectedNodeEl()
+        selectedNode: getSelectedNodeEl
       });
     }
 

--- a/js/scout/scout-draft.js
+++ b/js/scout/scout-draft.js
@@ -108,6 +108,19 @@
         const emotionTagsResult = validateEmotionTags(emotionTags);
         if (!emotionTagsResult.ok) return { ok: false, message: emotionTagsResult.message, field: 'emotionTags' };
 
+        // Ensure at least one of sourceUrl, excerpt, or memo has content
+        const hasSourceUrl = !!sourceUrlResult.value;
+        const hasExcerpt = !!excerptResult.value;
+        const hasMemo = !!memoResult.value;
+
+        if (!hasSourceUrl && !hasExcerpt && !hasMemo) {
+            return {
+                ok: false,
+                message: '출처 링크나 저장할 내용을 입력해 주세요.',
+                field: 'sourceUrl'
+            };
+        }
+
         const draft = {
             // Scout-specific metadata
             scoutVersion: 1,

--- a/tests/contracts/scout-draft-validation-contract.test.cjs
+++ b/tests/contracts/scout-draft-validation-contract.test.cjs
@@ -1,0 +1,184 @@
+/**
+ * Scout Draft Validation Contract Test
+ * 
+ * Verifies that Scout Draft validation correctly rejects empty drafts
+ * and accepts valid drafts with at least one content field.
+ * 
+ * Phase 1: Manual MVP - no AI/fetch/auto-extraction
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SCOUT_DRAFT_PATH = path.join(ROOT, 'js', 'scout', 'scout-draft.js');
+
+// Load the Scout Draft module
+function loadScoutDraft() {
+    const code = fs.readFileSync(SCOUT_DRAFT_PATH, 'utf8');
+    const vm = require('node:vm');
+    const context = {
+        window: {},
+        console: { log: () => {}, warn: () => {} },
+        URL: URL
+    };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+    return context.window.LoveBudScoutDraft;
+}
+
+test('Scout Draft Validation Contract', async () => {
+    const ScoutDraft = loadScoutDraft();
+    
+    // Test 1: Empty sourceUrl + empty excerpt + empty memo → reject
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: '',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, false, 'should reject completely empty draft');
+        assert.strictEqual(result.field, 'sourceUrl');
+        assert.ok(result.message.includes('출처 링크나 저장할 내용'), 'should have Korean error message');
+    }
+    
+    // Test 2: Whitespace-only inputs → reject
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: '   ',
+            excerpt: '   ',
+            memo: '   ',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, false, 'should reject whitespace-only draft');
+    }
+    
+    // Test 3: sourceUrl only → ok
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'https://example.com/video',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, true, 'should accept draft with only sourceUrl');
+        assert.strictEqual(result.data.sourceUrl, 'https://example.com/video');
+        assert.strictEqual(result.data.readyForSave, true);
+    }
+    
+    // Test 4: excerpt only → ok
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: '',
+            excerpt: '이것은 발췌문입니다.',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, true, 'should accept draft with only excerpt');
+        assert.strictEqual(result.data.excerpt, '이것은 발췌문입니다.');
+    }
+    
+    // Test 5: memo only → ok
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: '',
+            excerpt: '',
+            memo: '내 메모입니다.',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, true, 'should accept draft with only memo');
+        assert.strictEqual(result.data.memo, '내 메모입니다.');
+    }
+    
+    // Test 6: Invalid URL → reject
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'not-a-url',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, false, 'should reject invalid URL');
+        assert.strictEqual(result.field, 'sourceUrl');
+    }
+    
+    // Test 7: Valid URL + excerpt + memo → ok
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'https://youtube.com/watch?v=abc123',
+            excerpt: '핵심 내용 요약',
+            memo: '개인 메모',
+            emotionTags: ['감동', '행복'],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, true, 'should accept complete draft');
+        assert.strictEqual(result.data.emotionTags.length, 2);
+        assert.deepStrictEqual(result.data.emotionTags, ['감동', '행복']);
+    }
+    
+    // Test 8: Emotion tags trim/filter/max 4 유지
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'https://example.com',
+            excerpt: '',
+            memo: '',
+            emotionTags: ['  태그1  ', '', '태그2', '태그3', '태그4', '태그5', '태그6'],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(result.data.emotionTags.length, 4, 'should limit to 4 tags');
+        assert.deepStrictEqual(result.data.emotionTags, ['태그1', '태그2', '태그3', '태그4']);
+    }
+    
+    // Test 9: Emotion tag too long → reject
+    {
+        const result = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'https://example.com',
+            excerpt: '',
+            memo: '',
+            emotionTags: ['이 태그는 스무 자를 초과하는 매우 긴 태그입니다'],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(result.ok, false, 'should reject tag > 20 chars');
+        assert.strictEqual(result.field, 'emotionTags');
+    }
+    
+    // Test 10: sourceUrl with http/https only
+    {
+        const httpResult = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'http://example.com',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(httpResult.ok, true, 'should accept http URL');
+        
+        const httpsResult = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'https://example.com',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(httpsResult.ok, true, 'should accept https URL');
+        
+        const ftpResult = ScoutDraft.buildScoutDraft({
+            sourceUrl: 'ftp://example.com',
+            excerpt: '',
+            memo: '',
+            emotionTags: [],
+            treeId: 'test-tree'
+        });
+        assert.strictEqual(ftpResult.ok, false, 'should reject ftp URL');
+    }
+});

--- a/tests/contracts/scout-toolbar-wiring-contract.test.cjs
+++ b/tests/contracts/scout-toolbar-wiring-contract.test.cjs
@@ -1,0 +1,166 @@
+/**
+ * Scout Toolbar Wiring Contract Test
+ * 
+ * Verifies that the floating toolbar dropdown correctly forwards
+ * scoutAction and selectedNode to bindDropdownEvents.
+ * 
+ * Phase 1: Manual MVP - no AI/fetch/auto-extraction
+ * 
+ * This test uses static analysis of the source code to verify wiring.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+test('Scout Toolbar Wiring Contract - Source Code Analysis', () => {
+    // Read the dropdown module source
+    const dropdownPath = path.join(ROOT, 'js', 'editor', 'editor-floating-toolbar-dropdown.js');
+    const dropdownSource = fs.readFileSync(dropdownPath, 'utf8');
+    
+    // Test 1: bindToolbarDropdown function signature includes scoutAction and selectedNode
+    {
+        assert.ok(
+            dropdownSource.includes('scoutAction: ctx.scoutAction'),
+            'bindToolbarDropdown should pass scoutAction to bindDropdownEvents'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('selectedNode: ctx.selectedNode'),
+            'bindToolbarDropdown should pass selectedNode to bindDropdownEvents'
+        );
+        
+        // Check JSDoc includes the new params
+        assert.ok(
+            dropdownSource.includes('@param {HTMLElement} [ctx.scoutAction]'),
+            'JSDoc should document scoutAction parameter'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('@param {Function|HTMLElement} [ctx.selectedNode]'),
+            'JSDoc should document selectedNode parameter'
+        );
+    }
+    
+    // Test 2: bindDropdownEvents handles scoutAction click
+    {
+        assert.ok(
+            dropdownSource.includes('if (scoutAction)'),
+            'bindDropdownEvents should check for scoutAction'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('scoutAction.addEventListener'),
+            'bindDropdownEvents should add click listener to scoutAction'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('window.LoveBudScoutDraftUI.open'),
+            'scoutAction click should call LoveBudScoutDraftUI.open'
+        );
+        
+        // Check that selectedNode getter function is supported
+        assert.ok(
+            dropdownSource.includes('typeof selectedNodeEl === \'function\''),
+            'bindDropdownEvents should support selectedNode as getter function'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('selectedNodeEl = selectedNodeEl()'),
+            'bindDropdownEvents should call selectedNode getter function'
+        );
+        
+        assert.ok(
+            dropdownSource.includes('selectedNodeEl.dataset.id'),
+            'should extract data-id from selected node element'
+        );
+    }
+    
+    // Test 3: editor-floating-toolbar.js passes function reference
+    {
+        const toolbarPath = path.join(ROOT, 'js', 'editor', 'editor-floating-toolbar.js');
+        const toolbarSource = fs.readFileSync(toolbarPath, 'utf8');
+        
+        assert.ok(
+            toolbarSource.includes('selectedNode: getSelectedNodeEl'),
+            'editor-floating-toolbar.js should pass getSelectedNodeEl function reference, not call it'
+        );
+        
+        assert.ok(
+            !toolbarSource.includes('selectedNode: getSelectedNodeEl()'),
+            'should NOT pass stale element (getSelectedNodeEl())'
+        );
+        
+        assert.ok(
+            toolbarSource.includes('scoutAction: scoutAction'),
+            'should pass scoutAction to bindToolbarDropdown'
+        );
+    }
+    
+    // Test 4: getSelectedNodeEl function exists and is exported
+    {
+        const toolbarPath = path.join(ROOT, 'js', 'editor', 'editor-floating-toolbar.js');
+        const toolbarSource = fs.readFileSync(toolbarPath, 'utf8');
+        
+        assert.ok(
+            toolbarSource.includes('function getSelectedNodeEl()'),
+            'getSelectedNodeEl function should exist'
+        );
+        
+        assert.ok(
+            toolbarSource.includes('window.LoveBudFloatingToolbarSelection'),
+            'should delegate to LoveBudFloatingToolbarSelection helper'
+        );
+    }
+});
+
+test('Scout Toolbar Wiring Contract - Module Loading', async () => {
+    // Simple test that modules can be loaded without syntax errors
+    const modules = [
+        'js/editor/editor-floating-toolbar-elements.js',
+        'js/editor/editor-floating-toolbar-dropdown.js',
+        'js/editor/editor-floating-toolbar.js'
+    ];
+    
+    for (const mod of modules) {
+        const filePath = path.join(ROOT, mod);
+        const code = fs.readFileSync(filePath, 'utf8');
+        
+        const vm = require('node:vm');
+        const context = {
+            window: {},
+            document: {
+                getElementById: () => null,
+                querySelector: () => null,
+                querySelectorAll: () => [],
+                createElement: () => ({}),
+                body: { appendChild: () => {} },
+                addEventListener: () => {}
+            },
+            navigator: { clipboard: { writeText: () => Promise.resolve() } },
+            MutationObserver: class { observe() {} disconnect() {} },
+            requestAnimationFrame: (cb) => setTimeout(cb, 0),
+            console: { log: () => {}, warn: () => {}, error: () => {} },
+            URL: URL
+        };
+        
+        vm.createContext(context);
+        
+        // Should not throw
+        vm.runInContext(code, context);
+        
+        // Verify the module exposes its API
+        const moduleName = mod.split('/').pop().replace('.js', '');
+        if (moduleName.includes('elements')) {
+            assert.ok(context.window.LoveBudFloatingToolbarElements, `${mod} should expose LoveBudFloatingToolbarElements`);
+        } else if (moduleName.includes('dropdown')) {
+            assert.ok(context.window.LoveBudFloatingToolbarDropdown, `${mod} should expose LoveBudFloatingToolbarDropdown`);
+            assert.ok(typeof context.window.LoveBudFloatingToolbarDropdown.bindToolbarDropdown === 'function', 'bindToolbarDropdown should be a function');
+        } else if (moduleName.includes('editor-floating-toolbar') && !moduleName.includes('dropdown') && !moduleName.includes('elements')) {
+            // Main toolbar module doesn't expose a global API, just initializes
+        }
+    }
+});


### PR DESCRIPTION
Refs #1882

Closes #2204

## Summary

Follow-up hotfix after PR #2203.

Fix Scout Draft Phase 1 manual MVP wiring and validation:
- Ensure floating toolbar dropdown forwards scoutAction and selectedNode into bindDropdownEvents().
- Prefer passing selectedNode as a getter function instead of a stale selected element.
- Add validation so an empty Scout draft cannot be saved.
- Add contract tests for Scout toolbar wiring and empty draft rejection.

## Changes

### editor-floating-toolbar-dropdown.js
- bindToolbarDropdown() now forwards scoutAction and selectedNode to bindDropdownEvents()
- Scout dropdown click handler is now properly wired

### editor-floating-toolbar.js
- Pass getSelectedNodeEl function reference (not stale element) to bindToolbarDropdown

### js/scout/scout-draft.js
- Added validation to reject completely empty drafts (no sourceUrl, excerpt, or memo)
- At least one content field is now required

### Contract Tests
- Added tests/contracts/scout-draft-validation-contract.test.cjs
- Added tests/contracts/scout-toolbar-wiring-contract.test.cjs

## Safety

- No AI provider integration
- No external URL fetching
- No crawling or scraping
- No API keys or provider environment variables
- No backend/schema migration

## Validation

- npm test: 1850 passed
- npm run lint: passed