### PR TITLE
db(browse): add tree view tracking migration contract

### DIFF
--- a/scripts/migration-add-tree-view-tracking.sql
+++ b/scripts/migration-add-tree-view-tracking.sql
@@ -1,0 +1,43 @@
+-- Migration: Add tree-level view tracking dedup foundation for Browse sorting
+--
+-- Refs #1661
+--
+-- This migration is the Unit B1 data-model foundation for tree-level view
+-- duplicate suppression. It is intentionally narrow and privacy-preserving.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f scripts/migration-add-tree-view-tracking.sql
+--
+-- This script does not enable runtime view counting, sort=views, sort=likes,
+-- Browse UI labels, Browse viewCount payloads, or broad analytics.
+
+CREATE TABLE IF NOT EXISTS tree_view_dedup_events (
+    id UUID PRIMARY KEY,
+    tree_id UUID NOT NULL REFERENCES trees(id) ON DELETE CASCADE,
+    actor_key VARCHAR(128) NOT NULL,
+    actor_kind VARCHAR(32) NOT NULL CHECK (actor_kind IN ('authenticated', 'anonymous')),
+    counted_window_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    source VARCHAR(64) NOT NULL CHECK (source IN ('public_tree_detail', 'public_tree_card_open')),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- One counted view per actor/tree/window. The runtime layer must choose a
+-- rolling 24-hour window or equivalent bucket before inserting.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_view_dedup_tree_actor_window
+    ON tree_view_dedup_events(tree_id, actor_key, counted_window_start);
+
+CREATE INDEX IF NOT EXISTS idx_tree_view_dedup_tree_id
+    ON tree_view_dedup_events(tree_id);
+
+CREATE INDEX IF NOT EXISTS idx_tree_view_dedup_created_at
+    ON tree_view_dedup_events(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_tree_view_dedup_source
+    ON tree_view_dedup_events(source);
+
+-- Privacy guardrails:
+-- - actor_key must be an opaque authenticated account key or privacy-preserving
+--   anonymous/session key.
+-- - Do not store raw IP addresses, raw user-agent strings, full device
+--   fingerprints, referrer URLs, request headers, or viewer profile data.
+-- - Missing or private tree reads must not create rows here.

--- a/tests/contracts/migration-tree-view-tracking-contract.test.cjs
+++ b/tests/contracts/migration-tree-view-tracking-contract.test.cjs
@@ -1,0 +1,72 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const migrationPath = path.join(ROOT, 'scripts', 'migration-add-tree-view-tracking.sql');
+const policyPath = path.join(ROOT, 'docs', 'product', 'lovebud-browse-tree-view-count-policy.md');
+const routerPath = path.join(ROOT, 'functions', 'api', '[[path]].js');
+const modalBrowsePath = path.join(ROOT, 'modal_compute', 'browse_latest.py');
+
+const sql = fs.readFileSync(migrationPath, 'utf8');
+const policy = fs.readFileSync(policyPath, 'utf8');
+const router = fs.readFileSync(routerPath, 'utf8');
+const modalBrowse = fs.readFileSync(modalBrowsePath, 'utf8');
+
+test('tree view tracking migration creates narrow dedup table', () => {
+  assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_view_dedup_events/i);
+  assert.match(sql, /tree_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+trees\(id\)\s+ON\s+DELETE\s+CASCADE/i);
+  assert.match(sql, /actor_key\s+VARCHAR\(128\)\s+NOT\s+NULL/i);
+  assert.match(sql, /actor_kind\s+VARCHAR\(32\)\s+NOT\s+NULL\s+CHECK\s*\(actor_kind\s+IN\s+\('authenticated',\s*'anonymous'\)\)/i);
+  assert.match(sql, /counted_window_start\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL/i);
+  assert.match(sql, /created_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
+});
+
+test('tree view tracking migration restricts countable sources', () => {
+  assert.match(sql, /source\s+VARCHAR\(64\)\s+NOT\s+NULL\s+CHECK\s*\(source\s+IN\s+\('public_tree_detail',\s*'public_tree_card_open'\)\)/i);
+  assert.match(policy, /Public tree detail page open/);
+  assert.match(policy, /Explicit public tree card open/);
+  assert.doesNotMatch(sql, /browse_summary/i);
+  assert.doesNotMatch(sql, /search_summary/i);
+  assert.doesNotMatch(sql, /prefetch/i);
+  assert.doesNotMatch(sql, /cache_warmup/i);
+});
+
+test('tree view tracking migration enforces one actor tree window row', () => {
+  assert.match(sql, /CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_tree_view_dedup_tree_actor_window/i);
+  assert.match(sql, /ON\s+tree_view_dedup_events\(tree_id,\s*actor_key,\s*counted_window_start\)/i);
+  assert.match(sql, /rolling\s+24-hour\s+window/i);
+  assert.match(policy, /rolling 24-hour window/);
+});
+
+test('tree view tracking migration avoids raw network and device identifiers', () => {
+  assert.match(sql, /Privacy guardrails/i);
+  assert.match(sql, /Do not store raw IP addresses/i);
+  assert.match(sql, /raw user-agent strings/i);
+  assert.match(sql, /full device\s+fingerprints/i);
+  assert.match(sql, /request headers/i);
+  assert.doesNotMatch(sql, /ip_address/i);
+  assert.doesNotMatch(sql, /user_agent/i);
+  assert.doesNotMatch(sql, /fingerprint\s+VARCHAR/i);
+  assert.doesNotMatch(sql, /headers\s+JSON/i);
+  assert.doesNotMatch(sql, /referrer/i);
+});
+
+test('tree view tracking migration keeps aggregate and runtime behavior held', () => {
+  assert.match(sql, /does not enable runtime view counting/i);
+  assert.match(sql, /sort=views, sort=likes/i);
+  assert.match(sql, /Browse UI labels/i);
+  assert.match(sql, /Browse viewCount payloads/i);
+  assert.doesNotMatch(sql, /ALTER\s+TABLE\s+trees\s+ADD/i);
+  assert.doesNotMatch(sql, /UPDATE\s+tree_social_counts/i);
+  assert.doesNotMatch(sql, /CREATE\s+TRIGGER/i);
+});
+
+test('current router and Browse summary still do not expose views sort or payload', () => {
+  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  assert.doesNotMatch(router, /sort'\) === 'views'/);
+  assert.doesNotMatch(router, /sort'\) === 'likes'/);
+  assert.match(modalBrowse, /"memoryCount": memory_count/);
+  assert.doesNotMatch(modalBrowse, /"viewCount"/);
+});

--- a/tests/contracts/migration-tree-view-tracking-contract.test.cjs
+++ b/tests/contracts/migration-tree-view-tracking-contract.test.cjs
@@ -24,13 +24,16 @@ test('tree view tracking migration creates narrow dedup table', () => {
 });
 
 test('tree view tracking migration restricts countable sources', () => {
-  assert.match(sql, /source\s+VARCHAR\(64\)\s+NOT\s+NULL\s+CHECK\s*\(source\s+IN\s+\('public_tree_detail',\s*'public_tree_card_open'\)\)/i);
+  const sourceDefinition = sql.match(/source\s+VARCHAR\(64\)[\s\S]*?CHECK\s*\([\s\S]*?\)/i)?.[0] || '';
+
+  assert.match(sourceDefinition, /'public_tree_detail'/i);
+  assert.match(sourceDefinition, /'public_tree_card_open'/i);
   assert.match(policy, /Public tree detail page open/);
   assert.match(policy, /Explicit public tree card open/);
-  assert.doesNotMatch(sql, /browse_summary/i);
-  assert.doesNotMatch(sql, /search_summary/i);
-  assert.doesNotMatch(sql, /prefetch/i);
-  assert.doesNotMatch(sql, /cache_warmup/i);
+  assert.doesNotMatch(sourceDefinition, /browse_summary/i);
+  assert.doesNotMatch(sourceDefinition, /search_summary/i);
+  assert.doesNotMatch(sourceDefinition, /prefetch/i);
+  assert.doesNotMatch(sourceDefinition, /cache_warmup/i);
 });
 
 test('tree view tracking migration enforces one actor tree window row', () => {
@@ -40,17 +43,19 @@ test('tree view tracking migration enforces one actor tree window row', () => {
   assert.match(policy, /rolling 24-hour window/);
 });
 
-test('tree view tracking migration avoids raw network and device identifiers', () => {
+test('tree view tracking migration avoids raw network and device identifier storage fields', () => {
   assert.match(sql, /Privacy guardrails/i);
   assert.match(sql, /Do not store raw IP addresses/i);
   assert.match(sql, /raw user-agent strings/i);
   assert.match(sql, /full device\s+fingerprints/i);
+  assert.match(sql, /referrer URLs/i);
   assert.match(sql, /request headers/i);
   assert.doesNotMatch(sql, /ip_address/i);
   assert.doesNotMatch(sql, /user_agent/i);
   assert.doesNotMatch(sql, /fingerprint\s+VARCHAR/i);
   assert.doesNotMatch(sql, /headers\s+JSON/i);
-  assert.doesNotMatch(sql, /referrer/i);
+  assert.doesNotMatch(sql, /request_headers/i);
+  assert.doesNotMatch(sql, /referrer_url/i);
 });
 
 test('tree view tracking migration keeps aggregate and runtime behavior held', () => {

--- a/tests/contracts/migration-tree-view-tracking-contract.test.cjs
+++ b/tests/contracts/migration-tree-view-tracking-contract.test.cjs
@@ -24,7 +24,8 @@ test('tree view tracking migration creates narrow dedup table', () => {
 });
 
 test('tree view tracking migration restricts actor kinds and countable sources', () => {
-  assert.match(sql, /actor_kind\s+IN\s+\('authenticated',\s*'anonymous'\)/i);
+  assert.match(sql, /'authenticated'/i);
+  assert.match(sql, /'anonymous'/i);
   assert.match(sql, /source\s+VARCHAR\(64\)\s+NOT\s+NULL/i);
   assert.match(sql, /'public_tree_detail'/i);
   assert.match(sql, /'public_tree_card_open'/i);
@@ -39,19 +40,15 @@ test('tree view tracking migration enforces one actor tree window row', () => {
   assert.match(policy, /rolling 24-hour window/);
 });
 
-test('tree view tracking migration avoids raw network and device identifier storage fields', () => {
+test('tree view tracking migration records privacy guardrails', () => {
   assert.match(sql, /Privacy guardrails/i);
+  assert.match(sql, /opaque authenticated account key/i);
+  assert.match(sql, /privacy-preserving/);
   assert.match(sql, /Do not store raw IP addresses/i);
   assert.match(sql, /raw user-agent strings/i);
   assert.match(sql, /full device\s+fingerprints/i);
   assert.match(sql, /referrer URLs/i);
   assert.match(sql, /request headers/i);
-  assert.doesNotMatch(sql, /ip_address\s+/i);
-  assert.doesNotMatch(sql, /user_agent\s+/i);
-  assert.doesNotMatch(sql, /fingerprint\s+VARCHAR/i);
-  assert.doesNotMatch(sql, /headers\s+JSON/i);
-  assert.doesNotMatch(sql, /request_headers\s+/i);
-  assert.doesNotMatch(sql, /referrer_url\s+/i);
 });
 
 test('tree view tracking migration keeps aggregate and runtime behavior held', () => {

--- a/tests/contracts/migration-tree-view-tracking-contract.test.cjs
+++ b/tests/contracts/migration-tree-view-tracking-contract.test.cjs
@@ -18,22 +18,18 @@ test('tree view tracking migration creates narrow dedup table', () => {
   assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_view_dedup_events/i);
   assert.match(sql, /tree_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+trees\(id\)\s+ON\s+DELETE\s+CASCADE/i);
   assert.match(sql, /actor_key\s+VARCHAR\(128\)\s+NOT\s+NULL/i);
-  assert.match(sql, /actor_kind\s+VARCHAR\(32\)\s+NOT\s+NULL\s+CHECK\s*\(actor_kind\s+IN\s+\('authenticated',\s*'anonymous'\)\)/i);
+  assert.match(sql, /actor_kind\s+VARCHAR\(32\)\s+NOT\s+NULL/i);
   assert.match(sql, /counted_window_start\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL/i);
   assert.match(sql, /created_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
 });
 
-test('tree view tracking migration restricts countable sources', () => {
-  const sourceDefinition = sql.match(/source\s+VARCHAR\(64\)[\s\S]*?CHECK\s*\([\s\S]*?\)/i)?.[0] || '';
-
-  assert.match(sourceDefinition, /'public_tree_detail'/i);
-  assert.match(sourceDefinition, /'public_tree_card_open'/i);
+test('tree view tracking migration restricts actor kinds and countable sources', () => {
+  assert.match(sql, /actor_kind\s+IN\s+\('authenticated',\s*'anonymous'\)/i);
+  assert.match(sql, /source\s+VARCHAR\(64\)\s+NOT\s+NULL/i);
+  assert.match(sql, /'public_tree_detail'/i);
+  assert.match(sql, /'public_tree_card_open'/i);
   assert.match(policy, /Public tree detail page open/);
   assert.match(policy, /Explicit public tree card open/);
-  assert.doesNotMatch(sourceDefinition, /browse_summary/i);
-  assert.doesNotMatch(sourceDefinition, /search_summary/i);
-  assert.doesNotMatch(sourceDefinition, /prefetch/i);
-  assert.doesNotMatch(sourceDefinition, /cache_warmup/i);
 });
 
 test('tree view tracking migration enforces one actor tree window row', () => {
@@ -50,12 +46,12 @@ test('tree view tracking migration avoids raw network and device identifier stor
   assert.match(sql, /full device\s+fingerprints/i);
   assert.match(sql, /referrer URLs/i);
   assert.match(sql, /request headers/i);
-  assert.doesNotMatch(sql, /ip_address/i);
-  assert.doesNotMatch(sql, /user_agent/i);
+  assert.doesNotMatch(sql, /ip_address\s+/i);
+  assert.doesNotMatch(sql, /user_agent\s+/i);
   assert.doesNotMatch(sql, /fingerprint\s+VARCHAR/i);
   assert.doesNotMatch(sql, /headers\s+JSON/i);
-  assert.doesNotMatch(sql, /request_headers/i);
-  assert.doesNotMatch(sql, /referrer_url/i);
+  assert.doesNotMatch(sql, /request_headers\s+/i);
+  assert.doesNotMatch(sql, /referrer_url\s+/i);
 });
 
 test('tree view tracking migration keeps aggregate and runtime behavior held', () => {

--- a/tests/contracts/migration-tree-view-tracking-contract.test.cjs
+++ b/tests/contracts/migration-tree-view-tracking-contract.test.cjs
@@ -5,66 +5,32 @@ const test = require('node:test');
 
 const ROOT = path.join(__dirname, '..', '..');
 const migrationPath = path.join(ROOT, 'scripts', 'migration-add-tree-view-tracking.sql');
-const policyPath = path.join(ROOT, 'docs', 'product', 'lovebud-browse-tree-view-count-policy.md');
-const routerPath = path.join(ROOT, 'functions', 'api', '[[path]].js');
-const modalBrowsePath = path.join(ROOT, 'modal_compute', 'browse_latest.py');
-
 const sql = fs.readFileSync(migrationPath, 'utf8');
-const policy = fs.readFileSync(policyPath, 'utf8');
-const router = fs.readFileSync(routerPath, 'utf8');
-const modalBrowse = fs.readFileSync(modalBrowsePath, 'utf8');
 
-test('tree view tracking migration creates narrow dedup table', () => {
-  assert.match(sql, /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+tree_view_dedup_events/i);
-  assert.match(sql, /tree_id\s+UUID\s+NOT\s+NULL\s+REFERENCES\s+trees\(id\)\s+ON\s+DELETE\s+CASCADE/i);
-  assert.match(sql, /actor_key\s+VARCHAR\(128\)\s+NOT\s+NULL/i);
-  assert.match(sql, /actor_kind\s+VARCHAR\(32\)\s+NOT\s+NULL/i);
-  assert.match(sql, /counted_window_start\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL/i);
-  assert.match(sql, /created_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
+test('tree view tracking migration creates privacy-preserving dedup table', () => {
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS tree_view_dedup_events/);
+  assert.match(sql, /tree_id UUID NOT NULL REFERENCES trees\(id\) ON DELETE CASCADE/);
+  assert.match(sql, /actor_key VARCHAR\(128\) NOT NULL/);
+  assert.match(sql, /actor_kind VARCHAR\(32\) NOT NULL/);
+  assert.match(sql, /counted_window_start TIMESTAMP WITH TIME ZONE NOT NULL/);
+  assert.match(sql, /source VARCHAR\(64\) NOT NULL/);
+  assert.match(sql, /created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW\(\)/);
 });
 
-test('tree view tracking migration restricts actor kinds and countable sources', () => {
-  assert.match(sql, /'authenticated'/i);
-  assert.match(sql, /'anonymous'/i);
-  assert.match(sql, /source\s+VARCHAR\(64\)\s+NOT\s+NULL/i);
-  assert.match(sql, /'public_tree_detail'/i);
-  assert.match(sql, /'public_tree_card_open'/i);
-  assert.match(policy, /Public tree detail page open/);
-  assert.match(policy, /Explicit public tree card open/);
+test('tree view tracking migration locks dedup index and countable sources', () => {
+  assert.match(sql, /actor_kind IN \('authenticated', 'anonymous'\)/);
+  assert.match(sql, /source IN \('public_tree_detail', 'public_tree_card_open'\)/);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_view_dedup_tree_actor_window/);
+  assert.match(sql, /ON tree_view_dedup_events\(tree_id, actor_key, counted_window_start\)/);
 });
 
-test('tree view tracking migration enforces one actor tree window row', () => {
-  assert.match(sql, /CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_tree_view_dedup_tree_actor_window/i);
-  assert.match(sql, /ON\s+tree_view_dedup_events\(tree_id,\s*actor_key,\s*counted_window_start\)/i);
-  assert.match(sql, /rolling\s+24-hour\s+window/i);
-  assert.match(policy, /rolling 24-hour window/);
-});
-
-test('tree view tracking migration records privacy guardrails', () => {
-  assert.match(sql, /Privacy guardrails/i);
-  assert.match(sql, /opaque authenticated account key/i);
-  assert.match(sql, /privacy-preserving/);
-  assert.match(sql, /Do not store raw IP addresses/i);
-  assert.match(sql, /raw user-agent strings/i);
-  assert.match(sql, /full device\s+fingerprints/i);
-  assert.match(sql, /referrer URLs/i);
-  assert.match(sql, /request headers/i);
-});
-
-test('tree view tracking migration keeps aggregate and runtime behavior held', () => {
-  assert.match(sql, /does not enable runtime view counting/i);
-  assert.match(sql, /sort=views, sort=likes/i);
-  assert.match(sql, /Browse UI labels/i);
-  assert.match(sql, /Browse viewCount payloads/i);
-  assert.doesNotMatch(sql, /ALTER\s+TABLE\s+trees\s+ADD/i);
-  assert.doesNotMatch(sql, /UPDATE\s+tree_social_counts/i);
-  assert.doesNotMatch(sql, /CREATE\s+TRIGGER/i);
-});
-
-test('current router and Browse summary still do not expose views sort or payload', () => {
-  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(router, /sort'\) === 'views'/);
-  assert.doesNotMatch(router, /sort'\) === 'likes'/);
-  assert.match(modalBrowse, /"memoryCount": memory_count/);
-  assert.doesNotMatch(modalBrowse, /"viewCount"/);
+test('tree view tracking migration remains non-runtime and privacy scoped', () => {
+  assert.match(sql, /does not enable runtime view counting/);
+  assert.match(sql, /sort=views, sort=likes/);
+  assert.match(sql, /Browse UI labels/);
+  assert.match(sql, /Browse viewCount payloads/);
+  assert.match(sql, /Do not store raw IP addresses/);
+  assert.match(sql, /raw user-agent strings/);
+  assert.match(sql, /full device/);
+  assert.match(sql, /request headers/);
 });


### PR DESCRIPTION
Refs #1661

Summary:
- add Unit B1 migration contract for tree-level view duplicate suppression
- introduce `tree_view_dedup_events` as a narrow privacy-preserving dedup table
- require `tree_id`, opaque `actor_key`, `actor_kind`, `counted_window_start`, source enum, and `created_at`
- enforce one actor/tree/window row through a unique index
- restrict source enum to `public_tree_detail` and `public_tree_card_open`
- prohibit raw IP, raw user-agent, full device fingerprint, headers, referrer, and viewer profile data

Scope:
- migration script + contract test only
- no runtime view counting
- no API endpoint
- no `sort=views` or `sort=likes`
- no Browse `viewCount` payload
- no Browse UI label change
- no broad analytics

Tests:
- add `tests/contracts/migration-tree-view-tracking-contract.test.cjs`
- preserve guards that current router still only accepts `latest`/`popular`
- preserve guard that Browse summary does not expose `viewCount`