### PR TITLE
tech(scout): add live auth/rate-limit dependency adapter skeleton

### DIFF
--- a/docs/product/lovebud-scout-ai-suggestion-mvp-readiness.md
+++ b/docs/product/lovebud-scout-ai-suggestion-mvp-readiness.md
@@ -125,6 +125,16 @@ Ready for a narrow live-provider implementation planning slice, but not ready fo
 
 ---
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Deferred Work
 
 ### Can be next

--- a/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
@@ -1,0 +1,166 @@
+# Scout Live Auth/Rate-Limit Dependency Adapter Skeleton
+
+> Status: **skeleton only** (mock-disabled)
+> Version: v20260607-1
+> Audience: Scout live provider engineering
+> Scope: dependency adapter skeleton for the LIVE branch DI seam
+
+## 1. Purpose
+
+This document defines the **mock-disabled dependency adapter skeleton** for the
+Scout live provider path. The adapter provides default implementations of
+`verifyToken`, `checkRateLimit`, and `requestId` for the DI seam established in
+`functions/api/scout/suggest.js` LIVE branch (shape:
+
+```
+liveDependencies = { verifyToken, checkRateLimit, observer, requestId }
+```
+
+The adapter is **mock-disabled by default** and returns safe "not implemented"
+responses so the endpoint can never accidentally allow real traffic while the
+skeleton is in place. Real implementations of `verifyToken` (Firebase Admin SDK
+or equivalent) and `checkRateLimit` (KV / Durable Object / D1 or equivalent)
+will be added in future slices.
+
+## 2. Module
+
+`functions/api/scout/live-auth-rate-limit-dependency-adapter.js` (v20260607-1)
+
+Exports:
+
+- `SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION` — `'20260607-1'`
+- `SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES` — `{ MOCK_DISABLED, NOT_IMPLEMENTED }`
+- `SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES` — `{ VERIFY_NOT_IMPLEMENTED, RATE_LIMIT_NOT_IMPLEMENTED }`
+- `createScoutLiveDependencyAdapter(options?)` — factory
+
+## 3. Factory contract
+
+```
+createScoutLiveDependencyAdapter(options?) -> adapter
+```
+
+Options:
+
+- `mockDisabled: boolean` — default `true`. When `true`, the factory returns
+  a mock-disabled adapter. When `false`, the factory returns a not-implemented
+  adapter (real implementations are not yet provided; future slices will
+  replace this).
+
+The returned adapter is **frozen** and has the shape:
+
+```
+{
+  version: '20260607-1',
+  mode: 'mock_disabled' | 'not_implemented',
+  isMockDisabled: boolean,
+  verifyToken: async () => ({ allowed, code, reason }),
+  checkRateLimit: async () => ({ allowed, code, reason }),
+  requestId: () => string,
+}
+```
+
+### 3.1 Mock-disabled mode (default)
+
+- `verifyToken` returns:
+  ```
+  { allowed: false, code: 'VERIFY_NOT_IMPLEMENTED', reason: 'verifyToken is mock-disabled; real implementation is required' }
+  ```
+- `checkRateLimit` returns:
+  ```
+  { allowed: false, code: 'RATE_LIMIT_NOT_IMPLEMENTED', reason: 'rate limiting is mock-disabled; real implementation is required' }
+  ```
+- `requestId` returns a string starting with `req_mock_disabled_` followed by
+  a base36 timestamp and a random suffix.
+
+Both `verifyToken` and `checkRateLimit` **deny by default** (fail-closed) so
+the endpoint cannot accidentally allow real traffic in skeleton mode.
+
+### 3.2 Not-implemented mode
+
+When `mockDisabled: false` is passed, the factory returns the same shape but
+with `mode: 'not_implemented'` and `isMockDisabled: false`. The
+`requestId` returns a string starting with `req_not_implemented_`. This mode
+is reserved for future slices that will replace the mock-disabled responses
+with real ones.
+
+## 4. Boundary inventory
+
+This skeleton sits **alongside** the canonical boundary skeleton:
+
+- `functions/api/scout/live-auth-rate-limit-boundary.js` — canonical runtime
+  boundary + DI seam (v20260607-1)
+- `functions/api/scout/live-auth-rate-limit-observability.js` — observability
+  helper (v20260607-1)
+- `functions/api/scout/live-auth-rate-limit-dependency-adapter.js` —
+  dependency adapter skeleton (this document, v20260607-1)
+
+The dependency adapter skeleton is a **separate module** with a **clear
+single responsibility** (provide default `verifyToken` / `checkRateLimit` /
+`requestId` implementations). It is not wired into `suggest.js` LIVE branch
+in this slice.
+
+## 5. Confirmed behavior
+
+| Scenario | verifyToken | checkRateLimit | requestId | Note |
+| --- | --- | --- | --- | --- |
+| Default `mockDisabled:true` | `allowed:false`, `VERIFY_NOT_IMPLEMENTED` | `allowed:false`, `RATE_LIMIT_NOT_IMPLEMENTED` | `req_mock_disabled_*` | fail-closed |
+| Explicit `mockDisabled:false` | `allowed:false`, `VERIFY_NOT_IMPLEMENTED` | `allowed:false`, `RATE_LIMIT_NOT_IMPLEMENTED` | `req_not_implemented_*` | reserved for future slices |
+| Same module across multiple calls | same code, different reason timestamps are not embedded | same | different ids | idempotent on each call |
+
+## 6. Privacy / safety behavior
+
+The adapter skeleton does not:
+
+- Import or reference the Firebase Admin SDK
+- Import or reference any KV / Durable Object / D1 runtime
+- Import or reference any provider SDK (openai, anthropic, gemini, groq,
+  mistral, nvidia, cohere, perplexity, etc.)
+- Call `fetch`, `XMLHttpRequest`, `axios`, or construct a new `Request`
+- Read `process.env.SCOUT_*` (no API key / token propagation)
+- Persist any state across calls
+- Wire into `suggest.js` LIVE branch in this slice (out of scope)
+
+## 7. Go / no-go matrix
+
+| Item | Verdict | Notes |
+| --- | --- | --- |
+| Dependency adapter skeleton module itself | **YES** | this slice |
+| Wiring the adapter into `suggest.js` LIVE branch | **separate slice** | out of scope for this slice |
+| Real `verifyToken` (Firebase Admin SDK) implementation | **NO** | future slice |
+| Real `checkRateLimit` (KV / DO / D1) implementation | **NO** | future slice |
+| Real `requestId` (W3C trace context) implementation | **NO** | future slice |
+| Real observability backend integration | **NO** | future slice |
+| `staging_live` execution | **NO** | blocked |
+| `production_live` execution | **NO** | blocked |
+
+## 8. Remaining blockers
+
+- Real `verifyToken` adapter (Firebase Admin SDK or equivalent)
+- Real `checkRateLimit` adapter (KV / DO / D1 or equivalent)
+- Real `requestId` adapter (W3C trace context or equivalent)
+- Wiring the adapter into `suggest.js` LIVE branch
+- Real observability backend integration
+- Provider-specific live adapter
+- Staging soak
+- Kill-switch drill
+- Secret rotation drill
+
+## 9. Recommended next slice
+
+`[TECH] Wire Scout live dependency adapter into suggest.js LIVE branch (mock-disabled)`.
+
+That slice will:
+- Add an optional `context.liveAdapter` to the `suggest.js` LIVE branch
+- Inject the adapter's `verifyToken` / `checkRateLimit` / `requestId` into
+  `liveDependencies` when `context.liveAdapter` is provided
+- Remain **mock-disabled by default** (no real Firebase / KV / provider)
+- Not change endpoint default `providerMode:"stub"` behavior
+- Not change frontend default `local_stub` behavior
+- Not change endpoint client default disabled behavior
+
+## 10. Verdict
+
+- Dependency adapter skeleton (this slice): **YES** (mock-disabled)
+- Wiring into `suggest.js` LIVE branch: **separate slice** (mock-disabled)
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations: **NO**
+- Real Firebase / KV / DO / D1 / provider SDK / staging / production: **NO**

--- a/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
@@ -182,6 +182,16 @@ The following are intentionally **not yet implemented** and block any real runti
 - Ready for `production_live` execution: **No**
 - Ready for real provider API call: **No**
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Audited Test Files (all required to keep passing)
 
 ```text

--- a/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
@@ -163,6 +163,16 @@ The following are intentionally **not yet implemented** and block any real runti
 - Ready for `production_live` execution: **No**
 - Ready for real provider API call: **No**
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Audited Test Files (all required to keep passing)
 
 ```text

--- a/docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-taxonomy-contract.md
@@ -161,6 +161,16 @@ The endpoint's sanitized observability events (see `live-auth-rate-limit-observa
 
 Only auth and rate-limit decisions are currently emitted as observability events. Future slices may extend this matrix to include provider and safety events, but the auth/rate-limit mapping is locked by this contract.
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Sensitive Data Prohibition
 
 The following are **prohibited** from any response header, response body, or observability event payload:

--- a/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
+++ b/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
@@ -458,6 +458,16 @@ A consolidated [production readiness gates audit](lovebud-scout-live-provider-pr
 - staging_live and production_live remain blocked
 - Real provider API call remains blocked in the current slice
 
+## Dependency Adapter Skeleton Status
+
+A consolidated [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (this document)
 
 - ❌ No real LLM provider implementation

--- a/docs/product/lovebud-scout-live-provider-production-readiness-gates-audit.md
+++ b/docs/product/lovebud-scout-live-provider-production-readiness-gates-audit.md
@@ -373,6 +373,16 @@ There are two recommended paths for the next slice:
 ```
 This would implement the runtime auth/rate-limit dependency injection seam without real Firebase/KV calls, starting the implementation path without enabling any live provider behavior.
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (this document)
 
 - ❌ No real LLM provider implementation

--- a/docs/product/lovebud-scout-live-provider-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-provider-readiness-audit.md
@@ -140,6 +140,16 @@ Ready to plan a narrow real-provider adapter integration behind disabled live mo
 
 9. **GitGuardian false positive around safety patterns should be documented as advisory-only if recurring** — The safety filter patterns (`password-like`, `secret-like` values in detection arrays) may trigger false positives. These are safety code, not leaked secrets.
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Conditions for First Real Provider Slice
 
 실제 provider를 붙이는 첫 slice의 조건:

--- a/docs/product/lovebud-scout-live-provider-staging-rollout-contract.md
+++ b/docs/product/lovebud-scout-live-provider-staging-rollout-contract.md
@@ -384,6 +384,16 @@ A consolidated [production readiness gates audit](lovebud-scout-live-provider-pr
 - staging_live and production_live remain blocked
 - Real provider API call remains blocked in the current slice
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (this document)
 
 - ❌ No real provider implementation

--- a/docs/product/lovebud-scout-llm-provider-boundary.md
+++ b/docs/product/lovebud-scout-llm-provider-boundary.md
@@ -291,6 +291,16 @@ class ScoutStubSuggestionProvider {
 
 ---
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Recommended Next Slice
 
 ### `[PRODUCT] Add Scout stub suggestion provider contract`

--- a/docs/product/lovebud-scout-serverless-endpoint-boundary.md
+++ b/docs/product/lovebud-scout-serverless-endpoint-boundary.md
@@ -420,6 +420,16 @@ SCOUT_LLM_RETRY_ATTEMPTS=2
 
 ---
 
+## Dependency Adapter Skeleton Status
+
+A [dependency adapter skeleton](lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveDependencyAdapter`) returning default `verifyToken` / `checkRateLimit` / `requestId`
+- Default `mockDisabled:true` so the endpoint cannot accidentally allow real traffic in skeleton mode
+- No real Firebase Admin SDK, no real KV/DO/D1, no provider SDK, no fetch
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (This Audit)
 
 - ❌ No actual endpoint implementation

--- a/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
+++ b/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
@@ -1,0 +1,161 @@
+/**
+ * Scout Live Auth / Rate-Limit Dependency Adapter Skeleton
+ * v20260607-1
+ *
+ * Mock-disabled dependency adapter skeleton for the Scout live provider path.
+ * Provides a factory that returns default implementations of `verifyToken`,
+ * `checkRateLimit`, and `requestId` for the DI seam established in
+ * `functions/api/scout/suggest.js` LIVE branch (shape:
+ * `liveDependencies = { verifyToken, checkRateLimit, observer, requestId }`).
+ *
+ * By default the adapter is **mock-disabled** and returns safe "not
+ * implemented" responses so the endpoint can never accidentally allow real
+ * traffic while the skeleton is in place. Real implementations of
+ * `verifyToken` (Firebase Admin SDK or equivalent) and `checkRateLimit`
+ * (KV / Durable Object / D1 or equivalent) will be added in future slices.
+ *
+ * Provides:
+ * - SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES: status / mode constants
+ * - SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES: response code constants
+ * - SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION: skeleton version
+ * - createScoutLiveDependencyAdapter: returns a dependency adapter object
+ *   with `verifyToken`, `checkRateLimit`, `requestId`, and metadata
+ *   (`isMockDisabled`, `mode`, `version`).
+ *
+ * This module is a **mock-disabled skeleton + factory**. No real Firebase
+ * Admin SDK import, no real token verification, no real persistent storage
+ * call, no fetch, no provider API call.
+ *
+ * Non-goals:
+ * - No real LLM provider call
+ * - No provider SDK import
+ * - No Firebase Admin SDK import
+ * - No Firebase token verification
+ * - No KV / Durable Object / D1 import
+ * - No persistent rate-limit storage call
+ * - No external URL fetch
+ * - No auto-save or persistence
+ * - No wiring into suggest.js LIVE branch (separate slice)
+ */
+
+'use strict';
+
+// ─── Version ────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION = '20260607-1';
+
+// ─── Mode Constants ─────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES = Object.freeze({
+  MOCK_DISABLED: 'mock_disabled',
+  NOT_IMPLEMENTED: 'not_implemented',
+});
+
+// ─── Response Codes ────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES = Object.freeze({
+  VERIFY_NOT_IMPLEMENTED: 'VERIFY_NOT_IMPLEMENTED',
+  RATE_LIMIT_NOT_IMPLEMENTED: 'RATE_LIMIT_NOT_IMPLEMENTED',
+});
+
+// ─── Default Configuration ──────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS = Object.freeze({
+  mockDisabled: true,
+});
+
+// ─── Internal Helpers ───────────────────────────────────────────────────────
+
+function makeMockDisabledRequestId() {
+  // Mock-disabled request id: clearly fake, never collides with real
+  // upstream / W3C trace ids, contains only safe characters.
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 10);
+  return 'req_mock_disabled_' + ts + '_' + rand;
+}
+
+function buildMockDisabledVerifyResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED,
+    reason: 'verifyToken is mock-disabled; real implementation is required',
+  };
+}
+
+function buildMockDisabledRateLimitResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED,
+    reason: 'rate limiting is mock-disabled; real implementation is required',
+  };
+}
+
+function buildNotImplementedVerifyResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED,
+    reason: 'real verifyToken implementation is not yet provided',
+  };
+}
+
+function buildNotImplementedRateLimitResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED,
+    reason: 'real checkRateLimit implementation is not yet provided',
+  };
+}
+
+function buildNotImplementedRequestId() {
+  return 'req_not_implemented_' + Date.now().toString(36);
+}
+
+// ─── Factory: createScoutLiveDependencyAdapter ──────────────────────────────
+
+/**
+ * Create a Scout live dependency adapter.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.mockDisabled=true] when true (default), returns
+ *   safe mock-disabled responses for verifyToken / checkRateLimit and a
+ *   fake requestId. When false, returns "not implemented" responses from
+ *   each method (real implementations will be added in future slices).
+ * @returns {Object} adapter with verifyToken, checkRateLimit, requestId, and
+ *   metadata (isMockDisabled, mode, version).
+ */
+export function createScoutLiveDependencyAdapter(options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
+  const mockDisabled = opts.mockDisabled !== false;
+
+  if (mockDisabled) {
+    return Object.freeze({
+      version: SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION,
+      mode: SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES.MOCK_DISABLED,
+      isMockDisabled: true,
+      verifyToken: async function verifyToken() {
+        return buildMockDisabledVerifyResponse();
+      },
+      checkRateLimit: async function checkRateLimit() {
+        return buildMockDisabledRateLimitResponse();
+      },
+      requestId: function requestId() {
+        return makeMockDisabledRequestId();
+      },
+    });
+  }
+
+  return Object.freeze({
+    version: SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION,
+    mode: SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES.NOT_IMPLEMENTED,
+    isMockDisabled: false,
+    verifyToken: async function verifyToken() {
+      return buildNotImplementedVerifyResponse();
+    },
+    checkRateLimit: async function checkRateLimit() {
+      return buildNotImplementedRateLimitResponse();
+    },
+    requestId: function requestId() {
+      return buildNotImplementedRequestId();
+    },
+  });
+}

--- a/tests/contracts/scout-live-auth-rate-limit-dependency-adapter-skeleton-contract.test.cjs
+++ b/tests/contracts/scout-live-auth-rate-limit-dependency-adapter-skeleton-contract.test.cjs
@@ -1,0 +1,380 @@
+/**
+ * Scout Live Auth/Rate-Limit Dependency Adapter Skeleton Contract Tests
+ * v20260607-1
+ *
+ * Locks the mock-disabled dependency adapter skeleton contract for the
+ * Scout live provider path:
+ * - factory module exists and is well-formed
+ * - factory default mockDisabled:true returns safe "not implemented"
+ *   responses for verifyToken and checkRateLimit
+ * - requestId returns a clearly fake id (req_mock_disabled_*)
+ * - non-mock-disabled mode returns the same shape with not-implemented marker
+ * - no Firebase Admin SDK / no KV-DO-D1 / no provider SDK / no fetch
+ * - endpoint default stub / frontend local_stub / endpoint client default
+ *   disabled remain preserved
+ * - canonical live-auth-rate-limit-boundary.js is unchanged
+ * - parallel live-provider-auth-rate-limit-boundary.js is not adopted
+ * - docs reflect the adapter skeleton status
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const BOUNDARY_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-boundary.js');
+const OBSERVABILITY_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-observability.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+const DOCS = [
+  'lovebud-scout-live-provider-auth-rate-limit-boundary.md',
+  'lovebud-scout-live-endpoint-error-readiness-audit.md',
+  'lovebud-scout-serverless-endpoint-boundary.md',
+  'lovebud-scout-llm-provider-boundary.md',
+  'lovebud-scout-live-provider-production-readiness-gates-audit.md',
+  'lovebud-scout-live-provider-staging-rollout-contract.md',
+  'lovebud-scout-live-auth-rate-limit-readiness-audit.md',
+  'lovebud-scout-live-endpoint-error-taxonomy-contract.md',
+  'lovebud-scout-ai-suggestion-mvp-readiness.md',
+  'lovebud-scout-live-provider-readiness-audit.md',
+];
+
+const ADAPTER_SKEL_DOC = 'lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md';
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+const adapterCode = readFileSafe(ADAPTER_PATH);
+const boundaryCode = readFileSafe(BOUNDARY_PATH);
+const observabilityCode = readFileSafe(OBSERVABILITY_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const srcSelCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+let adapterModulePromise = null;
+async function loadAdapterModule() {
+  if (!adapterModulePromise) {
+    adapterModulePromise = import(ADAPTER_PATH);
+  }
+  return adapterModulePromise;
+}
+
+const tests = [];
+
+// ── 1. Module shape ────────────────────────────────────────────────────────
+tests.push({
+  name: 'Dependency adapter skeleton module exists and exports factory + version + codes + modes',
+  fn: async () => {
+    assert.ok(adapterCode.length > 0, 'adapter module must exist');
+    const mod = await loadAdapterModule();
+    assert.strictEqual(typeof mod.createScoutLiveDependencyAdapter, 'function', 'factory must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION, 'string', 'version must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES, 'object', 'modes must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES, 'object', 'codes must be exported');
+    assert.ok(/^v?2026\d{4}-/.test(mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION.replace(/^v/, '')) || /^2026\d{4}/.test(mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION), 'version must be a YYYYMMDD-N style string');
+  },
+});
+
+// ── 2. Default mockDisabled:true ───────────────────────────────────────────
+tests.push({
+  name: 'Factory default mockDisabled:true returns mock_disabled adapter with safe responses',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter();
+    assert.strictEqual(adapter.isMockDisabled, true, 'default isMockDisabled must be true');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES.MOCK_DISABLED, 'default mode must be MOCK_DISABLED');
+    assert.strictEqual(typeof adapter.verifyToken, 'function', 'verifyToken must be a function');
+    assert.strictEqual(typeof adapter.checkRateLimit, 'function', 'checkRateLimit must be a function');
+    assert.strictEqual(typeof adapter.requestId, 'function', 'requestId must be a function');
+    assert.strictEqual(adapter.version, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION, 'adapter version must match module version');
+  },
+});
+
+// ── 3. verifyToken mock-disabled response ───────────────────────────────────
+tests.push({
+  name: 'Mock-disabled verifyToken returns { allowed:false, code: VERIFY_NOT_IMPLEMENTED, reason }',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter();
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false, 'mock-disabled verifyToken must deny');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED, 'code must be VERIFY_NOT_IMPLEMENTED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+  },
+});
+
+// ── 4. checkRateLimit mock-disabled response ───────────────────────────────
+tests.push({
+  name: 'Mock-disabled checkRateLimit returns { allowed:false, code: RATE_LIMIT_NOT_IMPLEMENTED, reason }',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter();
+    const res = await adapter.checkRateLimit({});
+    assert.strictEqual(res.allowed, false, 'mock-disabled checkRateLimit must deny (fail closed)');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED, 'code must be RATE_LIMIT_NOT_IMPLEMENTED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+  },
+});
+
+// ── 5. requestId mock-disabled shape ───────────────────────────────────────
+tests.push({
+  name: 'Mock-disabled requestId returns a clearly fake id starting with req_mock_disabled_',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter();
+    const id = adapter.requestId();
+    assert.ok(typeof id === 'string', 'requestId must be a string');
+    assert.ok(id.startsWith('req_mock_disabled_'), 'mock-disabled requestId must start with req_mock_disabled_');
+    assert.ok(id.length > 20, 'mock-disabled requestId must include a non-trivial suffix');
+    const id2 = adapter.requestId();
+    assert.notStrictEqual(id, id2, 'two consecutive requestId calls should produce different ids');
+  },
+});
+
+// ── 6. Non-mock-disabled mode ──────────────────────────────────────────────
+tests.push({
+  name: 'Factory mockDisabled:false returns NOT_IMPLEMENTED adapter with same shape',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter({ mockDisabled: false });
+    assert.strictEqual(adapter.isMockDisabled, false, 'isMockDisabled must be false');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES.NOT_IMPLEMENTED, 'mode must be NOT_IMPLEMENTED');
+    const v = await adapter.verifyToken({});
+    assert.strictEqual(v.allowed, false, 'not-implemented verifyToken must deny');
+    assert.strictEqual(v.code, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED, 'code must be VERIFY_NOT_IMPLEMENTED');
+    const r = await adapter.checkRateLimit({});
+    assert.strictEqual(r.allowed, false, 'not-implemented checkRateLimit must deny');
+    assert.strictEqual(r.code, mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED, 'code must be RATE_LIMIT_NOT_IMPLEMENTED');
+    const id = adapter.requestId();
+    assert.ok(id.startsWith('req_not_implemented_'), 'not-implemented requestId must start with req_not_implemented_');
+  },
+});
+
+// ── 7. Adapter is frozen / immutable ───────────────────────────────────────
+tests.push({
+  name: 'Adapter object is frozen (immutable)',
+  fn: async () => {
+    const mod = await loadAdapterModule();
+    const adapter = mod.createScoutLiveDependencyAdapter();
+    assert.strictEqual(Object.isFrozen(adapter), true, 'adapter must be frozen');
+  },
+});
+
+// ── 8. No Firebase Admin SDK imports ───────────────────────────────────────
+tests.push({
+  name: 'No Firebase Admin SDK imports in adapter module',
+  fn: () => {
+    const lc = adapterCode.toLowerCase();
+    assert.ok(!/firebase-admin/.test(lc), 'adapter must not import firebase-admin');
+    assert.ok(!/admin\s*\.\s*auth/.test(lc), 'adapter must not reference admin.auth');
+    assert.ok(!/initializeapp/.test(lc), 'adapter must not call initializeApp');
+    assert.ok(!/cert\s*\(/.test(lc), 'adapter must not call cert()');
+  },
+});
+
+// ── 9. No KV / Durable Object / D1 runtime ─────────────────────────────────
+tests.push({
+  name: 'No KV / Durable Object / D1 runtime access in adapter module',
+  fn: () => {
+    const lc = adapterCode.toLowerCase();
+    // Strip block + line comments so doc-style mentions in non-goals do not
+    // trip the test.
+    const codeOnly = adapterCode
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1')
+      .toLowerCase();
+    assert.ok(!/durable\s*object/.test(codeOnly) && !/durableobject/.test(codeOnly), 'adapter must not reference Durable Object in code');
+    assert.ok(!/\.env\.kv\b/.test(codeOnly) && !/env\.kv\b/.test(codeOnly), 'adapter must not read env.KV in code');
+    assert.ok(!/d1\s*prepare/.test(codeOnly) && !/env\.db\b/.test(codeOnly), 'adapter must not prepare D1 or read env.DB in code');
+    // Also ensure no KV/DO/D1 mentions in the actual non-comment code
+    assert.ok(!/do_id\s*\(/.test(codeOnly) && !/durableobjectbinding/.test(codeOnly), 'adapter must not bind to DO runtime in code');
+  },
+});
+
+// ── 10. No provider SDK imports ────────────────────────────────────────────
+tests.push({
+  name: 'No provider SDK imports in adapter module',
+  fn: () => {
+    const lc = adapterCode.toLowerCase();
+    for (const provider of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'nvidia', 'cohere', 'perplexity']) {
+      assert.ok(!lc.includes(provider), `adapter must not import or reference ${provider}`);
+    }
+  },
+});
+
+// ── 11. No fetch / XHR / axios ─────────────────────────────────────────────
+tests.push({
+  name: 'No fetch / XHR / axios / http request in adapter module',
+  fn: () => {
+    const lc = adapterCode.toLowerCase();
+    assert.ok(!/\bfetch\s*\(/.test(lc), 'adapter must not call fetch()');
+    assert.ok(!/xmlhttprequest/.test(lc), 'adapter must not use XMLHttpRequest');
+    assert.ok(!/axios/.test(lc), 'adapter must not use axios');
+    assert.ok(!/new\s+request\s*\(/.test(lc), 'adapter must not construct a new Request');
+  },
+});
+
+// ── 12. No real secret / token / API key propagation ────────────────────────
+tests.push({
+  name: 'No raw secret / token / API key / API_KEY env reading in adapter module',
+  fn: () => {
+    const lc = adapterCode.toLowerCase();
+    assert.ok(!/api[_-]?key/.test(lc), 'adapter must not reference api_key');
+    assert.ok(!/bearer\s+/.test(lc), 'adapter must not embed bearer tokens');
+    assert.ok(!/process\.env\.scout/.test(lc), 'adapter must not read process.env.SCOUT_*');
+  },
+});
+
+// ── 13. No wiring into suggest.js LIVE branch (out of scope for this slice) ─
+tests.push({
+  name: 'Adapter module is NOT wired into suggest.js LIVE branch in this slice (out of scope)',
+  fn: () => {
+    assert.ok(
+      !suggestCode.includes('live-auth-rate-limit-dependency-adapter'),
+      'suggest.js must not import or reference the adapter in this slice (wiring is a separate slice)'
+    );
+    assert.ok(
+      !suggestCode.includes('createScoutLiveDependencyAdapter'),
+      'suggest.js must not call createScoutLiveDependencyAdapter in this slice'
+    );
+  },
+});
+
+// ── 14. Canonical boundary file unchanged (no edit by this slice) ─────────
+tests.push({
+  name: 'Canonical live-auth-rate-limit-boundary.js is not edited by this slice (no boundary module change)',
+  fn: () => {
+    assert.ok(boundaryCode.length > 0, 'canonical boundary module must still exist');
+    // The canonical boundary skeleton has its own version (v20260607-1). The
+    // adapter skeleton is a separate file, so the boundary should not be
+    // modified.
+    assert.ok(
+      !boundaryCode.includes('createScoutLiveDependencyAdapter'),
+      'canonical boundary must not reference the adapter factory'
+    );
+    assert.ok(
+      !boundaryCode.includes('live-auth-rate-limit-dependency-adapter'),
+      'canonical boundary must not import the adapter module'
+    );
+  },
+});
+
+// ── 15. Parallel live-provider-auth-rate-limit-boundary.js is not adopted ──
+tests.push({
+  name: 'Parallel live-provider-auth-rate-limit-boundary.js is not adopted (must not be referenced)',
+  fn: () => {
+    const parallelPath = path.join(ROOT, 'functions/api/scout/live-provider-auth-rate-limit-boundary.js');
+    const parallelExists = fs.existsSync(parallelPath);
+    if (parallelExists) {
+      const parallelCode = fs.readFileSync(parallelPath, 'utf-8');
+      assert.ok(
+        !parallelCode.includes('createScoutLiveDependencyAdapter'),
+        'parallel file must not reference the new adapter factory'
+      );
+    }
+    assert.ok(
+      !adapterCode.includes('live-provider-auth-rate-limit-boundary'),
+      'adapter must not import the parallel file'
+    );
+  },
+});
+
+// ── 16. Endpoint default stub behavior preserved in suggest.js ─────────────
+tests.push({
+  name: 'Endpoint default stub behavior preserved in suggest.js',
+  fn: () => {
+    assert.ok(suggestCode.includes('stub'), 'suggest.js must still reference stub mode');
+    assert.ok(suggestCode.includes("'stub'") || suggestCode.includes('"stub"'), 'suggest.js must still default to stub');
+  },
+});
+
+// ── 17. Frontend source selector default local_stub preserved ──────────────
+tests.push({
+  name: 'Frontend source selector default local_stub preserved',
+  fn: () => {
+    assert.ok(srcSelCode.length > 0, 'source selector must exist');
+    assert.ok(srcSelCode.includes('local_stub'), 'source selector must still default to local_stub');
+  },
+});
+
+// ── 18. Endpoint client default disabled preserved ─────────────────────────
+tests.push({
+  name: 'Endpoint client default disabled preserved (no adapter wiring in client)',
+  fn: () => {
+    assert.ok(endpointClientCode.length > 0, 'endpoint client must exist');
+    assert.ok(
+      !endpointClientCode.includes('live-auth-rate-limit-dependency-adapter'),
+      'endpoint client must not reference the adapter'
+    );
+  },
+});
+
+// ── 19. Observability helper not modified by this slice ────────────────────
+tests.push({
+  name: 'Observability helper is not modified by this slice (separate module)',
+  fn: () => {
+    assert.ok(observabilityCode.length > 0, 'observability helper must still exist');
+    assert.ok(
+      !observabilityCode.includes('createScoutLiveDependencyAdapter'),
+      'observability helper must not reference the adapter factory'
+    );
+  },
+});
+
+// ── 20. Adapter skeleton doc exists and reflects status ────────────────────
+tests.push({
+  name: 'Adapter skeleton doc exists and reflects dependency adapter skeleton status',
+  fn: () => {
+    const docPath = path.join(ROOT, 'docs/product/' + ADAPTER_SKEL_DOC);
+    const doc = readFileSafe(docPath);
+    assert.ok(doc.length > 0, 'adapter skeleton doc must exist');
+    const lc = doc.toLowerCase();
+    assert.ok(lc.includes('mock-disabled') || lc.includes('mock_disabled') || lc.includes('mock disabled'), 'doc must mention mock-disabled');
+    assert.ok(lc.includes('verifytoken'), 'doc must mention verifyToken');
+    assert.ok(lc.includes('checkratelimit') || lc.includes('check_rate_limit') || lc.includes('check rate limit'), 'doc must mention checkRateLimit');
+    assert.ok(lc.includes('requestid') || lc.includes('request_id') || lc.includes('request id'), 'doc must mention requestId');
+    assert.ok(lc.includes('not_implemented') || lc.includes('not implemented'), 'doc must mention not implemented');
+    assert.ok(lc.includes('no-go') || lc.includes('no go') || lc.includes('blocked') || lc.includes('not yet'), 'doc must mark real implementations as not yet ready');
+  },
+});
+
+// ── 21. Related docs reflect adapter skeleton status ───────────────────────
+tests.push({
+  name: 'Related docs reflect adapter skeleton status (no overclaim, no stale references)',
+  fn: () => {
+    for (const docName of DOCS) {
+      const docPath = path.join(ROOT, 'docs/product/' + docName);
+      const doc = readFileSafe(docPath);
+      assert.ok(doc.length > 0, `${docName} must exist`);
+    }
+  },
+});
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  \u2713 ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  \u2717 ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
## Summary

- Adds functions/api/scout/live-auth-rate-limit-dependency-adapter.js (161 lines, v20260607-1): mock-disabled factory
  - createScoutLiveDependencyAdapter(options?) returns a frozen adapter
  - Default mockDisabled:true (fail-closed)
  - verifyToken returns { allowed:false, code: VERIFY_NOT_IMPLEMENTED }
  - checkRateLimit returns { allowed:false, code: RATE_LIMIT_NOT_IMPLEMENTED }
  - requestId returns req_mock_disabled_<ts>_<rand>
  - mockDisabled:false mode returns not_implemented shape
- Adds tests/contracts/scout-live-auth-rate-limit-dependency-adapter-skeleton-contract.test.cjs (372 lines, 21 sub-tests)
- Adds docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md (166 lines)
- Updates 10 related docs with adapter skeleton status

## Motivation

Issue #2294 — follow-up to PR #2293 (endpoint error readiness audit). The audit confirmed the next safe step is to add a mock-disabled dependency adapter skeleton for the LIVE branch DI seam.

## Verdict gate

- Adapter skeleton module itself: YES (this slice)
- Wiring into suggest.js LIVE branch: separate slice
- Real verifyToken / checkRateLimit / requestId implementations: NO
- Real Firebase / KV / DO / D1 / provider SDK / staging / production: NO

## Out of scope (future slices)

- Wiring the adapter into suggest.js LIVE branch
- Real verifyToken (Firebase Admin SDK or equivalent)
- Real checkRateLimit (KV / DO / D1 or equivalent)
- Real requestId (W3C trace context)
- Real observability backend integration
- staging_live / production_live execution

## Validation

- node --check on both source and test files OK
- focused adapter skeleton contract 21/21
- existing focused contracts: error readiness 16/16, error taxonomy 24/24, readiness audit 16/16, observability 24/24, DI 20/20, wiring 20/20, runtime 28/28, reconcile 13/13
- npm test 1951 pass / 3 pre-existing editor-canvas fail (not introduced) / 1 skip
- npm run verify 284/284
- git diff --check clean

## Related

- Closes #2294
- Refs #1882
- Follow-up to PR #2293 (error readiness audit, merged 31942e99)