### PR TITLE
fix(settings): allow profile menu trigger clicks

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -311,13 +311,6 @@
         closeSettings();
       }
     });
-
-    document.addEventListener('click', function(e) {
-      var trigger = e.target.closest('.user-dropdown-trigger');
-      if (!trigger) return;
-      e.preventDefault();
-      e.stopPropagation();
-    }, true);
   }
 
   var settingsStarted = false;

--- a/tests/contracts/settings-profile-menu-click-contract.test.cjs
+++ b/tests/contracts/settings-profile-menu-click-contract.test.cjs
@@ -1,0 +1,14 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const settingsJsPath = path.join(__dirname, '..', '..', 'js', 'settings.js');
+
+test('settings page does not block shared profile dropdown trigger clicks', () => {
+  const source = fs.readFileSync(settingsJsPath, 'utf8');
+
+  assert.match(source, /function bindCloseInteractions\(\)/);
+  assert.doesNotMatch(source, /document\.addEventListener\(\s*['"]click['"][\s\S]*?user-dropdown-trigger[\s\S]*?preventDefault\(\)[\s\S]*?stopPropagation\(\)[\s\S]*?true\s*\)/);
+  assert.doesNotMatch(source, /e\.target\.closest\(['"]\.user-dropdown-trigger['"]\)[\s\S]*?e\.preventDefault\(\)[\s\S]*?e\.stopPropagation\(\)/);
+});


### PR DESCRIPTION
Closes #2401

Summary:
- remove the settings-page capture listener that blocked `.user-dropdown-trigger` clicks
- allow the shared auth dropdown listener to open the profile/account menu on settings page
- add a contract test guarding against reintroducing the blocker

Scope:
- no auth/session behavior change
- no backend/API change
- no account menu redesign

Test:
- added tests/contracts/settings-profile-menu-click-contract.test.cjs