### PR TITLE
fix(editor): hide selected detail controls without memory

### DIFF
--- a/js/editor/editor-detail-ui.js
+++ b/js/editor/editor-detail-ui.js
@@ -38,8 +38,6 @@ function createEditorDetailUI(deps) {
         getMemoFallbackText
     } = createEditorDetailUIBuilders({ formatI18nText });
 
-    // ── Tree meta boundary integration ───────────────────────────────────────
-    // Use extracted helper from PR #664 for tree meta boundary
     const treeMetaBoundary = window.createEditorDetailTreeMetaBoundary({
         i18n,
         formatI18nText,
@@ -49,7 +47,6 @@ function createEditorDetailUI(deps) {
         openCurrentMomentDetail
     });
     const { buildTreeMetaRenderModel, renderTreeMetaBoundary } = treeMetaBoundary;
-    // ──────────────────────────────────────────────────────────────────
 
     const getTreeState = () => {
         const canonicalRootId = getCanonicalRootId();
@@ -71,8 +68,6 @@ function createEditorDetailUI(deps) {
         };
     };
 
-    // ── Inline edit boundary integration ───────────────────────────────────────
-    // Use extracted helper for title/memo edit boundaries
     const inlineEditHelper = window.createEditorDetailInlineEditBoundary({
         updateSelectedMemoryFields,
         showToast,
@@ -82,7 +77,17 @@ function createEditorDetailUI(deps) {
     });
     const createTitleEditBoundary = inlineEditHelper.createTitleEditBoundary;
     const createMemoEditBoundary = inlineEditHelper.createMemoEditBoundary;
-    // ──────────────────────────────────────────────────────────────────────────
+
+    const clearDetailMedia = () => {
+        const mediaWrap = detailPanel.querySelector('.detail-video');
+        const imgEl = detailPanel.querySelector('.detail-video img');
+        if (imgEl) {
+            imgEl.removeAttribute('src');
+            imgEl.src = '';
+            imgEl.alt = '';
+        }
+        if (mediaWrap) mediaWrap.style.display = 'none';
+    };
 
     const resetDetailViewState = () => {
         const headerEl = detailPanel.querySelector('h3');
@@ -90,30 +95,19 @@ function createEditorDetailUI(deps) {
             headerEl.textContent = formatI18nText('editor_current_hub_heading', '현재 순간 허브');
         }
 
-        const imgEl = detailPanel.querySelector('.detail-video img');
-        if (imgEl) {
-            imgEl.removeAttribute('src');
-            imgEl.src = '';
-            imgEl.alt = '';
-        }
+        clearDetailMedia();
 
         const treeMetaMount = document.getElementById('detailTreeMetaMount');
         if (treeMetaMount) treeMetaMount.innerHTML = '';
 
         const dateEl = document.getElementById('detailDateText');
-        if (dateEl) {
-            dateEl.textContent = '';
-        }
+        if (dateEl) dateEl.textContent = '';
 
         const tagsContainer = detailPanel.querySelector('.tags-container');
-        if (tagsContainer) {
-            tagsContainer.innerHTML = '';
-        }
+        if (tagsContainer) tagsContainer.innerHTML = '';
 
         const noteEl = document.querySelector('.diary-note');
-        if (noteEl) {
-            noteEl.innerHTML = '';
-        }
+        if (noteEl) noteEl.innerHTML = '';
 
         const editTitleInput = document.getElementById('editTitleInput');
         const editMemoInput = document.getElementById('editMemoInput');
@@ -136,6 +130,21 @@ function createEditorDetailUI(deps) {
         }
     };
 
+    const bindDetailEmptyStartButton = (emptyState) => {
+        const startBtn = emptyState && emptyState.querySelector('#detailEmptyStartBtn');
+        if (!startBtn || startBtn.dataset.bound === '1') return;
+        startBtn.dataset.bound = '1';
+        startBtn.addEventListener('click', () => {
+            const addBtn = document.getElementById('addMemoryBtn');
+            if (addBtn) {
+                addBtn.click();
+                return;
+            }
+            const emptyStartBtn = document.getElementById('canvasEmptyStartBtn');
+            if (emptyStartBtn) emptyStartBtn.click();
+        });
+    };
+
     const setDetailEmptyState = (isEmpty) => {
         const detailContent = document.getElementById('detailContent');
         if (!detailContent) return;
@@ -144,28 +153,34 @@ function createEditorDetailUI(deps) {
         if (!emptyState) {
             emptyState = document.createElement('div');
             emptyState.id = 'detailEmptyState';
-            emptyState.innerHTML = '<div style="text-align:center;padding:40px 24px;color:var(--on-surface-variant);"><span class="material-symbols-outlined" style="font-size:48px;opacity:0.4;margin-bottom:16px;display:block;">sentiment_satisfied</span><p style="font-size:1rem;font-weight:700;margin-bottom:8px;color:var(--on-surface);">' + formatI18nText('detail_empty_title', '첫 순간이 트리를 깨워요') + '</p><p style="font-size:0.9rem;opacity:0.78;line-height:1.6;">' + formatI18nText('detail_empty_desc', '첫 순간을 심으면 이 패널이 현재 순간 허브로 바뀝니다.') + '</p></div>';
+            emptyState.innerHTML = [
+                '<div style="text-align:center;padding:40px 24px;color:var(--on-surface-variant);">',
+                '<span class="material-symbols-outlined" style="font-size:48px;opacity:0.4;margin-bottom:16px;display:block;">sentiment_satisfied</span>',
+                '<p style="font-size:1rem;font-weight:700;margin-bottom:8px;color:var(--on-surface);">' + formatI18nText('detail_empty_title', '첫 순간이 트리를 깨워요') + '</p>',
+                '<p style="font-size:0.9rem;opacity:0.78;line-height:1.6;margin-bottom:18px;">' + formatI18nText('detail_empty_desc', '첫 순간을 심으면 이 패널이 현재 순간 허브로 바뀝니다.') + '</p>',
+                '<button type="button" id="detailEmptyStartBtn" class="btn-round btn-primary">' + formatI18nText('create_first_moment', '첫 순간 만들기') + '</button>',
+                '</div>'
+            ].join('');
             detailContent.appendChild(emptyState);
         }
+        bindDetailEmptyStartButton(emptyState);
 
         const viewMode = document.getElementById('detailViewMode');
         const editMode = document.getElementById('detailEditMode');
         const actions = detailContent.querySelector('.memory-actions');
         const indicator = document.getElementById('saveStatusIndicator');
+        const reactionsCard = document.getElementById('momentReactionsCard');
 
-        if (isEmpty) {
-            resetDetailViewState();
-        }
+        if (isEmpty) resetDetailViewState();
 
         if (emptyState) emptyState.style.display = isEmpty ? 'block' : 'none';
         if (viewMode) viewMode.style.display = isEmpty ? 'none' : 'block';
         if (editMode) editMode.style.display = 'none';
         if (actions) actions.style.display = isEmpty ? 'none' : 'flex';
         if (indicator && isEmpty) indicator.style.display = 'none';
+        if (reactionsCard && isEmpty) reactionsCard.style.display = 'none';
         const footer = document.getElementById('detailPanelFooter');
-        if (footer) {
-            footer.style.display = 'none';
-        }
+        if (footer) footer.style.display = 'none';
     };
 
     const updateFocusSelectedBtn = () => {
@@ -218,49 +233,64 @@ function createEditorDetailUI(deps) {
         return actionSlot;
     };
 
-     const updateDetailPanel = (data) => {
-         const currentTree = getCurrentTreeData() || {};
-         const treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
-         const treeState = getTreeState();
-         const canonicalRootId = treeState.canonicalRootId;
-         const isEmptyState = !!data?.isNewTree && !treeState.hasMoments;
-         const isRootSelected = !isEmptyState && isRootMemory(data, canonicalRootId);
-         const localSaveMode = getLocalSaveMode();
+    const updateDetailPanel = (data) => {
+        const currentTree = getCurrentTreeData() || {};
+        const treeId = currentTree.id || new URLSearchParams(window.location.search).get('tree');
+        const treeState = getTreeState();
+        const canonicalRootId = treeState.canonicalRootId;
+        const selectedNodeId = getSelectedNodeId();
+        const hasSelectedMemory = !!(data && data.id && !data.isNewTree && selectedNodeId);
+        const isEmptyState = !hasSelectedMemory || !treeState.hasMoments || !!data?.isNewTree;
+        const isRootSelected = !isEmptyState && isRootMemory(data, canonicalRootId);
+        const localSaveMode = getLocalSaveMode();
 
-         const headerEl = detailPanel.querySelector('h3');
-         if (headerEl) {
-             headerEl.textContent = formatI18nText('editor_current_hub_heading', '현재 순간 허브');
-         }
+        const headerEl = detailPanel.querySelector('h3');
+        if (headerEl) {
+            headerEl.textContent = formatI18nText('editor_current_hub_heading', '현재 순간 허브');
+        }
 
-         const badgeEl = document.getElementById('detailCurrentMomentBadge');
-         const titleEl = document.getElementById('detailCurrentMomentTitle');
-         const hintEl = document.getElementById('detailCurrentMomentHint');
-         const treeMetaMount = document.getElementById('detailTreeMetaMount');
-         const imgEl = detailPanel.querySelector('.detail-video img');
-         const dateEl = document.getElementById('detailDateText');
-         const tagsContainer = detailPanel.querySelector('.tags-container');
-         const noteEl = document.querySelector('.diary-note');
-         const memoEditButtonMount = prepareMemoHeadingActionSlot();
-         const memoryActions = detailPanel.querySelector('.memory-actions');
+        const badgeEl = document.getElementById('detailCurrentMomentBadge');
+        const titleEl = document.getElementById('detailCurrentMomentTitle');
+        const hintEl = document.getElementById('detailCurrentMomentHint');
+        const treeMetaMount = document.getElementById('detailTreeMetaMount');
+        const imgEl = detailPanel.querySelector('.detail-video img');
+        const mediaWrap = detailPanel.querySelector('.detail-video');
+        const dateEl = document.getElementById('detailDateText');
+        const tagsContainer = detailPanel.querySelector('.tags-container');
+        const noteEl = document.querySelector('.diary-note');
+        const memoEditButtonMount = prepareMemoHeadingActionSlot();
+        const memoryActions = detailPanel.querySelector('.memory-actions');
 
-         const treeMetaModel = buildTreeMetaRenderModel({
-             currentTree: currentTree || {},
-             treeState,
-             data,
-             isEmptyState,
-             localSaveMode
-         });
+        if (isEmptyState) {
+            if (badgeEl) badgeEl.textContent = formatI18nText('waiting_first_moment', '첫 순간을 기다리고 있어요');
+            if (titleEl) titleEl.textContent = formatI18nText('editor_current_moment_empty_title', '이 트리의 첫 장면을 심어 보세요');
+            if (hintEl) {
+                hintEl.textContent = '';
+                hintEl.hidden = true;
+            }
+            setDetailEmptyState(true);
+            updateFocusSelectedBtn();
+            return;
+        }
 
-         if (treeMetaMount) {
-             renderTreeMetaBoundary(treeMetaMount, treeMetaModel, treeId, data);
-         }
+        setDetailEmptyState(false);
+
+        const treeMetaModel = buildTreeMetaRenderModel({
+            currentTree: currentTree || {},
+            treeState,
+            data,
+            isEmptyState,
+            localSaveMode
+        });
+
+        if (treeMetaMount) {
+            renderTreeMetaBoundary(treeMetaMount, treeMetaModel, treeId, data);
+        }
 
         if (badgeEl) {
-            badgeEl.textContent = isEmptyState
-                ? formatI18nText('waiting_first_moment', '첫 순간을 기다리고 있어요')
-                : isRootSelected
-                    ? formatI18nText('start_moment', '시작 순간')
-                    : formatI18nText('selected_moment', '선택된 순간');
+            badgeEl.textContent = isRootSelected
+                ? formatI18nText('start_moment', '시작 순간')
+                : formatI18nText('selected_moment', '선택된 순간');
         }
 
         if (titleEl) {
@@ -274,9 +304,7 @@ function createEditorDetailUI(deps) {
 
             const titleText = document.createElement('span');
             titleText.style.flex = '1';
-            titleText.textContent = isEmptyState
-                ? formatI18nText('editor_current_moment_empty_title', '이 트리의 첫 장면을 심어 보세요')
-                : (data.title || formatI18nText('editor_current_moment_title', '지금 마음이 머문 장면'));
+            titleText.textContent = data.title || formatI18nText('editor_current_moment_title', '지금 마음이 머문 장면');
 
             titleContainer.appendChild(titleText);
 
@@ -297,12 +325,18 @@ function createEditorDetailUI(deps) {
         }
 
         if (imgEl) {
-            imgEl.src = resolveMemoryThumbnail(data);
-            imgEl.alt = isEmptyState ? '' : (data.title || '');
+            const thumbnail = resolveMemoryThumbnail(data);
+            if (thumbnail) {
+                imgEl.src = thumbnail;
+                imgEl.alt = data.title || '';
+                if (mediaWrap) mediaWrap.style.display = '';
+            } else {
+                clearDetailMedia();
+            }
         }
 
         if (dateEl) {
-            dateEl.textContent = isEmptyState ? '' : (data?.timestamp || '');
+            dateEl.textContent = data?.timestamp || '';
         }
 
         if (tagsContainer) {
@@ -327,9 +361,7 @@ function createEditorDetailUI(deps) {
             memoBody.style.fontSize = '0.95rem';
             memoBody.style.color = 'var(--on-surface)';
             memoBody.style.whiteSpace = 'pre-line';
-            memoBody.textContent = isEmptyState
-                ? getMemoFallbackText({ isEmptyState: true })
-                : (data.memo || formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요'));
+            memoBody.textContent = data.memo || formatI18nText('emptyMemoryNote', '아직 메모가 남겨지지 않았어요');
             memoContainer.appendChild(memoBody);
 
             createMemoEditBoundary(memoContainer, data, {
@@ -343,30 +375,27 @@ function createEditorDetailUI(deps) {
 
             noteEl.appendChild(memoContainer);
 
-            if (!isEmptyState) {
-                const memoHint = document.createElement('div');
-                memoHint.style.marginTop = '12px';
-                memoHint.style.fontSize = '12px';
-                memoHint.style.lineHeight = '1.65';
+            const memoHint = document.createElement('div');
+            memoHint.style.marginTop = '12px';
+            memoHint.style.fontSize = '12px';
+            memoHint.style.lineHeight = '1.65';
 
-                if (isRootSelected) {
-                    memoHint.style.color = 'var(--primary)';
-                    memoHint.innerHTML = `<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:4px;">star</span> ${formatI18nText('root_moment_hint', '이 순간은 현재 트리의 시작점입니다')}`;
-                } else if (data.parentId) {
-                    memoHint.style.paddingTop = '12px';
-                    memoHint.style.borderTop = '1px solid var(--outline-variant)';
-                }
+            if (isRootSelected) {
+                memoHint.style.color = 'var(--primary)';
+                memoHint.innerHTML = `<span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle;margin-right:4px;">star</span> ${formatI18nText('root_moment_hint', '이 순간은 현재 트리의 시작점입니다')}`;
+            } else if (data.parentId) {
+                memoHint.style.paddingTop = '12px';
+                memoHint.style.borderTop = '1px solid var(--outline-variant)';
+            }
 
-                if (memoHint.innerHTML) {
-                    noteEl.appendChild(memoHint);
-                }
+            if (memoHint.innerHTML) {
+                noteEl.appendChild(memoHint);
             }
         }
 
-        // --- 1288 Phase B: Reactions & Comments ---
         const reactionsCard = document.getElementById('momentReactionsCard');
         if (reactionsCard) {
-            if (isRootMemory(data, canonicalRootId)) {
+            if (isEmptyState || !data?.id || isRootMemory(data, canonicalRootId)) {
                 reactionsCard.style.display = 'none';
             } else {
                 reactionsCard.style.display = '';
@@ -374,7 +403,7 @@ function createEditorDetailUI(deps) {
                 const likeBtn = document.getElementById('momentLikeBtn');
                 const likeCount = document.getElementById('momentLikeCount');
                 const commentCount = document.getElementById('momentCommentCount');
-                
+
                 if (likeBtn && likeCount && commentCount) {
                     likeBtn.dataset.reacted = 'false';
                     likeBtn.querySelector('.editor-reaction-like-icon').textContent = '🤍';
@@ -434,7 +463,6 @@ function createEditorDetailUI(deps) {
                 }
             }
         }
-        // --- End Reactions ---
 
         if (memoryActions) {
             memoryActions.style.display = isEmptyState ? 'none' : 'flex';
@@ -442,7 +470,6 @@ function createEditorDetailUI(deps) {
         }
     };
 
-    /* #1035: Wire up selected moment action buttons */
     const viewMomentDetailBtn = document.getElementById('viewMomentDetailBtn');
     if (viewMomentDetailBtn && viewMomentDetailBtn.dataset.bound !== '1') {
         viewMomentDetailBtn.dataset.bound = '1';
@@ -461,12 +488,10 @@ function createEditorDetailUI(deps) {
     if (continueFromMomentBtn && continueFromMomentBtn.dataset.bound !== '1') {
         continueFromMomentBtn.dataset.bound = '1';
         continueFromMomentBtn.addEventListener('click', () => {
-            /* Trigger add memory form — same as canvas "add memory" affordance */
             const addBtn = document.getElementById('addMemoryBtn');
             if (addBtn) {
                 addBtn.click();
             } else {
-                /* Fallback: try the canvas empty start button */
                 const emptyStartBtn = document.getElementById('canvasEmptyStartBtn');
                 if (emptyStartBtn) emptyStartBtn.click();
             }

--- a/tests/contracts/editor-empty-detail-panel-contract.test.cjs
+++ b/tests/contracts/editor-empty-detail-panel-contract.test.cjs
@@ -1,0 +1,20 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const detailUiPath = path.join(__dirname, '..', '..', 'js', 'editor', 'editor-detail-ui.js');
+
+test('editor detail panel hides selected-memory UI when no memory is selected', () => {
+  const source = fs.readFileSync(detailUiPath, 'utf8');
+
+  assert.match(source, /const selectedNodeId = getSelectedNodeId\(\);/);
+  assert.match(source, /const hasSelectedMemory = !!\(data && data\.id && !data\.isNewTree && selectedNodeId\);/);
+  assert.match(source, /const isEmptyState = !hasSelectedMemory \|\| !treeState\.hasMoments \|\| !!data\?\.isNewTree;/);
+  assert.match(source, /if \(isEmptyState\) \{[\s\S]*?setDetailEmptyState\(true\);[\s\S]*?return;[\s\S]*?\}/);
+  assert.match(source, /if \(reactionsCard && isEmpty\) reactionsCard\.style\.display = 'none';/);
+  assert.match(source, /if \(isEmptyState \|\| !data\?\.id \|\| isRootMemory\(data, canonicalRootId\)\) \{[\s\S]*?reactionsCard\.style\.display = 'none';/);
+  assert.match(source, /const thumbnail = resolveMemoryThumbnail\(data\);[\s\S]*?if \(thumbnail\) \{[\s\S]*?\} else \{[\s\S]*?clearDetailMedia\(\);[\s\S]*?\}/);
+  assert.match(source, /id="detailEmptyStartBtn"/);
+  assert.match(source, /formatI18nText\('create_first_moment', '첫 순간 만들기'\)/);
+});


### PR DESCRIPTION
Closes #2400

Summary:
- treat no selected memory / no moments / new-tree sentinel data as editor detail empty state
- hide selected-moment media, actions, forms, and reactions in empty state
- clear invalid media instead of rendering a broken image box
- add a detail empty-state first-moment CTA that reuses the add-memory/canvas-empty affordance
- add a regression contract for empty detail panel rendering

Scope:
- no backend/API change
- no data model migration
- no Browse #1661 work
- no unrelated editor redesign

Test:
- added tests/contracts/editor-empty-detail-panel-contract.test.cjs