### PR TITLE
docs(scout): add storage hash helper parent index update

### DIFF
--- a/docs/product/lovebud-scout-storage-hash-helper-docs-index-audit-summary.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-docs-index-audit-summary.md
@@ -1,0 +1,31 @@
+# Scout Storage Hash Helper Docs Index and Audit Summary
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2380
+
+Summary status: Implementation remains blocked.
+
+Related docs:
+- Readiness audit: lovebud-scout-storage-hash-namespace-production-readiness-audit.md
+- Rollout checklist: lovebud-scout-storage-hash-helper-rollout-checklist.md
+- Implementation gate: lovebud-scout-storage-hash-helper-implementation-gate.md
+- Threat model note: lovebud-scout-storage-hash-helper-threat-model-note.md
+- Preflight checklist: lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md
+
+Audit summary:
+- Readiness must be reviewed.
+- Rollout must be reviewed.
+- Implementation gate must be reviewed.
+- Threat model must be reviewed.
+- Preflight checklist must pass.
+
+Out of scope:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/docs/product/lovebud-scout-storage-hash-helper-parent-index-update.md
+++ b/docs/product/lovebud-scout-storage-hash-helper-parent-index-update.md
@@ -1,0 +1,35 @@
+# Scout Storage Hash Helper Parent Index Update
+
+Status: docs/tests only. No runtime change.
+
+Parent issue: #1882
+Depends on: #2382
+
+Index update status: Parent link note only.
+
+Parent plan:
+- lovebud-scout-runtime-rate-limit-storage-implementation-plan.md
+
+Hash helper index:
+- lovebud-scout-storage-hash-helper-docs-index-audit-summary.md
+
+Linked preparation docs:
+- lovebud-scout-storage-hash-namespace-production-readiness-audit.md
+- lovebud-scout-storage-hash-helper-rollout-checklist.md
+- lovebud-scout-storage-hash-helper-implementation-gate.md
+- lovebud-scout-storage-hash-helper-threat-model-note.md
+- lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md
+
+Summary:
+- The runtime rate-limit storage implementation plan remains the parent plan.
+- The hash helper docs index is the child audit summary for hash-specific preparation.
+- Implementation remains blocked until readiness, rollout, gate, threat model, and preflight checks pass.
+
+Out of scope:
+- No real hashing.
+- No salt or secret access.
+- No KV/DO/D1.
+- No endpoint wiring change.
+- No frontend default source change.
+- No provider integration.
+- No Browse #1661 work.

--- a/tests/contracts/scout-storage-hash-helper-docs-index-audit-summary-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-docs-index-audit-summary-contract.test.cjs
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-docs-index-audit-summary.md');
+
+test('Scout storage hash helper docs index audit summary is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2380',
+    'Implementation remains blocked',
+    'lovebud-scout-storage-hash-namespace-production-readiness-audit.md',
+    'lovebud-scout-storage-hash-helper-rollout-checklist.md',
+    'lovebud-scout-storage-hash-helper-implementation-gate.md',
+    'lovebud-scout-storage-hash-helper-threat-model-note.md',
+    'lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md',
+    'Readiness must be reviewed',
+    'Rollout must be reviewed',
+    'Implementation gate must be reviewed',
+    'Threat model must be reviewed',
+    'Preflight checklist must pass',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});

--- a/tests/contracts/scout-storage-hash-helper-parent-index-update-contract.test.cjs
+++ b/tests/contracts/scout-storage-hash-helper-parent-index-update-contract.test.cjs
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const docPath = path.join(__dirname, '..', '..', 'docs', 'product', 'lovebud-scout-storage-hash-helper-parent-index-update.md');
+
+test('Scout storage hash helper parent index update is documented', () => {
+  const doc = fs.readFileSync(docPath, 'utf8');
+  for (const phrase of [
+    '#1882',
+    '#2382',
+    'Parent link note only',
+    'lovebud-scout-runtime-rate-limit-storage-implementation-plan.md',
+    'lovebud-scout-storage-hash-helper-docs-index-audit-summary.md',
+    'lovebud-scout-storage-hash-namespace-production-readiness-audit.md',
+    'lovebud-scout-storage-hash-helper-rollout-checklist.md',
+    'lovebud-scout-storage-hash-helper-implementation-gate.md',
+    'lovebud-scout-storage-hash-helper-threat-model-note.md',
+    'lovebud-scout-storage-hash-helper-implementation-preflight-checklist.md',
+    'Implementation remains blocked until readiness, rollout, gate, threat model, and preflight checks pass',
+    'No runtime change',
+    'No real hashing',
+    'No salt or secret access',
+    'No KV/DO/D1'
+  ]) {
+    assert.match(doc, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});


### PR DESCRIPTION
Refs #1882

Closes #2384

Docs/tests only. No runtime change. No hashing. No salt/secret access. No KV/DO/D1. No endpoint/frontend/provider change.