### PR TITLE
docs(scout): add storage hash helper threat model note

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-threat-model-note.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-threat-model-note.md
@@ -1,0 +1,26 @@
+# Scout Storage Hash Helper Threat Model Note
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2376
+
+Threat model status: Pre-implementation note only.
+
+Threat surfaces to review:
+- Salt exposure.
+- Namespace secret exposure.
+- Hash key exposure.
+- Environment namespace confusion.
+- Preview/dev promotion to production.
+- Rollback to the wrong namespace version.
+- Frontend exposure of secrets or hash internals.
+
+Out of scope:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-helper-threat-model-note-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-threat-model-note-contract.test.cjs
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-threat-model-note.md');
+
+test('Scout storage hash helper threat model note is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2376',
+    'Pre-implementation note only',
+    'Salt exposure',
+    'Namespace secret exposure',
+    'Hash key exposure',
+    'Environment namespace confusion',
+    'Preview/dev promotion to production',
+    'Rollback to the wrong namespace version',
+    'Frontend exposure of secrets or hash internals',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2378

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.