### PR TITLE
test(scout): add dependency storage safe-fail regression matrix

### DIFF
--- a/docs/product/lovebud-scout-dependency-storage-safe-fail-regression-matrix.md
+++ b/docs/product/lovebud-scout-dependency-storage-safe-fail-regression-matrix.md
@@ -1,0 +1,93 @@
+# LoveBud Scout Dependency Storage Safe-Fail Regression Matrix
+
+Version: v20260608-1  
+Status: regression matrix only / no runtime behavior expansion  
+Parent issue: #1882  
+Slice issue: #2347  
+Depends on: #2345
+
+## 1. Purpose
+
+This document locks the dependency adapter storage safe-fail mapping matrix for the Scout live auth/rate-limit/storage boundary.
+
+The goal is regression protection only. This slice documents expected mappings and adds contract coverage so future changes do not accidentally expose storage internals, key-builder internals, raw fields, or live storage/provider behavior.
+
+## 2. Runtime scope
+
+This slice should not expand runtime behavior.
+
+Allowed scope:
+
+- add this regression matrix document;
+- add contract tests that inspect existing dependency adapter mapping behavior;
+- preserve existing code behavior.
+
+Disallowed scope:
+
+- endpoint wiring change;
+- real storage key generation;
+- real hashing implementation;
+- secret or salt access;
+- real KV access;
+- real Durable Object access;
+- real D1 access;
+- frontend source selector change;
+- provider integration;
+- deployment configuration;
+- Browse #1661 work.
+
+## 3. Regression matrix
+
+| Storage adapter result code | Dependency adapter result code | Decision | Rationale |
+| --- | --- | --- | --- |
+| `STORAGE_PAYLOAD_PROHIBITED` | `RATE_LIMIT_PAYLOAD_PROHIBITED` | deny | Storage payload itself contained prohibited fields, so preserve payload-policy failure. |
+| `STORAGE_NOT_IMPLEMENTED` | `RATE_LIMIT_NOT_IMPLEMENTED` | deny | Storage adapter is explicitly not implemented. |
+| `STORAGE_MOCK_DISABLED` | `RATE_LIMIT_NOT_IMPLEMENTED` | deny | Default mock-disabled storage is a not-implemented safe-fail. |
+| `STORAGE_KV_DISABLED` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | KV runtime scaffold is disabled. |
+| `STORAGE_DURABLE_OBJECT_DISABLED` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Durable Object runtime scaffold is disabled. |
+| `STORAGE_D1_DISABLED` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | D1 runtime scaffold is disabled. |
+| `STORAGE_CONFIG_MISSING` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Storage runtime configuration is missing. |
+| `STORAGE_KEY_BUILDER_DISABLED` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Storage key builder is intentionally disabled and cannot provide a usable key. |
+| `STORAGE_KEY_PAYLOAD_PROHIBITED` | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Key-builder payload policy failed; dependency boundary must not leak key-builder details. |
+| unknown storage code | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Unknown storage result must fail closed. |
+| missing storage code | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Missing storage result code must fail closed. |
+| storage adapter throw | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny | Exceptions are swallowed to a storage-unavailable safe-fail. |
+
+## 4. Boundary rule
+
+The dependency adapter is the interpretation boundary. It may know storage adapter codes, but endpoint-facing behavior should only receive dependency-layer codes.
+
+Storage-specific and key-builder-specific details must not leak beyond the dependency adapter. In particular, key-builder codes should be collapsed into `RATE_LIMIT_STORAGE_UNAVAILABLE`.
+
+## 5. Default preservation
+
+The regression matrix must preserve:
+
+- dependency adapter default `mockDisabled: true`;
+- endpoint default `stub`;
+- frontend default `local_stub`;
+- endpoint client disabled by default;
+- no live provider call;
+- no real storage backend call;
+- no real storage key generation;
+- no real hashing or salt access.
+
+## 6. Contract expectations
+
+Contract tests must verify:
+
+- every matrix source code is documented;
+- every matrix target code is documented;
+- dependency adapter code recognizes the expected explicit source codes;
+- `STORAGE_PAYLOAD_PROHIBITED` remains mapped to `RATE_LIMIT_PAYLOAD_PROHIBITED`;
+- storage mock/not-implemented codes remain mapped to `RATE_LIMIT_NOT_IMPLEMENTED`;
+- storage runtime scaffold and key-builder safe-fail codes remain mapped to `RATE_LIMIT_STORAGE_UNAVAILABLE`;
+- unknown or missing storage code still fails closed to `RATE_LIMIT_STORAGE_UNAVAILABLE`;
+- endpoint/frontend defaults are unchanged;
+- no real storage, hashing, provider, or Browse #1661 work is introduced.
+
+## 7. Current verdict
+
+GO for regression matrix documentation and contract tests.
+
+NO-GO for runtime behavior expansion, endpoint wiring, real key generation, real hashing, real storage backend access, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.

--- a/tests/contracts/scout-dependency-storage-safe-fail-regression-matrix-contract.test.cjs
+++ b/tests/contracts/scout-dependency-storage-safe-fail-regression-matrix-contract.test.cjs
@@ -1,0 +1,193 @@
+/**
+ * Scout Dependency Storage Safe-Fail Regression Matrix Contract Tests
+ * v20260608-1
+ *
+ * Regression-only coverage for dependency adapter storage result mapping.
+ * This test must not require runtime behavior expansion, endpoint wiring,
+ * real key generation, hashing, real storage backends, frontend source changes,
+ * provider integration, or Browse #1661 work.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-dependency-storage-safe-fail-regression-matrix.md');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const KEY_BUILDER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-key-builder.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const doc = readFile(DOC_PATH);
+const depAdapter = readFile(DEP_ADAPTER_PATH);
+const depAdapterCode = codeOnly(depAdapter);
+const storageAdapter = readFile(STORAGE_ADAPTER_PATH);
+const storageAdapterCode = codeOnly(storageAdapter);
+const keyBuilder = readFile(KEY_BUILDER_PATH);
+const keyBuilderCode = codeOnly(keyBuilder);
+const suggest = readFile(SUGGEST_PATH);
+const suggestCode = codeOnly(suggest);
+const sourceSelector = readFile(SOURCE_SELECTOR_PATH);
+const endpointClient = readFile(ENDPOINT_CLIENT_PATH);
+
+const tests = [];
+
+function push(name, fn) {
+  tests.push({ name, fn });
+}
+
+const matrixRows = [
+  ['STORAGE_PAYLOAD_PROHIBITED', 'RATE_LIMIT_PAYLOAD_PROHIBITED'],
+  ['STORAGE_NOT_IMPLEMENTED', 'RATE_LIMIT_NOT_IMPLEMENTED'],
+  ['STORAGE_MOCK_DISABLED', 'RATE_LIMIT_NOT_IMPLEMENTED'],
+  ['STORAGE_KV_DISABLED', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+  ['STORAGE_DURABLE_OBJECT_DISABLED', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+  ['STORAGE_D1_DISABLED', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+  ['STORAGE_CONFIG_MISSING', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+  ['STORAGE_KEY_BUILDER_DISABLED', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+  ['STORAGE_KEY_PAYLOAD_PROHIBITED', 'RATE_LIMIT_STORAGE_UNAVAILABLE'],
+];
+
+push('Regression matrix document exists with expected status and references', () => {
+  assert.ok(doc.includes('Status: regression matrix only / no runtime behavior expansion'));
+  assert.ok(doc.includes('Parent issue: #1882'));
+  assert.ok(doc.includes('Slice issue: #2347'));
+  assert.ok(doc.includes('Depends on: #2345'));
+});
+
+push('Regression matrix documents every explicit storage mapping row', () => {
+  for (const [sourceCode, targetCode] of matrixRows) {
+    assert.ok(doc.includes('`' + sourceCode + '`'), `doc must include source ${sourceCode}`);
+    assert.ok(doc.includes('`' + targetCode + '`'), `doc must include target ${targetCode}`);
+  }
+});
+
+push('Dependency adapter recognizes every explicit storage source code', () => {
+  for (const [sourceCode] of matrixRows) {
+    assert.ok(depAdapter.includes("code === '" + sourceCode + "'"), `dependency adapter must recognize ${sourceCode}`);
+  }
+});
+
+push('Payload prohibited mapping remains payload-prohibited', () => {
+  assert.ok(depAdapter.includes("code === 'STORAGE_PAYLOAD_PROHIBITED'"));
+  assert.ok(depAdapter.includes('RATE_LIMIT_PAYLOAD_PROHIBITED'));
+  assert.ok(doc.includes('| `STORAGE_PAYLOAD_PROHIBITED` | `RATE_LIMIT_PAYLOAD_PROHIBITED` | deny |'));
+});
+
+push('Mock-disabled and not-implemented storage mappings remain not-implemented', () => {
+  assert.ok(depAdapter.includes("code === 'STORAGE_NOT_IMPLEMENTED'"));
+  assert.ok(depAdapter.includes("code === 'STORAGE_MOCK_DISABLED'"));
+  assert.ok(depAdapter.includes('RATE_LIMIT_NOT_IMPLEMENTED'));
+  assert.ok(doc.includes('| `STORAGE_NOT_IMPLEMENTED` | `RATE_LIMIT_NOT_IMPLEMENTED` | deny |'));
+  assert.ok(doc.includes('| `STORAGE_MOCK_DISABLED` | `RATE_LIMIT_NOT_IMPLEMENTED` | deny |'));
+});
+
+push('Runtime scaffold and key-builder safe-fail mappings remain storage-unavailable', () => {
+  for (const code of [
+    'STORAGE_KV_DISABLED',
+    'STORAGE_DURABLE_OBJECT_DISABLED',
+    'STORAGE_D1_DISABLED',
+    'STORAGE_CONFIG_MISSING',
+    'STORAGE_KEY_BUILDER_DISABLED',
+    'STORAGE_KEY_PAYLOAD_PROHIBITED',
+  ]) {
+    assert.ok(depAdapter.includes("code === '" + code + "'"), `dependency adapter must recognize ${code}`);
+  }
+  assert.ok(depAdapter.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'));
+});
+
+push('Unknown and missing storage codes fail closed to storage unavailable', () => {
+  assert.ok(doc.includes('| unknown storage code | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny |'));
+  assert.ok(doc.includes('| missing storage code | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny |'));
+  assert.ok(depAdapter.includes('rate-limit storage adapter returned an unknown result'));
+});
+
+push('Storage adapter throw fail-closed behavior remains documented and implemented', () => {
+  assert.ok(doc.includes('| storage adapter throw | `RATE_LIMIT_STORAGE_UNAVAILABLE` | deny |'));
+  assert.ok(depAdapter.includes('rate-limit storage adapter threw an exception'));
+});
+
+push('Default dependency, endpoint, and frontend behavior remain preserved', () => {
+  assert.ok(depAdapter.includes('mockDisabled: true'), 'dependency adapter default mockDisabled must remain');
+  assert.ok(depAdapter.includes('SCOUT_LIVE_DEPENDENCY_ADAPTER_MODES.MOCK_DISABLED'), 'dependency adapter mock mode must remain');
+  assert.ok(suggest.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'endpoint must retain STUB mode');
+  assert.ok(sourceSelector.includes('local_stub'), 'frontend source selector must retain local_stub');
+  assert.ok(endpointClient.includes('Disabled by default'), 'endpoint client must remain disabled by default');
+});
+
+push('No endpoint or frontend key-builder exposure is introduced', () => {
+  assert.ok(!suggestCode.includes('live-rate-limit-storage-key-builder'), 'endpoint must not import key builder');
+  assert.ok(!suggestCode.includes('STORAGE_KEY_BUILDER_DISABLED'), 'endpoint must not expose key builder code');
+  assert.ok(!suggestCode.includes('STORAGE_KEY_PAYLOAD_PROHIBITED'), 'endpoint must not expose key builder code');
+  assert.ok(!sourceSelector.includes('storageKeyBuilder'), 'frontend selector must not expose key builder');
+  assert.ok(!endpointClient.includes('storageKeyBuilder'), 'endpoint client must not expose key builder');
+});
+
+push('No real storage, hashing, provider, or secret boundary is introduced', () => {
+  const combinedBoundaryCode = [depAdapterCode, storageAdapterCode, keyBuilderCode].join('\n');
+  for (const forbidden of [
+    'crypto.subtle.digest',
+    'createHash',
+    'HMAC',
+    'SCOUT_STORAGE_KEY_SALT',
+    'SCOUT_RATE_LIMIT_KV',
+    'SCOUT_RATE_LIMIT_DO',
+    'SCOUT_RATE_LIMIT_D1',
+    'DurableObjectNamespace',
+    'idFromName(',
+    'getByName(',
+    '.prepare(',
+    '.batch(',
+    'axios',
+    'openai.chat.completions',
+    'anthropic.messages',
+    'generateContent',
+  ]) {
+    assert.ok(!combinedBoundaryCode.includes(forbidden), `must not introduce ${forbidden}`);
+  }
+});
+
+push('Document locks non-goals and regression-only scope', () => {
+  for (const phrase of [
+    'This slice should not expand runtime behavior.',
+    'GO for regression matrix documentation and contract tests.',
+    'NO-GO for runtime behavior expansion, endpoint wiring, real key generation, real hashing, real storage backend access, frontend changes, provider integration, deployment changes, or Browse #1661 work in this slice.',
+  ]) {
+    assert.ok(doc.includes(phrase), `doc must include ${phrase}`);
+  }
+});
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  ✓ ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  ✗ ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Refs #1882

Closes #2347

Scope:
- Add a dependency adapter storage safe-fail regression matrix for Scout live auth/rate-limit/storage boundaries.
- Lock expected mapping behavior for storage adapter result codes including `STORAGE_PAYLOAD_PROHIBITED`, `STORAGE_NOT_IMPLEMENTED`, `STORAGE_MOCK_DISABLED`, `STORAGE_KV_DISABLED`, `STORAGE_DURABLE_OBJECT_DISABLED`, `STORAGE_D1_DISABLED`, `STORAGE_CONFIG_MISSING`, `STORAGE_KEY_BUILDER_DISABLED`, `STORAGE_KEY_PAYLOAD_PROHIBITED`, unknown code, missing code, and storage adapter throw.
- Add contract coverage that verifies the matrix is documented and the dependency adapter code still recognizes mapped storage codes.
- Preserve default stub behavior, frontend `local_stub`, endpoint client disabled-by-default, and all no-real-storage/no-real-provider guardrails.

Non-goals:
- No runtime behavior expansion beyond regression documentation/tests.
- No endpoint wiring change.
- No real storage key generation for live traffic.
- No real hashing implementation or secret/salt access.
- No real KV, Durable Object, or D1 implementation.
- No frontend default source change.
- No provider integration.
- No Browse #1661 work.