### PR TITLE
feat(scout): wire AI suggestion button to stub provider UI

### DIFF
--- a/css/scout/scout-draft.css
+++ b/css/scout/scout-draft.css
@@ -239,6 +239,15 @@
     background: var(--color-cream-200);
 }
 
+/* Suggestion feedback area */
+.scout-suggest-feedback {
+    font-size: 0.8125rem;
+    padding: 12px 16px;
+    border-radius: 10px;
+    background: rgba(249, 168, 149, 0.1);
+    color: var(--color-brown-600);
+}
+
 /* Preview overlay */
 .scout-preview-overlay {
     position: fixed;

--- a/js/i18n/i18n-scout.js
+++ b/js/i18n/i18n-scout.js
@@ -138,6 +138,24 @@
         'scout_trigger_tooltip': {
             ko: '직접 링크와 메모로 순간을 저장합니다 (AI 없이)',
             en: 'Save a moment manually with link and note (no AI)'
+        },
+
+        // Suggestion button & messages
+        'scout_suggest_btn': {
+            ko: 'AI 제안 받기',
+            en: 'Get AI Suggestion'
+        },
+        'scout_suggest_applied': {
+            ko: '제안이 적용되었습니다.',
+            en: 'Suggestion applied.'
+        },
+        'scout_suggest_unavailable': {
+            ko: 'AI 제안을 불러오지 못했습니다. 직접 입력 후 저장할 수 있습니다.',
+            en: 'AI suggestion unavailable. You can enter content and save manually.'
+        },
+        'scout_suggest_error': {
+            ko: 'AI 제안을 불러오지 못했습니다.',
+            en: 'Failed to get AI suggestion.'
         }
     };
 })();

--- a/js/scout/scout-draft-ui.js
+++ b/js/scout/scout-draft-ui.js
@@ -1,7 +1,7 @@
 /**
  * LoveBud Scout Draft UI Module
- * Phase 1: Manual draft entrypoint UI
- * v20260605-1
+ * Phase 2: Stub suggestion provider wiring (manual save still required)
+ * v20260615-1
  *
  * Provides the UI for:
  * - Public source URL input
@@ -9,6 +9,7 @@
  * - Memo textarea
  * - Emotion tags input
  * - Save/preview actions
+ * - AI 제안 받기 button wired to stub provider
  */
 
 (function() {
@@ -24,7 +25,11 @@
     }
 
     const ScoutDraft = window.LoveBudScoutDraft;
+    const ScoutSuggestionProvider = window.LoveBudScoutSuggestionProvider;
     const i18n = window.t || function(key) { return key; };
+
+    // Track suggestion state for UI
+    let suggestionState = 'idle'; // idle, loading, success, error, unavailable
 
     function createScoutDraftUI(deps) {
         const {
@@ -57,7 +62,9 @@
                 cancelBtn: document.getElementById('scoutDraftCancelBtn'),
                 closeBtn: document.getElementById('scoutDraftCloseBtn'),
                 sourceUrlError: document.getElementById('scoutSourceUrlError'),
-                previewBtn: document.getElementById('scoutDraftPreviewBtn')
+                previewBtn: document.getElementById('scoutDraftPreviewBtn'),
+                suggestBtn: document.getElementById('scoutDraftSuggestBtn'),
+                suggestFeedback: document.getElementById('scoutSuggestFeedback')
             };
         }
 
@@ -79,19 +86,189 @@
             });
         }
 
+        function setSuggestionState(state, message) {
+            suggestionState = state;
+            if (refs.suggestBtn) {
+                refs.suggestBtn.disabled = state === 'loading';
+            }
+            if (refs.suggestFeedback) {
+                if (state === 'success' || state === 'error' || state === 'unavailable') {
+                    refs.suggestFeedback.style.display = 'block';
+                    refs.suggestFeedback.textContent = message || '';
+                } else {
+                    refs.suggestFeedback.style.display = 'none';
+                    refs.suggestFeedback.textContent = '';
+                }
+            }
+        }
+
         function resetForm() {
             refs.sourceUrlInput.value = '';
             refs.excerptTextarea.value = '';
             refs.memoTextarea.value = '';
             refs.emotionTagsInput.value = '';
+            suggestionState = 'idle';
+            setSuggestionState('idle', '');
             clearAllErrors();
+        }
+
+        function createModalInDOM() {
+            const mount = document.body;
+
+            // Overlay
+            const overlay = document.createElement('div');
+            overlay.className = 'scout-draft-modal-overlay';
+            overlay.id = 'scoutDraftModal';
+
+            // Modal
+            const modal = document.createElement('div');
+            modal.className = 'scout-draft-modal';
+
+            // Header
+            const header = document.createElement('div');
+            header.className = 'scout-draft-header';
+            const h2 = document.createElement('h2');
+            h2.textContent = t('scout_draft_title') || 'Scout 순간 저장';
+            header.appendChild(h2);
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.className = 'scout-draft-close-btn';
+            closeBtn.id = 'scoutDraftCloseBtn';
+            closeBtn.setAttribute('aria-label', '닫기');
+            closeBtn.textContent = '×';
+            header.appendChild(closeBtn);
+            modal.appendChild(header);
+
+            // Form
+            const form = document.createElement('form');
+            form.className = 'scout-draft-form';
+
+            // Source URL field
+            const sourceField = document.createElement('div');
+            sourceField.className = 'scout-field';
+            const sourceLabel = document.createElement('label');
+            sourceLabel.htmlFor = 'scoutSourceUrlInput';
+            sourceLabel.textContent = t('scout_source_url_label') || '출처 링크';
+            const sourceInput = document.createElement('input');
+            sourceInput.type = 'url';
+            sourceInput.id = 'scoutSourceUrlInput';
+            sourceInput.className = 'scout-input';
+            sourceInput.placeholder = 'https://';
+            const sourceHint = document.createElement('div');
+            sourceHint.className = 'field-hint';
+            sourceHint.textContent = t('scout_source_url_hint') || 'URL 또는 발췌/메모 중 하나를 입력하세요';
+            const sourceError = document.createElement('div');
+            sourceError.className = 'scout-error';
+            sourceError.id = 'scoutSourceUrlError';
+            sourceField.appendChild(sourceLabel);
+            sourceField.appendChild(sourceInput);
+            sourceField.appendChild(sourceHint);
+            sourceField.appendChild(sourceError);
+            form.appendChild(sourceField);
+
+            // Excerpt field
+            const excerptField = document.createElement('div');
+            excerptField.className = 'scout-field';
+            const excerptLabel = document.createElement('label');
+            excerptLabel.htmlFor = 'scoutExcerptTextarea';
+            excerptLabel.textContent = t('scout_excerpt_label') || '발췌';
+            const excerptTextarea = document.createElement('textarea');
+            excerptTextarea.id = 'scoutExcerptTextarea';
+            excerptTextarea.className = 'scout-textarea';
+            excerptTextarea.placeholder = t('scout_excerpt_placeholder') || '핵심 내용을 발췌하세요';
+            excerptTextarea.rows = 3;
+            excerptField.appendChild(excerptLabel);
+            excerptField.appendChild(excerptTextarea);
+            form.appendChild(excerptField);
+
+            // Memo field
+            const memoField = document.createElement('div');
+            memoField.className = 'scout-field';
+            const memoLabel = document.createElement('label');
+            memoLabel.htmlFor = 'scoutMemoTextarea';
+            memoLabel.textContent = t('scout_memo_label') || '메모';
+            const memoTextarea = document.createElement('textarea');
+            memoTextarea.id = 'scoutMemoTextarea';
+            memoTextarea.className = 'scout-textarea';
+            memoTextarea.placeholder = t('scout_memo_placeholder') || '개인 메모를 입력하세요';
+            memoTextarea.rows = 3;
+            memoField.appendChild(memoLabel);
+            memoField.appendChild(memoTextarea);
+            form.appendChild(memoField);
+
+            // Emotion tags field
+            const tagsField = document.createElement('div');
+            tagsField.className = 'scout-field';
+            const tagsLabel = document.createElement('label');
+            tagsLabel.htmlFor = 'scoutEmotionTagsInput';
+            tagsLabel.textContent = t('scout_emotion_tags_label') || '감정 태그';
+            const tagsInput = document.createElement('input');
+            tagsInput.type = 'text';
+            tagsInput.id = 'scoutEmotionTagsInput';
+            tagsInput.className = 'scout-input';
+            tagsInput.placeholder = t('scout_emotion_tags_placeholder') || '태그1, 태그2, 태그3';
+            const tagsHint = document.createElement('div');
+            tagsHint.className = 'field-hint';
+            tagsHint.textContent = t('scout_emotion_tags_hint') || '최대 4개, 각 20자 이내';
+            tagsField.appendChild(tagsLabel);
+            tagsField.appendChild(tagsInput);
+            tagsField.appendChild(tagsHint);
+            form.appendChild(tagsField);
+
+            // Suggestion feedback area
+            const feedbackDiv = document.createElement('div');
+            feedbackDiv.className = 'scout-field scout-suggest-feedback';
+            feedbackDiv.id = 'scoutSuggestFeedback';
+            feedbackDiv.style.display = 'none';
+            form.appendChild(feedbackDiv);
+
+            modal.appendChild(form);
+
+            // Actions
+            const actions = document.createElement('div');
+            actions.className = 'scout-draft-actions';
+
+            const suggestBtn = document.createElement('button');
+            suggestBtn.type = 'button';
+            suggestBtn.className = 'scout-btn scout-btn-secondary';
+            suggestBtn.id = 'scoutDraftSuggestBtn';
+            suggestBtn.textContent = t('scout_suggest_btn') || 'AI 제안 받기';
+            actions.appendChild(suggestBtn);
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.type = 'button';
+            cancelBtn.className = 'scout-btn scout-btn-outline';
+            cancelBtn.id = 'scoutDraftCancelBtn';
+            cancelBtn.textContent = t('cancel') || '취소';
+            actions.appendChild(cancelBtn);
+
+            const previewBtn = document.createElement('button');
+            previewBtn.type = 'button';
+            previewBtn.className = 'scout-btn scout-btn-outline';
+            previewBtn.id = 'scoutDraftPreviewBtn';
+            previewBtn.textContent = t('preview') || '미리보기';
+            actions.appendChild(previewBtn);
+
+            const saveBtn = document.createElement('button');
+            saveBtn.type = 'button';
+            saveBtn.className = 'scout-btn scout-btn-primary';
+            saveBtn.id = 'scoutDraftSaveBtn';
+            saveBtn.textContent = t('save') || '저장';
+            actions.appendChild(saveBtn);
+
+            modal.appendChild(actions);
+            overlay.appendChild(modal);
+            mount.appendChild(overlay);
+
+            scoutUIDebugLog('[ScoutDraftUI] Modal rendered dynamically');
         }
 
         function openModal() {
             refs = getRefs();
             if (!refs.modal) {
-                scoutUIDebugLog('[ScoutDraftUI] Modal not found in DOM');
-                return false;
+                createModalInDOM();
+                refs = getRefs();
+                scoutUIDebugLog('[ScoutDraftUI] Modal created dynamically');
             }
             resetForm();
             refs.modal.style.display = 'flex';
@@ -123,6 +300,16 @@
             // Bind save
             if (refs.saveBtn) {
                 refs.saveBtn.onclick = handleSave;
+            }
+
+            // Bind preview
+            if (refs.previewBtn) {
+                refs.previewBtn.onclick = handlePreview;
+            }
+
+            // Bind suggest button
+            if (refs.suggestBtn) {
+                refs.suggestBtn.onclick = handleSuggest;
             }
 
             // Bind cancel/close
@@ -211,6 +398,49 @@
             }
 
             scoutUIDebugLog('[ScoutDraftUI] Draft saved', payloadResult.data);
+        }
+
+        async function handleSuggest() {
+            if (!ScoutSuggestionProvider || !ScoutSuggestionProvider.createScoutStubSuggestionProvider) {
+                setSuggestionState('unavailable', t('scout_suggest_unavailable') || 'AI 제안을 불러오지 못했습니다. 직접 입력 후 저장할 수 있습니다.');
+                return;
+            }
+
+            const sourceUrl = refs.sourceUrlInput?.value || '';
+            const excerpt = refs.excerptTextarea?.value || '';
+            const memo = refs.memoTextarea?.value || '';
+
+            setSuggestionState('loading');
+
+            try {
+                const provider = ScoutSuggestionProvider.createScoutStubSuggestionProvider();
+                const suggestion = await provider.suggest({
+                    sourceUrl: sourceUrl,
+                    excerpt: excerpt,
+                    summary: excerpt,
+                    memo: memo,
+                    requestedLanguage: t.getLocale ? t.getLocale() : 'ko',
+                    desiredTone: 'neutral',
+                    maxOutputLength: 200
+                });
+
+                // Apply suggestions to editable fields (excerpt/memo only, no auto-save)
+                if (suggestion.summarySuggestion && refs.excerptTextarea) {
+                    refs.excerptTextarea.value = suggestion.summarySuggestion;
+                }
+                if (suggestion.memoSuggestion && refs.memoTextarea) {
+                    refs.memoTextarea.value = suggestion.memoSuggestion;
+                }
+                if (suggestion.emotionTags && suggestion.emotionTags.length && refs.emotionTagsInput) {
+                    refs.emotionTagsInput.value = suggestion.emotionTags.join(', ');
+                }
+
+                setSuggestionState('success', t('scout_suggest_applied') || '제안이 적용되었습니다.');
+                scoutUIDebugLog('[ScoutDraftUI] Stub suggestion applied', suggestion);
+            } catch (err) {
+                setSuggestionState('error', t('scout_suggest_error') || 'AI 제안을 불러오지 못했습니다.');
+                scoutUIDebugLog('[ScoutDraftUI] Suggestion error', err);
+            }
         }
 
         function handlePreview() {

--- a/tests/contracts/scout-draft-suggestion-ui-contract.test.cjs
+++ b/tests/contracts/scout-draft-suggestion-ui-contract.test.cjs
@@ -1,0 +1,200 @@
+/**
+ * Scout Draft Suggestion UI Contract Tests
+ * Phase 2: Stub provider wiring verification
+ *
+ * Guardrails:
+ * - No innerHTML/dangerouslySetInnerHTML in UI code
+ * - No network calls (fetch/XMLHttpRequest/axios)
+ * - No real AI provider (only stub provider)
+ * - User review required before save (no auto-save)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const EDITOR_UI_PATH = path.join(__dirname, '../../js/scout/scout-draft-ui.js');
+const PROVIDER_PATH = path.join(__dirname, '../../js/scout/scout-suggestion-provider.js');
+
+// ─── Helper Functions ───────────────────────────────────────────────────────────
+
+function readFileSafe(filePath) {
+    try {
+        return fs.readFileSync(filePath, 'utf8');
+    } catch (e) {
+        return '';
+    }
+}
+
+// ─── Test Suite ────────────────────────────────────────────────────────────────
+
+console.log('🧪 Scout Draft Suggestion UI Contracts\n');
+
+// Test 1: AI Suggestion button renders in dynamically created modal
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    const buttonPattern = /scoutDraftSuggestBtn/;
+    const suggestLabel = /AI 제안 받기|scout_suggest_btn/;
+    
+    assert.ok(ui.includes('suggestBtn'), 'editor-ui should have suggestBtn ref');
+    assert.ok(buttonPattern.test(ui), 'editor-ui should reference suggestDraftSuggestBtn ID');
+    assert.ok(suggestLabel.test(ui), 'editor-ui should have Korean label "AI 제안 받기"');
+    
+    // Verify button is in createModalInDOM
+    const createModalPattern = /createModalInDOM[\s\S]*?suggestBtn/;
+    assert.ok(createModalPattern.test(ui), 'suggestBtn should be created in createModalInDOM');
+    
+    console.log('  ✅ AI 제안 받기 button renders in dynamically created modal');
+}
+
+// Test 2: Suggestion state management exists
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    assert.ok(ui.includes('suggestionState'), 'UI should have suggestionState variable');
+    assert.ok(ui.includes('setSuggestionState'), 'UI should have setSuggestionState function');
+    assert.ok(ui.includes("state === 'loading'"), 'UI should handle loading state');
+    assert.ok(ui.includes("state === 'success'"), 'UI should handle success state');
+    assert.ok(ui.includes("state === 'error'"), 'UI should handle error state');
+    assert.ok(ui.includes("state === 'unavailable'"), 'UI should handle unavailable state');
+    
+    console.log('  ✅ Suggestion state management implemented');
+}
+
+// Test 3: No innerHTML usage in suggestion-related code
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    // Find innerHTML usages - should only be comments
+    const innerHtmlMatches = ui.match(/(\.innerHTML\s*=|innerHTML:)/g) || [];
+    assert.strictEqual(innerHtmlMatches.length, 0, 'No innerHTML assignments should exist');
+    
+    // Verify safe DOM methods are used
+    assert.ok(ui.includes('.textContent'), 'Should use textContent for text');
+    assert.ok(ui.includes('.value'), 'Should use value property for inputs');
+    
+    console.log('  ✅ No innerHTML usage in suggestion UI code');
+}
+
+// Test 4: No network calls in scout-draft-ui.js
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    const networkPatterns = [
+        /\bfetch\s*\(/,
+        /XMLHttpRequest/,
+        /\baxios\b/,
+        /\.ajax\s*\(/,
+        /\bimport\s+['"]fetch\b/,
+    ];
+    
+    for (const pattern of networkPatterns) {
+        assert.ok(!pattern.test(ui), `Should not use network pattern: ${pattern}`);
+    }
+    
+    console.log('  ✅ No network calls in scout-draft-ui.js');
+}
+
+// Test 5: Stub provider is used, not real AI provider
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    const provider = readFileSafe(PROVIDER_PATH);
+    
+    // UI should reference the stub provider
+    assert.ok(ui.includes('createScoutStubSuggestionProvider'), 'UI should use stub provider');
+    
+    // Provider should have stub markers
+    assert.ok(provider.includes('STUB'), 'Provider should have STUB marking');
+    assert.ok(provider.includes('Phase 2'), 'Provider should mark Phase 2');
+    
+    // No real AI provider imports/usage
+    const realAiPatterns = [
+        /openai/i,
+        /anthropic/i,
+        /claude/i,
+        /gemini/i,
+        /nvidia/i,
+        /mistral/i,
+        /process\.env\./,
+        /apiKey/i,
+        /api_key/i,
+    ];
+    
+    for (const pattern of realAiPatterns) {
+        assert.ok(!pattern.test(ui), `UI should not reference real AI provider: ${pattern}`);
+    }
+    
+    console.log('  ✅ Stub provider used, no real AI provider references');
+}
+
+// Test 6: Suggestions apply to fields, no auto-save
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    // Verify suggestions are applied to editable fields
+    assert.ok(ui.includes('refs.excerptTextarea.value'), 'Should apply suggestion to excerpt textarea');
+    assert.ok(ui.includes('refs.memoTextarea.value'), 'Should apply suggestion to memo textarea');
+    assert.ok(ui.includes('refs.emotionTagsInput.value'), 'Should apply suggestion to emotion tags input');
+    
+    // No auto-save after suggestion (should not call onDraftSave directly in handleSuggest)
+    const handleSuggest = ui.match(/async\s*function\s*handleSuggest[\s\S]*?}\s*}/);
+    assert.ok(handleSuggest, 'handleSuggest function should exist');
+    
+    const handleSuggestContent = handleSuggest[0];
+    
+    // Should NOT auto-save
+    assert.ok(!handleSuggestContent.includes('onDraftSave('), 'handleSuggest should NOT call onDraftSave');
+    assert.ok(!handleSuggestContent.includes('closeModal('), 'handleSuggest should NOT auto-close modal');
+    assert.ok(!handleSuggestContent.includes('showToast('), 'handleSuggest should NOT auto-show save toast');
+    
+    console.log('  ✅ Suggestions apply to fields, no auto-save behavior');
+}
+
+// Test 7: User review required - manual save still available
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    // Save button should still exist and be wired
+    assert.ok(ui.includes('refs.saveBtn.onclick = handleSave'), 'Save button should be wired in openModal');
+    assert.ok(ui.includes('function handleSave'), 'handleSave function should exist');
+    
+    console.log('  ✅ Manual save flow preserved for user review');
+}
+
+// Test 8: Provider input normalization used
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    assert.ok(ui.includes('requestedLanguage'), 'Should pass requestedLanguage to provider');
+    assert.ok(ui.includes('desiredTone'), 'Should pass desiredTone to provider');
+    assert.ok(ui.includes('maxOutputLength'), 'Should pass maxOutputLength to provider');
+    
+    console.log('  ✅ Provider input normalization used');
+}
+
+// Test 9: Safe fallback when provider unavailable
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    
+    assert.ok(ui.includes('unavailable'), 'Should handle unavailable state');
+    assert.ok(ui.includes('AI 제안을 불러오지 못했습니다'), 'Should have Korean fallback message');
+    
+    console.log('  ✅ Safe fallback when provider unavailable');
+}
+
+// Test 10: Suggestion feedback area in DOM
+{
+    const ui = readFileSafe(EDITOR_UI_PATH);
+    const css = readFileSafe(path.join(__dirname, '../../css/scout/scout-draft.css'));
+    
+    assert.ok(ui.includes('scoutSuggestFeedback'), 'Should have suggestFeedback ref');
+    assert.ok(ui.includes('suggestFeedback'), 'Should reference suggestFeedback element');
+    
+    // CSS for feedback area
+    assert.ok(css.includes('.scout-suggest-feedback'), 'CSS should style suggestion feedback area');
+    
+    console.log('  ✅ Suggestion feedback area in DOM and CSS');
+}
+
+console.log('\n✅ All Scout Draft Suggestion UI contracts passed.');
+console.log('Guardrails verified: no innerHTML, no network, no real AI provider, no auto-save.\n');


### PR DESCRIPTION
Refs #1882

## Changes
- Add AI 제안 받기 button in Scout Draft modal (dynamically rendered)
- Wire button to LoveBudScoutSuggestionProvider stub provider
- Apply suggestions to excerpt/memo/emotion tags fields
- No auto-save - user review required before save
- Add suggestion feedback area styling and i18n keys

## Guardrails Verified
- No innerHTML usage in suggestion UI code
- No network calls (fetch/XMLHttpRequest)
- No real AI provider references
- Manual save flow preserved
- Contract tests added for verification