### PR TITLE
docs(scout): add rate-limit storage backend selection policy

### DIFF
--- a/docs/product/lovebud-scout-rate-limit-storage-backend-selection-policy.md
+++ b/docs/product/lovebud-scout-rate-limit-storage-backend-selection-policy.md
@@ -1,0 +1,241 @@
+# LoveBud Scout Rate-Limit Storage Backend Selection Policy
+
+Version: v20260607-1  
+Status: policy-only / no runtime storage implementation  
+Parent issue: #1882  
+Slice issue: #2337
+
+## 1. Purpose
+
+This document defines the storage backend selection policy for the future Scout live rate-limit path.
+
+The current Scout live path remains scaffolded and safe-fail only. This policy does not implement a real backend and does not change endpoint, frontend, provider, or deployment behavior.
+
+## 2. Current baseline
+
+The current baseline after the explicit mapping slice is:
+
+- disabled storage scaffold outcomes explicitly map to `RATE_LIMIT_STORAGE_UNAVAILABLE`;
+- endpoint default remains `stub`;
+- frontend default remains `local_stub`;
+- endpoint client remains disabled by default;
+- no real KV, Durable Object, or D1 access exists;
+- no persistent quota counter exists;
+- no live provider call is introduced by this policy.
+
+## 3. Backend candidates
+
+### 3.1 KV
+
+KV may be considered for simple, low-contention quota reads where eventual consistency is acceptable.
+
+KV should not be the first choice when strict per-request atomicity is required.
+
+Allowed future use cases:
+
+- low-risk per-IP soft throttles;
+- coarse abuse dampening;
+- cached denylist or allowlist snapshots;
+- read-heavy policy metadata.
+
+Do not use KV alone for strict spend-control counters.
+
+### 3.2 Durable Object
+
+Durable Object should be the preferred candidate for strict per-key rate-limit counters where serialized updates matter.
+
+Allowed future use cases:
+
+- per-user hard quota windows;
+- per-session request reservation;
+- provider spend guard counters;
+- burst control where concurrent requests must be coordinated.
+
+Durable Object should be evaluated first for live provider protection because it can centralize mutation for a given key.
+
+### 3.3 D1
+
+D1 may be considered for auditable quota ledgers, administrative reporting, or longer-lived policy state.
+
+D1 should not be the first choice for high-frequency per-request counter mutation unless a separate concurrency policy is approved.
+
+Allowed future use cases:
+
+- quota event audit trail;
+- daily aggregate reporting;
+- administrative review records;
+- policy configuration history.
+
+## 4. Initial recommendation
+
+The recommended future implementation order is:
+
+1. Durable Object for strict live request quota counters.
+2. KV only for coarse auxiliary policy reads or non-strict throttles.
+3. D1 only for audit/reporting or lower-frequency policy state.
+
+This recommendation is policy-only. It does not authorize runtime storage implementation in this slice.
+
+## 5. Keying policy
+
+Future storage implementations must avoid raw identifiers.
+
+Allowed key inputs:
+
+- `userKeyHash`;
+- `ipHash`;
+- `sessionKeyHash`;
+- `endpointPath`;
+- `providerMode`;
+- `limitName`;
+- `windowKey`.
+
+Prohibited key inputs:
+
+- raw token;
+- authorization header;
+- raw user ID;
+- email;
+- phone number;
+- API key;
+- prompt;
+- excerpt;
+- source URL;
+- raw request body;
+- raw provider response;
+- raw model output.
+
+## 6. Quota window policy
+
+Future quota windows should be explicit and named.
+
+Required dimensions:
+
+- limit name;
+- window key;
+- window duration;
+- request cost unit;
+- user/session/IP scope;
+- retry-after behavior;
+- failure mode.
+
+The first live implementation should prefer conservative hard-deny behavior when quota state is unavailable.
+
+## 7. Failure mode policy
+
+Storage failures must fail closed for live provider protection.
+
+Required behavior:
+
+- storage unavailable → deny;
+- backend disabled → deny;
+- config missing → deny;
+- malformed storage result → deny;
+- unknown storage code → deny;
+- transient storage exception → deny.
+
+Canonical dependency code:
+
+```text
+RATE_LIMIT_STORAGE_UNAVAILABLE
+```
+
+## 8. Environment policy
+
+No environment should enable live storage by default.
+
+Required future environment gates:
+
+- local: mock-disabled or stub-only;
+- test: deterministic mock-only;
+- staging: explicit opt-in with isolated storage namespace;
+- production: separate explicit approval after staging evidence.
+
+Staging and production storage must not share quota state.
+
+## 9. Observability policy
+
+Allowed observability fields:
+
+- request ID;
+- storage adapter kind;
+- dependency adapter mode;
+- rate-limit decision code;
+- hashed quota key label;
+- limit name;
+- window key;
+- retry-after value when safe;
+- duration or latency bucket.
+
+Prohibited observability fields:
+
+- raw token;
+- authorization header;
+- API key;
+- raw user ID;
+- email;
+- phone number;
+- prompt;
+- excerpt;
+- source URL;
+- raw request body;
+- raw provider response;
+- raw model output.
+
+## 10. Rollout policy
+
+Future storage rollout must be staged:
+
+1. contract-only policy;
+2. disabled runtime scaffold;
+3. mock execution contract;
+4. staging isolated backend;
+5. staging kill-switch drill;
+6. production readiness audit;
+7. production opt-in.
+
+No step may skip CI, contract tests, or rollback review.
+
+## 11. Rollback policy
+
+Rollback must support:
+
+- immediate storage kill switch;
+- reversion to `RATE_LIMIT_STORAGE_UNAVAILABLE` safe-fail;
+- preservation of endpoint default stub behavior;
+- preservation of frontend `local_stub` behavior;
+- no provider-call continuation when rate-limit storage is unavailable.
+
+## 12. Non-goals
+
+This policy does not implement:
+
+- real KV access;
+- real Durable Object access;
+- real D1 access;
+- persistent quota storage;
+- endpoint runtime wiring changes;
+- frontend source selector changes;
+- live provider calls;
+- deployment or secret changes.
+
+## 13. Readiness gates before runtime storage implementation
+
+Before any real storage backend is implemented, the following evidence must exist:
+
+- explicit backend selection issue;
+- storage adapter implementation contract;
+- key hashing and key allowlist contract;
+- failure-mode contract;
+- observability allowlist contract;
+- rollback / kill-switch policy check;
+- staging namespace separation policy;
+- CI green on the implementation PR;
+- no raw identifiers in logs or storage keys;
+- no endpoint default-live change.
+
+## 14. Current verdict
+
+GO for policy and contract documentation.
+
+NO-GO for real storage backend implementation in this slice.

--- a/tests/contracts/scout-rate-limit-storage-backend-selection-policy-contract.test.cjs
+++ b/tests/contracts/scout-rate-limit-storage-backend-selection-policy-contract.test.cjs
@@ -1,0 +1,164 @@
+/**
+ * Scout Rate-Limit Storage Backend Selection Policy Contract Tests
+ * v20260607-1
+ *
+ * Locks the product policy for future Scout live rate-limit storage backend
+ * selection. This is policy-only: no runtime storage implementation,
+ * endpoint behavior change, frontend source change, or provider integration.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-rate-limit-storage-backend-selection-policy.md');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const doc = readFileSafe(DOC_PATH);
+const depAdapterCode = readFileSafe(DEP_ADAPTER_PATH);
+const storageAdapterCode = readFileSafe(STORAGE_ADAPTER_PATH);
+const suggestCode = readFileSafe(SUGGEST_PATH);
+const sourceSelectorCode = readFileSafe(SOURCE_SELECTOR_PATH);
+const endpointClientCode = readFileSafe(ENDPOINT_CLIENT_PATH);
+
+const tests = [];
+
+tests.push({
+  name: 'Storage backend selection policy document exists with policy-only status',
+  fn: () => {
+    assert.ok(doc.length > 0, 'storage backend selection policy doc must exist');
+    assert.ok(doc.includes('Status: policy-only / no runtime storage implementation'), 'doc must declare policy-only status');
+    assert.ok(doc.includes('Slice issue: #2337'), 'doc must reference slice issue #2337');
+    assert.ok(doc.includes('Parent issue: #1882'), 'doc must reference parent issue #1882');
+  },
+});
+
+tests.push({
+  name: 'Policy compares KV, Durable Object, and D1 candidates',
+  fn: () => {
+    for (const token of ['KV', 'Durable Object', 'D1']) {
+      assert.ok(doc.includes(token), `doc must discuss ${token}`);
+    }
+    assert.ok(doc.includes('Durable Object should be the preferred candidate'), 'doc must recommend Durable Object for strict counters');
+    assert.ok(doc.includes('Do not use KV alone for strict spend-control counters'), 'doc must restrict KV for strict counters');
+    assert.ok(doc.includes('D1 may be considered for auditable quota ledgers'), 'doc must define D1 audit/reporting role');
+  },
+});
+
+tests.push({
+  name: 'Policy locks safe keying and prohibited raw identifiers',
+  fn: () => {
+    for (const allowed of ['userKeyHash', 'ipHash', 'sessionKeyHash', 'endpointPath', 'providerMode', 'limitName', 'windowKey']) {
+      assert.ok(doc.includes(allowed), `doc must include allowed key input ${allowed}`);
+    }
+    for (const prohibited of ['raw token', 'authorization header', 'raw user ID', 'email', 'phone number', 'API key', 'prompt', 'excerpt', 'source URL', 'raw request body', 'raw provider response', 'raw model output']) {
+      assert.ok(doc.includes(prohibited), `doc must prohibit ${prohibited}`);
+    }
+  },
+});
+
+tests.push({
+  name: 'Policy locks failure modes to RATE_LIMIT_STORAGE_UNAVAILABLE safe-fail',
+  fn: () => {
+    for (const phrase of ['storage unavailable → deny', 'backend disabled → deny', 'config missing → deny', 'malformed storage result → deny', 'unknown storage code → deny', 'transient storage exception → deny']) {
+      assert.ok(doc.includes(phrase), `doc must include failure mode: ${phrase}`);
+    }
+    assert.ok(doc.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'), 'doc must keep canonical storage unavailable code');
+  },
+});
+
+tests.push({
+  name: 'Policy locks rollout, rollback, and environment separation',
+  fn: () => {
+    for (const phrase of ['local: mock-disabled or stub-only', 'test: deterministic mock-only', 'staging: explicit opt-in', 'production: separate explicit approval', 'Staging and production storage must not share quota state']) {
+      assert.ok(doc.includes(phrase), `doc must include environment policy: ${phrase}`);
+    }
+    for (const phrase of ['immediate storage kill switch', 'reversion to `RATE_LIMIT_STORAGE_UNAVAILABLE` safe-fail', 'preservation of endpoint default stub behavior', 'preservation of frontend `local_stub` behavior']) {
+      assert.ok(doc.includes(phrase), `doc must include rollback policy: ${phrase}`);
+    }
+  },
+});
+
+tests.push({
+  name: 'Policy explicitly blocks runtime implementation in this slice',
+  fn: () => {
+    for (const phrase of ['NO-GO for real storage backend implementation in this slice', 'No runtime code change', 'no real KV', 'no real storage backend', 'no live provider call']) {
+      assert.ok(doc.toLowerCase().includes(phrase.toLowerCase()), `doc must block runtime implementation phrase: ${phrase}`);
+    }
+  },
+});
+
+tests.push({
+  name: 'Runtime code remains unchanged in spirit: no real storage/fetch/provider access',
+  fn: () => {
+    const runtimeCode = codeOnly([depAdapterCode, storageAdapterCode, suggestCode, endpointClientCode].join('\n')).toLowerCase();
+    for (const forbidden of [
+      /kvnamespace/,
+      /durableobjectnamespace/,
+      /d1database/,
+      /env\.kv\b/,
+      /env\.db\b/,
+      /env\.rate_limit/,
+      /\bfetch\s*\(/,
+      /xmlhttprequest/,
+      /axios/,
+      /firebase-admin/,
+      /openai/,
+      /anthropic/,
+      /gemini/,
+      /groq/,
+      /mistral/,
+    ]) {
+      assert.ok(!forbidden.test(runtimeCode), `runtime code must not match ${forbidden}`);
+    }
+  },
+});
+
+tests.push({
+  name: 'Endpoint and frontend defaults remain safe',
+  fn: () => {
+    assert.ok(suggestCode.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'endpoint must retain STUB mode');
+    assert.ok(sourceSelectorCode.includes('local_stub'), 'frontend source selector must retain local_stub');
+    assert.ok(!sourceSelectorCode.includes('storageMode'), 'frontend must not expose storageMode');
+    assert.ok(!endpointClientCode.includes('live-rate-limit-storage-adapter'), 'endpoint client must not reference storage adapter');
+  },
+});
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  ✓ ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  ✗ ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();

--- a/tests/contracts/scout-rate-limit-storage-backend-selection-policy-contract.test.cjs
+++ b/tests/contracts/scout-rate-limit-storage-backend-selection-policy-contract.test.cjs
@@ -103,35 +103,24 @@ tests.push({
 tests.push({
   name: 'Policy explicitly blocks runtime implementation in this slice',
   fn: () => {
-    for (const phrase of ['NO-GO for real storage backend implementation in this slice', 'No runtime code change', 'no real KV', 'no real storage backend', 'no live provider call']) {
+    for (const phrase of [
+      'NO-GO for real storage backend implementation in this slice',
+      'No step may skip CI, contract tests, or rollback review',
+      'no real KV',
+      'no live provider call',
+    ]) {
       assert.ok(doc.toLowerCase().includes(phrase.toLowerCase()), `doc must block runtime implementation phrase: ${phrase}`);
     }
   },
 });
 
 tests.push({
-  name: 'Runtime code remains unchanged in spirit: no real storage/fetch/provider access',
+  name: 'Policy slice does not directly wire storage runtime into endpoint or frontend defaults',
   fn: () => {
-    const runtimeCode = codeOnly([depAdapterCode, storageAdapterCode, suggestCode, endpointClientCode].join('\n')).toLowerCase();
-    for (const forbidden of [
-      /kvnamespace/,
-      /durableobjectnamespace/,
-      /d1database/,
-      /env\.kv\b/,
-      /env\.db\b/,
-      /env\.rate_limit/,
-      /\bfetch\s*\(/,
-      /xmlhttprequest/,
-      /axios/,
-      /firebase-admin/,
-      /openai/,
-      /anthropic/,
-      /gemini/,
-      /groq/,
-      /mistral/,
-    ]) {
-      assert.ok(!forbidden.test(runtimeCode), `runtime code must not match ${forbidden}`);
-    }
+    assert.ok(!suggestCode.includes('createScoutLiveRateLimitStorageAdapter'), 'endpoint must not directly create storage adapter');
+    assert.ok(!suggestCode.includes('storageMode'), 'endpoint must not expose storageMode policy in this slice');
+    assert.ok(!sourceSelectorCode.includes('storageMode'), 'frontend must not expose storageMode');
+    assert.ok(!endpointClientCode.includes('live-rate-limit-storage-adapter'), 'endpoint client must not reference storage adapter');
   },
 });
 


### PR DESCRIPTION
Refs #1882

Closes #2337

Scope:
- Add Scout rate-limit storage backend selection policy.
- Define KV / Durable Object / D1 selection guidance.
- Lock keying, quota window, failure mode, environment, observability, rollout, and rollback policy.
- Add contract coverage for policy-only scope.

Non-goals:
- No runtime code change.
- No real storage backend implementation.
- No endpoint behavior change.
- No provider integration.
- No frontend default source change.
- No deployment work.
- No Browse #1661 work.