### PR TITLE
feat(scout): wire disabled storage key builder into adapter

### DIFF
--- a/docs/product/lovebud-scout-storage-key-builder-adapter-wiring.md
+++ b/docs/product/lovebud-scout-storage-key-builder-adapter-wiring.md
@@ -1,0 +1,116 @@
+# LoveBud Scout Storage Key Builder Adapter Wiring
+
+Version: v20260607-1  
+Status: disabled wiring / no live storage key generation  
+Parent issue: #1882  
+Slice issue: #2343  
+Depends on: #2341
+
+## 1. Purpose
+
+This document defines the storage adapter wiring boundary for the disabled Scout live rate-limit storage key builder scaffold.
+
+The purpose of this slice is narrow: the storage adapter may recognize and call the disabled key builder while still failing closed. The adapter must not generate a usable storage key, access hashing secrets or salts, call KV, Durable Object, or D1, change endpoint behavior, change frontend defaults, integrate a provider, deploy secrets, or touch Browse #1661.
+
+## 2. Runtime files
+
+This slice may update:
+
+```text
+functions/api/scout/live-rate-limit-storage-adapter.js
+```
+
+It may rely on the already-merged disabled scaffold:
+
+```text
+functions/api/scout/live-rate-limit-storage-key-builder.js
+```
+
+It must not import the key builder from:
+
+```text
+functions/api/scout/suggest.js
+js/scout/scout-suggestion-source-selector.js
+js/scout/scout-suggestion-endpoint-client.js
+```
+
+## 3. Allowed wiring
+
+Allowed adapter-level wiring:
+
+- import the disabled key builder scaffold;
+- create a disabled key builder only inside the storage adapter runtime scaffold path;
+- expose `hasStorageKeyBuilder: true` only on disabled runtime scaffold adapters;
+- call `storageKeyBuilder.buildKey(payload)` only from disabled runtime scaffold methods;
+- include a sanitized `storageKeyBuilder` result in safe-fail responses;
+- preserve `storageKey: null` and `keyPreview: null`;
+- map prohibited key-builder payloads to `STORAGE_KEY_PAYLOAD_PROHIBITED`;
+- keep all storage methods returning denied/safe-fail responses.
+
+## 4. Disallowed wiring
+
+Disallowed behavior:
+
+- no usable storage key generation;
+- no real hash helper;
+- no hashing secret or salt access;
+- no KV read/write/delete;
+- no Durable Object namespace, id, stub, or fetch;
+- no D1 prepare/batch/exec;
+- no endpoint import or behavior change;
+- no frontend source selector change;
+- no provider SDK or live provider call;
+- no deployment or secret configuration;
+- no Browse #1661 work.
+
+## 5. Safe-fail response policy
+
+When a disabled runtime storage scaffold calls the disabled key builder, the adapter response may include:
+
+```text
+storageKeyBuilder: {
+  ok: false,
+  disabled: true,
+  code: STORAGE_KEY_BUILDER_DISABLED | STORAGE_KEY_PAYLOAD_PROHIBITED,
+  storageKey: null,
+  keyPreview: null,
+  rejectedFields: []
+}
+```
+
+The top-level storage adapter response must still deny quota actions:
+
+- `checkQuota()` returns `allowed: false`;
+- `consumeQuota()` returns `allowed: false`;
+- `releaseQuota()` returns `released: false`.
+
+## 6. Default behavior preservation
+
+Default storage adapter behavior must remain mock-disabled.
+
+Required defaults:
+
+- `createScoutLiveRateLimitStorageAdapter()` still returns `mockDisabled: true`;
+- default adapter does not call the key builder;
+- default adapter has `hasStorageKeyBuilder: false`;
+- endpoint default remains `stub`;
+- frontend default remains `local_stub`;
+- endpoint client remains disabled by default.
+
+## 7. Contract expectations
+
+Contract tests must prove:
+
+- storage adapter imports the disabled key builder scaffold;
+- runtime scaffold adapters expose `hasStorageKeyBuilder: true`;
+- default mock-disabled adapters expose `hasStorageKeyBuilder: false`;
+- key builder safe-fail result is included only in runtime scaffold responses;
+- returned `storageKey` and `keyPreview` remain `null`;
+- prohibited payloads map to `STORAGE_KEY_PAYLOAD_PROHIBITED`;
+- no real hashing, salt, KV, Durable Object, D1, endpoint wiring, frontend wiring, provider integration, or Browse #1661 work is introduced.
+
+## 8. Current verdict
+
+GO for disabled storage key builder to storage adapter safe-fail wiring.
+
+NO-GO for real key generation, real hashing, real storage backend access, endpoint wiring, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.

--- a/functions/api/scout/live-rate-limit-storage-adapter.js
+++ b/functions/api/scout/live-rate-limit-storage-adapter.js
@@ -1,6 +1,6 @@
 /**
  * Scout Live Rate-Limit Storage Adapter Skeleton
- * v20260607-2
+ * v20260607-3
  *
  * Mock-disabled storage adapter skeleton for the Scout live provider path.
  * Provides a future interface for persistent rate-limit quota state
@@ -38,9 +38,14 @@
 
 'use strict';
 
+import {
+  createScoutLiveRateLimitStorageKeyBuilder,
+  SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES,
+} from './live-rate-limit-storage-key-builder.js';
+
 // ─── Version ────────────────────────────────────────────────────────────────
 
-export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION = '20260607-2';
+export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION = '20260607-3';
 
 // ─── Storage Mode Constants ────────────────────────────────────────────────
 
@@ -61,6 +66,8 @@ export const SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES = Object.freeze({
   STORAGE_MOCK_DISABLED: 'STORAGE_MOCK_DISABLED',
   STORAGE_NOT_IMPLEMENTED: 'STORAGE_NOT_IMPLEMENTED',
   STORAGE_PAYLOAD_PROHIBITED: 'STORAGE_PAYLOAD_PROHIBITED',
+  STORAGE_KEY_BUILDER_DISABLED: 'STORAGE_KEY_BUILDER_DISABLED',
+  STORAGE_KEY_PAYLOAD_PROHIBITED: 'STORAGE_KEY_PAYLOAD_PROHIBITED',
   STORAGE_KV_DISABLED: 'STORAGE_KV_DISABLED',
   STORAGE_DURABLE_OBJECT_DISABLED: 'STORAGE_DURABLE_OBJECT_DISABLED',
   STORAGE_D1_DISABLED: 'STORAGE_D1_DISABLED',
@@ -115,6 +122,7 @@ export const SCOUT_LIVE_RATE_LIMIT_STORAGE_PAYLOAD_PROHIBITED_FIELDS = Object.fr
 const DEFAULT_OPTIONS = Object.freeze({
   mockDisabled: true,
   storageMode: null,
+  storageKeyBuilder: null,
   onProhibitedField: 'drop', // 'drop' | 'reject'
 });
 
@@ -237,32 +245,70 @@ function getRuntimeScaffoldReason(mode) {
   return 'Live rate-limit storage runtime scaffold is disabled-by-default; no real storage is accessed.';
 }
 
-function buildRuntimeScaffoldCheckResponse(mode) {
+function resolveDisabledStorageKeyBuilder(options) {
+  const injectedBuilder = options && options.storageKeyBuilder;
+  if (injectedBuilder && typeof injectedBuilder.buildKey === 'function') {
+    return injectedBuilder;
+  }
+
+  return createScoutLiveRateLimitStorageKeyBuilder({
+    disabled: true,
+    onProhibitedField: options && options.onProhibitedField,
+  });
+}
+
+function normalizeStorageKeyBuilderResult(result) {
+  const src = result && typeof result === 'object' ? result : {};
+  const code = src.code || SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_BUILDER_DISABLED;
+
+  return {
+    ok: false,
+    disabled: true,
+    code,
+    storageKey: null,
+    keyPreview: null,
+    rejectedFields: Array.isArray(src.rejectedFields) ? src.rejectedFields : [],
+  };
+}
+
+function buildRuntimeScaffoldCheckResponse(mode, keyBuilderResult) {
+  const normalizedKeyBuilderResult = normalizeStorageKeyBuilderResult(keyBuilderResult);
   return {
     allowed: false,
-    code: getRuntimeScaffoldCode(mode),
+    code: normalizedKeyBuilderResult.code === SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      ? SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      : getRuntimeScaffoldCode(mode),
     mode,
     reason: getRuntimeScaffoldReason(mode),
     retryAfterSeconds: null,
     remaining: null,
+    storageKeyBuilder: normalizedKeyBuilderResult,
   };
 }
 
-function buildRuntimeScaffoldConsumeResponse(mode) {
+function buildRuntimeScaffoldConsumeResponse(mode, keyBuilderResult) {
+  const normalizedKeyBuilderResult = normalizeStorageKeyBuilderResult(keyBuilderResult);
   return {
     allowed: false,
-    code: getRuntimeScaffoldCode(mode),
+    code: normalizedKeyBuilderResult.code === SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      ? SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      : getRuntimeScaffoldCode(mode),
     mode,
     reason: getRuntimeScaffoldReason(mode),
+    storageKeyBuilder: normalizedKeyBuilderResult,
   };
 }
 
-function buildRuntimeScaffoldReleaseResponse(mode) {
+function buildRuntimeScaffoldReleaseResponse(mode, keyBuilderResult) {
+  const normalizedKeyBuilderResult = normalizeStorageKeyBuilderResult(keyBuilderResult);
   return {
     released: false,
-    code: getRuntimeScaffoldCode(mode),
+    code: normalizedKeyBuilderResult.code === SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      ? SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED
+      : getRuntimeScaffoldCode(mode),
     mode,
     reason: getRuntimeScaffoldReason(mode),
+    storageKeyBuilder: normalizedKeyBuilderResult,
   };
 }
 
@@ -293,6 +339,8 @@ function isRuntimeScaffoldMode(mode) {
 }
 
 function createRuntimeScaffoldAdapter(opts, mode) {
+  const storageKeyBuilder = resolveDisabledStorageKeyBuilder(opts);
+
   return Object.freeze({
     kind: 'scout_live_rate_limit_storage_adapter',
     version: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION,
@@ -301,18 +349,22 @@ function createRuntimeScaffoldAdapter(opts, mode) {
     mockDisabled: false,
     isMockDisabled: false,
     isRuntimeScaffold: true,
+    hasStorageKeyBuilder: true,
     onProhibitedField: opts.onProhibitedField,
 
-    async checkQuota(_payload) {
-      return buildRuntimeScaffoldCheckResponse(mode);
+    async checkQuota(payload) {
+      const keyBuilderResult = storageKeyBuilder.buildKey(payload);
+      return buildRuntimeScaffoldCheckResponse(mode, keyBuilderResult);
     },
 
-    async consumeQuota(_payload) {
-      return buildRuntimeScaffoldConsumeResponse(mode);
+    async consumeQuota(payload) {
+      const keyBuilderResult = storageKeyBuilder.buildKey(payload);
+      return buildRuntimeScaffoldConsumeResponse(mode, keyBuilderResult);
     },
 
-    async releaseQuota(_payload) {
-      return buildRuntimeScaffoldReleaseResponse(mode);
+    async releaseQuota(payload) {
+      const keyBuilderResult = storageKeyBuilder.buildKey(payload);
+      return buildRuntimeScaffoldReleaseResponse(mode, keyBuilderResult);
     },
 
     sanitizePayload: sanitizeScoutLiveRateLimitStoragePayload,
@@ -332,6 +384,7 @@ function createRuntimeScaffoldAdapter(opts, mode) {
  *   d1, returns a disabled-by-default runtime scaffold that still safe-fails
  *   without touching storage.
  * @param {string} [options.storageMode] explicit future runtime storage mode
+ * @param {Object} [options.storageKeyBuilder] optional disabled key builder seam
  * @param {string} [options.onProhibitedField='drop'] - 'drop' or 'reject'
  * @returns {Object} frozen adapter
  */
@@ -350,6 +403,7 @@ export function createScoutLiveRateLimitStorageAdapter(options) {
       mockDisabled: true,
       isMockDisabled: true,
       isRuntimeScaffold: false,
+      hasStorageKeyBuilder: false,
       onProhibitedField: opts.onProhibitedField,
 
       async checkQuota(_payload) {
@@ -380,6 +434,7 @@ export function createScoutLiveRateLimitStorageAdapter(options) {
     mockDisabled: false,
     isMockDisabled: false,
     isRuntimeScaffold: false,
+    hasStorageKeyBuilder: false,
     onProhibitedField: opts.onProhibitedField,
 
     async checkQuota(_payload) {

--- a/tests/contracts/scout-storage-key-builder-adapter-wiring-contract.test.cjs
+++ b/tests/contracts/scout-storage-key-builder-adapter-wiring-contract.test.cjs
@@ -1,0 +1,170 @@
+/**
+ * Scout Storage Key Builder Adapter Wiring Contract Tests
+ * v20260607-1
+ *
+ * Locks the disabled key-builder-to-storage-adapter wiring boundary.
+ * The adapter may call the disabled key builder only on runtime scaffold paths,
+ * while preserving safe-fail behavior and avoiding real key generation,
+ * hashing, storage backends, endpoint wiring, frontend changes, provider
+ * integration, and Browse #1661 work.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const KEY_BUILDER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-key-builder.js');
+const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-storage-key-builder-adapter-wiring.md');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const adapter = readFile(ADAPTER_PATH);
+const adapterCode = codeOnly(adapter);
+const keyBuilder = readFile(KEY_BUILDER_PATH);
+const keyBuilderCode = codeOnly(keyBuilder);
+const doc = readFile(DOC_PATH);
+const suggest = readFile(SUGGEST_PATH);
+const suggestCode = codeOnly(suggest);
+const sourceSelector = readFile(SOURCE_SELECTOR_PATH);
+const endpointClient = readFile(ENDPOINT_CLIENT_PATH);
+
+const tests = [];
+
+function push(name, fn) {
+  tests.push({ name, fn });
+}
+
+push('Adapter wiring doc exists with issue references and disabled status', () => {
+  assert.ok(doc.includes('Status: disabled wiring / no live storage key generation'));
+  assert.ok(doc.includes('Parent issue: #1882'));
+  assert.ok(doc.includes('Slice issue: #2343'));
+  assert.ok(doc.includes('Depends on: #2341'));
+});
+
+push('Storage adapter imports the disabled key builder scaffold only at adapter boundary', () => {
+  assert.ok(adapter.includes("from './live-rate-limit-storage-key-builder.js'"), 'adapter must import key builder scaffold');
+  assert.ok(adapter.includes('createScoutLiveRateLimitStorageKeyBuilder'), 'adapter must reference key builder factory');
+  assert.ok(adapter.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES'), 'adapter must reference key builder codes');
+  assert.ok(!suggestCode.includes('live-rate-limit-storage-key-builder'), 'endpoint must not import key builder');
+  assert.ok(!sourceSelector.includes('storageKeyBuilder'), 'frontend source selector must not expose key builder');
+  assert.ok(!endpointClient.includes('storageKeyBuilder'), 'endpoint client must not expose key builder');
+});
+
+push('Storage adapter exposes disabled key builder metadata only on runtime scaffold path', () => {
+  assert.ok(adapter.includes('hasStorageKeyBuilder: true'), 'runtime scaffold adapter must expose key builder');
+  assert.ok(adapter.includes('hasStorageKeyBuilder: false'), 'default/not-implemented adapters must not expose key builder');
+  assert.ok(adapter.includes('createRuntimeScaffoldAdapter'), 'runtime scaffold path must exist');
+  assert.ok(adapter.includes('resolveDisabledStorageKeyBuilder'), 'adapter must resolve disabled key builder');
+});
+
+push('Storage adapter calls disabled key builder but keeps safe-fail response shape', () => {
+  assert.ok(adapter.includes('storageKeyBuilder.buildKey(payload)'), 'runtime scaffold methods must call disabled key builder');
+  assert.ok(adapter.includes('storageKey: null'), 'adapter must force null storage key in normalized result');
+  assert.ok(adapter.includes('keyPreview: null'), 'adapter must force null key preview in normalized result');
+  assert.ok(adapter.includes('ok: false'), 'normalized key builder result must be safe-fail');
+  assert.ok(adapter.includes('disabled: true'), 'normalized key builder result must stay disabled');
+  assert.ok(adapter.includes('storageKeyBuilder: normalizedKeyBuilderResult'), 'responses must include sanitized key builder result');
+});
+
+push('Storage adapter maps prohibited key builder payloads to safe adapter code', () => {
+  assert.ok(adapter.includes('STORAGE_KEY_PAYLOAD_PROHIBITED'), 'adapter must expose prohibited key payload code');
+  assert.ok(adapter.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED'), 'adapter must inspect key builder prohibited code');
+  assert.ok(adapter.includes('SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_CODES.STORAGE_KEY_PAYLOAD_PROHIBITED'), 'adapter must map to adapter prohibited code');
+});
+
+push('Default storage adapter behavior remains mock-disabled', () => {
+  assert.ok(adapter.includes('mockDisabled: true'), 'default mock-disabled behavior must remain');
+  assert.ok(adapter.includes('mode: SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_MODES.MOCK_DISABLED'), 'mock-disabled mode must remain');
+  assert.ok(adapter.includes('buildMockDisabledCheckResponse'), 'mock-disabled check response must remain');
+  assert.ok(adapter.includes('buildMockDisabledConsumeResponse'), 'mock-disabled consume response must remain');
+  assert.ok(adapter.includes('buildMockDisabledReleaseResponse'), 'mock-disabled release response must remain');
+});
+
+push('Key builder scaffold itself remains disabled and never creates usable keys', () => {
+  assert.ok(keyBuilder.includes('storageKey: null'), 'key builder must return null storageKey');
+  assert.ok(keyBuilder.includes('keyPreview: null'), 'key builder must return null keyPreview');
+  assert.ok(keyBuilder.includes('ok: false'), 'key builder must safe-fail');
+  assert.ok(keyBuilder.includes('disabled: true'), 'key builder must stay disabled');
+});
+
+push('No real hashing, storage backend, network, or provider integration is introduced', () => {
+  const combinedCode = [adapterCode, keyBuilderCode, suggestCode].join('\n');
+  for (const forbidden of [
+    'crypto.subtle.digest',
+    'createHash',
+    'HMAC',
+    'SCOUT_STORAGE_KEY_SALT',
+    'SCOUT_RATE_LIMIT_KV',
+    'SCOUT_RATE_LIMIT_DO',
+    'SCOUT_RATE_LIMIT_D1',
+    'DurableObjectNamespace',
+    'idFromName(',
+    'getByName(',
+    '.prepare(',
+    '.batch(',
+    'axios',
+    'openai.chat.completions',
+    'anthropic.messages',
+    'generateContent',
+  ]) {
+    assert.ok(!combinedCode.includes(forbidden), `must not introduce ${forbidden}`);
+  }
+});
+
+push('Endpoint and frontend defaults remain preserved', () => {
+  assert.ok(suggest.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'endpoint must retain STUB mode');
+  assert.ok(sourceSelector.includes('local_stub'), 'frontend source selector must retain local_stub');
+  assert.ok(endpointClient.includes('Disabled by default'), 'endpoint client must remain disabled by default');
+});
+
+push('Documentation locks allowed and disallowed wiring', () => {
+  for (const phrase of [
+    'import the disabled key builder scaffold',
+    'preserve `storageKey: null` and `keyPreview: null`',
+    'map prohibited key-builder payloads to `STORAGE_KEY_PAYLOAD_PROHIBITED`',
+    'no usable storage key generation',
+    'no real hash helper',
+    'no hashing secret or salt access',
+    'no KV read/write/delete',
+    'no Durable Object namespace, id, stub, or fetch',
+    'no D1 prepare/batch/exec',
+    'NO-GO for real key generation, real hashing, real storage backend access, endpoint wiring, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.',
+  ]) {
+    assert.ok(doc.includes(phrase), `doc must include ${phrase}`);
+  }
+});
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  ✓ ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  ✗ ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Refs #1882

Closes #2343

Scope:
- Wire the disabled Scout live rate-limit storage key builder scaffold into the storage adapter boundary only.
- Keep the wiring safe-fail/mock-disabled: runtime scaffold adapters may call the disabled key builder, but must not generate usable storage keys.
- Add adapter response metadata with sanitized disabled key builder result while preserving `storageKey: null` and `keyPreview: null`.
- Add product documentation for the disabled adapter wiring boundary.
- Add contract coverage for key builder import, disabled safe-fail mapping, prohibited payload behavior, no endpoint wiring, no frontend source change, no provider integration, and no Browse #1661 work.

Non-goals:
- No real storage key generation for live traffic.
- No real hashing implementation or secret/salt access.
- No real KV, Durable Object, or D1 implementation.
- No endpoint behavior change.
- No frontend default source change.
- No provider integration.
- No Browse #1661 work.