### PR TITLE
test(tech): add Scout live endpoint error taxonomy contract

### DIFF
--- a/docs/product/lovebud-scout-ai-suggestion-mvp-readiness.md
+++ b/docs/product/lovebud-scout-ai-suggestion-mvp-readiness.md
@@ -2,6 +2,15 @@
 
 ## Baseline
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
@@ -11,6 +11,21 @@
 - **current open issues**: #1882 (Scout MVP), #1661 (Browse sorting / out of scope), #2234 (Scout live-provider prompt/response contract)
 - **current live provider status**: provider-specific adapter skeleton + selection boundary added behind disabled mode; no provider API call; staging_live and production_live remain blocked; endpoint live auth/rate-limit now has DI contract + sanitized observability contract in place
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories: `request_validation`, `auth`, `rate_limit`, `config`, `provider_availability`, `provider_response`, `output_safety`, `observability`, `internal_boundary`
+- canonical error codes: `INVALID_REQUEST`, `VALIDATION_ERROR`, `AUTH_REQUIRED`, `AUTH_INVALID`, `RATE_LIMITED`, `RATE_LIMIT_UNAVAILABLE`, `CONFIG_MISSING`, `PROVIDER_UNAVAILABLE`, `PROVIDER_ERROR`, `OUTPUT_SAFETY_BLOCKED`, `OBSERVABILITY_UNAVAILABLE`, `INTERNAL_BOUNDARY_ERROR`
+- HTTP status mapping locked (400 / 401 / 429 / 503 / 422 / 502 / 500)
+- response body shape locked: `{ ok: false, providerMode: "live", error: { code, message } }`
+- `Retry-After` header policy: only on `RATE_LIMITED` with positive `retryAfterSeconds`
+- observability mapping locked: auth/rate-limit error codes → `boundaryDecision` / `authStatus` / `rateLimitStatus` / `errorCode`; `OBSERVABILITY_UNAVAILABLE` is never returned to the client (safe-swallowed)
+- sensitive data prohibition locked for all response headers / bodies / observability events
+- endpoint default remains stub
+- UI default remains `local_stub`
+- real Firebase / KV / provider API work remains blocked
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Document Status
 
 - This document is an **audit-only** deliverable. It does not change runtime behavior.

--- a/docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md
@@ -1,0 +1,234 @@
+# LoveBud Scout Live Provider Endpoint Error Taxonomy Contract
+
+## Baseline
+
+- **current main HEAD**: `cdcaf6d2`
+- **related issue**: #1882 (PRODUCT: Explore LoveBud Scout link-based fan assistant MVP)
+- **Browse #1661** remains out of scope
+- **open PR count**: 0
+- **recently merged Scout PRs (auth/rate-limit track)**: #2276 / #2278 / #2280 / #2283 / #2285 / #2287 / #2289
+- **related closed issues**: #2275, #2277, #2279, #2282, #2284, #2286, #2288
+- **current open issues**: #1882 (Scout MVP), #1661 (Browse sorting / out of scope), #2234 (Scout live-provider prompt/response contract)
+- **current live provider status**: provider-specific adapter skeleton + selection boundary + canonical auth/rate-limit runtime boundary + endpoint safe-fail wiring + injected dependency contract + sanitized observability contract all in place; no provider API call; staging_live and production_live remain blocked; real Firebase/KV/provider work remains blocked
+
+## Document Status
+
+- This document is a **contract-only** deliverable. It does not change runtime behavior.
+- It locks the Scout live endpoint error taxonomy so that future real Firebase / KV / provider work can be slotted in without renegotiating error codes, HTTP statuses, or response shapes.
+
+## Purpose
+
+- 실제 Firebase / KV / provider API 구현 전에, Scout live endpoint의 error code, HTTP status, response body shape, retry-after policy, observability decision mapping을 고정한다.
+- 이 문서는 구현이 아니라 contract이다.
+- default live AI usage는 여전히 금지다.
+
+## Non-goals
+
+- No real LLM provider implementation
+- No live provider API call
+- No provider SDK imports
+- No Firebase Admin SDK integration
+- No real Firebase token verification
+- No KV/Durable Object/D1 implementation
+- No runtime persistent rate-limit storage call
+- No external observability/logging backend integration
+- No external URL fetching
+- No crawler or metadata extraction
+- No frontend default endpoint_client behavior change
+- No source selector default change
+- No backend/schema migration
+- No automatic save
+- No Browse #1661 work
+
+## Error Categories
+
+The Scout live endpoint organizes its errors into the following categories. Every canonical error code belongs to exactly one category.
+
+| Category | Description |
+|---|---|
+| `request_validation` | Request shape, method, content-type, body size, JSON validity, and field-level validation failures |
+| `auth` | Missing / malformed / rejected bearer token in the live path |
+| `rate_limit` | Rate-limit decision outcomes (allowed / limited / unavailable) |
+| `config` | Provider / runtime configuration that prevents live path from running |
+| `provider_availability` | Live provider is disabled or adapter is not yet wired |
+| `provider_response` | Provider returned an error or the adapter interface reports a non-success state |
+| `output_safety` | Output was rejected by a safety filter (placeholder for a future slice) |
+| `observability` | Internal observability event emission (never returned to the client; safe-swallowed) |
+| `internal_boundary` | Unexpected boundary / runtime failures (kept for contract completeness) |
+
+## Canonical Error Codes
+
+| Error Code | Category | Description |
+|---|---|---|
+| `INVALID_REQUEST` | request_validation | The request did not match the documented request shape (mirrors `VALIDATION_ERROR` from existing endpoint code) |
+| `VALIDATION_ERROR` | request_validation | Field-level validation failure (length, language code, tone, etc.) |
+| `AUTH_REQUIRED` | auth | Live path was reached without an `Authorization` header |
+| `AUTH_INVALID` | auth | Authorization header is malformed, scheme is wrong, token is empty, token is rejected, or no verifier is wired |
+| `RATE_LIMITED` | rate_limit | Limiter returned `allowed: false` with a positive `retryAfterSeconds` |
+| `RATE_LIMIT_UNAVAILABLE` | rate_limit | Limiter is not configured, threw, or returned an invalid result; auth failed before limiter was called |
+| `CONFIG_MISSING` | config | Required provider env vars are missing |
+| `PROVIDER_UNAVAILABLE` | provider_availability | Provider adapter is disabled or not yet connected |
+| `PROVIDER_ERROR` | provider_response | Provider returned a non-success state (placeholder; future slice) |
+| `OUTPUT_SAFETY_BLOCKED` | output_safety | Output was rejected by a safety filter (placeholder; future slice) |
+| `OBSERVABILITY_UNAVAILABLE` | observability | Observability event emission failure (never returned to the client) |
+| `INTERNAL_BOUNDARY_ERROR` | internal_boundary | Unexpected boundary / runtime failure (500) |
+
+## HTTP Status Mapping
+
+The Scout live endpoint follows the convention below. Numbers in **bold** are the values that the current `suggest.js` LIVE branch actually returns today; other numbers are the contracted target values that future slices must preserve.
+
+| Error Code | HTTP Status | Notes |
+|---|---|---|
+| `INVALID_REQUEST` | **400** (or **405** for method, **413** for body size) | method/JSON/header validation |
+| `VALIDATION_ERROR` | **400** | field-level validation |
+| `AUTH_REQUIRED` | **401** | live path requires bearer token |
+| `AUTH_INVALID` | **401** | malformed or rejected token |
+| `RATE_LIMITED` | **429** | includes `Retry-After` header when `retryAfterSeconds > 0` |
+| `RATE_LIMIT_UNAVAILABLE` | **503** | boundary could not run a real check |
+| `CONFIG_MISSING` | **503** | required env vars missing |
+| `PROVIDER_UNAVAILABLE` | **503** | adapter disabled or not wired |
+| `PROVIDER_ERROR` | **502** (contracted) | provider returned a non-success state |
+| `OUTPUT_SAFETY_BLOCKED` | **422** (contracted) | output was rejected by a safety filter |
+| `OBSERVABILITY_UNAVAILABLE` | n/a (never returned) | safe-swallowed before response is built |
+| `INTERNAL_BOUNDARY_ERROR` | **500** (contracted) | unexpected runtime failure |
+
+## Response Body Shape
+
+All error responses follow this shape. The body is JSON with `charset=utf-8`.
+
+```json
+{
+  "ok": false,
+  "providerMode": "live",
+  "error": {
+    "code": "AUTH_REQUIRED",
+    "message": "Scout live auth requires a Bearer token."
+  }
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `ok` | `false` | yes | literal `false` on error |
+| `providerMode` | `"live"` | yes | always `"live"` for live-mode error responses; stub path uses `"stub"` in success responses |
+| `error.code` | string | yes | one of the canonical error codes above |
+| `error.message` | string | yes | safe user-facing message; never contains raw token / API key / prompt / excerpt / full sourceUrl / raw request body / raw provider output / PII / credentials |
+
+## Response Headers
+
+| Header | When Present | Notes |
+|---|---|---|
+| `content-type` | always | `application/json; charset=utf-8` |
+| `x-lovebud-request-id` | always | request id; safe characters only |
+| `x-lovebud-upstream` | always | `cloudflare` (current convention) |
+| `x-lovebud-route-status` | always on error | lowercase, dash-separated error code (e.g. `auth-required`, `rate-limited`, `rate-limit-unavailable`, `config-missing`, `provider-unavailable`) |
+| `retry-after` | `RATE_LIMITED` only, when `retryAfterSeconds > 0` | integer seconds; the value comes from the limiter's `retryAfterSeconds` |
+
+Sensitive data prohibition applies to **all** response headers and bodies: no raw token, no API key, no prompt, no excerpt, no full sourceUrl, no raw request body, no raw provider output, no credentials, no PII.
+
+## Retry-After Policy
+
+- `Retry-After` is **only** emitted on `RATE_LIMITED` responses, and **only** when the limiter returned a positive `retryAfterSeconds`.
+- The value is an integer (seconds) and is bounded by what the limiter returned. The boundary floors it to a non-negative integer.
+- `RATE_LIMIT_UNAVAILABLE`, `CONFIG_MISSING`, `PROVIDER_UNAVAILABLE`, `OUTPUT_SAFETY_BLOCKED`, `INTERNAL_BOUNDARY_ERROR` responses **do not** include `Retry-After`. The client may retry later based on its own policy, but the endpoint does not promise a specific delay.
+
+## Observability Mapping
+
+The endpoint's sanitized observability events (see `live-auth-rate-limit-observability.js`) record the decision behind every error. The mapping below locks the relationship between HTTP response error codes and observability event fields.
+
+| HTTP Error Code | `boundaryDecision` | `authStatus` | `rateLimitStatus` | `errorCode` |
+|---|---|---|---|---|
+| `AUTH_REQUIRED` | `auth_required` | `auth_required` | `null` | `AUTH_REQUIRED` |
+| `AUTH_INVALID` | `auth_invalid` | `auth_invalid` | `null` | `AUTH_INVALID` |
+| `RATE_LIMITED` | `rate_limited` | `authenticated` | `rate_limited` | `RATE_LIMITED` |
+| `RATE_LIMIT_UNAVAILABLE` | `rate_limit_unavailable` | `authenticated` (or upstream auth status) | `rate_limit_unavailable` | `RATE_LIMIT_UNAVAILABLE` |
+| `CONFIG_MISSING` | (no observability event) | n/a | n/a | n/a |
+| `PROVIDER_UNAVAILABLE` | (no observability event) | n/a | n/a | n/a |
+| `PROVIDER_ERROR` | (no observability event) | n/a | n/a | n/a |
+| `OUTPUT_SAFETY_BLOCKED` | (no observability event) | n/a | n/a | n/a |
+| `OBSERVABILITY_UNAVAILABLE` | n/a | n/a | n/a | n/a (safe-swallowed; never reaches client) |
+| `INTERNAL_BOUNDARY_ERROR` | (no observability event) | n/a | n/a | n/a |
+
+Only auth and rate-limit decisions are currently emitted as observability events. Future slices may extend this matrix to include provider and safety events, but the auth/rate-limit mapping is locked by this contract.
+
+## Sensitive Data Prohibition
+
+The following are **prohibited** from any response header, response body, or observability event payload:
+
+- raw `Authorization` token
+- raw API key value (any provider)
+- prompt text
+- excerpt text
+- full `sourceUrl` (including query string)
+- raw request body
+- raw provider output
+- user email / phone / address / PII
+- Firebase / Cloudflare / Modal / Neon / signing credentials
+- password / secret / cookie / session token / private key fields
+
+Any error response that violates this contract is considered a regression. Test fixtures use `TEST_FIXTURE_*_NOT_A_REAL_SECRET_*` markers to keep GitGuardian from flagging obviously-fake strings.
+
+## Default Behavior Guardrails
+
+| Guardrail | Status |
+|---|---|
+| Endpoint default `providerMode` is `"stub"` | ✅ preserved |
+| Explicit stub (`SCOUT_SUGGEST_PROVIDER_MODE=stub`) returns `providerMode: "stub"` | ✅ preserved |
+| Frontend default `local_stub` | ✅ preserved |
+| Endpoint client default disabled | ✅ preserved |
+| Default stub does not call boundary | ✅ preserved |
+| Explicit stub does not call boundary | ✅ preserved |
+| Live mode invokes boundary | ✅ preserved |
+| `staging_live` execution | ❌ blocked (no real backends) |
+| `production_live` execution | ❌ blocked (no real backends) |
+| Real provider API call | ❌ blocked (no real backends) |
+
+## Audit Anchor
+
+This document builds on top of the readiness audit (see `docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`). All five readiness verifications are reproduced here for clarity.
+
+| Workstream | Verdict | Rationale |
+|---|---|---|
+| Endpoint live auth/rate-limit runtime boundary skeleton | **GO** | MERGED #2278 + #2280 |
+| Endpoint safe-fail wiring | **GO** | MERGED #2283 |
+| Endpoint injected dependency contract | **GO** | MERGED #2285 |
+| Sanitized observability contract | **GO** | MERGED #2287 |
+| Endpoint error taxonomy contract | **GO** | this slice |
+| Real Firebase auth verifier implementation | **NO-GO** | no Firebase Admin SDK in repo |
+| Persistent rate-limit store (KV / DO / D1) | **NO-GO** | no real storage in repo |
+| Real observability backend | **NO-GO** | observer seam only |
+| Provider-specific live adapter (real call) | **NO-GO** | inert by design |
+| `staging_live` execution | **NO-GO** | all real backends are NO-GO |
+| `production_live` execution | **NO-GO** | all real backends are NO-GO |
+| Real provider API call | **NO-GO** | no provider SDK; no real call path enabled |
+
+## Audited Test Files (all required to keep passing)
+
+```text
+tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs (this slice)
+tests/contracts/scout-live-auth-rate-limit-readiness-audit-contract.test.cjs (16/16)
+tests/contracts/scout-live-auth-rate-limit-endpoint-observability-contract.test.cjs (24/24)
+tests/contracts/scout-live-auth-rate-limit-endpoint-di-contract.test.cjs (20/20)
+tests/contracts/scout-live-auth-rate-limit-endpoint-safe-fail-wiring-contract.test.cjs (20/20)
+tests/contracts/scout-live-auth-rate-limit-boundary-reconcile-contract.test.cjs (13/13)
+tests/contracts/scout-live-auth-rate-limit-runtime-boundary-contract.test.cjs (28/28)
+tests/contracts/scout-provider-specific-adapter-selection-boundary-contract.test.cjs
+tests/contracts/scout-provider-specific-adapter-skeleton-contract.test.cjs
+tests/contracts/scout-live-provider-auth-rate-limit-boundary.test.cjs
+tests/contracts/scout-live-provider-production-readiness-gates-audit-contract.test.cjs
+tests/contracts/scout-live-provider-staging-rollout-contract.test.cjs
+tests/contracts/scout-real-provider-mock-executor-integration-contract.test.cjs
+tests/contracts/scout-real-provider-disabled-endpoint-contract.test.cjs
+tests/contracts/scout-real-provider-adapter-interface-contract.test.cjs
+```
+
+## Related Documents
+
+- `docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`
+- `docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md`
+- `docs/product/lovebud-scout-serverless-endpoint-boundary.md`
+- `docs/product/lovebud-scout-llm-provider-boundary.md`
+- `docs/product/lovebud-scout-live-provider-production-readiness-gates-audit.md`
+- `docs/product/lovebud-scout-live-provider-staging-rollout-contract.md`
+- `docs/product/lovebud-scout-ai-suggestion-mvp-readiness.md`
+- `docs/product/lovebud-scout-live-provider-readiness-audit.md`

--- a/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
+++ b/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
@@ -17,6 +17,15 @@
 - `tests/contracts/scout-live-auth-rate-limit-runtime-boundary-contract.test.cjs` — 28 sub-tests covering DI, safe defaults, no SDK / no storage / no fetch
 - `verifyScoutLiveAuthBoundary` / `checkScoutLiveRateLimitBoundary` wrappers expose injected `verifyToken` / `checkRateLimit`
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-live-provider-production-readiness-gates-audit.md
+++ b/docs/product/lovebud-scout-live-provider-production-readiness-gates-audit.md
@@ -2,6 +2,15 @@
 
 ## Document Status
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-live-provider-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-provider-readiness-audit.md
@@ -2,6 +2,15 @@
 
 ## Baseline
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-live-provider-staging-rollout-contract.md
+++ b/docs/product/lovebud-scout-live-provider-staging-rollout-contract.md
@@ -26,6 +26,15 @@
 
 ## Baseline
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-llm-provider-boundary.md
+++ b/docs/product/lovebud-scout-llm-provider-boundary.md
@@ -2,6 +2,15 @@
 
 ## Baseline
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/docs/product/lovebud-scout-serverless-endpoint-boundary.md
+++ b/docs/product/lovebud-scout-serverless-endpoint-boundary.md
@@ -2,6 +2,15 @@
 
 ## Baseline
 
+## Endpoint Live Error Taxonomy Contract (slice update)
+
+- endpoint error taxonomy contract added (`docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md`)
+- error categories / canonical error codes / HTTP status mapping / response body shape / Retry-After policy / observability mapping / sensitive data prohibition all locked
+- real Firebase / KV / provider API work remains blocked
+- endpoint default remains stub
+- UI default remains `local_stub`
+- `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` — focused taxonomy contract
+
 ## Endpoint Live Auth/Rate-Limit Readiness Audit (slice update)
 
 - endpoint live auth/rate-limit readiness audit added (`docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md`)

--- a/tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs
+++ b/tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs
@@ -1,0 +1,612 @@
+/**
+ * Scout Live Endpoint Error Taxonomy Contract Tests
+ * v20260607-1
+ *
+ * Locks the Scout live endpoint error taxonomy contract:
+ * - taxonomy document exists with required sections
+ * - error categories / canonical error codes / HTTP status mapping are documented
+ * - response body shape and Retry-After policy are documented
+ * - observability mapping is documented
+ * - sensitive data prohibition is documented
+ * - endpoint response shape matches taxonomy at the code level
+ *   (missing auth / malformed auth / rate-limited / rate-limit unavailable /
+ *    provider unavailable / observer throw / default stub / explicit stub)
+ * - no Firebase Admin SDK / no KV-DO-D1 / no provider SDK / no fetch
+ * - endpoint default stub / frontend local_stub / endpoint client default
+ *   disabled remain preserved
+ * - related docs updated
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const TAXONOMY_DOC = path.join(ROOT, 'docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md');
+const HELPER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-observability.js');
+const BOUNDARY_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-boundary.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/provider-specific-adapter.js');
+const LIVE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-provider-adapter.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+const RELATED_DOCS = [
+  'lovebud-scout-live-auth-rate-limit-readiness-audit.md',
+  'lovebud-scout-live-provider-auth-rate-limit-boundary.md',
+  'lovebud-scout-serverless-endpoint-boundary.md',
+  'lovebud-scout-llm-provider-boundary.md',
+  'lovebud-scout-live-provider-production-readiness-gates-audit.md',
+  'lovebud-scout-live-provider-staging-rollout-contract.md',
+  'lovebud-scout-ai-suggestion-mvp-readiness.md',
+  'lovebud-scout-live-provider-readiness-audit.md',
+];
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+const taxonomyDoc = readFileSafe(TAXONOMY_DOC);
+const helperCode = readFileSafe(HELPER_PATH);
+const boundaryCode = readFileSafe(BOUNDARY_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const adapterCode = readFileSafe(ADAPTER_PATH);
+const liveAdapterCode = readFileSafe(LIVE_ADAPTER_PATH);
+const srcSelCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+function cleanSource(code) {
+  return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+let handlerPromise = null;
+async function getOnRequestPost() {
+  if (!handlerPromise) {
+    handlerPromise = import(SUGGEST_PATH).then(m => m.onRequestPost);
+  }
+  return handlerPromise;
+}
+
+function createMockRequest(options = {}) {
+  const headers = new Map();
+  headers.set('content-type', 'application/json');
+  if (options.headers) {
+    for (const [k, v] of Object.entries(options.headers)) {
+      headers.set(k.toLowerCase(), v);
+    }
+  }
+  return {
+    method: options.method || 'POST',
+    headers: {
+      get: (name) => headers.get(name.toLowerCase()) || null,
+    },
+    text: async () => JSON.stringify(options.body || {}),
+  };
+}
+
+const tests = [];
+
+// ── 1. Taxonomy document exists ─────────────────────────────────────────────
+tests.push({
+  name: 'Taxonomy document exists',
+  fn: () => {
+    assert.ok(taxonomyDoc.length > 0, 'taxonomy document must exist at docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md');
+    assert.ok(/^#\s.*Error Taxonomy/m.test(taxonomyDoc), 'document must start with a top-level heading');
+  },
+});
+
+// ── 2. Error categories are documented ─────────────────────────────────────
+tests.push({
+  name: 'Error categories are documented (9 categories)',
+  fn: () => {
+    const lc = taxonomyDoc.toLowerCase();
+    for (const cat of [
+      'request_validation',
+      'auth',
+      'rate_limit',
+      'config',
+      'provider_availability',
+      'provider_response',
+      'output_safety',
+      'observability',
+      'internal_boundary',
+    ]) {
+      assert.ok(lc.includes(cat), `taxonomy must mention category "${cat}"`);
+    }
+  },
+});
+
+// ── 3. Canonical error codes are documented ─────────────────────────────────
+tests.push({
+  name: 'Canonical error codes are documented (12 codes)',
+  fn: () => {
+    for (const code of [
+      'INVALID_REQUEST',
+      'VALIDATION_ERROR',
+      'AUTH_REQUIRED',
+      'AUTH_INVALID',
+      'RATE_LIMITED',
+      'RATE_LIMIT_UNAVAILABLE',
+      'CONFIG_MISSING',
+      'PROVIDER_UNAVAILABLE',
+      'PROVIDER_ERROR',
+      'OUTPUT_SAFETY_BLOCKED',
+      'OBSERVABILITY_UNAVAILABLE',
+      'INTERNAL_BOUNDARY_ERROR',
+    ]) {
+      assert.ok(taxonomyDoc.includes(code), `taxonomy must mention code "${code}"`);
+    }
+  },
+});
+
+// ── 4. HTTP status mapping is documented ────────────────────────────────────
+tests.push({
+  name: 'HTTP status mapping is documented (400/401/405/413/422/429/500/502/503)',
+  fn: () => {
+    for (const status of ['400', '401', '405', '413', '422', '429', '500', '502', '503']) {
+      assert.ok(taxonomyDoc.includes(status), `taxonomy must mention HTTP status ${status}`);
+    }
+  },
+});
+
+// ── 5. Response body shape is documented ────────────────────────────────────
+tests.push({
+  name: 'Response body shape is documented (ok/providerMode/error.code/error.message)',
+  fn: () => {
+    assert.ok(taxonomyDoc.includes('"ok"') || /`ok`/.test(taxonomyDoc), 'taxonomy must document `ok` field');
+    assert.ok(taxonomyDoc.includes('"providerMode"') || /`providerMode`/.test(taxonomyDoc), 'taxonomy must document `providerMode` field');
+    assert.ok(taxonomyDoc.includes('error.code') || /`error\.code`/.test(taxonomyDoc) || /`code`/.test(taxonomyDoc), 'taxonomy must document error.code');
+    assert.ok(taxonomyDoc.includes('error.message') || /`error\.message`/.test(taxonomyDoc) || /`message`/.test(taxonomyDoc), 'taxonomy must document error.message');
+  },
+});
+
+// ── 6. Retry-After policy is documented ─────────────────────────────────────
+tests.push({
+  name: 'Retry-After policy is documented (only on RATE_LIMITED with positive retryAfterSeconds)',
+  fn: () => {
+    const lc = taxonomyDoc.toLowerCase();
+    assert.ok(lc.includes('retry-after'), 'taxonomy must mention Retry-After');
+    assert.ok(lc.includes('rate_limited') || lc.includes('ratelimited'), 'taxonomy must connect Retry-After to RATE_LIMITED');
+    assert.ok(
+      lc.includes('retry-after') && /Retry-After[\s\S]{0,200}RATE_LIMITED/i.test(taxonomyDoc),
+      'taxonomy must explain Retry-After is only on RATE_LIMITED'
+    );
+  },
+});
+
+// ── 7. Observability mapping is documented ─────────────────────────────────
+tests.push({
+  name: 'Observability mapping is documented (auth/rate-limit decisions; OBSERVABILITY_UNAVAILABLE safe-swallowed)',
+  fn: () => {
+    const lc = taxonomyDoc.toLowerCase();
+    assert.ok(lc.includes('boundarydecision'), 'taxonomy must mention boundaryDecision');
+    assert.ok(lc.includes('authstatus'), 'taxonomy must mention authStatus');
+    assert.ok(lc.includes('ratelimitstatus'), 'taxonomy must mention rateLimitStatus');
+    assert.ok(
+      lc.includes('safe-swallow') || lc.includes('safe swallow') || lc.includes('safely swallowed') || lc.includes('never returned'),
+      'taxonomy must explain OBSERVABILITY_UNAVAILABLE is safe-swallowed / never returned to client'
+    );
+  },
+});
+
+// ── 8. Sensitive data prohibition is documented ─────────────────────────────
+tests.push({
+  name: 'Sensitive data prohibition is documented (no raw token / API key / prompt / excerpt / sourceUrl / raw body / raw provider output / PII / credentials)',
+  fn: () => {
+    const lc = taxonomyDoc.toLowerCase();
+    for (const term of ['raw token', 'api key', 'prompt', 'excerpt', 'sourceurl', 'raw request body', 'raw provider output', 'credentials', 'pii']) {
+      assert.ok(lc.includes(term), `taxonomy must prohibit "${term}"`);
+    }
+  },
+});
+
+// ── 9. Endpoint missing auth response matches taxonomy ─────────────────────
+tests.push({
+  name: 'Endpoint missing auth response matches taxonomy (401 + AUTH_REQUIRED + safe shape)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const resp = await handler({
+      request: req,
+      env: { SCOUT_SUGGEST_PROVIDER_MODE: 'live' },
+    });
+    assert.strictEqual(resp.status, 401);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, false);
+    assert.strictEqual(body.error.code, 'AUTH_REQUIRED');
+    assert.ok(typeof body.error.message === 'string' && body.error.message.length > 0);
+  },
+});
+
+// ── 10. Endpoint malformed auth response matches taxonomy ──────────────────
+tests.push({
+  name: 'Endpoint malformed auth response matches taxonomy (401 + AUTH_INVALID + safe shape)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      headers: { Authorization: 'NotBearer xyz' },
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const resp = await handler({
+      request: req,
+      env: {
+        SCOUT_SUGGEST_PROVIDER_MODE: 'live',
+        SCOUT_SUGGEST_LLM_PROVIDER: 'openai',
+        SCOUT_SUGGEST_LLM_API_KEY: 'TEST_FIXTURE_API_KEY_xyz_taxonomy_malformed',
+        SCOUT_SUGGEST_MODEL: 'gpt-4',
+      },
+    });
+    assert.strictEqual(resp.status, 401);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, false);
+    assert.strictEqual(body.error.code, 'AUTH_INVALID');
+    assert.ok(typeof body.error.message === 'string' && body.error.message.length > 0);
+  },
+});
+
+// ── 11. Endpoint rate-limited response matches taxonomy ────────────────────
+tests.push({
+  name: 'Endpoint rate-limited response matches taxonomy (429 + RATE_LIMITED + Retry-After)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      headers: { Authorization: 'Bearer TEST_FIXTURE_TOKEN_xyz_taxonomy_limited' },
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const verifyToken = async () => ({ ok: true, uid: 'user-t1' });
+    const checkRateLimit = async () => ({ allowed: false, retryAfterSeconds: 9, bucket: 'scout:live:user:user-t1' });
+    const resp = await handler({
+      request: req,
+      env: {
+        SCOUT_SUGGEST_PROVIDER_MODE: 'live',
+        SCOUT_SUGGEST_LLM_PROVIDER: 'openai',
+        SCOUT_SUGGEST_LLM_API_KEY: 'TEST_FIXTURE_API_KEY_xyz_taxonomy_limited',
+        SCOUT_SUGGEST_MODEL: 'gpt-4',
+      },
+      verifyToken,
+      checkRateLimit,
+    });
+    assert.strictEqual(resp.status, 429);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, false);
+    assert.strictEqual(body.error.code, 'RATE_LIMITED');
+    const retryAfter = resp.headers.get('retry-after');
+    assert.strictEqual(retryAfter, '9');
+  },
+});
+
+// ── 12. Endpoint rate-limit unavailable response matches taxonomy ──────────
+tests.push({
+  name: 'Endpoint rate-limit unavailable response matches taxonomy (503 + RATE_LIMIT_UNAVAILABLE)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      headers: { Authorization: 'Bearer TEST_FIXTURE_TOKEN_xyz_taxonomy_unavail' },
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const verifyToken = async () => ({ ok: true, uid: 'user-t2' });
+    // no checkRateLimit
+    const resp = await handler({
+      request: req,
+      env: {
+        SCOUT_SUGGEST_PROVIDER_MODE: 'live',
+        SCOUT_SUGGEST_LLM_PROVIDER: 'openai',
+        SCOUT_SUGGEST_LLM_API_KEY: 'TEST_FIXTURE_API_KEY_xyz_taxonomy_unavail',
+        SCOUT_SUGGEST_MODEL: 'gpt-4',
+      },
+      verifyToken,
+    });
+    assert.strictEqual(resp.status, 503);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, false);
+    assert.strictEqual(body.error.code, 'RATE_LIMIT_UNAVAILABLE');
+  },
+});
+
+// ── 13. Endpoint config/provider unavailable response matches taxonomy ─────
+tests.push({
+  name: 'Endpoint config/provider unavailable response matches taxonomy (503 + CONFIG_MISSING or PROVIDER_UNAVAILABLE)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      headers: { Authorization: 'Bearer TEST_FIXTURE_TOKEN_xyz_taxonomy_provider' },
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const verifyToken = async () => ({ ok: true, uid: 'user-t3' });
+    const checkRateLimit = async () => ({ allowed: true, bucket: 'scout:live:user:user-t3' });
+    // env has no LLM_PROVIDER/API_KEY/MODEL — CONFIG_MISSING is expected
+    const resp = await handler({
+      request: req,
+      env: {
+        SCOUT_SUGGEST_PROVIDER_MODE: 'live',
+      },
+      verifyToken,
+      checkRateLimit,
+    });
+    assert.strictEqual(resp.status, 503);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, false);
+    assert.ok(
+      body.error.code === 'CONFIG_MISSING' || body.error.code === 'PROVIDER_UNAVAILABLE',
+      `expected CONFIG_MISSING or PROVIDER_UNAVAILABLE, got ${body.error.code}`
+    );
+  },
+});
+
+// ── 14. Response never leaks raw token/API key/prompt/sourceUrl ────────────
+tests.push({
+  name: 'Response never leaks raw token / API key / prompt / sourceUrl',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const secretToken = 'TEST_FIXTURE_TOKEN_xyz_taxonomy_leak';
+    const secretApiKey = 'TEST_FIXTURE_API_KEY_xyz_taxonomy_leak';
+    const req = createMockRequest({
+      headers: { Authorization: `Bearer ${secretToken}` },
+      body: {
+        excerpt: 'LEAK_PROMPT_TAX_xyz',
+        sourceUrl: 'https://example.com/LEAK_URL_TAX_xyz?secret=1',
+        requestedLanguage: 'ko',
+        desiredTone: 'polite',
+      }
+    });
+    const verifyToken = async () => ({ ok: true, uid: 'user-t4' });
+    const checkRateLimit = async () => ({ allowed: true, bucket: 'scout:live:user:user-t4' });
+    const resp = await handler({
+      request: req,
+      env: {
+        SCOUT_SUGGEST_PROVIDER_MODE: 'live',
+        SCOUT_SUGGEST_LLM_PROVIDER: 'openai',
+        SCOUT_SUGGEST_LLM_API_KEY: secretApiKey,
+        SCOUT_SUGGEST_MODEL: 'gpt-4',
+      },
+      verifyToken,
+      checkRateLimit,
+    });
+    const bodyText = await resp.text();
+    assert.ok(!bodyText.includes(secretToken), 'response body must not include raw token');
+    assert.ok(!bodyText.includes(secretApiKey), 'response body must not include API key value');
+    assert.ok(!bodyText.includes('LEAK_PROMPT_TAX_xyz'), 'response body must not include prompt/excerpt');
+    assert.ok(!bodyText.includes('LEAK_URL_TAX_xyz'), 'response body must not include full sourceUrl');
+  },
+});
+
+// ── 15. Observability throw does not change client response ────────────────
+tests.push({
+  name: 'Observability throw does not change client response (taxonomy response unchanged)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const throwingObserver = {
+      recordBoundaryDecision() { throw new Error('TEST_FIXTURE_OBSERVER_THROWS_TAX'); },
+    };
+    const req = createMockRequest({
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const resp = await handler({
+      request: req,
+      env: { SCOUT_SUGGEST_PROVIDER_MODE: 'live' },
+      observer: throwingObserver,
+    });
+    assert.strictEqual(resp.status, 401);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.error.code, 'AUTH_REQUIRED');
+  },
+});
+
+// ── 16. Default stub remains unchanged ──────────────────────────────────────
+tests.push({
+  name: 'Default stub remains unchanged (providerMode: stub success response)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const resp = await handler({ request: req, env: {} });
+    assert.strictEqual(resp.status, 200);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, true);
+    assert.strictEqual(body.providerMode, 'stub');
+  },
+});
+
+// ── 17. Explicit stub remains unchanged ────────────────────────────────────
+tests.push({
+  name: 'Explicit stub remains unchanged (providerMode: stub success response)',
+  fn: async () => {
+    const handler = await getOnRequestPost();
+    const req = createMockRequest({
+      body: { excerpt: 'Valid excerpt text', requestedLanguage: 'ko', desiredTone: 'polite' }
+    });
+    const resp = await handler({
+      request: req,
+      env: { SCOUT_SUGGEST_PROVIDER_MODE: 'stub' },
+    });
+    assert.strictEqual(resp.status, 200);
+    const body = JSON.parse(await resp.text());
+    assert.strictEqual(body.ok, true);
+    assert.strictEqual(body.providerMode, 'stub');
+  },
+});
+
+// ── 18. Frontend local_stub preserved ──────────────────────────────────────
+tests.push({
+  name: 'Frontend source selector default local_stub preserved',
+  fn: () => {
+    assert.ok(srcSelCode.length > 0);
+    assert.ok(
+      srcSelCode.includes("LOCAL_STUB: 'local_stub'") || srcSelCode.includes('LOCAL_STUB: "local_stub"'),
+      'local_stub must remain defined'
+    );
+  },
+});
+
+// ── 19. Endpoint client default disabled preserved ──────────────────────────
+tests.push({
+  name: 'Endpoint client default disabled preserved (no boundary / observability / taxonomy wiring)',
+  fn: () => {
+    assert.ok(endpointClientCode.length > 0);
+    assert.ok(
+      !endpointClientCode.includes('live-auth-rate-limit-boundary'),
+      'endpoint client must not import auth/rate-limit boundary'
+    );
+    assert.ok(
+      !endpointClientCode.includes('live-auth-rate-limit-observability'),
+      'endpoint client must not import observability helper'
+    );
+    assert.ok(
+      !endpointClientCode.includes('live-endpoint-error-taxonomy'),
+      'endpoint client must not import error taxonomy helper'
+    );
+  },
+});
+
+// ── 20. No Firebase Admin SDK ───────────────────────────────────────────────
+tests.push({
+  name: 'No Firebase Admin SDK in any scout source file',
+  fn: () => {
+    const files = [
+      ['helper', cleanSource(helperCode)],
+      ['boundary', cleanSource(boundaryCode)],
+      ['suggest', cleanSource(suggestCode)],
+      ['adapter', cleanSource(adapterCode)],
+      ['live-adapter', cleanSource(liveAdapterCode)],
+    ];
+    const patterns = [
+      /require\(['"]firebase-admin['"]\)/,
+      /from\s+['"]firebase-admin['"]/,
+      /require\(['"]firebase\/[^'"]+['"]\)/,
+      /from\s+['"]firebase\/[^'"]+['"]/,
+    ];
+    for (const [name, code] of files) {
+      for (const p of patterns) {
+        assert.ok(!p.test(code), `${name} must not import Firebase Admin SDK`);
+      }
+    }
+  },
+});
+
+// ── 21. No KV / Durable Object / D1 runtime access ─────────────────────────
+tests.push({
+  name: 'No KV / Durable Object / D1 runtime access in any scout source file',
+  fn: () => {
+    const files = [
+      ['helper', cleanSource(helperCode)],
+      ['boundary', cleanSource(boundaryCode)],
+      ['suggest', cleanSource(suggestCode)],
+      ['adapter', cleanSource(adapterCode)],
+      ['live-adapter', cleanSource(liveAdapterCode)],
+    ];
+    for (const [name, code] of files) {
+      assert.ok(
+        !/KVNamespace|DurableObject|D1Database|env\.KV|env\.DB|env\.DO/.test(code),
+        `${name} must not reference KV/DO/D1 runtime APIs`
+      );
+      assert.ok(
+        !/platform\.|wrangler\./.test(code),
+        `${name} must not reference Cloudflare platform globals`
+      );
+    }
+  },
+});
+
+// ── 22. No provider SDK imports ─────────────────────────────────────────────
+tests.push({
+  name: 'No provider SDK imports in any scout source file',
+  fn: () => {
+    const forbidden = [
+      'openai', '@anthropic-ai/sdk', '@google/generative-ai', 'groq-sdk',
+      '@mistralai/mistralai', 'nvidia-modulus', 'grok-client',
+    ];
+    const files = [
+      ['helper', cleanSource(helperCode)],
+      ['boundary', cleanSource(boundaryCode)],
+      ['suggest', cleanSource(suggestCode)],
+      ['adapter', cleanSource(adapterCode)],
+      ['live-adapter', cleanSource(liveAdapterCode)],
+    ];
+    for (const [name, code] of files) {
+      for (const pkg of forbidden) {
+        const esc = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const requireRe = new RegExp(`require\\(['"\`]${esc}['"\`]`);
+        const fromRe = new RegExp(`from\\s+['"\`]${esc}['"\`]`);
+        assert.ok(
+          !requireRe.test(code) && !fromRe.test(code),
+          `${name} must not import SDK "${pkg}"`
+        );
+      }
+    }
+  },
+});
+
+// ── 23. No fetch / XHR / axios ──────────────────────────────────────────────
+tests.push({
+  name: 'No fetch / XHR / axios in any scout source file',
+  fn: () => {
+    const files = [
+      ['helper', cleanSource(helperCode)],
+      ['boundary', cleanSource(boundaryCode)],
+      ['suggest', cleanSource(suggestCode)],
+      ['adapter', cleanSource(adapterCode)],
+      ['live-adapter', cleanSource(liveAdapterCode)],
+    ];
+    for (const [name, code] of files) {
+      assert.ok(!/\bfetch\s*\(/.test(code), `${name} must not use fetch(`);
+      assert.ok(!/XMLHttpRequest/.test(code), `${name} must not use XMLHttpRequest`);
+      assert.ok(!/axios/.test(code), `${name} must not use axios`);
+    }
+  },
+});
+
+// ── 24. Related docs updated ────────────────────────────────────────────────
+tests.push({
+  name: 'Related docs reflect endpoint error taxonomy contract status',
+  fn: () => {
+    for (const rel of RELATED_DOCS) {
+      const filePath = path.join(ROOT, 'docs/product', rel);
+      const content = readFileSafe(filePath);
+      assert.ok(content.length > 0, `${rel} must exist`);
+      const lc = content.toLowerCase();
+      assert.ok(
+        lc.includes('error taxonomy') || lc.includes('error-taxonomy'),
+        `${rel} must mention the error taxonomy contract`
+      );
+    }
+  },
+});
+
+// ── Run ──────────────────────────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+
+async function run() {
+  for (const test of tests) {
+    try {
+      const result = test.fn();
+      if (result && typeof result.then === 'function') {
+        await result;
+      }
+      console.log(`  ✓ ${test.name}`);
+      passed++;
+    } catch (err) {
+      console.log(`  ✗ ${test.name}`);
+      console.log(`    ${err.message}`);
+      if (err.stack) console.log(err.stack);
+      failed++;
+    }
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(e => {
+  console.error('Test runner error:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md` (240 lines): error categories, canonical error codes, HTTP status mapping, response body shape, Retry-After policy, observability mapping, sensitive data prohibition, default behavior guardrails
- Adds `tests/contracts/scout-live-endpoint-error-taxonomy-contract.test.cjs` (24 sub-tests)
- Updates 8 related docs with the error taxonomy contract status

## Motivation

Issue #2290 — follow-up after the Scout live auth/rate-limit readiness audit (#2289). Locks the endpoint error taxonomy so future real Firebase / KV / provider work can be slotted in without renegotiating error codes, HTTP statuses, or response shapes.

## Categories / codes locked

- Categories (9): `request_validation`, `auth`, `rate_limit`, `config`, `provider_availability`, `provider_response`, `output_safety`, `observability`, `internal_boundary`
- Codes (12): `INVALID_REQUEST`, `VALIDATION_ERROR`, `AUTH_REQUIRED`, `AUTH_INVALID`, `RATE_LIMITED`, `RATE_LIMIT_UNAVAILABLE`, `CONFIG_MISSING`, `PROVIDER_UNAVAILABLE`, `PROVIDER_ERROR`, `OUTPUT_SAFETY_BLOCKED`, `OBSERVABILITY_UNAVAILABLE`, `INTERNAL_BOUNDARY_ERROR`
- HTTP status mapping locked (400 / 401 / 405 / 413 / 422 / 429 / 500 / 502 / 503)

## Response shape



## Validation

- `node --check` on test file OK
- focused error taxonomy contract 24/24
- existing focused contracts: readiness audit 16/16, observability 24/24, DI 20/20, wiring 20/20, runtime 28/28, reconcile 13/13
- `npm test` 1949 pass / 3 pre-existing editor-canvas fail (not introduced) / 1 skip
- `npm run verify` 284/284
- `git diff --check` clean

## Related

- Closes #2290
- Refs #1882
- Follow-up to PR #2289 (readiness audit, merged `cdcaf6d2`)