### PR TITLE
feat(scout): add live rate-limit storage adapter skeleton

### DIFF
--- a/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
@@ -93,6 +93,8 @@ This skeleton sits **alongside** the canonical boundary skeleton:
   helper (v20260607-1)
 - `functions/api/scout/live-auth-rate-limit-dependency-adapter.js` —
   dependency adapter skeleton (this document, v20260607-1)
+- `functions/api/scout/live-rate-limit-storage-adapter.js` — storage adapter
+  skeleton (v20260607-1, separate slice)
 
 The dependency adapter skeleton is a **separate module** with a **clear
 single responsibility** (provide default `verifyToken` / `checkRateLimit` /
@@ -144,6 +146,8 @@ The adapter skeleton does not:
 - Staging soak
 - Kill-switch drill
 - Secret rotation drill
+- Real storage adapter implementation (KV / Durable Object / D1) — see
+  [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md)
 
 ## 9. Recommended next slice
 

--- a/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
@@ -207,6 +207,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Audited Test Files (all required to keep passing)
 
 ```text

--- a/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
@@ -188,6 +188,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Audited Test Files (all required to keep passing)
 
 ```text

--- a/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
+++ b/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
@@ -485,6 +485,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (this document)
 
 - ❌ No real LLM provider implementation

--- a/docs/product/lovebud-scout-live-provider-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-provider-readiness-audit.md
@@ -165,6 +165,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Conditions for First Real Provider Slice
 
 실제 provider를 붙이는 첫 slice의 조건:

--- a/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
@@ -1,0 +1,259 @@
+# Scout Live Rate-Limit Storage Adapter Skeleton
+
+> Status: **skeleton only** (mock-disabled)
+> Version: v20260607-1
+> Audience: Scout live provider engineering
+> Scope: storage adapter skeleton for the future runtime rate-limit backend
+
+## 1. Purpose
+
+This document defines the **mock-disabled storage adapter skeleton** for the
+Scout live provider path. The adapter provides a future interface for
+persistent rate-limit quota state (KV / Durable Object / D1) **without**
+actually accessing any external storage in this slice.
+
+Real implementations of the storage adapter (e.g. Cloudflare KV binding,
+Durable Object namespace, D1 database) will be added in future slices.
+This skeleton locks the interface, default fail-closed behavior, and
+sensitive-data payload guardrails so the endpoint can never accidentally
+read or write real storage while the skeleton is in place.
+
+## 2. Module
+
+`functions/api/scout/live-rate-limit-storage-adapter.js` (v20260607-1)
+
+Exports:
+
+- `SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION` — `'20260607-1'`
+- `SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES` — `{ MOCK_DISABLED, NOT_IMPLEMENTED }`
+- `SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES` — `{ STORAGE_MOCK_DISABLED, STORAGE_NOT_IMPLEMENTED, STORAGE_PAYLOAD_PROHIBITED }`
+- `SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS` — allowlist
+- `SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS` — denylist
+- `sanitizeScoutLiveRateLimitStoragePayload(payload, options?)` — pure helper
+- `createScoutLiveRateLimitStorageAdapter(options?)` — factory
+
+## 3. Factory contract
+
+```
+createScoutLiveRateLimitStorageAdapter(options?) -> adapter
+```
+
+Options:
+
+- `mockDisabled: boolean` — default `true`. When `true`, the factory returns
+  a mock-disabled adapter. When `false`, the factory returns a not-implemented
+  adapter (real implementations are not yet provided).
+- `onProhibitedField: 'drop' | 'reject'` — default `'drop'`. Controls how
+  `sanitizePayload` handles prohibited fields in a payload.
+
+The returned adapter is **frozen** and has the shape:
+
+```
+{
+  kind: 'scout_live_rate_limit_storage_adapter',
+  version: '20260607-1',
+  mode: 'mock_disabled' | 'not_implemented',
+  mockDisabled: boolean,
+  isMockDisabled: boolean,
+  onProhibitedField: 'drop' | 'reject',
+  checkQuota: async (payload) => { allowed, code, reason, retryAfterSeconds, remaining },
+  consumeQuota: async (payload) => { allowed, code, reason },
+  releaseQuota: async (payload) => { released, code, reason },
+  sanitizePayload: (payload, options?) => { payload, rejected, rejectedFields },
+}
+```
+
+## 4. Method inventory
+
+### 4.1 checkQuota
+
+Returns a quota-check result.
+
+Mock-disabled:
+
+```
+{
+  allowed: false,
+  code: 'STORAGE_MOCK_DISABLED',
+  reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+  retryAfterSeconds: null,
+  remaining: null,
+}
+```
+
+Not-implemented:
+
+```
+{
+  allowed: false,
+  code: 'STORAGE_NOT_IMPLEMENTED',
+  reason: 'Live rate-limit storage adapter is not implemented; real implementation is required.',
+  retryAfterSeconds: null,
+  remaining: null,
+}
+```
+
+### 4.2 consumeQuota
+
+Returns a consume-quota result.
+
+Mock-disabled:
+
+```
+{
+  allowed: false,
+  code: 'STORAGE_MOCK_DISABLED',
+  reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+}
+```
+
+### 4.3 releaseQuota
+
+Returns a release-quota result.
+
+Mock-disabled:
+
+```
+{
+  released: false,
+  code: 'STORAGE_MOCK_DISABLED',
+  reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+}
+```
+
+## 5. Storage payload policy
+
+### 5.1 Allowed fields (allowlist)
+
+The `sanitizePayload` helper only preserves these fields:
+
+- `requestId`
+- `userKeyHash`
+- `ipHash`
+- `sessionKeyHash`
+- `endpointPath`
+- `providerMode`
+- `windowKey`
+- `limitName`
+- `nowMs`
+
+All other fields (including unknown fields) are dropped.
+
+### 5.2 Prohibited fields (denylist)
+
+These fields are **always** stripped or rejected:
+
+- `token`, `rawToken`, `authorization`
+- `apiKey`, `secret`
+- `prompt`, `excerpt`, `sourceUrl`
+- `rawRequestBody`, `rawProviderResponse`, `rawModelOutput`
+- `password`, `cookie`, `sessionCookie`
+- `firebaseToken`
+- `openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`, `mistralApiKey`, `nvidiaApiKey`
+
+### 5.3 `onProhibitedField` modes
+
+- `'drop'` (default) — prohibited fields are silently stripped; the helper
+  tracks them in `rejectedFields` but does not fail the call.
+- `'reject'` — if any prohibited field is present, the helper returns
+  `{ payload: {}, rejected: true, rejectedFields: [...] }` and the
+  caller should treat the call as failed.
+
+## 6. No external storage access guarantee
+
+This skeleton does **not** access:
+
+- Cloudflare KV (`env.KV`, `KVNamespace`)
+- Durable Objects (`DurableObjectNamespace`, `DurableObjectBinding`)
+- D1 database (`env.DB`, `D1Database`, `d1.prepare()`)
+- Any other database (Postgres, MySQL, SQLite, etc.)
+- Any `fetch`, `XMLHttpRequest`, `axios`, or `new Request(...)` call
+- Any `env.SCOUT_*`, `env.STORAGE`, `env.RATE_LIMIT` binding
+- Any `process.env.SCOUT_*` or `import.meta.env` reading
+- Any Firebase Admin SDK import
+- Any provider SDK import (openai, anthropic, gemini, groq, mistral, nvidia, cohere, perplexity)
+
+## 7. Error mapping
+
+| Storage adapter code | Endpoint boundary code | HTTP status |
+| --- | --- | --- |
+| `STORAGE_MOCK_DISABLED` | `RATE_LIMIT_UNAVAILABLE` | 503 |
+| `STORAGE_NOT_IMPLEMENTED` | `RATE_LIMIT_UNAVAILABLE` | 503 |
+| `STORAGE_PAYLOAD_PROHIBITED` | `RATE_LIMIT_UNAVAILABLE` | 503 |
+
+The mapping is performed at the endpoint boundary (future slice) — the
+storage adapter itself does not perform the mapping.
+
+## 8. Privacy / safety guardrails
+
+- Raw tokens, API keys, prompts, excerpts, source URLs, and raw request
+  bodies are never accepted as storage payload fields
+- The denylist is exported as a frozen constant so future implementations
+  cannot accidentally bypass it
+- The allowlist is exported as a frozen constant so future implementations
+  have a single source of truth for safe payload fields
+- `sanitizePayload` is a pure helper (no side effects, no storage call)
+- The adapter is frozen and immutable at runtime
+
+## 9. Boundary inventory
+
+This skeleton sits **alongside** the existing boundary modules:
+
+- `functions/api/scout/live-auth-rate-limit-boundary.js` — canonical runtime
+  boundary + DI seam
+- `functions/api/scout/live-auth-rate-limit-observability.js` — observability
+  helper
+- `functions/api/scout/live-auth-rate-limit-dependency-adapter.js` —
+  dependency adapter skeleton (verifyToken / checkRateLimit / requestId)
+- `functions/api/scout/live-rate-limit-storage-adapter.js` — storage
+  adapter skeleton (checkQuota / consumeQuota / releaseQuota) — this document
+
+The storage adapter skeleton is a **separate module** with a **clear
+single responsibility** (provide default storage adapter interface for
+future KV/DO/D1 implementations). It is not wired into `suggest.js` LIVE
+branch in this slice.
+
+## 10. Go / no-go matrix
+
+| Item | Verdict | Notes |
+| --- | --- | --- |
+| Storage adapter skeleton module itself | **YES** | this slice |
+| Wiring the storage adapter into `suggest.js` LIVE branch | **separate slice** | out of scope for this slice |
+| Real KV adapter implementation | **NO** | future slice |
+| Real Durable Object adapter implementation | **NO** | future slice |
+| Real D1 adapter implementation | **NO** | future slice |
+| Real database adapter implementation (Postgres / MySQL / SQLite) | **NO** | future slice |
+| Real observability backend integration | **NO** | future slice |
+| `staging_live` execution | **NO** | blocked |
+| `production_live` execution | **NO** | blocked |
+| Real provider API call | **NO** | blocked |
+
+## 11. Remaining blockers
+
+- Real KV adapter (Cloudflare KV binding)
+- Real Durable Object adapter (DurableObjectNamespace)
+- Real D1 adapter (D1Database)
+- Wiring the storage adapter into the dependency adapter or `suggest.js`
+- Real observability backend integration
+- Provider-specific live adapter
+- Staging soak
+- Kill-switch drill
+- Secret rotation drill
+- Real `verifyToken` adapter (Firebase Admin SDK or equivalent)
+- Real `checkRateLimit` adapter that uses this storage adapter
+
+## 12. Recommended next slice
+
+`[TECH] Wire Scout storage adapter into live dependency adapter mock path`
+or
+`[TECH] Add Scout live auth verifier adapter skeleton`.
+
+Both slices will continue to be mock-disabled / no external calls / no
+real provider API.
+
+## 13. Verdict
+
+- Storage adapter skeleton (this slice): **YES** (mock-disabled)
+- Wiring into `suggest.js` LIVE branch: **separate slice** (mock-disabled)
+- Real KV / Durable Object / D1 / database implementations: **NO**
+- Real Firebase / provider SDK / staging / production: **NO**

--- a/docs/product/lovebud-scout-llm-provider-boundary.md
+++ b/docs/product/lovebud-scout-llm-provider-boundary.md
@@ -316,6 +316,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Recommended Next Slice
 
 ### `[PRODUCT] Add Scout stub suggestion provider contract`

--- a/docs/product/lovebud-scout-serverless-endpoint-boundary.md
+++ b/docs/product/lovebud-scout-serverless-endpoint-boundary.md
@@ -445,6 +445,18 @@ The dependency adapter skeleton is now wired into `functions/api/scout/suggest.j
 - Real Firebase Admin SDK, real KV/DO/D1, provider SDK, and fetch are still NOT used
 - Real `verifyToken` / `checkRateLimit` / `requestId` implementations, staging_live, and production_live all remain blocked
 
+## Storage Adapter Skeleton Status
+
+A [storage adapter skeleton](lovebud-scout-live-rate-limit-storage-adapter-skeleton.md) has been added (v20260607-1). It provides:
+- A mock-disabled factory (`createScoutLiveRateLimitStorageAdapter`) returning default `checkQuota` / `consumeQuota` / `releaseQuota` / `sanitizePayload`
+- Default `mockDisabled:true` so the endpoint cannot accidentally read or write real storage in skeleton mode
+- No real KV / Durable Object / D1 / database / fetch / env storage binding access
+- Storage payload sensitive data guardrails: allowlist (requestId, userKeyHash, ipHash, etc.) + denylist (token, apiKey, prompt, excerpt, sourceUrl, rawRequestBody, etc.)
+- Response codes (`STORAGE_MOCK_DISABLED`, `STORAGE_NOT_IMPLEMENTED`) mappable to `RATE_LIMIT_UNAVAILABLE` at the endpoint boundary
+- Not wired into `suggest.js` LIVE branch in this slice (wiring is a separate slice)
+- Endpoint default `providerMode:"stub"` and frontend default `local_stub` preserved
+- Real KV / Durable Object / D1 / database implementations, staging_live, and production_live all remain blocked
+
 ## Non-goals (This Audit)
 
 - ❌ No actual endpoint implementation

--- a/functions/api/scout/live-rate-limit-storage-adapter.js
+++ b/functions/api/scout/live-rate-limit-storage-adapter.js
@@ -1,0 +1,261 @@
+/**
+ * Scout Live Rate-Limit Storage Adapter Skeleton
+ * v20260607-1
+ *
+ * Mock-disabled storage adapter skeleton for the Scout live provider path.
+ * Provides a future interface for persistent rate-limit quota state
+ * (KV / Durable Object / D1) without actually accessing any external
+ * storage in this slice.
+ *
+ * Provides:
+ * - SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION: skeleton version
+ * - SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES: response code constants
+ * - SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS: allowlist
+ * - SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS: denylist
+ * - sanitizeScoutLiveRateLimitStoragePayload: pure helper that strips
+ *   prohibited fields from a payload
+ * - createScoutLiveRateLimitStorageAdapter: factory
+ *
+ * This module is a **mock-disabled skeleton + factory**. No KV, no
+ * Durable Object, no D1, no database, no fetch, no env storage binding
+ * is accessed. No real storage call is made. The factory returns
+ * safe "not implemented" / "mock-disabled" responses from each method
+ * so the endpoint can never accidentally read or write real storage
+ * while the skeleton is in place.
+ *
+ * Non-goals:
+ * - No real LLM provider call
+ * - No provider SDK import
+ * - No Firebase Admin SDK import
+ * - No Firebase token verification
+ * - No KV / Durable Object / D1 import
+ * - No persistent rate-limit storage call
+ * - No external URL fetch
+ * - No auto-save or persistence
+ * - No env storage binding access
+ * - No wiring into suggest.js LIVE branch (separate slice)
+ */
+
+'use strict';
+
+// ─── Version ────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION = '20260607-1';
+
+// ─── Storage Mode Constants ────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES = Object.freeze({
+  MOCK_DISABLED: 'mock_disabled',
+  NOT_IMPLEMENTED: 'not_implemented',
+});
+
+// ─── Response Codes ────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES = Object.freeze({
+  STORAGE_MOCK_DISABLED: 'STORAGE_MOCK_DISABLED',
+  STORAGE_NOT_IMPLEMENTED: 'STORAGE_NOT_IMPLEMENTED',
+  STORAGE_PAYLOAD_PROHIBITED: 'STORAGE_PAYLOAD_PROHIBITED',
+});
+
+// ─── Payload Policy ────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS = Object.freeze([
+  'requestId',
+  'userKeyHash',
+  'ipHash',
+  'sessionKeyHash',
+  'endpointPath',
+  'providerMode',
+  'windowKey',
+  'limitName',
+  'nowMs',
+]);
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS = Object.freeze([
+  'token',
+  'rawToken',
+  'authorization',
+  'apiKey',
+  'secret',
+  'prompt',
+  'excerpt',
+  'sourceUrl',
+  'rawRequestBody',
+  'rawProviderResponse',
+  'rawModelOutput',
+  'password',
+  'cookie',
+  'sessionCookie',
+  'firebaseToken',
+  'openaiApiKey',
+  'anthropicApiKey',
+  'geminiApiKey',
+  'groqApiKey',
+  'mistralApiKey',
+  'nvidiaApiKey',
+]);
+
+// ─── Default Configuration ──────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS = Object.freeze({
+  mockDisabled: true,
+  onProhibitedField: 'drop', // 'drop' | 'reject'
+});
+
+// ─── Pure Helper: sanitizeScoutLiveRateLimitStoragePayload ─────────────────
+
+/**
+ * Pure helper: strip prohibited fields from a storage payload.
+ * Returns a new object with only allowed fields. Prohibited fields are
+ * dropped (default) or cause the helper to return a rejection result.
+ *
+ * @param {Object} payload
+ * @param {Object} [options]
+ * @param {string} [options.onProhibitedField='drop'] - 'drop' or 'reject'
+ * @returns {Object} { payload: sanitized, rejected: boolean, rejectedFields: string[] }
+ */
+export function sanitizeScoutLiveRateLimitStoragePayload(payload, options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
+  const src = (payload && typeof payload === 'object') ? payload : {};
+  const out = {};
+  const rejectedFields = [];
+
+  for (const key of Object.keys(src)) {
+    if (SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS.includes(key)) {
+      rejectedFields.push(key);
+      if (opts.onProhibitedField === 'reject') {
+        // Reject immediately: return empty payload with rejected flag
+        return { payload: {}, rejected: true, rejectedFields };
+      }
+      // 'drop': skip this field
+      continue;
+    }
+    // Only copy allowed fields
+    if (SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS.includes(key)) {
+      out[key] = src[key];
+    }
+    // Unknown fields are also dropped (allowlist-only)
+  }
+
+  return { payload: out, rejected: false, rejectedFields };
+}
+
+// ─── Internal Response Builders ─────────────────────────────────────────────
+
+function buildMockDisabledCheckResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED,
+    reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+    retryAfterSeconds: null,
+    remaining: null,
+  };
+}
+
+function buildMockDisabledConsumeResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED,
+    reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+  };
+}
+
+function buildMockDisabledReleaseResponse() {
+  return {
+    released: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED,
+    reason: 'Live rate-limit storage adapter is mock-disabled; no real storage is accessed.',
+  };
+}
+
+function buildNotImplementedCheckResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED,
+    reason: 'Live rate-limit storage adapter is not implemented; real implementation is required.',
+    retryAfterSeconds: null,
+    remaining: null,
+  };
+}
+
+function buildNotImplementedConsumeResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED,
+    reason: 'Live rate-limit storage adapter is not implemented; real implementation is required.',
+  };
+}
+
+function buildNotImplementedReleaseResponse() {
+  return {
+    released: false,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED,
+    reason: 'Live rate-limit storage adapter is not implemented; real implementation is required.',
+  };
+}
+
+// ─── Factory: createScoutLiveRateLimitStorageAdapter ──────────────────────
+
+/**
+ * Create a Scout live rate-limit storage adapter.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.mockDisabled=true] when true (default), returns
+ *   safe mock-disabled responses from checkQuota / consumeQuota /
+ *   releaseQuota. When false, returns "not implemented" responses
+ *   (real implementations will be added in future slices).
+ * @param {string} [options.onProhibitedField='drop'] - 'drop' or 'reject'
+ * @returns {Object} frozen adapter
+ */
+export function createScoutLiveRateLimitStorageAdapter(options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
+  const mockDisabled = opts.mockDisabled !== false;
+
+  if (mockDisabled) {
+    return Object.freeze({
+      kind: 'scout_live_rate_limit_storage_adapter',
+      version: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION,
+      mode: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES.MOCK_DISABLED,
+      mockDisabled: true,
+      isMockDisabled: true,
+      onProhibitedField: opts.onProhibitedField,
+
+      async checkQuota(_payload) {
+        return buildMockDisabledCheckResponse();
+      },
+
+      async consumeQuota(_payload) {
+        return buildMockDisabledConsumeResponse();
+      },
+
+      async releaseQuota(_payload) {
+        return buildMockDisabledReleaseResponse();
+      },
+
+      sanitizePayload: sanitizeScoutLiveRateLimitStoragePayload,
+    });
+  }
+
+  return Object.freeze({
+    kind: 'scout_live_rate_limit_storage_adapter',
+    version: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION,
+    mode: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES.NOT_IMPLEMENTED,
+    mockDisabled: false,
+    isMockDisabled: false,
+    onProhibitedField: opts.onProhibitedField,
+
+    async checkQuota(_payload) {
+      return buildNotImplementedCheckResponse();
+    },
+
+    async consumeQuota(_payload) {
+      return buildNotImplementedConsumeResponse();
+    },
+
+    async releaseQuota(_payload) {
+      return buildNotImplementedReleaseResponse();
+    },
+
+    sanitizePayload: sanitizeScoutLiveRateLimitStoragePayload,
+  });
+}

--- a/tests/contracts/scout-live-rate-limit-storage-adapter-skeleton-contract.test.cjs
+++ b/tests/contracts/scout-live-rate-limit-storage-adapter-skeleton-contract.test.cjs
@@ -1,0 +1,419 @@
+/**
+ * Scout Live Rate-Limit Storage Adapter Skeleton Contract Tests
+ * v20260607-1
+ *
+ * Locks the mock-disabled storage adapter skeleton contract for the
+ * Scout live provider path:
+ * - module exists and is well-formed
+ * - factory default mockDisabled:true returns safe "not implemented"
+ *   responses for checkQuota / consumeQuota / releaseQuota
+ * - sanitizePayload strips prohibited fields
+ * - not-implemented mode returns the same shape with not-implemented marker
+ * - no KV / Durable Object / D1 / database / fetch / env storage binding
+ * - no Firebase Admin SDK / no provider SDK / no fetch
+ * - endpoint default stub / frontend local_stub / endpoint client default
+ *   disabled remain preserved
+ * - existing dependency adapter wiring contract still passes
+ * - docs reflect storage adapter skeleton status
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+const DOCS = [
+  'lovebud-scout-live-rate-limit-storage-adapter-skeleton.md',
+  'lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md',
+  'lovebud-scout-live-endpoint-error-readiness-audit.md',
+  'lovebud-scout-live-auth-rate-limit-readiness-audit.md',
+  'lovebud-scout-live-provider-auth-rate-limit-boundary.md',
+  'lovebud-scout-serverless-endpoint-boundary.md',
+  'lovebud-scout-llm-provider-boundary.md',
+  'lovebud-scout-live-provider-readiness-audit.md',
+];
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+const storageCode = readFileSafe(STORAGE_ADAPTER_PATH);
+const depAdapterCode = readFileSafe(DEP_ADAPTER_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const srcSelCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+let storageModulePromise = null;
+async function loadStorageModule() {
+  if (!storageModulePromise) {
+    storageModulePromise = import(STORAGE_ADAPTER_PATH);
+  }
+  return storageModulePromise;
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const tests = [];
+
+// ── 1. Module exists ────────────────────────────────────────────────────────
+tests.push({
+  name: 'Storage adapter skeleton module exists',
+  fn: () => {
+    assert.ok(storageCode.length > 0, 'storage adapter module must exist');
+  },
+});
+
+// ── 2. Module exports factory and version ──────────────────────────────────
+tests.push({
+  name: 'Module exports factory, version, codes, modes, allowed/prohibited fields',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    assert.strictEqual(typeof mod.createScoutLiveRateLimitStorageAdapter, 'function', 'factory must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION, 'string', 'version must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES, 'object', 'codes must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES, 'object', 'modes must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS, 'object', 'allowed fields must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS, 'object', 'prohibited fields must be exported');
+    assert.strictEqual(typeof mod.sanitizeScoutLiveRateLimitStoragePayload, 'function', 'sanitizePayload must be exported');
+    assert.ok(/^v?2026\d{4}-/.test(mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION.replace(/^v/, '')) || /^2026\d{4}/.test(mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION), 'version must be a YYYYMMDD-N style string');
+  },
+});
+
+// ── 3. Default adapter is mock-disabled ────────────────────────────────────
+tests.push({
+  name: 'Factory default mockDisabled:true returns mock_disabled adapter',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter();
+    assert.strictEqual(adapter.mockDisabled, true, 'default mockDisabled must be true');
+    assert.strictEqual(adapter.isMockDisabled, true, 'default isMockDisabled must be true');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES.MOCK_DISABLED, 'default mode must be MOCK_DISABLED');
+    assert.strictEqual(adapter.kind, 'scout_live_rate_limit_storage_adapter', 'kind must be set');
+    assert.strictEqual(adapter.version, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION, 'adapter version must match module version');
+  },
+});
+
+// ── 4. Adapter object is frozen ────────────────────────────────────────────
+tests.push({
+  name: 'Adapter object is frozen (immutable)',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter();
+    assert.strictEqual(Object.isFrozen(adapter), true, 'adapter must be frozen');
+  },
+});
+
+// ── 5. checkQuota safe-fails ───────────────────────────────────────────────
+tests.push({
+  name: 'Mock-disabled checkQuota returns { allowed:false, code: STORAGE_MOCK_DISABLED }',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter();
+    const res = await adapter.checkQuota({});
+    assert.strictEqual(res.allowed, false, 'mock-disabled checkQuota must deny');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED, 'code must be STORAGE_MOCK_DISABLED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+  },
+});
+
+// ── 6. consumeQuota safe-fails ─────────────────────────────────────────────
+tests.push({
+  name: 'Mock-disabled consumeQuota returns { allowed:false, code: STORAGE_MOCK_DISABLED }',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter();
+    const res = await adapter.consumeQuota({});
+    assert.strictEqual(res.allowed, false, 'mock-disabled consumeQuota must deny');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED, 'code must be STORAGE_MOCK_DISABLED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+  },
+});
+
+// ── 7. releaseQuota safe-fails ─────────────────────────────────────────────
+tests.push({
+  name: 'Mock-disabled releaseQuota returns { released:false, code: STORAGE_MOCK_DISABLED }',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter();
+    const res = await adapter.releaseQuota({});
+    assert.strictEqual(res.released, false, 'mock-disabled releaseQuota must return released:false');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_MOCK_DISABLED, 'code must be STORAGE_MOCK_DISABLED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+  },
+});
+
+// ── 8. mockDisabled:false returns not-implemented shape ───────────────────
+tests.push({
+  name: 'Factory mockDisabled:false returns NOT_IMPLEMENTED adapter with same shape',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const adapter = mod.createScoutLiveRateLimitStorageAdapter({ mockDisabled: false });
+    assert.strictEqual(adapter.mockDisabled, false, 'mockDisabled must be false');
+    assert.strictEqual(adapter.isMockDisabled, false, 'isMockDisabled must be false');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES.NOT_IMPLEMENTED, 'mode must be NOT_IMPLEMENTED');
+    const c = await adapter.checkQuota({});
+    assert.strictEqual(c.allowed, false, 'not-implemented checkQuota must deny');
+    assert.strictEqual(c.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED, 'code must be STORAGE_NOT_IMPLEMENTED');
+    const cn = await adapter.consumeQuota({});
+    assert.strictEqual(cn.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED, 'code must be STORAGE_NOT_IMPLEMENTED');
+    const r = await adapter.releaseQuota({});
+    assert.strictEqual(r.released, false, 'not-implemented releaseQuota must return released:false');
+    assert.strictEqual(r.code, mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_NOT_IMPLEMENTED, 'code must be STORAGE_NOT_IMPLEMENTED');
+  },
+});
+
+// ── 9. sanitizePayload strips prohibited fields (drop mode) ───────────────
+tests.push({
+  name: 'sanitizePayload strips prohibited fields (drop mode) and keeps allowed fields',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const result = mod.sanitizeScoutLiveRateLimitStoragePayload({
+      requestId: 'req_test_123',
+      userKeyHash: 'hk_abc',
+      token: 'Bearer TEST_FIXTURE_TOKEN_NOT_A_REAL_SECRET',
+      apiKey: 'TEST_FIXTURE_KEY',
+      prompt: 'TEST_FIXTURE_PROMPT',
+      excerpt: 'TEST_FIXTURE_EXCERPT',
+      sourceUrl: 'https://example.com/test',
+      rawRequestBody: '{"foo":"bar"}',
+      unknownField: 'should be dropped',
+    });
+    assert.strictEqual(result.rejected, false, 'drop mode must not reject');
+    assert.deepStrictEqual(result.rejectedFields.sort(), ['apiKey', 'excerpt', 'prompt', 'rawRequestBody', 'sourceUrl', 'token'].sort(), 'prohibited fields must be tracked');
+    assert.strictEqual(result.payload.requestId, 'req_test_123', 'allowed field must be kept');
+    assert.strictEqual(result.payload.userKeyHash, 'hk_abc', 'allowed field must be kept');
+    assert.strictEqual(result.payload.token, undefined, 'prohibited field must be dropped');
+    assert.strictEqual(result.payload.unknownField, undefined, 'unknown field must be dropped');
+  },
+});
+
+// ── 10. sanitizePayload reject mode ───────────────────────────────────────
+tests.push({
+  name: 'sanitizePayload reject mode returns rejected:true with rejectedFields',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const result = mod.sanitizeScoutLiveRateLimitStoragePayload(
+      { requestId: 'req_test_123', token: 'TEST_FIXTURE_TOKEN' },
+      { onProhibitedField: 'reject' }
+    );
+    assert.strictEqual(result.rejected, true, 'reject mode must set rejected:true');
+    assert.ok(result.rejectedFields.includes('token'), 'rejectedFields must include token');
+    assert.strictEqual(result.payload.token, undefined, 'rejected payload must not contain prohibited field');
+  },
+});
+
+// ── 11. No external storage access in code ─────────────────────────────────
+tests.push({
+  name: 'No KV / Durable Object / D1 / database runtime access in storage adapter code',
+  fn: () => {
+    const code = codeOnly(storageCode).toLowerCase();
+    assert.ok(!/kvnamespace/.test(code), 'storage adapter must not reference KVNamespace in code');
+    assert.ok(!/durableobject/.test(code), 'storage adapter must not reference DurableObject in code');
+    assert.ok(!/d1database/.test(code), 'storage adapter must not reference D1Database in code');
+    assert.ok(!/env\.kv\b/.test(code), 'storage adapter must not read env.KV in code');
+    assert.ok(!/env\.db\b/.test(code), 'storage adapter must not read env.DB in code');
+    assert.ok(!/env\.rate_limit/.test(code), 'storage adapter must not read env.RATE_LIMIT in code');
+    assert.ok(!/env\.storage/.test(code), 'storage adapter must not read env.STORAGE in code');
+  },
+});
+
+// ── 12. No fetch / XHR / axios ─────────────────────────────────────────────
+tests.push({
+  name: 'No fetch / XHR / axios in storage adapter code',
+  fn: () => {
+    const code = codeOnly(storageCode).toLowerCase();
+    assert.ok(!/\bfetch\s*\(/.test(code), 'storage adapter must not call fetch in code');
+    assert.ok(!/xmlhttprequest/.test(code), 'storage adapter must not use XMLHttpRequest in code');
+    assert.ok(!/axios/.test(code), 'storage adapter must not use axios in code');
+    assert.ok(!/new\s+request\s*\(/.test(code), 'storage adapter must not construct a new Request in code');
+  },
+});
+
+// ── 13. No Firebase Admin SDK ──────────────────────────────────────────────
+tests.push({
+  name: 'No Firebase Admin SDK imports in storage adapter code',
+  fn: () => {
+    const code = codeOnly(storageCode).toLowerCase();
+    assert.ok(!/firebase-admin/.test(code), 'storage adapter must not import firebase-admin in code');
+    assert.ok(!/admin\s*\.\s*auth/.test(code), 'storage adapter must not reference admin.auth in code');
+    assert.ok(!/initializeapp/.test(code), 'storage adapter must not call initializeApp in code');
+  },
+});
+
+// ── 14. No provider SDK imports ────────────────────────────────────────────
+tests.push({
+  name: 'No provider SDK imports in storage adapter code (imports only, denylist field names allowed)',
+  fn: () => {
+    const code = codeOnly(storageCode).toLowerCase();
+    // Check for import statements only, not field names in denylist constants.
+    // The module's SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS may
+    // include "openaiApiKey" etc. as denylist field names — that is allowed.
+    for (const provider of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'nvidia', 'cohere', 'perplexity']) {
+      const importPattern = new RegExp(`(import|require).*${provider}`, 'i');
+      assert.ok(!importPattern.test(code), `storage adapter must not import ${provider} in code`);
+    }
+  },
+});
+
+// ── 15. No secrets / env usage ─────────────────────────────────────────────
+tests.push({
+  name: 'No raw secret / env storage binding / process.env reading in storage adapter code',
+  fn: () => {
+    const code = codeOnly(storageCode).toLowerCase();
+    assert.ok(!/process\.env\.scout/.test(code), 'storage adapter must not read process.env.SCOUT_* in code');
+    assert.ok(!/import\.meta\.env/.test(code), 'storage adapter must not read import.meta.env in code');
+    assert.ok(!/api_key\s*=/.test(code), 'storage adapter must not assign api_key in code');
+    assert.ok(!/bearer\s+/.test(code), 'storage adapter must not embed bearer tokens in code');
+  },
+});
+
+// ── 16. Prohibited payload fields are documented in module ─────────────────
+tests.push({
+  name: 'Prohibited payload fields are documented in module (denylist exported)',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const prohibited = mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS;
+    assert.ok(Array.isArray(prohibited), 'prohibited fields must be an array');
+    for (const field of ['token', 'rawToken', 'authorization', 'apiKey', 'secret', 'prompt', 'excerpt', 'sourceUrl', 'rawRequestBody']) {
+      assert.ok(prohibited.includes(field), `prohibited fields must include "${field}"`);
+    }
+  },
+});
+
+// ── 17. Allowed payload fields are documented in module ────────────────────
+tests.push({
+  name: 'Allowed payload fields are documented in module (allowlist exported)',
+  fn: async () => {
+    const mod = await loadStorageModule();
+    const allowed = mod.SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_ALLOWED_FIELDS;
+    assert.ok(Array.isArray(allowed), 'allowed fields must be an array');
+    for (const field of ['requestId', 'userKeyHash', 'ipHash', 'endpointPath', 'providerMode', 'windowKey', 'limitName']) {
+      assert.ok(allowed.includes(field), `allowed fields must include "${field}"`);
+    }
+  },
+});
+
+// ── 18. Endpoint default stub preserved ────────────────────────────────────
+tests.push({
+  name: 'Endpoint default providerMode:"stub" is preserved in suggest.js',
+  fn: () => {
+    assert.ok(suggestCode.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'suggest.js must reference STUB mode');
+    assert.ok(suggestCode.includes("STUB: 'stub'") || suggestCode.includes('STUB: "stub"'), 'suggest.js must define STUB mode constant');
+  },
+});
+
+// ── 19. Frontend default local_stub preserved ──────────────────────────────
+tests.push({
+  name: 'Frontend source selector default local_stub is preserved',
+  fn: () => {
+    assert.ok(srcSelCode.length > 0, 'source selector must exist');
+    assert.ok(srcSelCode.includes('local_stub'), 'source selector must default to local_stub');
+  },
+});
+
+// ── 20. Endpoint client default disabled preserved ─────────────────────────
+tests.push({
+  name: 'Endpoint client default disabled is preserved (no storage adapter wiring in client)',
+  fn: () => {
+    assert.ok(endpointClientCode.length > 0, 'endpoint client must exist');
+    assert.ok(
+      !endpointClientCode.includes('live-rate-limit-storage-adapter'),
+      'endpoint client must not reference the storage adapter'
+    );
+  },
+});
+
+// ── 21. No wiring into suggest.js LIVE branch in this slice ────────────────
+tests.push({
+  name: 'Storage adapter module is NOT wired into suggest.js LIVE branch in this slice (out of scope)',
+  fn: () => {
+    assert.ok(
+      !suggestCode.includes('live-rate-limit-storage-adapter'),
+      'suggest.js must not import or reference the storage adapter in this slice (wiring is a separate slice)'
+    );
+    assert.ok(
+      !suggestCode.includes('createScoutLiveRateLimitStorageAdapter'),
+      'suggest.js must not call createScoutLiveRateLimitStorageAdapter in this slice'
+    );
+  },
+});
+
+// ── 22. Dependency adapter endpoint wiring still passes ───────────────────
+tests.push({
+  name: 'Dependency adapter endpoint wiring remains intact (suggest.js still imports createScoutLiveDependencyAdapter)',
+  fn: () => {
+    assert.ok(
+      suggestCode.includes('createScoutLiveDependencyAdapter'),
+      'suggest.js must still import createScoutLiveDependencyAdapter (wiring from previous slice)'
+    );
+    assert.ok(
+      depAdapterCode.includes('SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION'),
+      'dependency adapter module must still exist'
+    );
+  },
+});
+
+// ── 23. Storage adapter skeleton doc exists and reflects status ───────────
+tests.push({
+  name: 'Storage adapter skeleton doc exists and reflects skeleton status',
+  fn: () => {
+    const docPath = path.join(ROOT, 'docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md');
+    const doc = readFileSafe(docPath);
+    assert.ok(doc.length > 0, 'storage adapter skeleton doc must exist');
+    const lc = doc.toLowerCase();
+    assert.ok(lc.includes('mock-disabled') || lc.includes('mock_disabled') || lc.includes('mock disabled'), 'doc must mention mock-disabled');
+    assert.ok(lc.includes('checkquota') || lc.includes('check_quota') || lc.includes('check quota'), 'doc must mention checkQuota');
+    assert.ok(lc.includes('consumequota') || lc.includes('consume_quota') || lc.includes('consume quota'), 'doc must mention consumeQuota');
+    assert.ok(lc.includes('releasequota') || lc.includes('release_quota') || lc.includes('release quota'), 'doc must mention releaseQuota');
+    assert.ok(lc.includes('no-go') || lc.includes('no go') || lc.includes('blocked') || lc.includes('not yet'), 'doc must mark real storage as not yet ready');
+    assert.ok(lc.includes('kv') && lc.includes('durable') && lc.includes('d1'), 'doc must mention KV, Durable Object, and D1 as blocked');
+    assert.ok(lc.includes('token') || lc.includes('prohibited'), 'doc must mention prohibited payload fields');
+  },
+});
+
+// ── 24. Related docs reflect storage adapter skeleton status ──────────────
+tests.push({
+  name: 'Related docs exist and reflect storage adapter skeleton status',
+  fn: () => {
+    for (const docName of DOCS) {
+      const docPath = path.join(ROOT, 'docs/product/' + docName);
+      const doc = readFileSafe(docPath);
+      assert.ok(doc.length > 0, `${docName} must exist`);
+    }
+  },
+});
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  \u2713 ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  \u2717 ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
## Summary

- functions/api/scout/live-rate-limit-storage-adapter.js (new, 261 lines, v20260607-1): mock-disabled storage adapter skeleton
  - createScoutLiveRateLimitStorageAdapter(options?) factory
  - checkQuota / consumeQuota / releaseQuota safe-fail shape
  - sanitizePayload pure helper with allowlist + denylist + drop/reject modes
  - Default mockDisabled:true fail-closed
  - mockDisabled:false not-implemented shape
  - Object.freeze applied
- tests/contracts/scout-live-rate-limit-storage-adapter-skeleton-contract.test.cjs (new, 415 lines, 24 sub-tests)
- docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md (new, 259 lines)
- 7 related docs updated with 'Storage Adapter Skeleton Status' section

## Motivation

Issue #2298 — follow-up to PR #2297 (dependency adapter endpoint wiring). The storage adapter skeleton locks the future KV/DO/D1 interface, default fail-closed behavior, and sensitive-data payload guardrails before any real storage implementation.

## Verdict gate

- Storage adapter skeleton module: YES (this slice)
- Wiring into suggest.js LIVE branch: separate slice
- Real KV / Durable Object / D1 / database implementations: NO
- Real Firebase / provider SDK / staging / production: NO

## Validation

- node --check on both source and test files OK
- focused storage adapter skeleton contract 24/24
- existing focused contracts: dep adapter wiring 20/20, dep adapter skeleton 21/21, error readiness 16/16, error taxonomy 24/24, readiness audit 16/16, observability 24/24, DI 20/20, safe-fail wiring 20/20, runtime 28/28, reconcile 13/13
- npm test 1953 pass / 3 pre-existing editor-canvas fail (not introduced) / 1 skip
- npm run verify 284/284
- npm run lint clean (pre-existing trailing whitespace only)
- git diff --check clean

## Related

- Closes #2298
- Refs #1882
- Follow-up to PR #2297 (dep adapter wiring, merged 320bc7af)