### PR TITLE
docs(scout): plan storage hash environment namespace policy

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-environment-namespace-policy.md
+++ b/docs/product/lovebud-scout-storage-hash-environment-namespace-policy.md
@@ -1,0 +1,23 @@
+# Scout Storage Hash Environment Namespace Policy
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2365
+
+Policy:
+- Staging and production must use separate namespaces.
+- Future preview/dev namespaces must stay isolated.
+- Every namespace needs an explicit version label.
+- Frontend must not see salts, namespace secrets, or hash keys.
+- Preview/dev namespaces cannot promote to production automatically.
+- Namespace rotation needs rollback guidance.
+
+Non-goals:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-environment-namespace-policy-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-environment-namespace-policy-contract.test.cjs
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-environment-namespace-policy.md');
+
+test('Scout storage hash environment namespace policy is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2365',
+    'Staging',
+    'production',
+    'separate namespaces',
+    'version label',
+    'Frontend',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2368

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.