### PR TITLE
db(browse): add tree social counts migration contract

### DIFF
--- a/scripts/migration-add-tree-social-counts.sql
+++ b/scripts/migration-add-tree-social-counts.sql
@@ -1,0 +1,42 @@
+-- Migration: Add tree-level social counts foundation for Browse sorting
+--
+-- Refs #1661
+--
+-- This migration is the Unit A1 data-model foundation for tree-level likes.
+-- It is intentionally separate from the existing memory-level reactions table.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/migration-add-tree-social-counts.sql
+--
+-- This script does not enable sort=likes, sort=views, Browse UI labels,
+-- runtime view tracking, or broad analytics.
+
+CREATE TABLE IF NOT EXISTS tree_likes (
+    id UUID PRIMARY KEY,
+    tree_id UUID NOT NULL REFERENCES trees(id) ON DELETE CASCADE,
+    owner_id VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP WITH TIME ZONE NULL
+);
+
+-- One active like per account per tree. Toggle-off semantics should set deleted_at.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_likes_tree_owner_active
+    ON tree_likes(tree_id, owner_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tree_likes_tree_id ON tree_likes(tree_id);
+CREATE INDEX IF NOT EXISTS idx_tree_likes_owner_id ON tree_likes(owner_id);
+CREATE INDEX IF NOT EXISTS idx_tree_likes_created_at ON tree_likes(created_at);
+
+CREATE TABLE IF NOT EXISTS tree_social_counts (
+    tree_id UUID PRIMARY KEY REFERENCES trees(id) ON DELETE CASCADE,
+    like_count INTEGER NOT NULL DEFAULT 0 CHECK (like_count >= 0),
+    view_count INTEGER NOT NULL DEFAULT 0 CHECK (view_count >= 0),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tree_social_counts_like_count
+    ON tree_social_counts(like_count DESC, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tree_social_counts_view_count
+    ON tree_social_counts(view_count DESC, updated_at DESC);

--- a/tests/contracts/migration-tree-social-counts-contract.test.cjs
+++ b/tests/contracts/migration-tree-social-counts-contract.test.cjs
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const migrationPath = path.join(ROOT, 'scripts', 'migration-add-tree-social-counts.sql');
+const memoryReactionMigrationPath = path.join(ROOT, 'scripts', 'migration-add-reactions-comments.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+const memoryReactionSql = fs.readFileSync(memoryReactionMigrationPath, 'utf8');
+
+test('tree social counts migration creates tree_likes separately from memory reactions', () => {
+  assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_likes/i);
+  assert.match(sql, /tree_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+trees\(id\)\s+ON\s+DELETE\s+CASCADE/i);
+  assert.match(sql, /owner_id\s+VARCHAR\(128\)\s+NOT\s+NULL/i);
+  assert.match(sql, /deleted_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NULL/i);
+  assert.doesNotMatch(sql, /memory_id\s+UUID/i);
+  assert.match(memoryReactionSql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+reactions/i);
+  assert.match(memoryReactionSql, /memory_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+memories\(id\)/i);
+});
+
+test('tree_likes migration enforces one active like per account per tree', () => {
+  assert.match(sql, /CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_tree_likes_tree_owner_active/i);
+  assert.match(sql, /ON\s+tree_likes\(tree_id,\s*owner_id\)/i);
+  assert.match(sql, /WHERE\s+deleted_at\s+IS\s+NULL/i);
+});
+
+test('tree social counts migration creates aggregate counts table', () => {
+  assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_social_counts/i);
+  assert.match(sql, /tree_id\s+UUID\s+PRIMARY\s+KEY\s+REFERENCES\s+trees\(id\)\s+ON\s+DELETE\s+CASCADE/i);
+  assert.match(sql, /like_count\s+INTEGER\s+NOT\s+NULL\s+DEFAULT\s+0\s+CHECK\s*\(like_count\s+>=\s+0\)/i);
+  assert.match(sql, /view_count\s+INTEGER\s+NOT\s+NULL\s+DEFAULT\s+0\s+CHECK\s*\(view_count\s+>=\s+0\)/i);
+  assert.match(sql, /updated_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
+});
+
+test('tree social counts migration prepares future sort indexes without enabling API sort', () => {
+  assert.match(sql, /idx_tree_social_counts_like_count/i);
+  assert.match(sql, /ON\s+tree_social_counts\(like_count\s+DESC,\s*updated_at\s+DESC\)/i);
+  assert.match(sql, /idx_tree_social_counts_view_count/i);
+  assert.match(sql, /ON\s+tree_social_counts\(view_count\s+DESC,\s*updated_at\s+DESC\)/i);
+  assert.doesNotMatch(sql, /sort=likes/i);
+  assert.doesNotMatch(sql, /sort=views/i);
+});
+
+test('tree social counts migration keeps scope narrow', () => {
+  assert.match(sql, /does not enable sort=likes, sort=views, Browse UI labels/i);
+  assert.match(sql, /runtime view tracking, or broad analytics/i);
+  assert.doesNotMatch(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_views/i);
+  assert.doesNotMatch(sql, /ALTER\s+TABLE\s+trees\s+ADD/i);
+});

--- a/tests/contracts/migration-tree-social-counts-contract.test.cjs
+++ b/tests/contracts/migration-tree-social-counts-contract.test.cjs
@@ -6,8 +6,10 @@ const test = require('node:test');
 const ROOT = path.join(__dirname, '..', '..');
 const migrationPath = path.join(ROOT, 'scripts', 'migration-add-tree-social-counts.sql');
 const memoryReactionMigrationPath = path.join(ROOT, 'scripts', 'migration-add-reactions-comments.sql');
+const routerPath = path.join(ROOT, 'functions', 'api', '[[path]].js');
 const sql = fs.readFileSync(migrationPath, 'utf8');
 const memoryReactionSql = fs.readFileSync(memoryReactionMigrationPath, 'utf8');
+const router = fs.readFileSync(routerPath, 'utf8');
 
 test('tree social counts migration creates tree_likes separately from memory reactions', () => {
   assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_likes/i);
@@ -33,13 +35,12 @@ test('tree social counts migration creates aggregate counts table', () => {
   assert.match(sql, /updated_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
 });
 
-test('tree social counts migration prepares future sort indexes without enabling API sort', () => {
+test('tree social counts migration prepares future count indexes without changing router behavior', () => {
   assert.match(sql, /idx_tree_social_counts_like_count/i);
   assert.match(sql, /ON\s+tree_social_counts\(like_count\s+DESC,\s*updated_at\s+DESC\)/i);
   assert.match(sql, /idx_tree_social_counts_view_count/i);
   assert.match(sql, /ON\s+tree_social_counts\(view_count\s+DESC,\s*updated_at\s+DESC\)/i);
-  assert.doesNotMatch(sql, /sort=likes/i);
-  assert.doesNotMatch(sql, /sort=views/i);
+  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
 });
 
 test('tree social counts migration keeps scope narrow', () => {


### PR DESCRIPTION
Refs #1661

Summary:
- add Unit A1 tree-level social counts migration contract
- introduce `tree_likes` separately from memory-level `reactions`
- enforce one active tree like per account/tree through a partial unique index
- introduce `tree_social_counts` aggregate table for future `likeCount` / `viewCount`
- add sort-prep indexes without enabling `sort=likes` or `sort=views`
- add contract tests that keep memory-level reactions separate and scope this slice narrowly

Scope:
- no API behavior change
- no Browse UI change
- no sort=likes or sort=views support
- no runtime view tracking
- no broad analytics
- no execution of the migration in this PR

Test:
- added tests/contracts/migration-tree-social-counts-contract.test.cjs