### PR TITLE
docs(scout): plan storage hash salt version policy

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-salt-version-policy.md
+++ b/docs/product/lovebud-scout-storage-hash-salt-version-policy.md
@@ -6,7 +6,9 @@ Rules:
 - No real hashing in this slice.
 - No salt or secret access in this slice.
 - Future hashes need a version label.
-- Future salts must stay server-side only.
-- Staging and production must not share hash namespace.
+- Future salts stay server-side only.
+- Staging and production use separate namespaces.
 - Rotation needs a rollback plan.
-- Frontend must never see salts, secrets
+- Frontend never sees salts or hash keys.
+
+Verdict: docs and contracts only. No runtime change.

--- a/docs/product/lovebud-scout-storage-hash-salt-version-policy.md
+++ b/docs/product/lovebud-scout-storage-hash-salt-version-policy.md
@@ -1,0 +1,12 @@
+# Scout storage hash salt/version policy
+
+Status: policy only. Issue: #2365. Refs #1882.
+
+Rules:
+- No real hashing in this slice.
+- No salt or secret access in this slice.
+- Future hashes need a version label.
+- Future salts must stay server-side only.
+- Staging and production must not share hash namespace.
+- Rotation needs a rollback plan.
+- Frontend must never see salts, secrets

--- a/tests/contracts/scout-storage-hash-salt-version-policy-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-salt-version-policy-contract.test.cjs
@@ -1,5 +1,7 @@
 const assert=require('assert');const fs=require('fs');
 const doc=fs.readFileSync('docs/product/lovebud-scout-storage-hash-salt-version-policy.md','utf8');
-const helper=fs.readFileSync('functions/api/scout/live-rate-limit-storage-hash-helper.js','utf8');
-['#2365','version label','server-side','separate namespaces','rollback','No runtime change'].forEach(s=>assert(doc.includes(s)));
-['SC
+assert(doc.includes('#2365'));
+assert(doc.includes('version label'));
+assert(doc.includes('server-side'));
+assert(doc.includes('separate namespaces'));
+assert(doc.includes('No runtime change'));

--- a/tests/contracts/scout-storage-hash-salt-version-policy-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-salt-version-policy-contract.test.cjs
@@ -1,0 +1,5 @@
+const assert=require('assert');const fs=require('fs');
+const doc=fs.readFileSync('docs/product/lovebud-scout-storage-hash-salt-version-policy.md','utf8');
+const helper=fs.readFileSync('functions/api/scout/live-rate-limit-storage-hash-helper.js','utf8');
+['#2365','version label','server-side','separate namespaces','rollback','No runtime change'].forEach(s=>assert(doc.includes(s)));
+['SC


### PR DESCRIPTION
Refs #1882

Closes #2365

Docs/tests only. Adds Scout storage hash salt/version policy plan.

No runtime hashing, no salt access, no KV/DO/D1, no endpoint/frontend/provider changes.