### PR TITLE
docs(scout): audit storage hash namespace production readiness

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-namespace-production-readiness-audit.md
+++ b/docs/product/lovebud-scout-storage-hash-namespace-production-readiness-audit.md
@@ -1,0 +1,25 @@
+# Scout Storage Hash Namespace Production Readiness Audit
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2370
+
+Verdict: Not ready for production hash use.
+
+Required before production:
+- Explicit namespace version labels.
+- Staging and production namespace separation.
+- Preview/dev namespace isolation.
+- Rollback guidance with previous namespace version label.
+- Frontend secret non-exposure review.
+- Production evidence review before enablement.
+
+Current guardrails:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-namespace-production-readiness-audit-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-namespace-production-readiness-audit-contract.test.cjs
@@ -1,0 +1,26 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-namespace-production-readiness-audit.md');
+
+test('Scout storage hash namespace production readiness audit is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2370',
+    'Not ready for production hash use',
+    'Explicit namespace version labels',
+    'Staging and production namespace separation',
+    'Preview/dev namespace isolation',
+    'Rollback guidance',
+    'Frontend secret non-exposure review',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2372

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.