### PR TITLE
docs(scout): plan storage hash helper rollout checklist

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-rollout-checklist.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-rollout-checklist.md
@@ -1,0 +1,25 @@
+# Scout Storage Hash Helper Rollout Checklist
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2372
+
+Rollout status: Blocked before implementation.
+
+Required before rollout:
+- Namespace version labels reviewed.
+- Rollback guidance reviewed.
+- Staging and production separation reviewed.
+- Preview/dev isolation reviewed.
+- Frontend secret non-exposure reviewed.
+- Production evidence reviewed.
+
+Out of scope:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-helper-rollout-checklist-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-rollout-checklist-contract.test.cjs
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-rollout-checklist.md');
+
+test('Scout storage hash helper rollout checklist is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2372',
+    'Blocked before implementation',
+    'Namespace version labels reviewed',
+    'Rollback guidance reviewed',
+    'Staging and production separation reviewed',
+    'Preview/dev isolation reviewed',
+    'Frontend secret non-exposure reviewed',
+    'Production evidence reviewed',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2374

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.