### PR TITLE
refactor(scout): wire auth verifier into live dependency mock path

### DIFF
--- a/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md
@@ -244,3 +244,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-auth-rate-limit-readiness-audit.md
@@ -300,3 +300,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md
@@ -297,3 +297,56 @@ It is mock-disabled, fail-closed, and does not access any external
 auth backend. The interface and sensitive-data guardrails are locked
 by contract tests so the next slice can safely wire it into the
 dependency adapter without expanding the trust boundary.
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-endpoint-error-readiness-audit.md
@@ -286,3 +286,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
+++ b/docs/product/lovebud-scout-live-provider-auth-rate-limit-boundary.md
@@ -562,3 +562,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-provider-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-provider-readiness-audit.md
@@ -303,3 +303,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
+++ b/docs/product/lovebud-scout-live-rate-limit-storage-adapter-skeleton.md
@@ -318,3 +318,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-llm-provider-boundary.md
+++ b/docs/product/lovebud-scout-llm-provider-boundary.md
@@ -445,3 +445,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/docs/product/lovebud-scout-serverless-endpoint-boundary.md
+++ b/docs/product/lovebud-scout-serverless-endpoint-boundary.md
@@ -570,3 +570,56 @@ of any Firebase Admin SDK integration. Status:
 - Runtime Firebase Admin SDK / real token verification /
   external auth service call: **NO** (blocked)
 - `staging_live` / `production_live` rollout: **NO** (blocked)
+
+## Auth Verifier Adapter Dependency Wiring Status
+
+The auth verifier adapter skeleton is now wired into the live dependency
+adapter mock path (v20260607-1, wiring slice):
+
+- `live-auth-rate-limit-dependency-adapter.js` imports
+  `createScoutLiveAuthVerifierAdapter` from `live-auth-verifier-adapter.js`
+- `createScoutLiveDependencyAdapter(options?)` accepts a `verifierAdapter`
+  option
+- When `verifierAdapter` is not provided, the canonical mock-disabled
+  verifier adapter
+  (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is used
+  as the default
+- `verifyToken` routes through `verifierAdapter.verifyToken` with an
+  **allowlisted payload only** (no raw token / authorization header /
+  API key / firebaseToken / session cookie / password / prompt /
+  excerpt / sourceUrl / raw request body / provider API key fields)
+- Allowed verifier payload fields (single source of truth at the dep
+  adapter → verifier seam):
+  - `requestId`
+  - `tokenHash`
+  - `authorizationScheme`
+  - `providerMode`
+  - `endpointPath`
+  - `nowMs`
+- Verifier result codes are mapped to dependency-adapter safe-fail codes:
+  - `VERIFIER_MOCK_DISABLED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_NOT_IMPLEMENTED` → `VERIFY_NOT_IMPLEMENTED`
+  - `VERIFIER_PAYLOAD_PROHIBITED` → `VERIFY_PAYLOAD_PROHIBITED`
+  - unknown / missing code → `VERIFY_UNAVAILABLE`
+- Verifier adapter throw is safe-swallowed (no throw propagation,
+  returns `VERIFY_UNAVAILABLE`)
+- The dependency adapter's `checkRateLimit` storage adapter wiring is
+  unchanged
+- The dependency adapter object remains frozen (immutable)
+- `verifyToken` result still includes `userKey: null` and
+  `userKeyHash: null` in mock-disabled / not-implemented mode (skeleton
+  does not return real user identifiers)
+- `suggest.js` is NOT modified in this slice (wiring is dependency-internal)
+- New dependency-adapter response codes:
+  - `VERIFY_PAYLOAD_PROHIBITED`
+  - `VERIFY_UNAVAILABLE`
+- No real Firebase Admin SDK, no `getAuth`, no `verifyIdToken`, no
+  `verifyAccessToken`, no `cert`, no `initializeApp` in code
+- No fetch / XMLHttpRequest / axios / external auth URL
+- No KV / Durable Object / D1 / database / env auth binding
+  (`env.AUTH`, `env.FIREBASE`, `process.env.SCOUT_*`, `import.meta.env`)
+- No provider SDK imports (OpenAI / Anthropic / Gemini / Groq / Mistral
+  / NVIDIA / Cohere / Perplexity)
+- Real Firebase Admin SDK / real token verification / external auth
+  service / `staging_live` / `production_live` / provider API all
+  remain blocked

--- a/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
+++ b/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
@@ -14,6 +14,17 @@
  * `verifyToken` (Firebase Admin SDK or equivalent) and `checkRateLimit`
  * (KV / Durable Object / D1 or equivalent) will be added in future slices.
  *
+ * `verifyToken` routes through an internal auth verifier adapter seam. The
+ * default verifier dependency is `createScoutLiveAuthVerifierAdapter`
+ * from `live-auth-verifier-adapter.js` (mock-disabled by default). The
+ * verifier's `verifyToken` is called with an allowlisted payload only
+ * (no raw token / authorization header / API key / firebaseToken / prompt
+ * / excerpt / sourceUrl). Verifier results are mapped back to
+ * dependency-adapter safe-fail shapes (`VERIFY_NOT_IMPLEMENTED`,
+ * `VERIFY_PAYLOAD_PROHIBITED`, `VERIFY_UNAVAILABLE`). The verifier adapter
+ * itself is mock-disabled and does NOT access any real Firebase Admin SDK,
+ * `getAuth`, `verifyIdToken`, external auth service, or network call.
+ *
  * `checkRateLimit` routes through an internal storage adapter seam. The
  * default storage dependency is `createScoutLiveRateLimitStorageAdapter`
  * from `live-rate-limit-storage-adapter.js` (mock-disabled by default). The
@@ -30,7 +41,8 @@
  * - SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION: skeleton version
  * - createScoutLiveDependencyAdapter: returns a dependency adapter object
  *   with `verifyToken`, `checkRateLimit`, `requestId`, and metadata
- *   (`isMockDisabled`, `mode`, `version`, `storageAdapterKind`).
+ *   (`isMockDisabled`, `mode`, `version`, `storageAdapterKind`,
+ *   `verifierAdapterKind`).
  *
  * This module is a **mock-disabled skeleton + factory**. No real Firebase
  * Admin SDK import, no real token verification, no real persistent storage
@@ -51,6 +63,7 @@
 'use strict';
 
 import { createScoutLiveRateLimitStorageAdapter } from './live-rate-limit-storage-adapter.js';
+import { createScoutLiveAuthVerifierAdapter } from './live-auth-verifier-adapter.js';
 
 // ─── Version ────────────────────────────────────────────────────────────────
 
@@ -63,10 +76,12 @@ export const SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES = Object.freeze({
   NOT_IMPLEMENTED: 'not_implemented',
 });
 
-// ─── Response Codes ────────────────────────────────────────────────────────
+// ─── Response Codes ─────────────────────────────────────────────────────────
 
 export const SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES = Object.freeze({
   VERIFY_NOT_IMPLEMENTED: 'VERIFY_NOT_IMPLEMENTED',
+  VERIFY_PAYLOAD_PROHIBITED: 'VERIFY_PAYLOAD_PROHIBITED',
+  VERIFY_UNAVAILABLE: 'VERIFY_UNAVAILABLE',
   RATE_LIMIT_NOT_IMPLEMENTED: 'RATE_LIMIT_NOT_IMPLEMENTED',
   RATE_LIMIT_PAYLOAD_PROHIBITED: 'RATE_LIMIT_PAYLOAD_PROHIBITED',
   RATE_LIMIT_STORAGE_UNAVAILABLE: 'RATE_LIMIT_STORAGE_UNAVAILABLE',
@@ -82,8 +97,8 @@ const DEFAULT_OPTIONS = Object.freeze({
 
 // The dependency adapter's checkRateLimit builds a storage payload using
 // ONLY these fields. No raw token / API key / prompt / excerpt / sourceUrl
-// ever enters the storage payload. This allowlist is the single source of
-// truth for safe payload fields at the dependency-adapter seam.
+// ever enters the storage payload. This allowlist is the single source
+// of truth for safe payload fields at the dependency-adapter seam.
 const STORAGE_PAYLOAD_ALLOWED_FIELDS = Object.freeze([
   'requestId',
   'userKeyHash',
@@ -107,6 +122,34 @@ function buildSafeStoragePayload(input) {
   return out;
 }
 
+// ─── Verifier Payload Allowlist (mirror of verifier adapter) ───────────────
+
+// The dependency adapter's verifyToken builds a verifier payload using
+// ONLY these future-safe derived fields. No raw token / authorization
+// header / API key / firebaseToken / session cookie / password / prompt
+// / excerpt / sourceUrl / raw request body ever enters the verifier
+// payload. This allowlist is the single source of truth for safe payload
+// fields at the dependency-adapter to verifier-adapter seam.
+const AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS = Object.freeze([
+  'requestId',
+  'tokenHash',
+  'authorizationScheme',
+  'providerMode',
+  'endpointPath',
+  'nowMs',
+]);
+
+function buildSafeVerifierPayload(input) {
+  const src = (input && typeof input === 'object') ? input : {};
+  const out = {};
+  for (const key of AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(src, key) && src[key] !== undefined) {
+      out[key] = src[key];
+    }
+  }
+  return out;
+}
+
 // ─── Internal Helpers ───────────────────────────────────────────────────────
 
 function makeMockDisabledRequestId() {
@@ -122,6 +165,8 @@ function buildMockDisabledVerifyResponse() {
     allowed: false,
     code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED,
     reason: 'verifyToken is mock-disabled; real implementation is required',
+    userKey: null,
+    userKeyHash: null,
   };
 }
 
@@ -138,6 +183,8 @@ function buildNotImplementedVerifyResponse() {
     allowed: false,
     code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED,
     reason: 'real verifyToken implementation is not yet provided',
+    userKey: null,
+    userKeyHash: null,
   };
 }
 
@@ -234,6 +281,86 @@ function buildStorageRoutedCheckRateLimit(storageAdapter) {
   };
 }
 
+// ─── Verifier-to-Dependency Response Mapping ───────────────────────────────
+
+/**
+ * Map a verifier adapter result to a dependency-adapter safe-fail shape.
+ * Verifier result codes are translated to dependency-adapter codes so
+ * the caller (boundary / endpoint) can reason about the decision
+ * consistently. The userKey / userKeyHash from a (theoretical) successful
+ * verification are stripped to null in this skeleton; the dependency
+ * adapter does not propagate raw user identifiers from the verifier in
+ * this slice.
+ *
+ * @param {Object} verifierResult - result from verifierAdapter.verifyToken
+ * @returns {Object} dependency-adapter safe-fail response
+ */
+function mapVerifierResultToDependencyResponse(verifierResult) {
+  const res = (verifierResult && typeof verifierResult === 'object') ? verifierResult : {};
+  const code = res.code;
+  if (code === 'VERIFIER_PAYLOAD_PROHIBITED') {
+    return {
+      allowed: false,
+      code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_PAYLOAD_PROHIBITED,
+      reason: typeof res.reason === 'string' && res.reason.length > 0
+        ? res.reason
+        : 'verifier payload contained prohibited fields',
+      userKey: null,
+      userKeyHash: null,
+    };
+  }
+  if (code === 'VERIFIER_MOCK_DISABLED' || code === 'VERIFIER_NOT_IMPLEMENTED') {
+    return {
+      allowed: false,
+      code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED,
+      reason: typeof res.reason === 'string' && res.reason.length > 0
+        ? res.reason
+        : 'auth verifier adapter is not implemented',
+      userKey: null,
+      userKeyHash: null,
+    };
+  }
+  // Unknown / missing code → generic verifier-unavailable safe-fail
+  return {
+    allowed: false,
+    code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_UNAVAILABLE,
+    reason: typeof res.reason === 'string' && res.reason.length > 0
+      ? res.reason
+      : 'auth verifier adapter returned an unknown result',
+    userKey: null,
+    userKeyHash: null,
+  };
+}
+
+/**
+ * Build a verifyToken function that routes through the given verifier
+ * adapter. The verifier payload is built from an allowlist only (no raw
+ * token / authorization header / API key / firebaseToken / session cookie
+ * / password / prompt / excerpt / sourceUrl / raw request body). Verifier
+ * adapter exceptions are safe-swallowed to a safe-fail response.
+ *
+ * @param {Object} verifierAdapter - verifier adapter (must have verifyToken)
+ * @returns {Function} async verifyToken function
+ */
+function buildVerifierRoutedVerifyToken(verifierAdapter) {
+  return async function verifyToken(payload) {
+    const safePayload = buildSafeVerifierPayload(payload);
+    let verifierResult;
+    try {
+      verifierResult = await verifierAdapter.verifyToken(safePayload);
+    } catch {
+      return {
+        allowed: false,
+        code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_UNAVAILABLE,
+        reason: 'auth verifier adapter threw an exception',
+        userKey: null,
+        userKeyHash: null,
+      };
+    }
+    return mapVerifierResultToDependencyResponse(verifierResult);
+  };
+}
+
 // ─── Factory: createScoutLiveDependencyAdapter ──────────────────────────────
 
 /**
@@ -251,8 +378,17 @@ function buildStorageRoutedCheckRateLimit(storageAdapter) {
  *   (`createScoutLiveRateLimitStorageAdapter({ mockDisabled: true })`) is
  *   used as the default. The storage adapter itself is mock-disabled and
  *   does NOT access any real KV / Durable Object / D1 / database.
+ * @param {Object} [options.verifierAdapter] optional auth verifier adapter
+ *   dependency. When provided, verifyToken routes through
+ *   `verifierAdapter.verifyToken` with an allowlisted payload. When
+ *   omitted, the canonical mock-disabled verifier adapter
+ *   (`createScoutLiveAuthVerifierAdapter({ mockDisabled: true })`) is
+ *   used as the default. The verifier adapter itself is mock-disabled
+ *   and does NOT access any real Firebase Admin SDK, `getAuth`,
+ *   `verifyIdToken`, external auth service, or network call.
  * @returns {Object} adapter with verifyToken, checkRateLimit, requestId, and
- *   metadata (isMockDisabled, mode, version, storageAdapterKind).
+ *   metadata (isMockDisabled, mode, version, storageAdapterKind,
+ *   verifierAdapterKind).
  */
 export function createScoutLiveDependencyAdapter(options) {
   const opts = Object.assign({}, DEFAULT_OPTIONS, options || {});
@@ -261,6 +397,10 @@ export function createScoutLiveDependencyAdapter(options) {
     ? opts.storageAdapter
     : createScoutLiveRateLimitStorageAdapter({ mockDisabled: true });
   const checkRateLimitFn = buildStorageRoutedCheckRateLimit(storageAdapter);
+  const verifierAdapter = (opts.verifierAdapter && typeof opts.verifierAdapter.verifyToken === 'function')
+    ? opts.verifierAdapter
+    : createScoutLiveAuthVerifierAdapter({ mockDisabled: true });
+  const verifyTokenFn = buildVerifierRoutedVerifyToken(verifierAdapter);
 
   if (mockDisabled) {
     return Object.freeze({
@@ -270,9 +410,9 @@ export function createScoutLiveDependencyAdapter(options) {
       isMockDisabled: true,
       storageAdapterKind: storageAdapter.kind || 'scout_live_rate_limit_storage_adapter',
       storageAdapterMockDisabled: storageAdapter.isMockDisabled === true,
-      verifyToken: async function verifyToken() {
-        return buildMockDisabledVerifyResponse();
-      },
+      verifierAdapterKind: verifierAdapter.kind || 'scout_live_auth_verifier_adapter',
+      verifierAdapterMockDisabled: verifierAdapter.isMockDisabled === true,
+      verifyToken: verifyTokenFn,
       checkRateLimit: checkRateLimitFn,
       requestId: function requestId() {
         return makeMockDisabledRequestId();
@@ -287,9 +427,9 @@ export function createScoutLiveDependencyAdapter(options) {
     isMockDisabled: false,
     storageAdapterKind: storageAdapter.kind || 'scout_live_rate_limit_storage_adapter',
     storageAdapterMockDisabled: storageAdapter.isMockDisabled === true,
-    verifyToken: async function verifyToken() {
-      return buildNotImplementedVerifyResponse();
-    },
+    verifierAdapterKind: verifierAdapter.kind || 'scout_live_auth_verifier_adapter',
+    verifierAdapterMockDisabled: verifierAdapter.isMockDisabled === true,
+    verifyToken: verifyTokenFn,
     checkRateLimit: checkRateLimitFn,
     requestId: function requestId() {
       return buildNotImplementedRequestId();

--- a/tests/contracts/scout-live-auth-verifier-adapter-skeleton-contract.test.cjs
+++ b/tests/contracts/scout-live-auth-verifier-adapter-skeleton-contract.test.cjs
@@ -374,21 +374,22 @@ tests.push({
   },
 });
 
-// ── 21. Dependency adapter is NOT wired to verifier yet ───────────────────
+// ── 21. Dependency adapter wiring is a separate slice (no overclaim) ──────
 tests.push({
-  name: 'Dependency adapter is not wired to the verifier adapter in this slice (separate slice)',
+  name: 'Verifier adapter skeleton does not overclaim — wiring into the dependency adapter is a separate slice',
   fn: () => {
+    // The skeleton slice (v20260607-1) only added the verifier module. Wiring
+    // the verifier adapter into the dependency adapter is a separate slice
+    // (tech/scout-auth-verifier-dependency-wiring). This test locks the
+    // skeleton's "module-only" property by asserting that the verifier
+    // module itself does not reach into the dependency adapter.
     assert.ok(
-      !depAdapterCode.includes('live-auth-verifier-adapter'),
-      'dependency adapter must not import the verifier adapter in this slice'
+      !verifierCode.includes('live-auth-rate-limit-dependency-adapter'),
+      'verifier adapter must not import the dependency adapter module'
     );
     assert.ok(
-      !depAdapterCode.includes('createScoutLiveAuthVerifierAdapter'),
-      'dependency adapter must not call createScoutLiveAuthVerifierAdapter in this slice'
-    );
-    assert.ok(
-      !depAdapterCode.includes('verifyTokenAdapter'),
-      'dependency adapter must not reference a verifyTokenAdapter seam in this slice'
+      !verifierCode.includes('createScoutLiveDependencyAdapter'),
+      'verifier adapter must not call createScoutLiveDependencyAdapter'
     );
   },
 });

--- a/tests/contracts/scout-live-auth-verifier-dependency-wiring-contract.test.cjs
+++ b/tests/contracts/scout-live-auth-verifier-dependency-wiring-contract.test.cjs
@@ -1,0 +1,592 @@
+/**
+ * Scout Live Auth Verifier Dependency Wiring Contract Tests
+ * v20260607-1
+ *
+ * Locks the wiring of the auth verifier adapter skeleton into the
+ * Scout live dependency adapter mock path:
+ * - dependency adapter imports the verifier adapter factory
+ * - dependency adapter accepts a verifierAdapter option
+ * - default verifier adapter is mock-disabled when none is provided
+ * - verifyToken calls verifierAdapter.verifyToken with allowlisted
+ *   payload only (no raw token / authorization / apiKey / firebaseToken /
+ *   sessionCookie / password / prompt / excerpt / sourceUrl / raw request)
+ * - verifyToken result does not propagate raw token fields
+ * - verifier mock-disabled / not-implemented / payload-prohibited / unknown
+ *   results are mapped to dependency-adapter safe-fail codes
+ * - verifier adapter throw is safe-swallowed
+ * - checkRateLimit storage wiring remains intact
+ * - adapter object is frozen
+ * - endpoint default stub / explicit stub / frontend local_stub / endpoint
+ *   client default disabled remain preserved
+ * - no Firebase Admin SDK / no getAuth / no verifyIdToken / no KV / DO / D1
+ *   / no fetch / no provider SDK / no secrets / no env auth binding
+ * - docs reflect auth verifier adapter dependency wiring status
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const VERIFIER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-verifier-adapter.js');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+const DOCS = [
+  'lovebud-scout-live-auth-verifier-adapter-skeleton.md',
+  'lovebud-scout-live-rate-limit-storage-adapter-skeleton.md',
+  'lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md',
+  'lovebud-scout-live-endpoint-error-readiness-audit.md',
+  'lovebud-scout-live-auth-rate-limit-readiness-audit.md',
+  'lovebud-scout-live-provider-auth-rate-limit-boundary.md',
+  'lovebud-scout-serverless-endpoint-boundary.md',
+  'lovebud-scout-llm-provider-boundary.md',
+  'lovebud-scout-live-provider-readiness-audit.md',
+];
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+const depCode = readFileSafe(DEP_ADAPTER_PATH);
+const verifierCode = readFileSafe(VERIFIER_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const srcSelCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+let depModulePromise = null;
+let verifierModulePromise = null;
+let storageModulePromise = null;
+async function loadDepModule() {
+  if (!depModulePromise) depModulePromise = import(DEP_ADAPTER_PATH);
+  return depModulePromise;
+}
+async function loadVerifierModule() {
+  if (!verifierModulePromise) verifierModulePromise = import(VERIFIER_PATH);
+  return verifierModulePromise;
+}
+async function loadStorageModule() {
+  if (!storageModulePromise) storageModulePromise = import(STORAGE_ADAPTER_PATH);
+  return storageModulePromise;
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const tests = [];
+
+// ── 1. Dependency adapter imports verifier adapter ────────────────────────
+tests.push({
+  name: 'Dependency adapter imports createScoutLiveAuthVerifierAdapter from verifier adapter module',
+  fn: () => {
+    assert.ok(
+      depCode.includes('live-auth-verifier-adapter'),
+      'dependency adapter must import from live-auth-verifier-adapter.js'
+    );
+    assert.ok(
+      depCode.includes('createScoutLiveAuthVerifierAdapter'),
+      'dependency adapter must import the createScoutLiveAuthVerifierAdapter factory'
+    );
+  },
+});
+
+// ── 2. Dependency adapter accepts verifierAdapter option ───────────────────
+tests.push({
+  name: 'createScoutLiveDependencyAdapter accepts verifierAdapter option',
+  fn: async () => {
+    const depMod = await loadDepModule();
+    const verifierMod = await loadVerifierModule();
+    const customVerifier = verifierMod.createScoutLiveAuthVerifierAdapter({ mockDisabled: true });
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: customVerifier });
+    assert.ok(adapter, 'adapter must be created with custom verifierAdapter');
+    assert.strictEqual(adapter.verifierAdapterKind, 'scout_live_auth_verifier_adapter', 'verifierAdapterKind must be set');
+    assert.strictEqual(adapter.verifierAdapterMockDisabled, true, 'verifierAdapterMockDisabled must reflect injected adapter');
+  },
+});
+
+// ── 3. Default verifier adapter is mock-disabled ──────────────────────────
+tests.push({
+  name: 'Default verifierAdapter (when none provided) is mock-disabled',
+  fn: async () => {
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter();
+    assert.strictEqual(adapter.verifierAdapterMockDisabled, true, 'default verifierAdapterMockDisabled must be true');
+    assert.strictEqual(adapter.isMockDisabled, true, 'default isMockDisabled must be true');
+  },
+});
+
+// ── 4. verifyToken calls verifierAdapter.verifyToken ────────────────────────
+tests.push({
+  name: 'verifyToken calls the injected verifierAdapter.verifyToken with allowlisted payload',
+  fn: async () => {
+    let callCount = 0;
+    let receivedPayload = null;
+    const fakeVerifier = {
+      kind: 'fake_verifier',
+      isMockDisabled: true,
+      async verifyToken(payload) {
+        callCount++;
+        receivedPayload = payload;
+        return {
+          allowed: false,
+          code: 'VERIFIER_MOCK_DISABLED',
+          reason: 'fake verifier mock-disabled',
+          userKey: null,
+          userKeyHash: null,
+        };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({
+      requestId: 'req_test_123',
+      tokenHash: 'hk_abc',
+      authorizationScheme: 'Bearer',
+      providerMode: 'live',
+      endpointPath: '/api/scout/suggest',
+      nowMs: Date.now(),
+      // sensitive fields that must be stripped
+      token: 'TEST_FIXTURE_TOKEN_NOT_A_REAL_SECRET',
+      authorization: 'Bearer TEST_FIXTURE_AUTH',
+      apiKey: 'TEST_FIXTURE_KEY',
+      firebaseToken: 'TEST_FIXTURE_FB',
+      sessionCookie: 'TEST_FIXTURE_SC',
+      password: 'TEST_FIXTURE_PW',
+      prompt: 'TEST_FIXTURE_PROMPT',
+      excerpt: 'TEST_FIXTURE_EXCERPT',
+      sourceUrl: 'https://example.com/test',
+      rawRequestBody: '{"foo":"bar"}',
+    });
+    assert.strictEqual(callCount, 1, 'verifierAdapter.verifyToken must be called exactly once');
+    assert.ok(receivedPayload, 'verifierAdapter.verifyToken must receive a payload');
+    // Allowlisted fields are preserved
+    assert.strictEqual(receivedPayload.requestId, 'req_test_123', 'requestId must be passed through');
+    assert.strictEqual(receivedPayload.tokenHash, 'hk_abc', 'tokenHash must be passed through');
+    assert.strictEqual(receivedPayload.authorizationScheme, 'Bearer', 'authorizationScheme must be passed through');
+    assert.strictEqual(receivedPayload.endpointPath, '/api/scout/suggest', 'endpointPath must be passed through');
+    // Sensitive fields are stripped
+    assert.strictEqual(receivedPayload.token, undefined, 'token must be stripped');
+    assert.strictEqual(receivedPayload.authorization, undefined, 'authorization must be stripped');
+    assert.strictEqual(receivedPayload.apiKey, undefined, 'apiKey must be stripped');
+    assert.strictEqual(receivedPayload.firebaseToken, undefined, 'firebaseToken must be stripped');
+    assert.strictEqual(receivedPayload.sessionCookie, undefined, 'sessionCookie must be stripped');
+    assert.strictEqual(receivedPayload.password, undefined, 'password must be stripped');
+    assert.strictEqual(receivedPayload.prompt, undefined, 'prompt must be stripped');
+    assert.strictEqual(receivedPayload.excerpt, undefined, 'excerpt must be stripped');
+    assert.strictEqual(receivedPayload.sourceUrl, undefined, 'sourceUrl must be stripped');
+    assert.strictEqual(receivedPayload.rawRequestBody, undefined, 'rawRequestBody must be stripped');
+    // Result is mapped to dependency-adapter safe-fail shape
+    assert.strictEqual(res.allowed, false, 'mapped result must deny');
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED, 'VERIFIER_MOCK_DISABLED must map to VERIFY_NOT_IMPLEMENTED');
+  },
+});
+
+// ── 5. verifyToken passes allowlisted payload only ─────────────────────────
+tests.push({
+  name: 'verifyToken only passes allowlisted fields to verifierAdapter (no sensitive data)',
+  fn: async () => {
+    let receivedPayload = null;
+    const fakeVerifier = {
+      kind: 'fake_verifier',
+      isMockDisabled: true,
+      async verifyToken(payload) {
+        receivedPayload = payload;
+        return { allowed: false, code: 'VERIFIER_MOCK_DISABLED', reason: 'fake', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    await adapter.verifyToken({
+      requestId: 'r1',
+      tokenHash: 'h1',
+      authorizationScheme: 'Bearer',
+      providerMode: 'live',
+      endpointPath: '/p',
+      nowMs: 1,
+      // All of these must be stripped:
+      token: 'T', rawToken: 'RT', authorization: 'A', authorizationHeader: 'AH',
+      apiKey: 'K', secret: 'S', password: 'PW', cookie: 'C', sessionCookie: 'SC',
+      firebaseToken: 'FT',
+      openaiApiKey: 'OAK', anthropicApiKey: 'AAK', geminiApiKey: 'GAK',
+      groqApiKey: 'GQK', mistralApiKey: 'MAK', nvidiaApiKey: 'NAK',
+      prompt: 'P', excerpt: 'E', sourceUrl: 'U', rawRequestBody: 'B',
+      unknownField: 'X',
+    });
+    const prohibited = [
+      'token', 'rawToken', 'authorization', 'authorizationHeader',
+      'apiKey', 'secret', 'password', 'cookie', 'sessionCookie', 'firebaseToken',
+      'openaiApiKey', 'anthropicApiKey', 'geminiApiKey',
+      'groqApiKey', 'mistralApiKey', 'nvidiaApiKey',
+      'prompt', 'excerpt', 'sourceUrl', 'rawRequestBody',
+    ];
+    for (const field of prohibited) {
+      assert.strictEqual(
+        receivedPayload[field],
+        undefined,
+        `prohibited field "${field}" must not be in verifier payload`
+      );
+    }
+    assert.strictEqual(receivedPayload.unknownField, undefined, 'unknown fields must be dropped');
+    // Allowed fields are present
+    assert.strictEqual(receivedPayload.requestId, 'r1');
+    assert.strictEqual(receivedPayload.tokenHash, 'h1');
+    assert.strictEqual(receivedPayload.authorizationScheme, 'Bearer');
+    assert.strictEqual(receivedPayload.nowMs, 1);
+  },
+});
+
+// ── 6. verifyToken result does not include raw token fields ───────────────
+tests.push({
+  name: 'verifyToken result does not include raw token / authorization / apiKey / firebaseToken',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: true,
+      async verifyToken() {
+        return { allowed: false, code: 'VERIFIER_MOCK_DISABLED', reason: 'fake', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({ token: 'TEST_FIXTURE_TOKEN_NOT_A_REAL_SECRET' });
+    const flat = JSON.stringify(res).toLowerCase();
+    assert.ok(!flat.includes('test_fixture_token'), 'result must not include raw token value');
+    assert.ok(!flat.includes('test_fixture_not_a_real_secret'), 'result must not include raw secret value');
+    assert.strictEqual(res.token, undefined, 'result must not have a token field');
+    assert.strictEqual(res.authorization, undefined, 'result must not have an authorization field');
+    assert.strictEqual(res.apiKey, undefined, 'result must not have an apiKey field');
+    assert.strictEqual(res.firebaseToken, undefined, 'result must not have a firebaseToken field');
+    assert.strictEqual(res.userKey, null, 'userKey must be null (skeleton)');
+    assert.strictEqual(res.userKeyHash, null, 'userKeyHash must be null (skeleton)');
+  },
+});
+
+// ── 7. VERIFIER_MOCK_DISABLED maps to VERIFY_NOT_IMPLEMENTED ───────────────
+tests.push({
+  name: 'VERIFIER_MOCK_DISABLED maps to dependency-adapter VERIFY_NOT_IMPLEMENTED',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: true,
+      async verifyToken() {
+        return { allowed: false, code: 'VERIFIER_MOCK_DISABLED', reason: 'mock-disabled', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false);
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED);
+    assert.strictEqual(res.userKey, null);
+    assert.strictEqual(res.userKeyHash, null);
+  },
+});
+
+// ── 8. VERIFIER_NOT_IMPLEMENTED maps to VERIFY_NOT_IMPLEMENTED ─────────────
+tests.push({
+  name: 'VERIFIER_NOT_IMPLEMENTED maps to dependency-adapter VERIFY_NOT_IMPLEMENTED',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: false,
+      async verifyToken() {
+        return { allowed: false, code: 'VERIFIER_NOT_IMPLEMENTED', reason: 'not-impl', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false);
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_NOT_IMPLEMENTED);
+  },
+});
+
+// ── 9. VERIFIER_PAYLOAD_PROHIBITED maps to VERIFY_PAYLOAD_PROHIBITED ───────
+tests.push({
+  name: 'VERIFIER_PAYLOAD_PROHIBITED maps to dependency-adapter VERIFY_PAYLOAD_PROHIBITED',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: true,
+      async verifyToken() {
+        return { allowed: false, code: 'VERIFIER_PAYLOAD_PROHIBITED', reason: 'prohibited', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false);
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_PAYLOAD_PROHIBITED);
+  },
+});
+
+// ── 10. Unknown verifier code maps to VERIFY_UNAVAILABLE ───────────────────
+tests.push({
+  name: 'Unknown verifier code maps to dependency-adapter VERIFY_UNAVAILABLE',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: true,
+      async verifyToken() {
+        return { allowed: false, code: 'UNKNOWN_VERIFIER_CODE', reason: 'mystery', userKey: null, userKeyHash: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    const res = await adapter.verifyToken({});
+    assert.strictEqual(res.allowed, false);
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_UNAVAILABLE);
+  },
+});
+
+// ── 11. Verifier adapter throw is safe-swallowed ───────────────────────────
+tests.push({
+  name: 'Verifier adapter throw is safe-swallowed (no throw propagation)',
+  fn: async () => {
+    const fakeVerifier = {
+      kind: 'fake',
+      isMockDisabled: true,
+      async verifyToken() {
+        throw new Error('TEST_FIXTURE_VERIFIER_THROW');
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ verifierAdapter: fakeVerifier });
+    let res;
+    let threw = false;
+    try {
+      res = await adapter.verifyToken({});
+    } catch (err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'verifyToken must not propagate verifier adapter throws');
+    assert.ok(res, 'safe-fail response must be returned');
+    assert.strictEqual(res.allowed, false, 'safe-fail response must deny');
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.VERIFY_UNAVAILABLE, 'throw must map to VERIFY_UNAVAILABLE');
+  },
+});
+
+// ── 12. checkRateLimit storage wiring remains intact ───────────────────────
+tests.push({
+  name: 'checkRateLimit storage adapter dependency wiring is unchanged (storage still routed)',
+  fn: async () => {
+    let storageCallCount = 0;
+    const fakeStorage = {
+      kind: 'fake_storage',
+      isMockDisabled: true,
+      async checkQuota() {
+        storageCallCount++;
+        return { allowed: false, code: 'STORAGE_MOCK_DISABLED', reason: 'fake', retryAfterSeconds: null };
+      },
+    };
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter({ storageAdapter: fakeStorage });
+    const res = await adapter.checkRateLimit({});
+    assert.strictEqual(storageCallCount, 1, 'storageAdapter.checkQuota must still be called by checkRateLimit');
+    assert.strictEqual(res.allowed, false);
+    assert.strictEqual(res.code, depMod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED, 'storage mapping unchanged');
+  },
+});
+
+// ── 13. Dependency adapter object remains frozen ───────────────────────────
+tests.push({
+  name: 'Dependency adapter object remains frozen (immutable)',
+  fn: async () => {
+    const depMod = await loadDepModule();
+    const adapter = depMod.createScoutLiveDependencyAdapter();
+    assert.strictEqual(Object.isFrozen(adapter), true, 'adapter must be frozen');
+  },
+});
+
+// ── 14. Endpoint default stub preserved ───────────────────────────────────
+tests.push({
+  name: 'Endpoint default providerMode:"stub" is preserved in suggest.js',
+  fn: () => {
+    assert.ok(suggestCode.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'suggest.js must reference STUB mode');
+  },
+});
+
+// ── 15. Explicit stub path preserved ───────────────────────────────────────
+tests.push({
+  name: 'Explicit stub path is preserved (providerMode:"stub" explicit)',
+  fn: () => {
+    assert.ok(suggestCode.includes("STUB: 'stub'") || suggestCode.includes('STUB: "stub"'), 'suggest.js must define STUB mode constant');
+  },
+});
+
+// ── 16. Frontend default local_stub preserved ──────────────────────────────
+tests.push({
+  name: 'Frontend source selector default local_stub is preserved',
+  fn: () => {
+    assert.ok(srcSelCode.length > 0, 'source selector must exist');
+    assert.ok(srcSelCode.includes('local_stub'), 'source selector must default to local_stub');
+  },
+});
+
+// ── 17. Endpoint client default disabled preserved ─────────────────────────
+tests.push({
+  name: 'Endpoint client default disabled is preserved (no verifier wiring in client)',
+  fn: () => {
+    assert.ok(endpointClientCode.length > 0, 'endpoint client must exist');
+    assert.ok(
+      !endpointClientCode.includes('live-auth-verifier-adapter'),
+      'endpoint client must not reference the verifier adapter'
+    );
+  },
+});
+
+// ── 18. suggest.js unchanged in this slice ─────────────────────────────────
+tests.push({
+  name: 'suggest.js LIVE branch wiring is not modified by this slice (verifier wiring is dependency-internal)',
+  fn: () => {
+    assert.ok(
+      !suggestCode.includes('live-auth-verifier-adapter'),
+      'suggest.js must not import the verifier adapter (wiring is dependency-internal in this slice)'
+    );
+    assert.ok(
+      !suggestCode.includes('createScoutLiveAuthVerifierAdapter'),
+      'suggest.js must not call createScoutLiveAuthVerifierAdapter in this slice'
+    );
+    assert.ok(
+      suggestCode.includes('createScoutLiveDependencyAdapter'),
+      'suggest.js must still import the dependency adapter (existing wiring preserved)'
+    );
+  },
+});
+
+// ── 19. No Firebase Admin SDK / getAuth / verifyIdToken in dep adapter code ─
+tests.push({
+  name: 'No Firebase Admin SDK / getAuth / verifyIdToken / cert / initializeApp in dep adapter code',
+  fn: () => {
+    const code = codeOnly(depCode).toLowerCase();
+    assert.ok(!/firebase-admin/.test(code), 'dep adapter must not import firebase-admin in code');
+    assert.ok(!/admin\s*\.\s*auth/.test(code), 'dep adapter must not reference admin.auth in code');
+    assert.ok(!/initializeapp/.test(code), 'dep adapter must not call initializeApp in code');
+    assert.ok(!/cert\s*\(/.test(code), 'dep adapter must not call cert() in code');
+    assert.ok(!/\bgetauth\b/.test(code), 'dep adapter must not call getAuth in code');
+    assert.ok(!/verifyidtoken/.test(code), 'dep adapter must not call verifyIdToken in code');
+    assert.ok(!/verifyaccesstoken/.test(code), 'dep adapter must not call verifyAccessToken in code');
+  },
+});
+
+// ── 20. No KV / Durable Object / D1 / database runtime access ──────────────
+tests.push({
+  name: 'No KV / Durable Object / D1 / database runtime access in dep adapter code',
+  fn: () => {
+    const code = codeOnly(depCode).toLowerCase();
+    assert.ok(!/kvnamespace/.test(code), 'dep adapter must not reference KVNamespace in code');
+    assert.ok(!/durableobject/.test(code), 'dep adapter must not reference DurableObject in code');
+    assert.ok(!/d1database/.test(code), 'dep adapter must not reference D1Database in code');
+    assert.ok(!/env\.kv\b/.test(code), 'dep adapter must not read env.KV in code');
+    assert.ok(!/env\.db\b/.test(code), 'dep adapter must not read env.DB in code');
+    assert.ok(!/env\.auth\b/.test(code), 'dep adapter must not read env.AUTH in code');
+    assert.ok(!/env\.firebase/.test(code), 'dep adapter must not read env.FIREBASE in code');
+  },
+});
+
+// ── 21. No fetch / XHR / axios in dep adapter code ─────────────────────────
+tests.push({
+  name: 'No fetch / XHR / axios in dep adapter code',
+  fn: () => {
+    const code = codeOnly(depCode).toLowerCase();
+    assert.ok(!/\bfetch\s*\(/.test(code), 'dep adapter must not call fetch() in code');
+    assert.ok(!/xmlhttprequest/.test(code), 'dep adapter must not use XMLHttpRequest in code');
+    assert.ok(!/axios/.test(code), 'dep adapter must not use axios in code');
+    assert.ok(!/new\s+request\s*\(/.test(code), 'dep adapter must not construct a new Request in code');
+  },
+});
+
+// ── 22. No provider SDK imports in dep adapter code ───────────────────────
+tests.push({
+  name: 'No provider SDK imports in dep adapter code (imports only)',
+  fn: () => {
+    const code = codeOnly(depCode).toLowerCase();
+    for (const provider of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'nvidia', 'cohere', 'perplexity']) {
+      const importPattern = new RegExp(`(import|require).*${provider}`, 'i');
+      assert.ok(!importPattern.test(code), `dep adapter must not import ${provider} in code`);
+    }
+  },
+});
+
+// ── 23. No secrets / env usage in dep adapter code ────────────────────────
+tests.push({
+  name: 'No raw secret / env auth binding / process.env reading in dep adapter code',
+  fn: () => {
+    const code = codeOnly(depCode).toLowerCase();
+    assert.ok(!/process\.env\.scout/.test(code), 'dep adapter must not read process.env.SCOUT_* in code');
+    assert.ok(!/import\.meta\.env/.test(code), 'dep adapter must not read import.meta.env in code');
+    assert.ok(!/process\.env\.firebase/.test(code), 'dep adapter must not read process.env.FIREBASE_* in code');
+    assert.ok(!/api_key\s*=/.test(code), 'dep adapter must not assign api_key in code');
+    assert.ok(!/bearer\s+/.test(code), 'dep adapter must not embed bearer tokens in code');
+  },
+});
+
+// ── 24. Verifier adapter module still exists and is well-formed ───────────
+tests.push({
+  name: 'Verifier adapter module still exists and is well-formed (no regression)',
+  fn: async () => {
+    const verifierMod = await loadVerifierModule();
+    assert.ok(typeof verifierMod.createScoutLiveAuthVerifierAdapter === 'function');
+    assert.ok(typeof verifierMod.SCOUT_LIVE_AUTH_VERIFIER_ADAPTER_VERSION === 'string');
+    assert.ok(typeof verifierMod.sanitizeScoutLiveAuthVerifierPayload === 'function');
+    assert.ok(typeof verifierMod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_ALLOWED_FIELDS !== 'undefined');
+    assert.ok(typeof verifierMod.SCOUT_LIVE_AUTH_VERIFIER_PAYLOAD_PROHIBITED_FIELDS !== 'undefined');
+  },
+});
+
+// ── 25. Docs reflect verifier adapter dependency wiring status ────────────
+tests.push({
+  name: 'Related docs exist and reflect verifier adapter dependency wiring status',
+  fn: () => {
+    for (const docName of DOCS) {
+      const docPath = path.join(ROOT, 'docs/product/' + docName);
+      const doc = readFileSafe(docPath);
+      assert.ok(doc.length > 0, `${docName} must exist`);
+    }
+    // The dependency adapter skeleton doc should mention verifier adapter wiring
+    const depDoc = readFileSafe(path.join(ROOT, 'docs/product/lovebud-scout-live-auth-rate-limit-dependency-adapter-skeleton.md'));
+    const lc = depDoc.toLowerCase();
+    assert.ok(
+      lc.includes('verifier') && (lc.includes('wiring') || lc.includes('wired') || lc.includes('routed')),
+      'dependency adapter doc should mention verifier adapter wiring'
+    );
+    // The verifier adapter skeleton doc should mention dependency wiring
+    const verifierDoc = readFileSafe(path.join(ROOT, 'docs/product/lovebud-scout-live-auth-verifier-adapter-skeleton.md'));
+    const lc2 = verifierDoc.toLowerCase();
+    assert.ok(
+      lc2.includes('dependency') && (lc2.includes('wiring') || lc2.includes('wired') || lc2.includes('adapter')),
+      'verifier adapter doc should mention dependency adapter wiring'
+    );
+  },
+});
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  \u2713 ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  \u2717 ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Refs #1882

Wires the auth verifier adapter skeleton into the live auth/rate-limit dependency adapter mock path. This slice is mock-path wiring only — no real Firebase Admin SDK, no real token verification, no external auth service call.

- live-auth-rate-limit-dependency-adapter.js imports createScoutLiveAuthVerifierAdapter
- createScoutLiveDependencyAdapter(options?) accepts a verifierAdapter option
- Default verifier dependency is createScoutLiveAuthVerifierAdapter({ mockDisabled: true })
- verifyToken routes through verifierAdapter.verifyToken with an allowlisted payload only (requestId / tokenHash / authorizationScheme / providerMode / endpointPath / nowMs)
- Verifier result codes mapped to dependency-adapter safe-fail codes:
  - VERIFIER_MOCK_DISABLED / VERIFIER_NOT_IMPLEMENTED → VERIFY_NOT_IMPLEMENTED
  - VERIFIER_PAYLOAD_PROHIBITED → VERIFY_PAYLOAD_PROHIBITED
  - unknown / missing → VERIFY_UNAVAILABLE
- Verifier adapter throw safe-swallowed → VERIFY_UNAVAILABLE
- checkRateLimit storage adapter wiring unchanged
- Adapter object remains frozen
- suggest.js NOT modified (wiring is dependency-internal)
- New codes: VERIFY_PAYLOAD_PROHIBITED, VERIFY_UNAVAILABLE
- No firebase-admin / no getAuth / no verifyIdToken / no verifyAccessToken / no cert / no initializeApp / no fetch / no KV / no DO / no D1 / no env auth binding
- Endpoint default stub / explicit stub / frontend local_stub / endpoint client default disabled all preserved

Closes the new subissue; references #1882.