### PR TITLE
feat(scout): add storage key builder disabled scaffold

### DIFF
--- a/docs/product/lovebud-scout-storage-key-builder-disabled-scaffold.md
+++ b/docs/product/lovebud-scout-storage-key-builder-disabled-scaffold.md
@@ -1,0 +1,145 @@
+# LoveBud Scout Storage Key Builder Disabled Scaffold
+
+Version: v20260607-1  
+Status: disabled scaffold / no live storage key generation  
+Parent issue: #1882  
+Slice issue: #2341  
+Depends on: #2339
+
+## 1. Purpose
+
+This document defines the disabled-by-default scaffold for future Scout live rate-limit storage key construction.
+
+The scaffold exists so the project can lock the interface, allowlist, prohibited input policy, and safe-fail behavior before any real storage key generation, hashing secret, KV, Durable Object, D1, endpoint behavior change, frontend source change, provider integration, deployment change, or Browse #1661 work.
+
+## 2. Scope
+
+This slice adds a scaffold module only:
+
+```text
+functions/api/scout/live-rate-limit-storage-key-builder.js
+```
+
+The scaffold may expose constants, allowlists, prohibited-input lists, a sanitizer, a disabled build function, and a factory.
+
+The scaffold must not generate usable storage keys for live traffic.
+
+## 3. Allowed inputs
+
+The scaffold locks the same future storage key inputs from the prior key hashing and allowlist contract:
+
+- `userKeyHash`;
+- `ipHash`;
+- `sessionKeyHash`;
+- `endpointPath`;
+- `providerMode`;
+- `limitName`;
+- `windowKey`.
+
+The scaffold must copy only allowed fields into the sanitized payload.
+
+## 4. Prohibited inputs
+
+The scaffold must reject or remove raw/sensitive fields, including:
+
+- raw token;
+- authorization header;
+- raw user ID;
+- email;
+- phone number;
+- API key;
+- prompt;
+- excerpt;
+- source URL;
+- raw request body;
+- raw provider response;
+- raw model output;
+- password;
+- cookie;
+- Firebase token.
+
+## 5. Disabled behavior
+
+The scaffold must be disabled by default.
+
+Required behavior:
+
+- `createScoutLiveRateLimitStorageKeyBuilder()` returns an object with `disabled: true`;
+- `buildScoutLiveRateLimitStorageKey()` returns `ok: false` by default;
+- the returned `storageKey` is always `null`;
+- the returned `keyPreview` is always `null`;
+- no usable storage key is generated;
+- prohibited fields return a safe prohibited-payload response;
+- unknown fields are not copied into the sanitized payload.
+
+Canonical scaffold codes:
+
+```text
+STORAGE_KEY_BUILDER_DISABLED
+STORAGE_KEY_BUILDER_NOT_IMPLEMENTED
+STORAGE_KEY_PAYLOAD_PROHIBITED
+```
+
+## 6. Non-goals
+
+This scaffold does not implement:
+
+- real storage key generation for live traffic;
+- real hash helper;
+- real hashing secret or salt access;
+- real KV access;
+- real Durable Object access;
+- real D1 access;
+- endpoint wiring;
+- dependency adapter wiring;
+- frontend source selector changes;
+- provider integration;
+- deployment or secret configuration;
+- Browse #1661 work.
+
+## 7. Runtime safety constraints
+
+The scaffold must not contain or call:
+
+- `crypto.subtle.digest`;
+- `createHash`;
+- `HMAC`;
+- `SCOUT_STORAGE_KEY_SALT`;
+- `SCOUT_RATE_LIMIT_KV`;
+- `SCOUT_RATE_LIMIT_DO`;
+- `SCOUT_RATE_LIMIT_D1`;
+- `DurableObjectNamespace`;
+- `fetch(`;
+- provider SDK calls.
+
+## 8. Endpoint and frontend preservation
+
+This slice must preserve:
+
+- endpoint default `stub` behavior;
+- frontend default `local_stub` behavior;
+- endpoint client disabled-by-default behavior;
+- no live provider call;
+- no runtime storage backend call.
+
+The scaffold module must not be imported by `functions/api/scout/suggest.js` in this slice.
+
+## 9. Future implementation gates
+
+Before a real storage key builder may replace this disabled scaffold, the project must add:
+
+- a dedicated implementation issue;
+- deterministic hash helper tests;
+- salt/version policy tests;
+- raw preimage non-persistence tests;
+- log redaction tests;
+- endpoint safe-fail tests;
+- staging/prod key namespace separation tests;
+- rollback/kill-switch confirmation;
+- CI green evidence.
+
+## 10. Current verdict
+
+GO for disabled scaffold and contract tests.
+
+NO-GO for real key generation, real hashing, real storage backend access, endpoint wiring, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.

--- a/functions/api/scout/live-rate-limit-storage-key-builder.js
+++ b/functions/api/scout/live-rate-limit-storage-key-builder.js
@@ -1,0 +1,157 @@
+/**
+ * Scout Live Rate-Limit Storage Key Builder — Disabled Scaffold
+ * v20260607-1
+ *
+ * Disabled-by-default scaffold for future Scout live rate-limit storage key
+ * construction. This module intentionally does not generate usable runtime
+ * storage keys for live traffic and does not access hashing secrets, salts,
+ * KV, Durable Object, D1, provider SDKs, network fetch, or endpoint state.
+ */
+
+'use strict';
+
+// ─── Version ────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_VERSION = '20260607-1';
+
+// ─── Modes ──────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_MODES = Object.freeze({
+  DISABLED: 'disabled',
+  NOT_IMPLEMENTED: 'not_implemented',
+});
+
+// ─── Codes ──────────────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES = Object.freeze({
+  STORAGE_KEY_BUILDER_DISABLED: 'STORAGE_KEY_BUILDER_DISABLED',
+  STORAGE_KEY_BUILDER_NOT_IMPLEMENTED: 'STORAGE_KEY_BUILDER_NOT_IMPLEMENTED',
+  STORAGE_KEY_PAYLOAD_PROHIBITED: 'STORAGE_KEY_PAYLOAD_PROHIBITED',
+});
+
+// ─── Payload Policy ─────────────────────────────────────────────────────────
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_ALLOWED_INPUTS = Object.freeze([
+  'userKeyHash',
+  'ipHash',
+  'sessionKeyHash',
+  'endpointPath',
+  'providerMode',
+  'limitName',
+  'windowKey',
+]);
+
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_PROHIBITED_INPUTS = Object.freeze([
+  'token',
+  'rawToken',
+  'authorization',
+  'authorizationHeader',
+  'rawUserId',
+  'rawUserID',
+  'rawUserIdentifier',
+  'uid',
+  'firebaseUid',
+  'email',
+  'phone',
+  'phoneNumber',
+  'apiKey',
+  'secret',
+  'prompt',
+  'excerpt',
+  'sourceUrl',
+  'rawRequestBody',
+  'rawProviderResponse',
+  'rawModelOutput',
+  'password',
+  'cookie',
+  'sessionCookie',
+  'firebaseToken',
+]);
+
+const DEFAULT_OPTIONS = Object.freeze({
+  disabled: true,
+  onProhibitedField: 'reject',
+});
+
+function normalizeOptions(options) {
+  return Object.assign({}, DEFAULT_OPTIONS, options || {});
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function sanitizeScoutLiveRateLimitStorageKeyPayload(payload, options) {
+  const opts = normalizeOptions(options);
+  const src = isPlainObject(payload) ? payload : {};
+  const sanitized = {};
+  const rejectedFields = [];
+
+  for (const key of Object.keys(src)) {
+    if (SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_PROHIBITED_INPUTS.includes(key)) {
+      rejectedFields.push(key);
+      if (opts.onProhibitedField === 'reject') {
+        return { payload: {}, rejected: true, rejectedFields };
+      }
+      continue;
+    }
+
+    if (SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_ALLOWED_INPUTS.includes(key)) {
+      sanitized[key] = src[key];
+    }
+  }
+
+  return { payload: sanitized, rejected: false, rejectedFields };
+}
+
+function buildDisabledResponse(payload, rejectedFields) {
+  return {
+    ok: false,
+    disabled: true,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_BUILDER_DISABLED,
+    reason: 'Scout live rate-limit storage key builder is disabled; no runtime storage key is generated.',
+    storageKey: null,
+    keyPreview: null,
+    payload,
+    rejectedFields: rejectedFields || [],
+  };
+}
+
+function buildProhibitedResponse(rejectedFields) {
+  return {
+    ok: false,
+    disabled: true,
+    code: SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED,
+    reason: 'Scout live rate-limit storage key payload contains prohibited fields.',
+    storageKey: null,
+    keyPreview: null,
+    payload: {},
+    rejectedFields,
+  };
+}
+
+export function buildScoutLiveRateLimitStorageKey(payload, options) {
+  const sanitized = sanitizeScoutLiveRateLimitStorageKeyPayload(payload, options);
+
+  if (sanitized.rejected) {
+    return buildProhibitedResponse(sanitized.rejectedFields);
+  }
+
+  return buildDisabledResponse(sanitized.payload, sanitized.rejectedFields);
+}
+
+export function createScoutLiveRateLimitStorageKeyBuilder(options) {
+  const opts = normalizeOptions(options);
+
+  return Object.freeze({
+    kind: 'scout_live_rate_limit_storage_key_builder',
+    version: SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_VERSION,
+    mode: opts.disabled
+      ? SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_MODES.DISABLED
+      : SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_MODES.NOT_IMPLEMENTED,
+    disabled: true,
+    allowedInputs: SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_ALLOWED_INPUTS,
+    prohibitedInputs: SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_PROHIBITED_INPUTS,
+    buildKey: (payload) => buildScoutLiveRateLimitStorageKey(payload, opts),
+  });
+}

--- a/tests/contracts/scout-storage-key-builder-disabled-scaffold-contract.test.cjs
+++ b/tests/contracts/scout-storage-key-builder-disabled-scaffold-contract.test.cjs
@@ -1,0 +1,193 @@
+/**
+ * Scout Storage Key Builder Disabled Scaffold Contract Tests
+ * v20260607-1
+ *
+ * Locks disabled-by-default behavior for the future Scout live rate-limit
+ * storage key builder. This contract allows the scaffold module but blocks
+ * real key generation, real hashing, real storage access, endpoint wiring,
+ * frontend source changes, provider integration, and Browse #1661 work.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const MODULE_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-key-builder.js');
+const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-storage-key-builder-disabled-scaffold.md');
+const PRIOR_CONTRACT_DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-storage-key-hashing-allowlist-contract.md');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const moduleSource = readFile(MODULE_PATH);
+const moduleCode = codeOnly(moduleSource);
+const doc = readFile(DOC_PATH);
+const priorDoc = readFile(PRIOR_CONTRACT_DOC_PATH);
+const suggest = readFile(SUGGEST_PATH);
+const suggestCode = codeOnly(suggest);
+const sourceSelector = readFile(SOURCE_SELECTOR_PATH);
+const endpointClient = readFile(ENDPOINT_CLIENT_PATH);
+
+const tests = [];
+
+function push(name, fn) {
+  tests.push({ name, fn });
+}
+
+const allowedInputs = [
+  'userKeyHash',
+  'ipHash',
+  'sessionKeyHash',
+  'endpointPath',
+  'providerMode',
+  'limitName',
+  'windowKey',
+];
+
+const prohibitedInputs = [
+  'rawToken',
+  'authorizationHeader',
+  'rawUserId',
+  'rawUserIdentifier',
+  'email',
+  'phoneNumber',
+  'apiKey',
+  'prompt',
+  'excerpt',
+  'sourceUrl',
+  'rawRequestBody',
+  'rawProviderResponse',
+  'rawModelOutput',
+  'firebaseToken',
+];
+
+push('Disabled scaffold module and doc exist with expected references', () => {
+  assert.ok(moduleSource.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_VERSION'));
+  assert.ok(doc.includes('Status: disabled scaffold / no live storage key generation'));
+  assert.ok(doc.includes('Parent issue: #1882'));
+  assert.ok(doc.includes('Slice issue: #2341'));
+  assert.ok(doc.includes('Depends on: #2339'));
+});
+
+push('Scaffold exports expected boundary names', () => {
+  for (const exported of [
+    'SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_VERSION',
+    'SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_MODES',
+    'SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES',
+    'SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_ALLOWED_INPUTS',
+    'SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_PROHIBITED_INPUTS',
+    'sanitizeScoutLiveRateLimitStorageKeyPayload',
+    'buildScoutLiveRateLimitStorageKey',
+    'createScoutLiveRateLimitStorageKeyBuilder',
+  ]) {
+    assert.ok(moduleSource.includes('export const ' + exported) || moduleSource.includes('export function ' + exported), `missing export ${exported}`);
+  }
+});
+
+push('Scaffold locks allowed and prohibited input names', () => {
+  for (const allowed of allowedInputs) {
+    assert.ok(moduleSource.includes("'" + allowed + "'"), `module must include allowed input ${allowed}`);
+    assert.ok(doc.includes('`' + allowed + '`'), `doc must include allowed input ${allowed}`);
+    assert.ok(priorDoc.includes('`' + allowed + '`'), `prior contract must include allowed input ${allowed}`);
+  }
+  for (const prohibited of prohibitedInputs) {
+    assert.ok(moduleSource.includes("'" + prohibited + "'"), `module must include prohibited input ${prohibited}`);
+  }
+});
+
+push('Scaffold default behavior is disabled and never returns a usable key', () => {
+  assert.ok(moduleSource.includes('disabled: true'), 'factory/result must expose disabled true');
+  assert.ok(moduleSource.includes('ok: false'), 'builder must safe-fail');
+  assert.ok(moduleSource.includes('storageKey: null'), 'builder must not return storageKey');
+  assert.ok(moduleSource.includes('keyPreview: null'), 'builder must not return keyPreview');
+  assert.ok(moduleSource.includes('STORAGE_KEY_BUILDER_DISABLED'), 'disabled code must be present');
+  assert.ok(moduleSource.includes('STORAGE_KEY_PAYLOAD_PROHIBITED'), 'prohibited payload code must be present');
+});
+
+push('Scaffold sanitizer is allowlist-only and rejects prohibited payloads', () => {
+  assert.ok(moduleSource.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_ALLOWED_INPUTS.includes(key)'), 'sanitizer must copy only allowed fields');
+  assert.ok(moduleSource.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_PROHIBITED_INPUTS.includes(key)'), 'sanitizer must inspect prohibited fields');
+  assert.ok(moduleSource.includes("onProhibitedField: 'reject'"), 'default must reject prohibited fields');
+  assert.ok(moduleSource.includes('rejected: true'), 'sanitizer must support rejected true');
+  assert.ok(moduleSource.includes('rejectedFields'), 'sanitizer must report rejected fields');
+});
+
+push('Scaffold blocks real hashing, secrets, storage backends, network, and provider integration', () => {
+  for (const forbidden of [
+    'crypto.subtle.digest',
+    'createHash',
+    'HMAC',
+    'SCOUT_STORAGE_KEY_SALT',
+    'SCOUT_RATE_LIMIT_KV',
+    'SCOUT_RATE_LIMIT_DO',
+    'SCOUT_RATE_LIMIT_D1',
+    'DurableObjectNamespace',
+    'fetch(',
+    'axios',
+    'openai.chat.completions',
+    'anthropic.messages',
+    'generateContent',
+  ]) {
+    assert.ok(!moduleCode.includes(forbidden), `module must not include ${forbidden}`);
+  }
+});
+
+push('Documentation locks non-goals and future gates', () => {
+  for (const phrase of [
+    'The scaffold must not generate usable storage keys for live traffic.',
+    'No-GO for real key generation',
+    'No-GO for real key generation, real hashing, real storage backend access, endpoint wiring, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.',
+    'deterministic hash helper tests',
+    'salt/version policy tests',
+    'raw preimage non-persistence tests',
+    'staging/prod key namespace separation tests',
+  ]) {
+    assert.ok(doc.toLowerCase().includes(phrase.toLowerCase()), `doc must include ${phrase}`);
+  }
+});
+
+push('Endpoint and frontend are not wired to the new key builder scaffold', () => {
+  assert.ok(!suggestCode.includes('live-rate-limit-storage-key-builder'), 'suggest.js must not import key builder scaffold');
+  assert.ok(!suggestCode.includes('createScoutLiveRateLimitStorageKeyBuilder'), 'suggest.js must not create key builder');
+  assert.ok(!sourceSelector.includes('storageKeyBuilder'), 'frontend selector must not expose key builder');
+  assert.ok(!endpointClient.includes('storageKeyBuilder'), 'endpoint client must not expose key builder');
+});
+
+push('Endpoint default stub and frontend local_stub remain preserved', () => {
+  assert.ok(suggest.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'endpoint must retain STUB mode');
+  assert.ok(sourceSelector.includes('local_stub'), 'frontend source selector must retain local_stub');
+  assert.ok(endpointClient.includes('Disabled by default'), 'endpoint client must remain disabled by default');
+});
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  ✓ ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  ✗ ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Refs #1882

Closes #2341

Scope:
- Add disabled-by-default Scout live rate-limit storage key builder scaffold.
- Expose constants, allowlists, prohibited-field checks, sanitizer, disabled build response, and factory.
- Add product documentation for the disabled scaffold boundary and future implementation gates.
- Add contract coverage for disabled default behavior, no usable runtime key, no real hashing secret/salt usage, no real KV / Durable Object / D1 access, no endpoint wiring, no frontend source change, and no provider integration.

Non-goals:
- No real storage key generation for live traffic.
- No real hashing implementation or secret/salt access.
- No real KV, Durable Object, or D1 implementation.
- No endpoint behavior change.
- No frontend default source change.
- No provider integration.
- No Browse #1661 work.