### PR TITLE
feat(browse): add tree like API boundary

### DIFF
--- a/functions/api/trees/[tree_id]/likes.js
+++ b/functions/api/trees/[tree_id]/likes.js
@@ -1,0 +1,137 @@
+function stripTrailingSlash(value) {
+  return String(value || '').replace(/\/$/, '');
+}
+
+const REQUEST_ID_HEADER = 'x-lovebud-request-id';
+const MODAL_FETCH_TIMEOUT_MS = 25000;
+
+function generateRequestId() {
+  return 'req-' + crypto.randomUUID();
+}
+
+function getOrCreateRequestId(request) {
+  const existing = request.headers.get(REQUEST_ID_HEADER);
+  return existing || generateRequestId();
+}
+
+function hasAuthorizationHeader(request) {
+  return !!(request.headers.get('authorization') || request.headers.get('Authorization'));
+}
+
+function buildMissingAuthorizationResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Authorization required' }), {
+    status: 401,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'cloudflare',
+      'x-lovebud-route-status': 'missing-authorization',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildModalUnavailableResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Modal backend unavailable' }), {
+    status: 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-degraded': 'modal-unavailable',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildModalTimeoutResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Modal upstream timeout' }), {
+    status: 504,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-route-status': 'modal-timeout',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildMethodNotAllowedResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+    status: 405,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'cloudflare',
+      'x-lovebud-route-status': 'method-not-allowed',
+      allow: 'GET, POST',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildModalUrl(request, env) {
+  const modalBaseUrl = stripTrailingSlash(env.MODAL_BASE_URL);
+  if (!modalBaseUrl) return null;
+  const url = new URL(request.url);
+  const parts = url.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+  const treeId = parts[2] || '';
+  if (!treeId) return null;
+  const target = new URL(modalBaseUrl);
+  target.pathname = `/modal/private/trees/${encodeURIComponent(decodeURIComponent(treeId))}/likes`;
+  return target;
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), MODAL_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function proxyTreeLike(request, env) {
+  const method = request.method.toUpperCase();
+  const requestId = getOrCreateRequestId(request);
+  if (!['GET', 'POST'].includes(method)) return buildMethodNotAllowedResponse(requestId);
+  if (!hasAuthorizationHeader(request)) return buildMissingAuthorizationResponse(requestId);
+
+  const modalUrl = buildModalUrl(request, env || {});
+  if (!modalUrl) return buildModalUnavailableResponse(requestId);
+
+  const headers = {
+    accept: 'application/json',
+    authorization: request.headers.get('authorization') || request.headers.get('Authorization'),
+    [REQUEST_ID_HEADER]: requestId
+  };
+
+  try {
+    const response = await fetchWithTimeout(modalUrl.toString(), {
+      method,
+      headers,
+      body: null
+    });
+    const responseHeaders = new Headers(response.headers);
+    responseHeaders.set('x-lovebud-upstream', 'modal');
+    responseHeaders.set(REQUEST_ID_HEADER, requestId);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders
+    });
+  } catch (error) {
+    if (error.name === 'AbortError') return buildModalTimeoutResponse(requestId);
+    return buildModalUnavailableResponse(requestId);
+  }
+}
+
+export async function onRequestGet(context) {
+  return proxyTreeLike(context.request, context.env || {});
+}
+
+export async function onRequestPost(context) {
+  return proxyTreeLike(context.request, context.env || {});
+}
+
+export async function onRequest(context) {
+  return proxyTreeLike(context.request, context.env || {});
+}

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -2,41 +2,20 @@ from __future__ import annotations
 
 import json
 import time
-import uuid
-from datetime import datetime
-from typing import Any
 
 import modal
 from fastapi import FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 
 from modal_compute.auth import (
     PlusRequiredError,
-    get_firebase_certs,
     require_firebase_user,
-    require_plus_for_private_storage,
 )
 from modal_compute.config import _allowed_origins as _config_allowed_origins
-from modal_compute.db import (
-    get_db_connection,
-    run_db_with_retry,
-)
-from modal_compute.logging import RequestLogger, log_request_event
-from modal_compute.api_response_helpers import (
-    add_request_id_to_response,
-    parse_json_body,
-)
+from modal_compute.logging import RequestLogger
+from modal_compute.api_response_helpers import parse_json_body
 from modal_compute.validation import (
-    _to_isoformat,
-    estimate_stage,
-    parse_tags,
-    normalize_tags,
-    normalize_memory_row,
-    normalize_tree_row,
-    normalize_row,
-    validate_visibility,
-    validate_optional_string,
     validate_required_uuid,
     validate_optional_uuid,
     validate_required_id,
@@ -63,17 +42,13 @@ from modal_compute.owner_writes import (
     delete_owner_memory,
     fork_public_tree,
 )
-
-from modal_compute.write_validation import (
-    fetch_tree_for_owner_check,
-    require_tree_owner,
-    fetch_memory_for_owner_check,
-    require_memory_owner,
-)
 from modal_compute.reactions import (
     toggle_reaction,
     fetch_reaction_summary,
-    fetch_reaction_counts,
+)
+from modal_compute.tree_likes import (
+    toggle_tree_like,
+    fetch_tree_like_summary,
 )
 from modal_compute.comments import (
     create_comment,
@@ -84,8 +59,6 @@ from modal_compute.comments import (
 def _allowed_origins() -> list[str]:
     return _config_allowed_origins()
 
-
-# --- Modal App Setup ---
 
 app = modal.App("lovebud-browse-snapshot")
 
@@ -159,7 +132,7 @@ def get_growing_browse_snapshot(
     x_lovebud_request_id: str | None = Header(default=None),
 ) -> list[dict]:
     handler_start = time.time()
-    print(f"[LoveBudModal] [TIMING] /modal/browse/growing handler entry")
+    print("[LoveBudModal] [TIMING] /modal/browse/growing handler entry")
     logger = RequestLogger(
         request_id=x_lovebud_request_id,
         route="/modal/browse/growing",
@@ -167,17 +140,13 @@ def get_growing_browse_snapshot(
     )
     try:
         result = fetch_growing_public_tree_snapshots(limit=limit)
-
         serialize_start = time.time()
         serialized_data = json.dumps(result)
         serialize_duration = (time.time() - serialize_start) * 1000
         print(f"[LoveBudModal] [TIMING] Result serialization (json.dumps) took {serialize_duration:.2f}ms (size={len(serialized_data)} bytes)")
-
         logger.log_success(status_code=200)
-
         total_elapsed = (time.time() - handler_start) * 1000
         print(f"[LoveBudModal] [TIMING] /modal/browse/growing handler response return. Total elapsed: {total_elapsed:.2f}ms")
-
         return result
     except Exception:
         logger.log_error(status_code=500, error_category="UNEXPECTED_ERROR")
@@ -316,6 +285,24 @@ def delete_private_tree(
     return delete_owner_tree(user["uid"], tree_id)
 
 
+@web_app.post("/modal/private/trees/{tree_id}/likes")
+def post_tree_like(
+    tree_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return toggle_tree_like(tree_id, user["uid"])
+
+
+@web_app.get("/modal/private/trees/{tree_id}/likes")
+def get_tree_likes(
+    tree_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    user = require_firebase_user(authorization)
+    return fetch_tree_like_summary(tree_id, user["uid"])
+
+
 @web_app.get("/modal/private/memories")
 def get_private_memories(
     treeId: str | None = None,
@@ -357,9 +344,6 @@ def delete_private_memory(
     return delete_owner_memory(user["uid"], memory_id)
 
 
-# ---- Reactions ---------------------------------------------------------------
-
-
 @web_app.post("/modal/private/memories/{memory_id}/reactions")
 async def post_memory_reaction(
     memory_id: str,
@@ -379,9 +363,6 @@ def get_memory_reactions(
 ) -> dict:
     user = require_firebase_user(authorization)
     return fetch_reaction_summary(memory_id, user["uid"])
-
-
-# ---- Comments ----------------------------------------------------------------
 
 
 @web_app.post("/modal/private/memories/{memory_id}/comments")

--- a/modal_compute/tree_likes.py
+++ b/modal_compute/tree_likes.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import get_db_connection, run_db_with_retry
+from modal_compute.validation import validate_required_uuid
+
+
+def require_public_tree_for_like(tree_id: str) -> dict[str, Any]:
+    def operation() -> dict[str, Any] | None:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, visibility
+                    FROM trees
+                    WHERE id = %s
+                    LIMIT 1
+                    """,
+                    (tree_id,),
+                )
+                return cur.fetchone()
+
+    tree = run_db_with_retry(operation)
+    if not tree or str(tree.get("visibility") or "public") != "public":
+        raise HTTPException(status_code=404, detail="Tree not found")
+    return tree
+
+
+def _ensure_tree_social_counts(cur, tree_id: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO tree_social_counts (tree_id, like_count, view_count, updated_at)
+        VALUES (%s, 0, 0, NOW())
+        ON CONFLICT (tree_id) DO NOTHING
+        """,
+        (tree_id,),
+    )
+
+
+def _fetch_like_count(cur, tree_id: str) -> int:
+    cur.execute(
+        """
+        SELECT like_count
+        FROM tree_social_counts
+        WHERE tree_id = %s
+        LIMIT 1
+        """,
+        (tree_id,),
+    )
+    row = cur.fetchone()
+    return int(row.get("like_count") or 0) if row else 0
+
+
+def fetch_tree_like_summary(tree_id: str, owner_id: str) -> dict[str, Any]:
+    safe_tree_id = validate_required_uuid(tree_id, "treeId")
+    require_public_tree_for_like(safe_tree_id)
+
+    def operation() -> dict[str, Any]:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                _ensure_tree_social_counts(cur, safe_tree_id)
+                cur.execute(
+                    """
+                    SELECT id
+                    FROM tree_likes
+                    WHERE tree_id = %s
+                      AND owner_id = %s
+                      AND deleted_at IS NULL
+                    LIMIT 1
+                    """,
+                    (safe_tree_id, owner_id),
+                )
+                active = cur.fetchone() is not None
+                like_count = _fetch_like_count(cur, safe_tree_id)
+                conn.commit()
+                return {"treeId": safe_tree_id, "active": active, "likeCount": like_count}
+
+    return run_db_with_retry(operation)
+
+
+def toggle_tree_like(tree_id: str, owner_id: str) -> dict[str, Any]:
+    safe_tree_id = validate_required_uuid(tree_id, "treeId")
+    require_public_tree_for_like(safe_tree_id)
+
+    def operation() -> dict[str, Any]:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                _ensure_tree_social_counts(cur, safe_tree_id)
+                cur.execute(
+                    """
+                    SELECT id
+                    FROM tree_likes
+                    WHERE tree_id = %s
+                      AND owner_id = %s
+                      AND deleted_at IS NULL
+                    LIMIT 1
+                    """,
+                    (safe_tree_id, owner_id),
+                )
+                existing = cur.fetchone()
+
+                if existing:
+                    cur.execute(
+                        """
+                        UPDATE tree_likes
+                        SET deleted_at = NOW()
+                        WHERE id = %s
+                        """,
+                        (existing["id"],),
+                    )
+                    cur.execute(
+                        """
+                        UPDATE tree_social_counts
+                        SET like_count = GREATEST(like_count - 1, 0),
+                            updated_at = NOW()
+                        WHERE tree_id = %s
+                        """,
+                        (safe_tree_id,),
+                    )
+                    active = False
+                else:
+                    cur.execute(
+                        """
+                        INSERT INTO tree_likes (id, tree_id, owner_id, created_at, deleted_at)
+                        VALUES (%s, %s, %s, NOW(), NULL)
+                        """,
+                        (str(uuid.uuid4()), safe_tree_id, owner_id),
+                    )
+                    cur.execute(
+                        """
+                        UPDATE tree_social_counts
+                        SET like_count = like_count + 1,
+                            updated_at = NOW()
+                        WHERE tree_id = %s
+                        """,
+                        (safe_tree_id,),
+                    )
+                    active = True
+
+                like_count = _fetch_like_count(cur, safe_tree_id)
+                conn.commit()
+                return {"treeId": safe_tree_id, "active": active, "likeCount": like_count}
+
+    return run_db_with_retry(operation)

--- a/tests/contracts/tree-like-api-boundary-contract.test.cjs
+++ b/tests/contracts/tree-like-api-boundary-contract.test.cjs
@@ -1,0 +1,72 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const modalApp = fs.readFileSync(path.join(ROOT, 'modal_compute', 'app.py'), 'utf8');
+const treeLikes = fs.readFileSync(path.join(ROOT, 'modal_compute', 'tree_likes.py'), 'utf8');
+const cloudflareRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', 'trees', '[tree_id]', 'likes.js'), 'utf8');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const browseSnapshot = fs.readFileSync(path.join(ROOT, 'modal_compute', 'browse_latest.py'), 'utf8');
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+test('Modal app exposes authenticated tree like summary and toggle routes', () => {
+  assert.match(modalApp, /from\s+modal_compute\.tree_likes\s+import\s*\([\s\S]*toggle_tree_like[\s\S]*fetch_tree_like_summary[\s\S]*\)/);
+  assert.match(modalApp, /@web_app\.post\("\/modal\/private\/trees\/\{tree_id\}\/likes"\)/);
+  assert.match(modalApp, /def\s+post_tree_like\(/);
+  assert.match(modalApp, /user\s*=\s*require_firebase_user\(authorization\)/);
+  assert.match(modalApp, /return\s+toggle_tree_like\(tree_id,\s*user\["uid"\]\)/);
+  assert.match(modalApp, /@web_app\.get\("\/modal\/private\/trees\/\{tree_id\}\/likes"\)/);
+  assert.match(modalApp, /def\s+get_tree_likes\(/);
+  assert.match(modalApp, /return\s+fetch_tree_like_summary\(tree_id,\s*user\["uid"\]\)/);
+});
+
+test('tree_likes repository keeps tree likes separate from memory reactions', () => {
+  assert.match(treeLikes, /CREATE|SELECT|INSERT|UPDATE/i);
+  assert.match(treeLikes, /FROM\s+tree_likes/i);
+  assert.match(treeLikes, /INSERT\s+INTO\s+tree_likes/i);
+  assert.match(treeLikes, /UPDATE\s+tree_likes/i);
+  assert.match(treeLikes, /tree_social_counts/i);
+  assert.doesNotMatch(treeLikes, /FROM\s+reactions/i);
+  assert.doesNotMatch(treeLikes, /INSERT\s+INTO\s+reactions/i);
+  assert.doesNotMatch(treeLikes, /memory_id/i);
+});
+
+test('tree like repository allows only public tree boundary and hides private trees as not found', () => {
+  const normalized = compact(treeLikes);
+  assert.match(normalized, /selectid,visibilityfromtreeswhereid=%slimit1/);
+  assert.match(normalized, /visibility.*public/);
+  assert.match(normalized, /httpexception\(status_code=404,detail="treenotfound"\)/);
+});
+
+test('tree like toggle updates active row and aggregate count safely', () => {
+  assert.match(treeLikes, /WHERE\s+tree_id\s+=\s+%s[\s\S]*AND\s+owner_id\s+=\s+%s[\s\S]*AND\s+deleted_at\s+IS\s+NULL/i);
+  assert.match(treeLikes, /SET\s+deleted_at\s+=\s+NOW\(\)/i);
+  assert.match(treeLikes, /GREATEST\(like_count\s+-\s+1,\s+0\)/i);
+  assert.match(treeLikes, /SET\s+like_count\s+=\s+like_count\s+\+\s+1/i);
+  assert.match(treeLikes, /"active"/);
+  assert.match(treeLikes, /"likeCount"/);
+});
+
+test('Cloudflare tree like route proxies only authenticated GET and POST to Modal private route', () => {
+  assert.match(cloudflareRoute, /export\s+async\s+function\s+onRequestGet/);
+  assert.match(cloudflareRoute, /export\s+async\s+function\s+onRequestPost/);
+  assert.match(cloudflareRoute, /Authorization required/);
+  assert.match(cloudflareRoute, /\/modal\/private\/trees\/\$\{encodeURIComponent\(decodeURIComponent\(treeId\)\)\}\/likes/);
+  assert.match(cloudflareRoute, /allow:\s*'GET, POST'/);
+  assert.doesNotMatch(cloudflareRoute, /\/modal\/browse\/latest/);
+  assert.doesNotMatch(cloudflareRoute, /sort=likes/);
+  assert.doesNotMatch(cloudflareRoute, /sort=views/);
+});
+
+test('Unit A2 does not enable Browse sort or public Browse count payloads', () => {
+  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+  assert.doesNotMatch(browseSnapshot, /likeCount/);
+  assert.doesNotMatch(browseSnapshot, /viewCount/);
+});


### PR DESCRIPTION
Refs #1661

Summary:
- add Unit A2 tree-level like repository/API boundary
- add `modal_compute/tree_likes.py` with authenticated tree-like summary and toggle helpers
- wire Modal private routes:
  - `GET /modal/private/trees/{tree_id}/likes`
  - `POST /modal/private/trees/{tree_id}/likes`
- add Cloudflare Pages route proxy:
  - `GET /api/trees/:tree_id/likes`
  - `POST /api/trees/:tree_id/likes`
- require Authorization before proxying tree-like read/write
- keep tree likes separate from memory-level reactions
- keep Browse sort and Browse summary payload unchanged
- add contract tests for the API boundary

Scope:
- no Browse UI change
- no `sort=likes` or `sort=views`
- no public Browse `likeCount`/`viewCount` payload
- no tree view tracking
- no broad analytics

Tests:
- added `tests/contracts/tree-like-api-boundary-contract.test.cjs`