### PR TITLE
docs(scout): audit live storage readiness

### DIFF
--- a/docs/product/lovebud-scout-live-storage-readiness-audit.md
+++ b/docs/product/lovebud-scout-live-storage-readiness-audit.md
@@ -1,0 +1,170 @@
+# LoveBud Scout Live Storage Readiness Audit
+
+Version: v20260608-1  
+Status: product readiness audit / no runtime behavior change  
+Parent issue: #1882  
+Slice issue: #2349  
+Depends on: #2347
+
+## 1. Purpose
+
+This audit summarizes the current Scout live storage readiness state after the safe-fail mapping matrix work.
+
+The goal is to decide what can safely proceed next before any real KV, Durable Object, D1, runtime storage key generation, live endpoint wiring, frontend source change, provider integration, staging live, or production live work.
+
+## 2. Baseline
+
+Audit baseline:
+
+```text
+main HEAD before this audit: 74f17432c56c5d2aec9def25309049707b955a36
+latest completed storage matrix issue: #2347
+latest completed storage matrix PR: #2348
+```
+
+This audit is documentation and contract only. It does not change runtime code.
+
+## 3. Completed storage safety slices
+
+| Slice | Status | Contribution |
+| --- | --- | --- |
+| #2337 / #2338 | Done | Rate-limit storage backend selection policy added before choosing KV / Durable Object / D1. |
+| #2339 / #2340 | Done | Storage key hashing and allowlist contract added before implementing runtime key generation. |
+| #2341 / #2342 | Done | Disabled storage key builder scaffold added with no usable key generation. |
+| #2343 / #2344 | Done | Disabled key builder wired into storage adapter safe-fail path only. |
+| #2345 / #2346 | Done | Storage key builder safe-fail codes mapped into dependency adapter as storage unavailable. |
+| #2347 / #2348 | Done | Dependency storage safe-fail regression matrix added. |
+
+## 4. Current implemented boundary inventory
+
+### 4.1 Storage backend selection policy
+
+Storage backend selection is documented but no backend is selected for live runtime use. The project still has no real KV, Durable Object, or D1 implementation.
+
+### 4.2 Key hashing and allowlist policy
+
+Allowed future key inputs are documented:
+
+- `userKeyHash`;
+- `ipHash`;
+- `sessionKeyHash`;
+- `endpointPath`;
+- `providerMode`;
+- `limitName`;
+- `windowKey`.
+
+Raw identifiers, tokens, authorization headers, emails, phone numbers, API keys, prompts, excerpts, source URLs, raw request bodies, raw provider responses, and raw model outputs remain prohibited.
+
+### 4.3 Disabled key builder scaffold
+
+The key builder scaffold exists but remains disabled. It returns no usable key.
+
+Expected safe shape remains:
+
+```text
+ok: false
+disabled: true
+storageKey: null
+keyPreview: null
+```
+
+### 4.4 Storage adapter safe-fail wiring
+
+The storage adapter can recognize the disabled key builder scaffold on runtime scaffold paths. It still does not read or write real storage.
+
+### 4.5 Dependency adapter safe-fail mapping
+
+The dependency adapter collapses storage-key-builder-specific outcomes into dependency-level safe-fail codes. It must not expose key-builder internals to endpoint-facing behavior.
+
+### 4.6 Regression matrix
+
+The regression matrix locks expected storage-to-dependency mapping for:
+
+- `STORAGE_PAYLOAD_PROHIBITED`;
+- `STORAGE_NOT_IMPLEMENTED`;
+- `STORAGE_MOCK_DISABLED`;
+- `STORAGE_KV_DISABLED`;
+- `STORAGE_DURABLE_OBJECT_DISABLED`;
+- `STORAGE_D1_DISABLED`;
+- `STORAGE_CONFIG_MISSING`;
+- `STORAGE_KEY_BUILDER_DISABLED`;
+- `STORAGE_KEY_PAYLOAD_PROHIBITED`;
+- unknown storage code;
+- missing storage code;
+- storage adapter throw.
+
+## 5. Current default behavior
+
+The current default behavior must remain:
+
+- endpoint default: `stub`;
+- frontend source selector default: `local_stub`;
+- endpoint client: disabled by default;
+- live provider call: not enabled;
+- real storage backend call: not enabled;
+- storage key generation for live traffic: not enabled;
+- hashing secret or salt access: not enabled;
+- Browse #1661: not touched.
+
+## 6. Go / no-go matrix
+
+| Area | Current decision | Reason |
+| --- | --- | --- |
+| Additional documentation / contract hardening | GO | Existing storage safety boundary can be further audited without runtime risk. |
+| Disabled scaffold refinements | CONDITIONAL GO | Allowed only if disabled-by-default and no endpoint/live backend behavior changes. |
+| Runtime key builder implementation | NO-GO | Needs deterministic hash helper, salt/version policy, key namespace design, and redaction tests first. |
+| Real KV implementation | NO-GO | Needs backend implementation plan, quota model, rollback policy, abuse monitoring, and staging evidence. |
+| Real Durable Object implementation | NO-GO | Needs object namespace design, concurrency model, cost/quota plan, and rollback policy. |
+| Real D1 implementation | NO-GO | Needs schema/migration plan, retention policy, query limits, and rollback policy. |
+| Endpoint live wiring | NO-GO | Must wait for runtime auth, rate-limit storage, observability, error taxonomy, and rollout gates. |
+| Frontend endpoint default change | NO-GO | `local_stub` must remain default until live endpoint readiness is separately approved. |
+| Staging live | NO-GO | Real auth/storage/provider dependencies are not ready. |
+| Production live | NO-GO | Staging evidence, monitoring, quota, abuse controls, rollback, and legal/privacy review remain missing. |
+| Provider integration | NO-GO | Storage readiness does not authorize live provider calls. |
+| Browse #1661 | NO-GO | Out of scope for this storage readiness track. |
+
+## 7. Remaining blockers before real storage backend work
+
+Before any real KV, Durable Object, or D1 implementation, the project still needs:
+
+1. Deterministic hash helper contract.
+2. Salt and versioning policy.
+3. Environment namespace separation policy for staging and production.
+4. Storage key format implementation contract.
+5. Raw preimage non-persistence tests.
+6. Log redaction and observability tests for storage keys.
+7. Quota window model and limit policy.
+8. Abuse monitoring policy.
+9. Backend-specific implementation plan for KV, Durable Object, or D1.
+10. Rollback and kill-switch plan for storage runtime.
+11. Cost and quota impact review.
+12. Staging-only rollout checklist.
+13. Privacy review for hashed identifiers and retention.
+14. Endpoint safe-fail integration tests.
+15. CI evidence that default stub and frontend `local_stub` remain unchanged.
+
+## 8. Recommended next slice
+
+Recommended next slice:
+
+```text
+[TECH] Add Scout storage hash helper disabled scaffold contract
+```
+
+This next slice should still avoid real hashing secret/salt access. It should define a disabled hash helper scaffold that refuses to produce real hashes until salt/version policy and environment namespace rules are finalized.
+
+## 9. Current verdict
+
+The storage safety track is ready for another disabled-by-default scaffold contract.
+
+It is not ready for real runtime key generation.
+
+It is not ready for real KV, Durable Object, or D1 implementation.
+
+It is not ready for endpoint live wiring.
+
+It is not ready for frontend default endpoint mode.
+
+It is not ready for staging live or production live.
+
+It is not ready for provider integration.

--- a/tests/contracts/scout-live-storage-readiness-audit-contract.test.cjs
+++ b/tests/contracts/scout-live-storage-readiness-audit-contract.test.cjs
@@ -1,0 +1,228 @@
+/**
+ * Scout Live Storage Readiness Audit Contract Tests
+ * v20260608-1
+ *
+ * Product readiness audit only. This contract verifies the audit document
+ * and guardrails after the storage safe-fail mapping matrix. It must not
+ * require runtime behavior expansion, endpoint wiring, real storage key
+ * generation, hashing, real storage backends, frontend changes, provider
+ * integration, or Browse #1661 work.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-live-storage-readiness-audit.md');
+const DEP_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-auth-rate-limit-dependency-adapter.js');
+const STORAGE_ADAPTER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-adapter.js');
+const KEY_BUILDER_PATH = path.join(ROOT, 'functions/api/scout/live-rate-limit-storage-key-builder.js');
+const SUGGEST_PATH = path.join(ROOT, 'functions/api/scout/suggest.js');
+const SOURCE_SELECTOR_PATH = path.join(ROOT, 'js/scout/scout-suggestion-source-selector.js');
+const ENDPOINT_CLIENT_PATH = path.join(ROOT, 'js/scout/scout-suggestion-endpoint-client.js');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function codeOnly(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function md5(filePath) {
+  return crypto.createHash('md5').update(readFile(filePath).replace(/\r\n/g, '\n')).digest('hex');
+}
+
+const doc = readFile(DOC_PATH);
+const depAdapter = readFile(DEP_ADAPTER_PATH);
+const depAdapterCode = codeOnly(depAdapter);
+const storageAdapter = readFile(STORAGE_ADAPTER_PATH);
+const storageAdapterCode = codeOnly(storageAdapter);
+const keyBuilder = readFile(KEY_BUILDER_PATH);
+const keyBuilderCode = codeOnly(keyBuilder);
+const suggest = readFile(SUGGEST_PATH);
+const suggestCode = codeOnly(suggest);
+const sourceSelector = readFile(SOURCE_SELECTOR_PATH);
+const endpointClient = readFile(ENDPOINT_CLIENT_PATH);
+
+const tests = [];
+
+function push(name, fn) {
+  tests.push({ name, fn });
+}
+
+push('Storage readiness audit document exists with baseline and references', () => {
+  assert.ok(doc.includes('Status: product readiness audit / no runtime behavior change'));
+  assert.ok(doc.includes('Parent issue: #1882'));
+  assert.ok(doc.includes('Slice issue: #2349'));
+  assert.ok(doc.includes('Depends on: #2347'));
+  assert.ok(doc.includes('main HEAD before this audit: 74f17432c56c5d2aec9def25309049707b955a36'));
+});
+
+push('Audit references the completed storage safety slice sequence', () => {
+  for (const sliceRef of [
+    '#2337 / #2338',
+    '#2339 / #2340',
+    '#2341 / #2342',
+    '#2343 / #2344',
+    '#2345 / #2346',
+    '#2347 / #2348',
+  ]) {
+    assert.ok(doc.includes(sliceRef), `audit must reference ${sliceRef}`);
+  }
+});
+
+push('Audit inventories implemented storage boundaries', () => {
+  for (const phrase of [
+    'Storage backend selection policy',
+    'Key hashing and allowlist policy',
+    'Disabled key builder scaffold',
+    'Storage adapter safe-fail wiring',
+    'Dependency adapter safe-fail mapping',
+    'Regression matrix',
+  ]) {
+    assert.ok(doc.includes(phrase), `audit must include ${phrase}`);
+  }
+});
+
+push('Audit preserves default behavior guardrails', () => {
+  for (const phrase of [
+    'endpoint default: `stub`',
+    'frontend source selector default: `local_stub`',
+    'endpoint client: disabled by default',
+    'live provider call: not enabled',
+    'real storage backend call: not enabled',
+    'storage key generation for live traffic: not enabled',
+    'hashing secret or salt access: not enabled',
+    'Browse #1661: not touched',
+  ]) {
+    assert.ok(doc.includes(phrase), `audit must preserve ${phrase}`);
+  }
+});
+
+push('Audit go/no-go matrix blocks live storage and provider work', () => {
+  for (const row of [
+    '| Runtime key builder implementation | NO-GO |',
+    '| Real KV implementation | NO-GO |',
+    '| Real Durable Object implementation | NO-GO |',
+    '| Real D1 implementation | NO-GO |',
+    '| Endpoint live wiring | NO-GO |',
+    '| Frontend endpoint default change | NO-GO |',
+    '| Staging live | NO-GO |',
+    '| Production live | NO-GO |',
+    '| Provider integration | NO-GO |',
+    '| Browse #1661 | NO-GO |',
+  ]) {
+    assert.ok(doc.includes(row), `go/no-go matrix must include ${row}`);
+  }
+});
+
+push('Audit lists remaining blockers before real storage backend work', () => {
+  for (const blocker of [
+    'Deterministic hash helper contract',
+    'Salt and versioning policy',
+    'Environment namespace separation policy for staging and production',
+    'Storage key format implementation contract',
+    'Raw preimage non-persistence tests',
+    'Log redaction and observability tests for storage keys',
+    'Quota window model and limit policy',
+    'Abuse monitoring policy',
+    'Backend-specific implementation plan for KV, Durable Object, or D1',
+    'Rollback and kill-switch plan for storage runtime',
+    'Cost and quota impact review',
+    'Staging-only rollout checklist',
+    'Privacy review for hashed identifiers and retention',
+    'Endpoint safe-fail integration tests',
+    'CI evidence that default stub and frontend `local_stub` remain unchanged',
+  ]) {
+    assert.ok(doc.includes(blocker), `audit must list blocker ${blocker}`);
+  }
+});
+
+push('Audit recommends the next disabled scaffold contract', () => {
+  assert.ok(doc.includes('[TECH] Add Scout storage hash helper disabled scaffold contract'));
+  assert.ok(doc.includes('should still avoid real hashing secret/salt access'));
+});
+
+push('Runtime files remain at current locked content hashes', () => {
+  assert.strictEqual(md5(DEP_ADAPTER_PATH), '6b62bb3d9100bd41995a929d93469851');
+  assert.strictEqual(md5(STORAGE_ADAPTER_PATH), '664a5c1315e792651bdb5972366709f8');
+  assert.strictEqual(md5(KEY_BUILDER_PATH), 'ff8e9aa518e1c0d47d16f20d0cb0fb68');
+});
+
+push('Endpoint and frontend defaults remain preserved', () => {
+  assert.ok(suggest.includes('SCOUT_SUGGEST_PROVIDER_MODES.STUB'), 'endpoint must retain STUB mode');
+  assert.ok(sourceSelector.includes('local_stub'), 'frontend source selector must retain local_stub');
+  assert.ok(endpointClient.includes('Disabled by default'), 'endpoint client must remain disabled by default');
+});
+
+push('No endpoint or frontend storage key exposure is introduced', () => {
+  assert.ok(!suggestCode.includes('live-rate-limit-storage-key-builder'), 'endpoint must not import key builder');
+  assert.ok(!suggestCode.includes('storageKeyBuilder'), 'endpoint must not expose storageKeyBuilder');
+  assert.ok(!sourceSelector.includes('storageKeyBuilder'), 'frontend selector must not expose storageKeyBuilder');
+  assert.ok(!endpointClient.includes('storageKeyBuilder'), 'endpoint client must not expose storageKeyBuilder');
+});
+
+push('No real hashing, storage backend, provider, or secret boundary is introduced', () => {
+  const combinedBoundaryCode = [depAdapterCode, storageAdapterCode, keyBuilderCode].join('\n');
+  for (const forbidden of [
+    'crypto.subtle.digest',
+    'createHash',
+    'HMAC',
+    'SCOUT_STORAGE_KEY_SALT',
+    'SCOUT_RATE_LIMIT_KV',
+    'SCOUT_RATE_LIMIT_DO',
+    'SCOUT_RATE_LIMIT_D1',
+    'DurableObjectNamespace',
+    'idFromName(',
+    'getByName(',
+    '.prepare(',
+    '.batch(',
+    'axios',
+    'openai.chat.completions',
+    'anthropic.messages',
+    'generateContent',
+  ]) {
+    assert.ok(!combinedBoundaryCode.includes(forbidden), `must not introduce ${forbidden}`);
+  }
+});
+
+push('Audit final verdict blocks runtime live work', () => {
+  for (const phrase of [
+    'The storage safety track is ready for another disabled-by-default scaffold contract.',
+    'It is not ready for real runtime key generation.',
+    'It is not ready for real KV, Durable Object, or D1 implementation.',
+    'It is not ready for endpoint live wiring.',
+    'It is not ready for frontend default endpoint mode.',
+    'It is not ready for staging live or production live.',
+    'It is not ready for provider integration.',
+  ]) {
+    assert.ok(doc.includes(phrase), `audit verdict must include ${phrase}`);
+  }
+});
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log('  ✓ ' + t.name);
+      passed++;
+    } catch (err) {
+      console.log('  ✗ ' + t.name);
+      console.log('    ' + (err && err.message ? err.message : String(err)));
+      failed++;
+    }
+  }
+
+  console.log('\n' + passed + ' passed, ' + failed + ' failed');
+  if (failed > 0) process.exit(1);
+})();

--- a/tests/contracts/scout-live-storage-readiness-audit-contract.test.cjs
+++ b/tests/contracts/scout-live-storage-readiness-audit-contract.test.cjs
@@ -14,7 +14,6 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 
 const ROOT = path.resolve(__dirname, '../..');
 const DOC_PATH = path.join(ROOT, 'docs/product/lovebud-scout-live-storage-readiness-audit.md');
@@ -33,10 +32,6 @@ function codeOnly(source) {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/(^|[^:])\/\/.*$/gm, '$1');
-}
-
-function md5(filePath) {
-  return crypto.createHash('md5').update(readFile(filePath).replace(/\r\n/g, '\n')).digest('hex');
 }
 
 const doc = readFile(DOC_PATH);
@@ -150,10 +145,18 @@ push('Audit recommends the next disabled scaffold contract', () => {
   assert.ok(doc.includes('should still avoid real hashing secret/salt access'));
 });
 
-push('Runtime files remain at current locked content hashes', () => {
-  assert.strictEqual(md5(DEP_ADAPTER_PATH), '6b62bb3d9100bd41995a929d93469851');
-  assert.strictEqual(md5(STORAGE_ADAPTER_PATH), '664a5c1315e792651bdb5972366709f8');
-  assert.strictEqual(md5(KEY_BUILDER_PATH), 'ff8e9aa518e1c0d47d16f20d0cb0fb68');
+push('Runtime files retain expected storage safety boundaries', () => {
+  assert.ok(depAdapter.includes("SCOUT_LIVE_DEPENDENCY_ADAPTER_VERSION = '20260607-1'"));
+  assert.ok(depAdapter.includes("code === 'STORAGE_KEY_BUILDER_DISABLED'"));
+  assert.ok(depAdapter.includes("code === 'STORAGE_KEY_PAYLOAD_PROHIBITED'"));
+  assert.ok(depAdapter.includes('RATE_LIMIT_STORAGE_UNAVAILABLE'));
+  assert.ok(storageAdapter.includes("SCOUT_LIVE_RATE_LIMIT_STORAGE_ADAPTER_VERSION = '20260607-3'"));
+  assert.ok(storageAdapter.includes('STORAGE_KEY_BUILDER_DISABLED'));
+  assert.ok(storageAdapter.includes('STORAGE_KEY_PAYLOAD_PROHIBITED'));
+  assert.ok(keyBuilder.includes("SCOUT_LIVE_RATE_LIMIT_STORAGE_KEY_BUILDER_VERSION = '20260607-1'"));
+  assert.ok(keyBuilder.includes('storageKey: null'));
+  assert.ok(keyBuilder.includes('keyPreview: null'));
+  assert.ok(keyBuilder.includes('disabled: true'));
 });
 
 push('Endpoint and frontend defaults remain preserved', () => {


### PR DESCRIPTION
Refs #1882

Closes #2349

Scope:
- Add Scout live storage readiness audit after the storage key builder, storage adapter, dependency adapter, and safe-fail regression matrix slices.
- Summarize implemented storage/auth/rate-limit safety boundaries and current default behavior.
- Document go/no-go status for disabled scaffold work, runtime key builder work, real KV / Durable Object / D1 work, endpoint wiring, staging live, production live, and provider integration.
- Lock remaining blockers before any real storage backend implementation.
- Add contract coverage proving the audit exists, references the recent completed slices, preserves default stub/frontend local_stub behavior, and does not introduce runtime code changes.

Non-goals:
- No runtime behavior change.
- No endpoint wiring change.
- No real storage key generation for live traffic.
- No real hashing implementation or secret/salt access.
- No real KV, Durable Object, or D1 implementation.
- No frontend default source change.
- No provider integration.
- No Browse #1661 work.