### PR TITLE
test(scout): add hash helper no-storage guardrail

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-no-storage-backend-guardrail.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-no-storage-backend-guardrail.md
@@ -1,11 +1,12 @@
-# Scout storage hash helper no-storage-backend guardrail
+# Scout storage hash helper no-storage guardrail
 
 Issue: #2361
 Refs: #1882
 
 Regression only.
 
-The storage hash helper must not use storage backend tokens:
+Storage backend markers covered by this guardrail:
 SCOUT_RATE_LIMIT_KV, SCOUT_RATE_LIMIT_DO, SCOUT_RATE_LIMIT_D1, DurableObjectNamespace, idFromName, getByName, prepare, batch, exec.
 
-No runtime change. No real hashing. No
+No runtime change.
+No real hashing.

--- a/docs/product/lovebud-scout-storage-hash-helper-no-storage-backend-guardrail.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-no-storage-backend-guardrail.md
@@ -1,0 +1,11 @@
+# Scout storage hash helper no-storage-backend guardrail
+
+Issue: #2361
+Refs: #1882
+
+Regression only.
+
+The storage hash helper must not use storage backend tokens:
+SCOUT_RATE_LIMIT_KV, SCOUT_RATE_LIMIT_DO, SCOUT_RATE_LIMIT_D1, DurableObjectNamespace, idFromName, getByName, prepare, batch, exec.
+
+No runtime change. No real hashing. No

--- a/tests/contracts/scout-storage-hash-helper-no-storage-backend-guardrail-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-no-storage-backend-guardrail-contract.test.cjs
@@ -1,0 +1,1 @@
+const fs=require('fs');const p='functions/api/scout/live-rate-limit-storage-hash-helper.js';const s=fs.readFileSync(p,'utf8');for(const x of ['SCOUT_RATE_LIMIT_KV','SCOUT_RATE_LIMIT_DO','SCOUT_RATE_LIMIT_D1','DurableObjectNamespace','idFromName','getByName','prepare','batch','exec']){if(s.includes(x)){throw new Error(x)}}console.log('hash helper no-storage guardrail ok');


### PR DESCRIPTION
Closes #2361

Refs #1882

Regression-only guardrail for storage hash helper backend tokens. No runtime behavior change.