### PR TITLE
docs(scout): add storage hash helper implementation preflight checklist

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md
@@ -1,0 +1,29 @@
+# Scout Storage Hash Helper Implementation Preflight Checklist
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2378
+
+Preflight status: Implementation blocked until all checks pass.
+
+Required preflight checks:
+- Readiness audit reviewed.
+- Rollout checklist reviewed.
+- Implementation gate reviewed.
+- Threat model note reviewed.
+- Namespace version labels reviewed.
+- Rollback guidance reviewed.
+- Environment separation reviewed.
+- Preview/dev isolation reviewed.
+- Frontend secret review complete.
+- Production evidence review complete.
+
+Out of scope:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-helper-implementation-preflight-checklist-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-implementation-preflight-checklist-contract.test.cjs
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md');
+
+test('Scout storage hash helper implementation preflight checklist is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2378',
+    'Implementation blocked until all checks pass',
+    'Readiness audit reviewed',
+    'Rollout checklist reviewed',
+    'Implementation gate reviewed',
+    'Threat model note reviewed',
+    'Namespace version labels reviewed',
+    'Rollback guidance reviewed',
+    'Environment separation reviewed',
+    'Preview/dev isolation reviewed',
+    'Frontend secret review complete',
+    'Production evidence review complete',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2380

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.