### PR TITLE
feat(scout): explicitly map disabled storage outcomes

### DIFF
--- a/docs/product/lovebud-scout-storage-safe-fail-fallback-docs-alignment.md
+++ b/docs/product/lovebud-scout-storage-safe-fail-fallback-docs-alignment.md
@@ -1,20 +1,20 @@
 # LoveBud Scout Storage Safe-Fail Fallback Docs Alignment
 
-Version: v20260607-1  
-Status: docs-only alignment  
+Version: v20260607-2  
+Status: explicit mapping alignment  
 Parent issue: #1882  
-Slice issue: #2330  
-Previous contract: PR #2329
+Slice issue: #2334  
+Previous contracts: PR #2329, PR #2333
 
 ## 1. Purpose
 
-This note records the current LoveBud Scout rate-limit storage fallback position after PR #2329.
+This note records the current LoveBud Scout rate-limit storage mapping position after the explicit dependency-adapter mapping slice.
 
 The important conclusion is narrow:
 
-> Disabled rate-limit storage scaffold outcomes are currently covered by the existing dependency-adapter unknown storage-code safe-fail fallback. They fail closed as `RATE_LIMIT_STORAGE_UNAVAILABLE` without adding explicit runtime mapping.
+> Disabled rate-limit storage scaffold outcomes now have explicit dependency-adapter mapping to `RATE_LIMIT_STORAGE_UNAVAILABLE`.
 
-This is a documentation alignment slice only. It does not add a storage backend and does not change endpoint or frontend behavior.
+This remains a safe-fail scaffold alignment. It does not add a storage backend and does not change endpoint or frontend behavior.
 
 ## 2. Current behavior
 
@@ -25,16 +25,24 @@ The storage adapter scaffold may expose disabled/config-missing storage outcomes
 - `STORAGE_D1_DISABLED`
 - `STORAGE_CONFIG_MISSING`
 
-The live dependency adapter already has a generic unknown storage-code fallback. When an unrecognized storage result reaches the dependency adapter, it returns a fail-closed dependency result:
+The live dependency adapter now explicitly maps these outcomes to a fail-closed dependency result:
 
 ```text
 allowed: false
 code: RATE_LIMIT_STORAGE_UNAVAILABLE
 ```
 
-Therefore the current safe path is not explicit per-backend mapping. It is the existing canonical fallback path.
+The generic unknown storage-code fallback remains in place for future unrecognized storage outcomes.
 
-## 3. Why this is acceptable for the current slice
+## 3. Promotion from fallback-only to explicit mapping
+
+Earlier slices used the existing unknown storage-code fallback as the safe path for disabled storage scaffold outcomes.
+
+That was acceptable while the project was still validating the scaffold boundary.
+
+This slice promotes the known disabled/config-missing scaffold outcomes from fallback-only behavior to explicit mapping behavior, while preserving the same canonical dependency result: `RATE_LIMIT_STORAGE_UNAVAILABLE`.
+
+## 4. Why this is acceptable for the current slice
 
 The current project phase is still scaffold and contract validation, not live runtime storage implementation.
 
@@ -47,9 +55,9 @@ For this phase, the desired behavior is:
 - do not add endpoint-level storage wiring;
 - do not change the frontend source selector.
 
-The existing fallback satisfies that requirement because disabled or unrecognized storage outcomes become `RATE_LIMIT_STORAGE_UNAVAILABLE`.
+The explicit mapping satisfies that requirement because known disabled/config-missing storage outcomes become `RATE_LIMIT_STORAGE_UNAVAILABLE` deterministically.
 
-## 4. Explicit non-goals
+## 5. Explicit non-goals
 
 This alignment does not implement any of the following:
 
@@ -62,7 +70,7 @@ This alignment does not implement any of the following:
 - provider API integration;
 - production or staging rollout.
 
-## 5. Runtime guardrails
+## 6. Runtime guardrails
 
 The following guardrails remain unchanged:
 
@@ -73,23 +81,23 @@ The following guardrails remain unchanged:
 - no real storage backend is introduced;
 - no raw token, API key, prompt, excerpt, source URL, raw request body, or raw model output should be propagated into storage payloads.
 
-## 6. Future implementation note
+## 7. Future implementation note
 
-A later runtime storage implementation may replace the fallback-only behavior with explicit mappings for backend-specific disabled/config-missing outcomes.
+A later runtime storage implementation may replace disabled scaffold responses with real backend quota decisions.
 
 That future slice should be separate and should include:
 
-- explicit dependency-adapter mapping tests;
-- updated error taxonomy documentation;
 - storage backend selection policy;
+- backend-specific adapter contract tests;
+- updated error taxonomy documentation;
 - rollback / kill-switch confirmation;
 - observability field allowlist confirmation;
 - staging-live and production-live gate checks.
 
-Until then, the fallback-only behavior is the intended safe scaffold position.
+Until then, explicit disabled/config-missing mapping to `RATE_LIMIT_STORAGE_UNAVAILABLE` is the intended safe scaffold position.
 
-## 7. Current verdict
+## 8. Current verdict
 
-GO for docs alignment only.
+GO for explicit mapping alignment only.
 
 NO-GO for real storage runtime implementation in this slice.

--- a/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
+++ b/functions/api/scout/live-auth-rate-limit-dependency-adapter.js
@@ -243,6 +243,21 @@ function mapStorageResultToDependencyResponse(storageResult) {
       retryAfterSeconds: null,
     };
   }
+  if (
+    code === 'STORAGE_KV_DISABLED' ||
+    code === 'STORAGE_DURABLE_OBJECT_DISABLED' ||
+    code === 'STORAGE_D1_DISABLED' ||
+    code === 'STORAGE_CONFIG_MISSING'
+  ) {
+    return {
+      allowed: false,
+      code: SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_STORAGE_UNAVAILABLE,
+      reason: typeof res.reason === 'string' && res.reason.length > 0
+        ? res.reason
+        : 'rate-limit storage scaffold is disabled or not configured',
+      retryAfterSeconds: null,
+    };
+  }
   // Unknown / missing code → generic storage-unavailable safe-fail
   return {
     allowed: false,

--- a/tests/contracts/scout-disabled-storage-mapping-dependency-contract.test.cjs
+++ b/tests/contracts/scout-disabled-storage-mapping-dependency-contract.test.cjs
@@ -1,19 +1,18 @@
 /**
  * Scout Disabled Storage Mapping Dependency Contract Tests
- * v20260607-1
+ * v20260607-2
  *
- * Locks the expected dependency-adapter behavior for disabled rate-limit
- * storage scaffold outcomes:
+ * Locks the dependency-adapter explicit mapping behavior for disabled
+ * rate-limit storage scaffold outcomes:
  * - STORAGE_KV_DISABLED
  * - STORAGE_DURABLE_OBJECT_DISABLED
  * - STORAGE_D1_DISABLED
  * - STORAGE_CONFIG_MISSING
  *
  * Contract expectation in this slice:
- * - dependency adapter does NOT add explicit per-backend mapping yet
- * - these outcomes still fail closed through the existing unknown storage
- *   result fallback
- * - mapped dependency code remains RATE_LIMIT_STORAGE_UNAVAILABLE
+ * - dependency adapter now contains explicit disabled-storage mapping branches
+ * - these outcomes fail closed as RATE_LIMIT_STORAGE_UNAVAILABLE
+ * - unknown storage-code fallback remains preserved
  */
 
 'use strict';
@@ -51,18 +50,20 @@ async function loadDepModule() {
   return depModulePromise;
 }
 
+const DISABLED_STORAGE_CODES = Object.freeze([
+  'STORAGE_KV_DISABLED',
+  'STORAGE_DURABLE_OBJECT_DISABLED',
+  'STORAGE_D1_DISABLED',
+  'STORAGE_CONFIG_MISSING',
+]);
+
 const tests = [];
 
 tests.push({
-  name: 'Disabled storage scaffold codes are still covered by existing dependency-adapter fallback',
+  name: 'Disabled storage scaffold codes explicitly map to storage unavailable',
   fn: async () => {
     const mod = await loadDepModule();
-    for (const storageCodeValue of [
-      'STORAGE_KV_DISABLED',
-      'STORAGE_DURABLE_OBJECT_DISABLED',
-      'STORAGE_D1_DISABLED',
-      'STORAGE_CONFIG_MISSING',
-    ]) {
+    for (const storageCodeValue of DISABLED_STORAGE_CODES) {
       const adapter = mod.createScoutLiveDependencyAdapter({
         storageAdapter: {
           kind: 'test_storage_adapter',
@@ -73,30 +74,76 @@ tests.push({
         },
       });
       const result = await adapter.checkRateLimit({ requestId: 'req_test' });
-      assert.strictEqual(result.allowed, false, `${storageCodeValue} fallback must deny`);
+      assert.strictEqual(result.allowed, false, `${storageCodeValue} explicit mapping must deny`);
       assert.strictEqual(
         result.code,
         mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_STORAGE_UNAVAILABLE,
-        `${storageCodeValue} fallback must map to RATE_LIMIT_STORAGE_UNAVAILABLE`
+        `${storageCodeValue} explicit mapping must return RATE_LIMIT_STORAGE_UNAVAILABLE`
       );
     }
   },
 });
 
 tests.push({
-  name: 'Dependency adapter does not yet contain explicit disabled-storage mapping branches',
+  name: 'Dependency adapter contains explicit disabled-storage mapping branches',
   fn: () => {
-    assert.ok(!depCode.includes('STORAGE_KV_DISABLED'), 'dependency adapter must not yet map KV disabled scaffold');
-    assert.ok(!depCode.includes('STORAGE_DURABLE_OBJECT_DISABLED'), 'dependency adapter must not yet map Durable Object disabled scaffold');
-    assert.ok(!depCode.includes('STORAGE_D1_DISABLED'), 'dependency adapter must not yet map D1 disabled scaffold');
+    for (const storageCodeValue of DISABLED_STORAGE_CODES) {
+      assert.ok(depCode.includes(storageCodeValue), `dependency adapter must explicitly map ${storageCodeValue}`);
+    }
+    const firstDisabledCode = depCode.indexOf('STORAGE_KV_DISABLED');
+    const unknownFallback = depCode.indexOf('rate-limit storage adapter returned an unknown result');
+    assert.ok(firstDisabledCode >= 0, 'explicit disabled-storage mapping block must exist');
+    assert.ok(unknownFallback > firstDisabledCode, 'explicit disabled-storage mapping must appear before unknown fallback');
   },
 });
 
 tests.push({
-  name: 'Existing storage-unavailable fallback message/contract is preserved',
-  fn: () => {
-    assert.ok(depCode.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'), 'dependency adapter must expose RATE_LIMIT_STORAGE_UNAVAILABLE');
-    assert.ok(depCode.includes('rate-limit storage adapter returned an unknown result') || depCode.includes('rate-limit storage adapter threw an exception'), 'dependency adapter must retain storage-unavailable fallback path');
+  name: 'Unknown storage-code fallback remains preserved',
+  fn: async () => {
+    const mod = await loadDepModule();
+    const adapter = mod.createScoutLiveDependencyAdapter({
+      storageAdapter: {
+        kind: 'test_storage_adapter',
+        isMockDisabled: false,
+        async checkQuota() {
+          return { allowed: false, code: 'STORAGE_FUTURE_UNKNOWN', reason: 'fixture unknown storage code' };
+        },
+      },
+    });
+    const result = await adapter.checkRateLimit({ requestId: 'req_test' });
+    assert.strictEqual(result.allowed, false, 'unknown storage fallback must deny');
+    assert.strictEqual(
+      result.code,
+      mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_STORAGE_UNAVAILABLE,
+      'unknown storage fallback must remain RATE_LIMIT_STORAGE_UNAVAILABLE'
+    );
+    assert.ok(depCode.includes('rate-limit storage adapter returned an unknown result'), 'dependency adapter must retain unknown storage fallback message');
+  },
+});
+
+tests.push({
+  name: 'Existing storage mappings remain preserved',
+  fn: async () => {
+    const mod = await loadDepModule();
+    const cases = [
+      ['STORAGE_MOCK_DISABLED', mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED],
+      ['STORAGE_NOT_IMPLEMENTED', mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_NOT_IMPLEMENTED],
+      ['STORAGE_PAYLOAD_PROHIBITED', mod.SCOUT_LIVE_DEPENDENCY_ADAPTER_CODES.RATE_LIMIT_PAYLOAD_PROHIBITED],
+    ];
+    for (const [storageCodeValue, expectedDependencyCode] of cases) {
+      const adapter = mod.createScoutLiveDependencyAdapter({
+        storageAdapter: {
+          kind: 'test_storage_adapter',
+          isMockDisabled: false,
+          async checkQuota() {
+            return { allowed: false, code: storageCodeValue, reason: 'fixture existing storage code' };
+          },
+        },
+      });
+      const result = await adapter.checkRateLimit({ requestId: 'req_test' });
+      assert.strictEqual(result.allowed, false, `${storageCodeValue} must deny`);
+      assert.strictEqual(result.code, expectedDependencyCode, `${storageCodeValue} mapping must be preserved`);
+    }
   },
 });
 
@@ -133,16 +180,17 @@ tests.push({
     for (const provider of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'nvidia']) {
       assert.ok(!new RegExp(`(import|require).*${provider}`, 'i').test(depCode), `dependency adapter must not import ${provider}`);
     }
+    assert.ok(storageCode.includes('STORAGE_KV_DISABLED'), 'storage adapter disabled scaffold code must remain');
   },
 });
 
 tests.push({
-  name: 'Docs reflect fallback-only alignment for disabled storage mapping',
+  name: 'Docs reflect explicit mapping promotion for disabled storage mapping',
   fn: () => {
     const docPath = path.join(ROOT, 'docs/product/lovebud-scout-storage-safe-fail-fallback-docs-alignment.md');
     const doc = readFileSafe(docPath);
-    assert.ok(doc.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'), 'docs must reference RATE_LIMIT_STORAGE_UNAVAILABLE fallback');
-    assert.ok(doc.includes('existing dependency-adapter unknown storage-code safe-fail fallback') || doc.includes('fallback-only'), 'docs must describe fallback-only behavior');
+    assert.ok(doc.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'), 'docs must reference RATE_LIMIT_STORAGE_UNAVAILABLE');
+    assert.ok(doc.includes('explicit mapping') || doc.includes('Explicit Mapping'), 'docs must describe explicit mapping promotion');
   },
 });
 

--- a/tests/contracts/scout-rate-limit-storage-disabled-scaffold-contract.test.cjs
+++ b/tests/contracts/scout-rate-limit-storage-disabled-scaffold-contract.test.cjs
@@ -1,6 +1,6 @@
 /**
  * Scout Rate-Limit Storage Disabled Runtime Scaffold Contract Tests
- * v20260607-1
+ * v20260607-2
  *
  * Locks the disabled-by-default runtime storage scaffold for Scout live
  * rate-limit storage. This is scaffold-only: no real KV, Durable Object,
@@ -209,12 +209,13 @@ tests.push({
 });
 
 tests.push({
-  name: 'Dependency adapter and suggest.js are not wired to runtime storage scaffold in this slice',
+  name: 'Dependency adapter explicitly maps disabled storage scaffold while suggest.js remains unwired',
   fn: () => {
     assert.ok(depAdapterCode.length > 0, 'dependency adapter must exist');
-    assert.ok(!depAdapterCode.includes('STORAGE_KV_DISABLED'), 'dependency adapter must not yet map KV disabled scaffold');
-    assert.ok(!depAdapterCode.includes('STORAGE_DURABLE_OBJECT_DISABLED'), 'dependency adapter must not yet map Durable Object disabled scaffold');
-    assert.ok(!depAdapterCode.includes('STORAGE_D1_DISABLED'), 'dependency adapter must not yet map D1 disabled scaffold');
+    assert.ok(depAdapterCode.includes('STORAGE_KV_DISABLED'), 'dependency adapter must explicitly map KV disabled scaffold');
+    assert.ok(depAdapterCode.includes('STORAGE_DURABLE_OBJECT_DISABLED'), 'dependency adapter must explicitly map Durable Object disabled scaffold');
+    assert.ok(depAdapterCode.includes('STORAGE_D1_DISABLED'), 'dependency adapter must explicitly map D1 disabled scaffold');
+    assert.ok(depAdapterCode.includes('STORAGE_CONFIG_MISSING'), 'dependency adapter must explicitly map storage config missing');
     assert.ok(!suggestCode.includes('live-rate-limit-storage-adapter'), 'suggest.js must not import storage adapter in this slice');
     assert.ok(!suggestCode.includes('createScoutLiveRateLimitStorageAdapter'), 'suggest.js must not call storage adapter factory in this slice');
   },


### PR DESCRIPTION
Refs #1882

Closes #2334

Scope:
- Add explicit dependency-adapter mapping for disabled/config-missing storage scaffold outcomes.
- Preserve existing storage mappings and unknown storage-code fallback.
- Update related contracts and docs to reflect fallback-only to explicit mapping promotion.

Non-goals:
- No real KV, Durable Object, or D1 implementation.
- No endpoint behavior change.
- No frontend default source change.
- No provider integration.
- No deployment work.
- No Browse #1661 work.