### PR TITLE
docs(scout): plan storage hash namespace rollback policy

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-namespace-rollback-policy.md
+++ b/docs/product/lovebud-scout-storage-hash-namespace-rollback-policy.md
@@ -1,0 +1,23 @@
+# Scout Storage Hash Namespace Rollback Policy
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2368
+
+Policy:
+- Namespace rotation must include rollback guidance.
+- Rollback must identify the previous namespace version label.
+- Rollback must keep staging and production separate.
+- Rollback must not auto-promote preview/dev namespaces to production.
+- Rollback must not expose salts, namespace secrets, or hash keys.
+- Rollback evidence must be reviewed before production use.
+
+Non-goals:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-namespace-rollback-policy-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-namespace-rollback-policy-contract.test.cjs
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-namespace-rollback-policy.md');
+
+test('Scout storage hash namespace rollback policy is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2368',
+    'rollback guidance',
+    'previous namespace version label',
+    'staging and production separate',
+    'preview/dev namespaces',
+    'salts, namespace secrets, or hash keys',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2370

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.