### PR TITLE
feat(scout): add live auth verifier adapter skeleton

### DIFF
--- a/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
@@ -203,3 +203,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - No Firebase Admin SDK, no provider SDK, no env.SCOUT_*
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
@@ -259,3 +259,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md
@@ -1,0 +1,299 @@
+# Scout Live Auth Verifier Adapter Skeleton
+
+> Status: **skeleton only** (mock-disabled)
+> Version: v20260607-1
+> Audience: Scout live provider engineering
+> Scope: auth verifier adapter skeleton for the future runtime auth backend
+> Related issue: #1882
+
+## 1. Purpose
+
+This document defines the **mock-disabled auth verifier adapter skeleton**
+for the Scout live provider path. The adapter provides a future interface
+for Firebase-style auth token verification (`verifyIdToken` or an
+equivalent custom auth service) **without** actually calling any external
+auth backend in this slice.
+
+Real implementations of the auth verifier (e.g. Firebase Admin SDK with
+`getAuth().verifyIdToken`, or a custom JWT verifier) will be added in
+future slices. This skeleton locks the interface, default fail-closed
+behavior, and sensitive-data payload guardrails so the endpoint can never
+accidentally verify a real token while the skeleton is in place.
+
+## 2. Non-goals
+
+- No real LLM provider call
+- No provider SDK import
+- No Firebase Admin SDK import
+- No Firebase token verification
+- No `getAuth` / `verifyIdToken` / `cert` / `initializeApp` call
+- No external auth service call
+- No fetch / XMLHttpRequest / axios
+- No env auth binding access
+- No raw token, authorization header, API key, or session cookie in any
+  response, log, or storage payload
+- No wiring into `suggest.js` LIVE branch (separate slice)
+- No wiring into the dependency adapter (separate slice)
+
+## 3. Module
+
+`functions/api/scout/live-auth-verifier-adapter.js` (v20260607-1)
+
+Exports:
+
+- `SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION` — `'20260607-1'`
+- `SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES` — `{ MOCK_DISABLED, NOT_IMPLEMENTED }`
+- `SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES` — `{ VERIFIER_MOCK_DISABLED, VERIFIER_NOT_IMPLEMENTED, VERIFIER_PAYLOAD_PROHIBITED }`
+- `SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS` — allowlist
+- `SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS` — denylist
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` — pure helper
+- `createScoutLiveAuthVerifierAdapter(options?)` — factory
+
+## 4. Factory contract
+
+```
+createScoutLiveAuthVerifierAdapter(options?) -> adapter
+```
+
+Options:
+
+- `mockDisabled: boolean` — default `true`. When `true`, the factory returns
+  a mock-disabled adapter. When `false`, the factory returns a
+  not-implemented adapter (real implementations are not yet provided).
+- `onProhibitedField: 'drop' | 'reject'` — default `'drop'`. Controls how
+  `sanitizePayload` handles prohibited fields in a payload.
+
+The returned adapter is **frozen** and has the shape:
+
+```
+{
+  kind: 'scout_live_auth_verifier_adapter',
+  version: '20260607-1',
+  mode: 'mock_disabled' | 'not_implemented',
+  mockDisabled: boolean,
+  isMockDisabled: boolean,
+  onProhibitedField: 'drop' | 'reject',
+  verifyToken: async (payload) => { allowed, code, reason, userKey, userKeyHash },
+  sanitizePayload: (payload, options?) => { payload, rejected, rejectedFields },
+}
+```
+
+## 5. Default mock-disabled behavior
+
+When `mockDisabled: true` (default), `verifyToken` returns:
+
+```
+{
+  allowed: false,
+  code: 'VERIFIER_MOCK_DISABLED',
+  reason: 'Live auth verifier adapter is mock-disabled; no real verification is performed.',
+  userKey: null,
+  userKeyHash: null,
+}
+```
+
+This is a fail-closed shape. The endpoint boundary can map
+`VERIFIER_MOCK_DISABLED` to `AUTH_UNAVAILABLE` (HTTP 503) or
+`AUTH_INVALID` (HTTP 401) depending on caller policy; the verifier
+itself does not decide the HTTP mapping.
+
+## 6. Not-implemented mode
+
+When `mockDisabled: false`, `verifyToken` returns:
+
+```
+{
+  allowed: false,
+  code: 'VERIFIER_NOT_IMPLEMENTED',
+  reason: 'Live auth verifier adapter is not implemented; real verification is required.',
+  userKey: null,
+  userKeyHash: null,
+}
+```
+
+This makes it explicit that a real implementation is required and must
+be wired before the endpoint can accept any non-mock traffic.
+
+## 7. Method inventory
+
+### 7.1 verifyToken
+
+Verifies (or would verify) an auth token. The mock-disabled and
+not-implemented modes both return safe fail-closed responses and never
+return a `userKey` or `userKeyHash`. Future real implementations will
+populate `userKey` and `userKeyHash` only when verification succeeds.
+
+The `payload` argument is never persisted, logged, or propagated to
+storage. If a future implementation needs to forward fields, it must
+use the `sanitizePayload` allowlist helper first.
+
+### 7.2 sanitizePayload (exposed helper)
+
+`adapter.sanitizePayload(payload, options?)` strips prohibited fields
+from a verifier payload. It returns `{ payload, rejected, rejectedFields }`
+where `rejected` is `true` when in `onProhibitedField: 'reject'` mode and a
+prohibited field was encountered.
+
+## 8. Token payload policy
+
+### 8.1 Allowed fields (allowlist)
+
+Only future-safe, derived, non-sensitive fields may be present in a
+verifier payload:
+
+- `requestId`
+- `tokenHash` (a pre-computed hash of the raw token; the raw token is
+  never stored or forwarded)
+- `authorizationScheme` (e.g. `"Bearer"`, `"Firebase"`)
+- `providerMode`
+- `endpointPath`
+- `nowMs`
+
+### 8.2 Prohibited fields (denylist)
+
+The following sensitive fields must never enter a verifier payload,
+response, log, or storage record:
+
+- `token`
+- `rawToken`
+- `authorization`
+- `authorizationHeader`
+- `apiKey`
+- `secret`
+- `password`
+- `cookie`
+- `sessionCookie`
+- `firebaseToken`
+- `openaiApiKey` / `anthropicApiKey` / `geminiApiKey` / `groqApiKey` /
+  `mistralApiKey` / `nvidiaApiKey`
+- `prompt`
+- `excerpt`
+- `sourceUrl`
+- `rawRequestBody`
+
+The denylist is the single source of truth at the verifier seam. Any
+field on this list is dropped (default) or causes the sanitizer to
+return `rejected: true` (in `onProhibitedField: 'reject'` mode).
+
+## 9. No external auth access guarantee
+
+The skeleton guarantees that it does **not** access any external auth
+backend or runtime:
+
+- **No Firebase Admin SDK** — `firebase-admin` is not imported; no
+  `initializeApp`, no `cert(...)`, no `getAuth()` call exists in code.
+- **No getAuth / verifyIdToken** — neither function is referenced in
+  code.
+- **No verifyAccessToken** — no alternative verification path is
+  implemented.
+- **No external auth service** — no fetch, no XMLHttpRequest, no axios,
+  no embedded external URL exists in code.
+- **No env auth binding** — `env.AUTH`, `env.FIREBASE`, `process.env.*`,
+  and `import.meta.env` are not read.
+- **No provider SDK import** — OpenAI, Anthropic, Gemini, Groq,
+  Mistral, NVIDIA, Cohere, and Perplexity SDKs are not imported.
+
+The verifier adapter does not import the dependency adapter or the
+storage adapter in this slice. The dependency adapter does not import
+the verifier adapter. Wiring the verifier adapter into the dependency
+adapter is a separate slice.
+
+## 10. Error mapping
+
+The verifier adapter returns one of three codes. The endpoint boundary
+(`live-auth-rate-limit-boundary.js`) and the dependency adapter are
+responsible for mapping these codes to HTTP responses.
+
+| Verifier code          | Suggested HTTP mapping         | Notes |
+|------------------------|--------------------------------|-------|
+| `VERIFIER_MOCK_DISABLED`   | 503 Service Unavailable (`AUTH_UNAVAILABLE`) | Skeleton / not yet wired |
+| `VERIFIER_NOT_IMPLEMENTED` | 503 Service Unavailable (`AUTH_UNAVAILABLE`) | Real impl required |
+| `VERIFIER_PAYLOAD_PROHIBITED` | 400 Bad Request (`AUTH_INVALID`)        | Sanitizer rejected |
+
+The verifier adapter itself never throws, never logs, and never
+embeds a raw token in any return value.
+
+## 11. Privacy / safety guardrails
+
+- **No raw token return**: `verifyToken` result never contains
+  `token`, `rawToken`, `authorization`, `authorizationHeader`,
+  `apiKey`, `firebaseToken`, `password`, `cookie`, or `sessionCookie`.
+- **No raw token in logs**: the verifier module does not call
+  `console.log`, `console.error`, or any logger; nothing is logged.
+- **No raw token in storage**: the verifier module does not import or
+  reference any storage adapter; nothing is persisted.
+- **No raw token propagation**: the verifier module does not import
+  the dependency adapter or the boundary; raw tokens cannot flow
+  through the verifier into another layer in this slice.
+- **No raw token forwarding**: the verifier module's only external
+  integration points are the `payload` argument (caller-controlled
+  and not stored) and the sanitized return value (denylist-enforced).
+
+## 12. Boundary inventory
+
+- `functions/api/scout/live-auth-rate-limit-boundary.js` — canonical
+  boundary. Unchanged in this slice.
+- `functions/api/scout/live-auth-rate-limit-dependency-adapter.js` —
+  dependency adapter. Not wired to the verifier in this slice.
+- `functions/api/scout/live-rate-limit-storage-adapter.js` — storage
+  adapter. Unchanged in this slice.
+- `functions/api/scout/live-auth-rate-limit-observability.js` —
+  observability helper. Unchanged in this slice.
+- `functions/api/scout/suggest.js` — endpoint. Not wired to the
+  verifier in this slice.
+- `js/scout/scout-suggestion-source-selector.js` — frontend source
+  selector. Default `local_stub` preserved.
+- `js/scout/scout-suggestion-endpoint-client.js` — frontend endpoint
+  client. Default disabled preserved.
+
+## 13. Go / no-go matrix
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Auth verifier adapter skeleton | **Done** | This slice |
+| `verifyToken` interface | **Done** | Mock-disabled default |
+| `sanitizePayload` helper | **Done** | Allowlist + denylist |
+| Dependency adapter wiring | **No** | Separate slice |
+| Endpoint wiring | **No** | Separate slice |
+| Runtime Firebase Admin SDK | **No** | Blocked |
+| Runtime `getAuth().verifyIdToken` | **No** | Blocked |
+| Runtime external auth service | **No** | Blocked |
+| `staging_live` rollout | **No** | Blocked |
+| `production_live` rollout | **No** | Blocked |
+| Real provider API call | **No** | Blocked |
+
+## 14. Remaining blockers
+
+A real implementation is required before the verifier can serve any
+non-mock traffic. The blockers are:
+
+- Real Firebase Admin SDK integration (project secret wiring,
+  service account credentials, `verifyIdToken` migration).
+- Custom JWT verifier (if Firebase is not used).
+- Token-hash precomputation pipeline at the endpoint boundary so the
+  verifier receives a `tokenHash` rather than a raw token.
+- A real auth audit pipeline (out of scope for this slice).
+- Production rollout gates (still blocked by upstream readiness).
+
+## 15. Recommended next slice
+
+`[TECH] Wire Scout auth verifier adapter into live dependency mock path`
+— mirror the storage-adapter dependency wiring pattern. The dependency
+adapter will accept an optional `verifierAdapter` option; the default
+will be `createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`.
+The verifier payload will be allowlisted (no raw token / API key /
+prompt / excerpt / sourceUrl). Verifier result codes will be mapped to
+dependency-adapter safe-fail codes (`VERIFIER_MOCK_DISABLED` /
+`VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`;
+`VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`).
+
+This next slice remains mock-disabled and does not introduce a real
+Firebase Admin SDK or real token verification.
+
+## 16. Explicit verdict
+
+The auth verifier adapter skeleton is **complete for this slice**.
+It is mock-disabled, fail-closed, and does not access any external
+auth backend. The interface and sensitive-data guardrails are locked
+by contract tests so the next slice can safely wire it into the
+dependency adapter without expanding the trust boundary.

--- a/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
@@ -245,3 +245,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
+++ b/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
@@ -521,3 +521,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-live-provider-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-provider-readiness-audit.md
@@ -262,3 +262,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
@@ -277,3 +277,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - No Firebase Admin SDK, no provider SDK, no env.SCOUT_*
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-llm-provider-boundary.md
+++ b/docs/product/lovebud-scout-llm-provider-boundary.md
@@ -404,3 +404,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/docs/product/lovebud-scout-serverless-endpoint-boundary.md
+++ b/docs/product/lovebud-scout-serverless-endpoint-boundary.md
@@ -529,3 +529,44 @@ The storage adapter skeleton is now wired into the live dependency adapter mock 
 - `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
 - No real KV / Durable Object / D1 / database / fetch / env storage binding
 - Real KV / DO / D1 / database / Firebase / provider SDK / staging / production all remain blocked
+
+## Auth Verifier Adapter Skeleton Status
+
+The auth verifier adapter skeleton has been added as a separate file
+(`functions/api/scout/live-auth-verifier-adapter.js`, v20260607-1) ahead
+of any Firebase Admin SDK integration. Status:
+
+- A new `live-auth-verifier-adapter.js` module has been added with
+  `createScoutLiveAuthVerifierAdapter(options?)` factory
+- Default `mockDisabled: true` fail-closed behavior; `verifyToken` always
+  returns `{ allowed: false, code: "VERIFIER_MOCK_DISABLED", userKey: null, userKeyHash: null }`
+- `mockDisabled: false` mode returns `VERIFIER_NOT_IMPLEMENTED` shape
+- Object.freeze applied to the returned adapter
+- `sanitizeScoutLiveAuthVerifierPayload(payload, options?)` pure helper
+  exported with `onProhibitedField: 'drop' | 'reject'` modes
+- Allowed fields (allowlist): `requestId`, `tokenHash`,
+  `authorizationScheme`, `providerMode`, `endpointPath`, `nowMs`
+- Prohibited fields (denylist): `token`, `rawToken`, `authorization`,
+  `authorizationHeader`, `apiKey`, `secret`, `password`, `cookie`,
+  `sessionCookie`, `firebaseToken`, provider API key fields
+  (`openaiApiKey`, `anthropicApiKey`, `geminiApiKey`, `groqApiKey`,
+  `mistralApiKey`, `nvidiaApiKey`), `prompt`, `excerpt`, `sourceUrl`,
+  `rawRequestBody`
+- No Firebase Admin SDK / no `getAuth` / no `verifyIdToken` /
+  no `verifyAccessToken` / no `cert` / no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth service URL
+- No env auth binding (`env.AUTH`, `env.FIREBASE`,
+  `process.env.SCOUT_*`, `import.meta.env`) access
+- No KV / Durable Object / D1 / database runtime access
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- `verifyToken` result never includes raw token / authorization /
+  apiKey / firebaseToken / sessionCookie
+- Dependency adapter is NOT yet wired to the verifier (separate slice)
+- `suggest.js` is NOT yet wired to the verifier (separate slice)
+- Endpoint default `providerMode: "stub"` preserved
+- Frontend source selector default `local_stub` preserved
+- Frontend endpoint client default disabled preserved
+- Runtime Firebase Admin SDK / real token verification /
+  external auth service call: **NO** (blocked)
+- `staging_live` / `production_live` rollout: **NO** (blocked)

--- a/functions/api/scout/live-auth-verifier-adapter.js
+++ b/functions/api/scout/live-auth-verifier-adapter.js
@@ -1,0 +1,222 @@
+/**
+ * Scout Live Auth Verifier Adapter Skeleton
+ * v20260607-1
+ *
+ * Mock-disabled auth verifier adapter skeleton for the Scout live provider
+ * path. Provides a future interface for Firebase-style auth token
+ * verification (e.g. Firebase Admin SDK `verifyIdToken`, or an equivalent
+ * custom auth service) **without** actually calling any external auth
+ * backend in this slice.
+ *
+ * Provides:
+ * - SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION: skeleton version
+ * - SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES: status / mode constants
+ * - SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES: response code constants
+ * - SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS: allowlist for
+ *   future-safe fields that may be present in a verifier payload
+ * - SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS: denylist for
+ *   sensitive fields that must never enter a verifier payload, response,
+ *   log, or storage record
+ * - sanitizeScoutLiveAuthVerifierPayload: pure helper that strips
+ *   prohibited fields from a verifier payload (drop or reject modes)
+ * - createScoutLiveAuthVerifierAdapter: factory
+ *
+ * This module is a **mock-disabled skeleton + factory**. No Firebase
+ * Admin SDK, no `getAuth`, no `verifyIdToken`, no external auth service,
+ * no fetch, no env auth binding is accessed. The factory returns safe
+ * "mock-disabled" or "not-implemented" responses from `verifyToken` so
+ * the endpoint can never accidentally verify a real token while the
+ * skeleton is in place.
+ *
+ * Non-goals:
+ * - No real LLM provider call
+ * - No provider SDK import
+ * - No Firebase Admin SDK import
+ * - No Firebase token verification
+ * - No getAuth / verifyIdToken / cert / initializeApp call
+ * - No external auth service call
+ * - No fetch / XMLHttpRequest / axios
+ * - No env auth binding access
+ * - No raw token, authorization header, API key, or session cookie
+ *   in any response, log, or storage payload
+ * - No wiring into suggest.js LIVE branch (separate slice)
+ */
+
+'use strict';
+
+// ─── Version ────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION = '20260607-1';
+
+// ─── Verifier Mode Constants ────────────────────────────────────────────────
+
+export const SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES = Object.freeze({
+  MOCK_DISABLED: 'mock_disabled',
+  NOT_IMPLEMENTED: 'not_implemented',
+});
+
+// ─── Response Codes ─────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES = Object.freeze({
+  VERIFIER_MOCK_DISABLED: 'VERIFIER_MOCK_DISABLED',
+  VERIFIER_NOT_IMPLEMENTED: 'VERIFIER_NOT_IMPLEMENTED',
+  VERIFIER_PAYLOAD_PROHIBITED: 'VERIFIER_PAYLOAD_PROHIBITED',
+});
+
+// ─── Payload Policy ─────────────────────────────────────────────────────────
+
+// Only future-safe, derived, non-sensitive fields are allowed to enter a
+// verifier payload. A token hash, scheme, request id, or a generated
+// nonce is acceptable; the raw token, raw authorization header, raw API
+// key, or raw request body is not.
+export const SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS = Object.freeze([
+  'requestId',
+  'tokenHash',
+  'authorizationScheme',
+  'providerMode',
+  'endpointPath',
+  'nowMs',
+]);
+
+// Sensitive fields that must never be returned, logged, persisted, or
+// routed through the verifier payload. The list is the single source
+// of truth at the verifier seam; sanitizePayload enforces it.
+export const SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS = Object.freeze([
+  'token',
+  'rawToken',
+  'authorization',
+  'authorizationHeader',
+  'apiKey',
+  'secret',
+  'password',
+  'cookie',
+  'sessionCookie',
+  'firebaseToken',
+  'openaiApiKey',
+  'anthropicApiKey',
+  'geminiApiKey',
+  'groqApiKey',
+  'mistralApiKey',
+  'nvidiaApiKey',
+  'prompt',
+  'excerpt',
+  'sourceUrl',
+  'rawRequestBody',
+]);
+
+// ─── Default Configuration ──────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS = Object.freeze({
+  mockDisabled: true,
+  onProhibitedField: 'drop', // 'drop' | 'reject'
+});
+
+// ─── Pure Helper: sanitizeScoutLiveAuthVerifierPayload ──────────────────────
+
+/**
+ * Pure helper: strip prohibited fields from an auth verifier payload.
+ * Returns a new object with only allowed fields. Prohibited fields are
+ * dropped (default) or cause the helper to return a rejection result.
+ *
+ * @param {Object} payload
+ * @param {Object} [options]
+ * @param {string} [options.onProhibitedField='drop'] - 'drop' or 'reject'
+ * @returns {Object} { payload: sanitized, rejected: boolean, rejectedFields: string[] }
+ */
+export function sanitizeScoutLiveAuthVerifierPayload(payload, options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
+  const src = (payload && typeof payload === 'object') ? payload : {};
+  const out = {};
+  const rejectedFields = [];
+
+  for (const key of Object.keys(src)) {
+    if (SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS.includes(key)) {
+      rejectedFields.push(key);
+      if (opts.onProhibitedField === 'reject') {
+        // Reject immediately: return empty payload with rejected flag
+        return { payload: {}, rejected: true, rejectedFields };
+      }
+      // 'drop': skip this field
+      continue;
+    }
+    // Only copy allowed fields
+    if (SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS.includes(key)) {
+      out[key] = src[key];
+    }
+    // Unknown fields are also dropped (allowlist-only)
+  }
+
+  return { payload: out, rejected: false, rejectedFields };
+}
+
+// ─── Internal Response Builders ─────────────────────────────────────────────
+
+function buildMockDisabledVerifyResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES.VERIFIER_MOCK_DISABLED,
+    reason: 'Live auth verifier adapter is mock-disabled; no real verification is performed.',
+    userKey: null,
+    userKeyHash: null,
+  };
+}
+
+function buildNotImplementedVerifyResponse() {
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES.VERIFIER_NOT_IMPLEMENTED,
+    reason: 'Live auth verifier adapter is not implemented; real verification is required.',
+    userKey: null,
+    userKeyHash: null,
+  };
+}
+
+// ─── Factory: createScoutLiveAuthVerifierAdapter ────────────────────────────
+
+/**
+ * Create a Scout live auth verifier adapter.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.mockDisabled=true] when true (default), returns
+ *   safe mock-disabled responses from verifyToken. When false, returns
+ *   "not implemented" responses (real implementations will be added in
+ *   future slices).
+ * @param {string} [options.onProhibitedField='drop'] - 'drop' or 'reject'
+ * @returns {Object} frozen adapter
+ */
+export function createScoutLiveAuthVerifierAdapter(options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
+  const mockDisabled = opts.mockDisabled !== false;
+
+  if (mockDisabled) {
+    return Object.freeze({
+      kind: 'scout_live_auth_verifier_adapter',
+      version: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION,
+      mode: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES.MOCK_DISABLED,
+      mockDisabled: true,
+      isMockDisabled: true,
+      onProhibitedField: opts.onProhibitedField,
+
+      async verifyToken(_payload) {
+        return buildMockDisabledVerifyResponse();
+      },
+
+      sanitizePayload: sanitizeScoutLiveAuthVerifierPayload,
+    });
+  }
+
+  return Object.freeze({
+    kind: 'scout_live_auth_verifier_adapter',
+    version: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION,
+    mode: SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES.NOT_IMPLEMENTED,
+    mockDisabled: false,
+    isMockDisabled: false,
+    onProhibitedField: opts.onProhibitedField,
+
+    async verifyToken(_payload) {
+      return buildNotImplementedVerifyResponse();
+    },
+
+    sanitizePayload: sanitizeScoutLiveAuthVerifierPayload,
+  });
+}

--- a/tests/contracts/scout-live-auth-verifier-adapter-skeleton-contract.test.cjs
+++ b/tests/contracts/scout-live-auth-verifier-adapter-skeleton-contract.test.cjs
@@ -1,0 +1,459 @@
+/**
+ * Scout Live Auth Verifier Adapter Skeleton Contract Tests
+ * v20260607-1
+ *
+ * Locks the mock-disabled auth verifier adapter skeleton contract for
+ * the Scout live provider path:
+ * - module exists and is well-formed
+ * - factory default mockDisabled:true returns safe "mock-disabled"
+ *   response for verifyToken (no real token verification)
+ * - sanitizePayload strips prohibited sensitive fields
+ * - not-implemented mode returns the same shape with not-implemented marker
+ * - no Firebase Admin SDK / no getAuth / no verifyIdToken
+ * - no external auth service / no fetch / no env auth binding
+ * - no KV / Durable Object / D1 / database
+ * - no provider SDK / no raw secret / no API key propagation
+ * - endpoint default stub / frontend local_stub / endpoint client
+ *   default disabled remain preserved
+ * - dependency adapter is NOT yet wired to the verifier (separate slice)
+ * - storage adapter dependency wiring still passes
+ * - docs reflect auth verifier adapter skeleton status
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const VERIFIER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-verifier-adapter.js');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const BOUNDARY_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-boundary.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+const DOCS = [
+  'lovebud-scout-live-auth-verifier-adapter-skeleton.md',
+  'lovebud-scout-live-rate-limit-storage-adapter-skeleton.md',
+  'lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md',
+  'lovebud-scout-live-endpoint-error-readiness-audit.md',
+  'lovebud-scout-live-auth-rate-limit-readiness-audit.md',
+  'lovebud-scout-live-provider-auth-rate-limit-boundary.md',
+  'lovebud-scout-serverless-endpoint-boundary.md',
+  'lovebud-scout-llm-provider-boundary.md',
+  'lovebud-scout-live-provider-readiness-audit.md',
+];
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+const verifierCode = readFileSafe(VERIFIER_PATH);
+const depAdapterCode = readFileSafe(DEP_ADAPTER_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const srcSelCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+let verifierModulePromise = null;
+async function loadVerifierModule() {
+  if (!verifierModulePromise) {
+    verifierModulePromise = import(VERIFIER_PATH);
+  }
+  return verifierModulePromise;
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const tests = [];
+
+// ── 1. Module exists ────────────────────────────────────────────────────────
+tests.push({
+  name: 'Auth verifier adapter skeleton module exists',
+  fn: () => {
+    assert.ok(verifierCode.length > 0, 'verifier adapter module must exist');
+  },
+});
+
+// ── 2. Module exports factory, version, codes, modes, fields, sanitizer ─────
+tests.push({
+  name: 'Module exports factory, version, codes, modes, allowlist, denylist, sanitizer',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    assert.strictEqual(typeof mod.createScoutLiveAuthVerifierAdapter, 'function', 'factory must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION, 'string', 'version must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES, 'object', 'codes must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES, 'object', 'modes must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS, 'object', 'allowed fields must be exported');
+    assert.strictEqual(typeof mod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS, 'object', 'prohibited fields must be exported');
+    assert.strictEqual(typeof mod.sanitizeScoutLiveAuthVerifierPayload, 'function', 'sanitizePayload must be exported');
+    const v = mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION.replace(/^v/, '');
+    assert.ok(/^2026\d{4}-/.test(v), 'version must be a YYYYMMDD-N style string');
+  },
+});
+
+// ── 3. Default adapter is mock-disabled ────────────────────────────────────
+tests.push({
+  name: 'Factory default mockDisabled:true returns mock_disabled adapter',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const adapter = mod.createScoutLiveAuthVerifierAdapter();
+    assert.strictEqual(adapter.mockDisabled, true, 'default mockDisabled must be true');
+    assert.strictEqual(adapter.isMockDisabled, true, 'default isMockDisabled must be true');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES.MOCK_DISABLED, 'default mode must be MOCK_DISABLED');
+    assert.strictEqual(adapter.kind, 'scout_live_auth_verifier_adapter', 'kind must be set');
+    assert.strictEqual(adapter.version, mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION, 'adapter version must match module version');
+  },
+});
+
+// ── 4. Adapter object is frozen ────────────────────────────────────────────
+tests.push({
+  name: 'Adapter object is frozen (immutable)',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const adapter = mod.createScoutLiveAuthVerifierAdapter();
+    assert.strictEqual(Object.isFrozen(adapter), true, 'adapter must be frozen');
+  },
+});
+
+// ── 5. verifyToken safe-fails (mock-disabled) ──────────────────────────────
+tests.push({
+  name: 'Mock-disabled verifyToken returns { allowed:false, code: VERIFIER_MOCK_DISABLED, userKey:null }',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const adapter = mod.createScoutLiveAuthVerifierAdapter();
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false, 'mock-disabled verifyToken must deny');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES.VERIFIER_MOCK_DISABLED, 'code must be VERIFIER_MOCK_DISABLED');
+    assert.ok(typeof res.reason === 'string' && res.reason.length > 0, 'reason must be a non-empty string');
+    assert.strictEqual(res.userKey, null, 'userKey must be null in mock-disabled');
+    assert.strictEqual(res.userKeyHash, null, 'userKeyHash must be null in mock-disabled');
+  },
+});
+
+// ── 6. verifyToken result does not include raw token ───────────────────────
+tests.push({
+  name: 'verifyToken result never includes raw token / authorization / apiKey / firebaseToken',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const adapter = mod.createScoutLiveAuthVerifierAdapter();
+    const res = await adapter.verifyToken({
+      token: 'TEST_FIXTURE_TOKEN_NOT_A_REAL_SECRET',
+      authorization: 'Bearer TEST_FIXTURE_NOT_A_REAL_SECRET',
+      apiKey: 'TEST_FIXTURE_KEY',
+      firebaseToken: 'TEST_FIXTURE_FB',
+    });
+    const flat = JSON.stringify(res).toLowerCase();
+    assert.ok(!flat.includes('test_fixture_token'), 'result must not include raw token value');
+    assert.ok(!flat.includes('test_fixture_not_a_real_secret'), 'result must not include raw authorization value');
+    assert.ok(!flat.includes('test_fixture_key'), 'result must not include raw api key value');
+    assert.ok(!flat.includes('test_fixture_fb'), 'result must not include raw firebase token value');
+    assert.strictEqual(res.token, undefined, 'result must not have a token field');
+    assert.strictEqual(res.authorization, undefined, 'result must not have an authorization field');
+    assert.strictEqual(res.apiKey, undefined, 'result must not have an apiKey field');
+    assert.strictEqual(res.firebaseToken, undefined, 'result must not have a firebaseToken field');
+  },
+});
+
+// ── 7. mockDisabled:false returns not-implemented shape ────────────────────
+tests.push({
+  name: 'Factory mockDisabled:false returns NOT_IMPLEMENTED adapter with same shape',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const adapter = mod.createScoutLiveAuthVerifierAdapter({ mockDisabled: false });
+    assert.strictEqual(adapter.mockDisabled, false, 'mockDisabled must be false');
+    assert.strictEqual(adapter.isMockDisabled, false, 'isMockDisabled must be false');
+    assert.strictEqual(adapter.mode, mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_MODES.NOT_IMPLEMENTED, 'mode must be NOT_IMPLEMENTED');
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false, 'not-implemented verifyToken must deny');
+    assert.strictEqual(res.code, mod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_CODES.VERIFIER_NOT_IMPLEMENTED, 'code must be VERIFIER_NOT_IMPLEMENTED');
+    assert.strictEqual(res.userKey, null, 'userKey must be null in not-implemented');
+  },
+});
+
+// ── 8. sanitizePayload strips prohibited fields (drop mode) ───────────────
+tests.push({
+  name: 'sanitizePayload strips prohibited fields (drop mode) and keeps allowed fields',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const result = mod.sanitizeScoutLiveAuthVerifierPayload({
+      requestId: 'req_test_123',
+      tokenHash: 'hk_abc',
+      authorizationScheme: 'Bearer',
+      token: 'Bearer TEST_FIXTURE_TOKEN_NOT_A_REAL_SECRET',
+      rawToken: 'TEST_FIXTURE_RAW',
+      authorization: 'Bearer TEST_FIXTURE_AUTH',
+      apiKey: 'TEST_FIXTURE_KEY',
+      firebaseToken: 'TEST_FIXTURE_FB',
+      prompt: 'TEST_FIXTURE_PROMPT',
+      excerpt: 'TEST_FIXTURE_EXCERPT',
+      sourceUrl: 'https://example.com/test',
+      rawRequestBody: '{"foo":"bar"}',
+      unknownField: 'should be dropped',
+    });
+    assert.strictEqual(result.rejected, false, 'drop mode must not reject');
+    const dropped = result.rejectedFields.sort();
+    assert.ok(dropped.includes('token'), 'rejectedFields must include token');
+    assert.ok(dropped.includes('rawToken'), 'rejectedFields must include rawToken');
+    assert.ok(dropped.includes('authorization'), 'rejectedFields must include authorization');
+    assert.ok(dropped.includes('apiKey'), 'rejectedFields must include apiKey');
+    assert.ok(dropped.includes('firebaseToken'), 'rejectedFields must include firebaseToken');
+    assert.ok(dropped.includes('prompt'), 'rejectedFields must include prompt');
+    assert.ok(dropped.includes('excerpt'), 'rejectedFields must include excerpt');
+    assert.ok(dropped.includes('sourceUrl'), 'rejectedFields must include sourceUrl');
+    assert.ok(dropped.includes('rawRequestBody'), 'rejectedFields must include rawRequestBody');
+    assert.strictEqual(result.payload.requestId, 'req_test_123', 'allowed field must be kept');
+    assert.strictEqual(result.payload.tokenHash, 'hk_abc', 'allowed field must be kept');
+    assert.strictEqual(result.payload.authorizationScheme, 'Bearer', 'allowed field must be kept');
+    assert.strictEqual(result.payload.token, undefined, 'prohibited field must be dropped');
+    assert.strictEqual(result.payload.unknownField, undefined, 'unknown field must be dropped');
+  },
+});
+
+// ── 9. sanitizePayload reject mode ────────────────────────────────────────
+tests.push({
+  name: 'sanitizePayload reject mode returns rejected:true with rejectedFields',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const result = mod.sanitizeScoutLiveAuthVerifierPayload(
+      { requestId: 'req_test_123', token: 'TEST_FIXTURE_TOKEN' },
+      { onProhibitedField: 'reject' }
+    );
+    assert.strictEqual(result.rejected, true, 'reject mode must set rejected:true');
+    assert.ok(result.rejectedFields.includes('token'), 'rejectedFields must include token');
+    assert.strictEqual(result.payload.token, undefined, 'rejected payload must not contain prohibited field');
+  },
+});
+
+// ── 10. No Firebase Admin SDK / getAuth / verifyIdToken in code ────────────
+tests.push({
+  name: 'No Firebase Admin SDK / getAuth / verifyIdToken / cert / initializeApp in code',
+  fn: () => {
+    const code = codeOnly(verifierCode).toLowerCase();
+    assert.ok(!/firebase-admin/.test(code), 'verifier must not import firebase-admin');
+    assert.ok(!/admin\s*\.\s*auth/.test(code), 'verifier must not reference admin.auth');
+    assert.ok(!/initializeapp/.test(code), 'verifier must not call initializeApp');
+    assert.ok(!/cert\s*\(/.test(code), 'verifier must not call cert()');
+    assert.ok(!/\bgetauth\b/.test(code), 'verifier must not call getAuth');
+    assert.ok(!/verifyidtoken/.test(code), 'verifier must not call verifyIdToken');
+    assert.ok(!/verifyaccesstoken/.test(code), 'verifier must not call verifyAccessToken');
+  },
+});
+
+// ── 11. No external auth service / network call in code ───────────────────
+tests.push({
+  name: 'No fetch / XHR / axios / external auth network call in code',
+  fn: () => {
+    const code = codeOnly(verifierCode).toLowerCase();
+    assert.ok(!/\bfetch\s*\(/.test(code), 'verifier must not call fetch()');
+    assert.ok(!/xmlhttprequest/.test(code), 'verifier must not use XMLHttpRequest');
+    assert.ok(!/axios/.test(code), 'verifier must not use axios');
+    assert.ok(!/new\s+request\s*\(/.test(code), 'verifier must not construct a new Request');
+    assert.ok(!/https?:\/\//.test(code), 'verifier must not embed external auth service URL');
+  },
+});
+
+// ── 12. No KV / Durable Object / D1 / database runtime access ──────────────
+tests.push({
+  name: 'No KV / Durable Object / D1 / database runtime access in code',
+  fn: () => {
+    const code = codeOnly(verifierCode).toLowerCase();
+    assert.ok(!/kvnamespace/.test(code), 'verifier must not reference KVNamespace in code');
+    assert.ok(!/durableobject/.test(code), 'verifier must not reference DurableObject in code');
+    assert.ok(!/d1database/.test(code), 'verifier must not reference D1Database in code');
+    assert.ok(!/env\.kv\b/.test(code), 'verifier must not read env.KV in code');
+    assert.ok(!/env\.db\b/.test(code), 'verifier must not read env.DB in code');
+    assert.ok(!/env\.auth/.test(code), 'verifier must not read env.AUTH in code');
+    assert.ok(!/env\.firebase/.test(code), 'verifier must not read env.FIREBASE in code');
+  },
+});
+
+// ── 13. No provider SDK imports ────────────────────────────────────────────
+tests.push({
+  name: 'No provider SDK imports in code (OpenAI / Anthropic / Gemini / Groq / Mistral / NVIDIA etc.)',
+  fn: () => {
+    const code = codeOnly(verifierCode).toLowerCase();
+    for (const provider of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'nvidia', 'cohere', 'perplexity']) {
+      const importPattern = new RegExp(`(import|require).*${provider}`, 'i');
+      assert.ok(!importPattern.test(code), `verifier must not import ${provider} in code`);
+    }
+  },
+});
+
+// ── 14. No secrets / env usage in code ─────────────────────────────────────
+tests.push({
+  name: 'No raw secret / env auth binding / process.env reading in code',
+  fn: () => {
+    const code = codeOnly(verifierCode).toLowerCase();
+    assert.ok(!/process\.env\.scout/.test(code), 'verifier must not read process.env.SCOUT_* in code');
+    assert.ok(!/import\.meta\.env/.test(code), 'verifier must not read import.meta.env in code');
+    assert.ok(!/process\.env\.firebase/.test(code), 'verifier must not read process.env.FIREBASE_* in code');
+    assert.ok(!/api_key\s*=/.test(code), 'verifier must not assign api_key in code');
+    assert.ok(!/bearer\s+/.test(code), 'verifier must not embed bearer tokens in code');
+  },
+});
+
+// ── 15. Prohibited payload fields are documented in module ─────────────────
+tests.push({
+  name: 'Prohibited payload fields are documented in module (denylist exported)',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const prohibited = mod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS;
+    assert.ok(Array.isArray(prohibited), 'prohibited fields must be an array');
+    for (const field of ['token', 'rawToken', 'authorization', 'authorizationHeader', 'apiKey', 'secret', 'password', 'cookie', 'sessionCookie', 'firebaseToken', 'prompt', 'excerpt', 'sourceUrl', 'rawRequestBody']) {
+      assert.ok(prohibited.includes(field), `prohibited fields must include "${field}"`);
+    }
+  },
+});
+
+// ── 16. Allowed payload fields are documented in module ────────────────────
+tests.push({
+  name: 'Allowed payload fields are documented in module (allowlist exported)',
+  fn: async () => {
+    const mod = await loadVerifierModule();
+    const allowed = mod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS;
+    assert.ok(Array.isArray(allowed), 'allowed fields must be an array');
+    for (const field of ['requestId', 'tokenHash', 'authorizationScheme', 'providerMode', 'endpointPath', 'nowMs']) {
+      assert.ok(allowed.includes(field), `allowed fields must include "${field}"`);
+    }
+  },
+});
+
+// ── 17. Endpoint default stub preserved ────────────────────────────────────
+tests.push({
+  name: 'Endpoint default providerMode:"stub" is preserved in suggest.js',
+  fn: () => {
+    assert.ok(suggestCode.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'suggest.js must reference STUB mode');
+    assert.ok(suggestCode.includes("STUB: 'stub'") || suggestCode.includes('STUB: "stub"'), 'suggest.js must define STUB mode constant');
+  },
+});
+
+// ── 18. Frontend default local_stub preserved ──────────────────────────────
+tests.push({
+  name: 'Frontend source selector default local_stub is preserved',
+  fn: () => {
+    assert.ok(srcSelCode.length > 0, 'source selector must exist');
+    assert.ok(srcSelCode.includes('local_stub'), 'source selector must default to local_stub');
+  },
+});
+
+// ── 19. Endpoint client default disabled preserved ─────────────────────────
+tests.push({
+  name: 'Endpoint client default disabled is preserved (no verifier adapter wiring in client)',
+  fn: () => {
+    assert.ok(endpointClientCode.length > 0, 'endpoint client must exist');
+    assert.ok(
+      !endpointClientCode.includes('live-auth-verifier-adapter'),
+      'endpoint client must not reference the verifier adapter'
+    );
+  },
+});
+
+// ── 20. No wiring into suggest.js LIVE branch in this slice ────────────────
+tests.push({
+  name: 'Verifier adapter module is NOT wired into suggest.js LIVE branch in this slice (out of scope)',
+  fn: () => {
+    assert.ok(
+      !suggestCode.includes('live-auth-verifier-adapter'),
+      'suggest.js must not import or reference the verifier adapter in this slice (wiring is a separate slice)'
+    );
+    assert.ok(
+      !suggestCode.includes('createScoutLiveAuthVerifierAdapter'),
+      'suggest.js must not call createScoutLiveAuthVerifierAdapter in this slice'
+    );
+  },
+});
+
+// ── 21. Dependency adapter is NOT wired to verifier yet ───────────────────
+tests.push({
+  name: 'Dependency adapter is not wired to the verifier adapter in this slice (separate slice)',
+  fn: () => {
+    assert.ok(
+      !depAdapterCode.includes('live-auth-verifier-adapter'),
+      'dependency adapter must not import the verifier adapter in this slice'
+    );
+    assert.ok(
+      !depAdapterCode.includes('createScoutLiveAuthVerifierAdapter'),
+      'dependency adapter must not call createScoutLiveAuthVerifierAdapter in this slice'
+    );
+    assert.ok(
+      !depAdapterCode.includes('verifyTokenAdapter'),
+      'dependency adapter must not reference a verifyTokenAdapter seam in this slice'
+    );
+  },
+});
+
+// ── 22. Storage adapter dependency wiring still passes ─────────────────────
+tests.push({
+  name: 'Storage adapter dependency wiring remains intact (dep adapter still imports createScoutLiveRateLimitStorageAdapter)',
+  fn: () => {
+    assert.ok(
+      depAdapterCode.includes('createScoutLiveRateLimitStorageAdapter'),
+      'dependency adapter must still import createScoutLiveRateLimitStorageAdapter (wiring from previous slice)'
+    );
+    assert.ok(
+      depAdapterCode.includes('storageAdapter'),
+      'dependency adapter must still accept a storageAdapter option'
+    );
+  },
+});
+
+// ── 23. Verifier adapter skeleton doc exists and reflects status ───────────
+tests.push({
+  name: 'Verifier adapter skeleton doc exists and reflects skeleton status',
+  fn: () => {
+    const docPath = path.join(ROOT, 'docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md');
+    const doc = readFileSafe(docPath);
+    assert.ok(doc.length > 0, 'verifier adapter skeleton doc must exist');
+    const lc = doc.toLowerCase();
+    assert.ok(lc.includes('mock-disabled') || lc.includes('mock_disabled') || lc.includes('mock disabled'), 'doc must mention mock-disabled');
+    assert.ok(lc.includes('verifytoken'), 'doc must mention verifyToken');
+    assert.ok(lc.includes('firebase') || lc.includes('admin sdk'), 'doc must mention Firebase / Admin SDK');
+    assert.ok(lc.includes('getauth') || lc.includes('verifyidtoken') || lc.includes('verify_id_token'), 'doc must mention getAuth / verifyIdToken');
+    assert.ok(lc.includes('tokenhash') || lc.includes('token_hash'), 'doc must mention tokenHash');
+    assert.ok(lc.includes('prohibited') || lc.includes('denylist') || lc.includes('deny list'), 'doc must mention prohibited fields');
+    assert.ok(lc.includes('no-go') || lc.includes('no go') || lc.includes('blocked') || lc.includes('not yet'), 'doc must mark real verification as not yet ready');
+    assert.ok(lc.includes('staging') && lc.includes('production') && lc.includes('blocked'), 'doc must mark staging_live and production_live as blocked');
+  },
+});
+
+// ── 24. Related docs reflect verifier adapter skeleton status ─────────────
+tests.push({
+  name: 'Related docs exist and reflect verifier adapter skeleton status',
+  fn: () => {
+    for (const docName of DOCS) {
+      const docPath = path.join(ROOT, 'docs/product/' + docName);
+      const doc = readFileSafe(docPath);
+      assert.ok(doc.length > 0, `${docName} must exist`);
+    }
+  },
+});
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  \u2713 ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  \u2717 ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Refs #1882

Adds a mock-disabled Scout live auth verifier adapter skeleton ahead of any Firebase Admin SDK integration. This slice locks the verifier interface, fail-closed default behavior, and sensitive-data payload guardrails (no raw token / authorization / API key / firebaseToken / sessionCookie) without performing any real token verification.

- New module: functions/api/scout/live-auth-verifier-adapter.js
- Factory: createScoutLiveAuthVerifierAdapter({ mockDisabled: true })
- verifyToken safe-fails with VERIFIER_MOCK_DISABLED / VERIFIER_NOT_IMPLEMENTED
- sanitizeScoutLiveAuthVerifierPayload enforces allowlist (requestId / tokenHash / authorizationScheme / providerMode / endpointPath / nowMs) and denylist (token / rawToken / authorization / authorizationHeader / apiKey / secret / password / cookie / sessionCookie / firebaseToken / provider API keys / prompt / excerpt / sourceUrl / rawRequestBody)
- No firebase-admin / no getAuth / no verifyIdToken / no cert / no initializeApp / no fetch / no KV / no DO / no D1 / no provider SDK / no env auth binding
- Dependency adapter is NOT yet wired to the verifier (separate slice)
- suggest.js is NOT yet wired to the verifier (separate slice)
- Endpoint default stub / explicit stub / frontend local_stub / endpoint client default disabled all preserved

Closes a new issue documenting the slice; references #1882.