### PR TITLE
docs(scout): audit storage hash helper readiness

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-readiness-audit.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-readiness-audit.md
@@ -1,0 +1,20 @@
+# Scout storage hash helper readiness audit
+
+Status: docs/tests only.
+Issue: #2363.
+Parent: #1882.
+
+Covered boundaries:
+- disabled hash helper scaffold
+- sanitizer allows only userKeyHash
+- prohibited-field regression
+- no-crypto guardrail
+- no-storage-backend guardrail
+
+Current verdict:
+- GO: more docs and contracts.
+- NO-GO: real hashing.
+- NO-GO: salt or secret access.
+- NO-GO: KV, Durable Object, or D1.
+- NO-GO: endpoint or frontend changes.
+- NO-GO: provider integration

--- a/tests/contracts/scout-storage-hash-helper-readiness-audit-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-readiness-audit-contract.test.cjs
@@ -1,0 +1,1 @@
+const fs=require('fs');const a=fs.readFileSync('docs/product/lovebud-scout-storage-hash-helper-readiness-audit.md','utf8');for(const s of ['#2363','disabled hash helper scaffold','sanitizer allows only userKeyHash','no-crypto guardrail','no-storage-backend guardrail','NO-GO: real hashing','NO-GO: KV, Durable Object, or D1']){if(!a.includes(s))throw new Error(s)}


### PR DESCRIPTION
Refs #1882

Closes #2363

Docs/tests only. Adds Scout storage hash helper readiness audit and contract.

No runtime behavior change. No real hashing. No salt/secret access. No storage backend. No endpoint/frontend/provider change. No Browse #1661 work.