### PR TITLE
docs(scout): plan storage hash helper implementation gate

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-implementation-gate.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-implementation-gate.md
@@ -1,0 +1,26 @@
+# Scout Storage Hash Helper Implementation Gate
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2374
+
+Gate status: Implementation blocked.
+
+Required before implementation:
+- Rollout checklist reviewed.
+- Namespace version labels reviewed.
+- Rollback guidance reviewed.
+- Environment separation reviewed.
+- Preview/dev isolation reviewed.
+- Frontend secret review complete.
+- Production evidence review complete.
+
+Blocked surfaces:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-helper-implementation-gate-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-implementation-gate-contract.test.cjs
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-implementation-gate.md');
+
+test('Scout storage hash helper implementation gate is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2374',
+    'Implementation blocked',
+    'Rollout checklist reviewed',
+    'Namespace version labels reviewed',
+    'Rollback guidance reviewed',
+    'Environment separation reviewed',
+    'Preview/dev isolation reviewed',
+    'Frontend secret review complete',
+    'Production evidence review complete',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2376

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.