### PR TITLE
fix(intro): align intro hero with home

### DIFF
--- a/css/intro/hero/base.css
+++ b/css/intro/hero/base.css
@@ -1,17 +1,19 @@
 .intro-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(380px, 0.78fr);
+  grid-template-columns: minmax(0, 1.05fr) minmax(420px, 0.95fr);
   gap: var(--hero-gap);
   align-items: center;
-  padding: 52px var(--lovetree-page-pad-desktop) 32px;
-  max-width: var(--lovetree-page-shell-max);
+  padding: 28px 0 24px;
+  max-width: var(--page-shell-max);
   margin: 0 auto;
-  width: 100%;
+  width: min(var(--page-shell-max), calc(100% - (var(--page-pad-desktop) * 2)));
   min-height: min(820px, calc(100vh - 108px));
 }
 
 .intro-hero-copy {
   min-width: 0;
+  max-width: 600px;
+  padding: 0 0 16px;
 }
 
 .intro-hero-eyebrow {
@@ -20,7 +22,7 @@
   gap: 8px;
   min-height: 24px;
   padding: 0;
-  margin-bottom: 16px;
+  margin-bottom: 0;
   border-radius: 0;
   background: transparent;
   border: 0;
@@ -35,5 +37,5 @@
   content: "";
   width: 28px;
   height: 1px;
-  background: rgba(144, 73, 81, 0.42);
+  background: var(--eyebrow-line-color);
 }

--- a/css/intro/hero/layout.css
+++ b/css/intro/hero/layout.css
@@ -1,6 +1,6 @@
 .intro-hero h1 {
   font-size: clamp(3.45rem, 5.8vw, 5.15rem);
-  font-weight: 900;
+  font-weight: 700;
   color: var(--on-surface);
   margin: 20px 0 14px;
   line-height: 0.99;
@@ -15,25 +15,24 @@
 .intro-hero h1 .title-line:nth-child(1) {
   color: var(--on-surface-variant);
   font-weight: 700;
-  opacity: 0.9;
 }
 
 .intro-hero h1 .title-accent {
   color: var(--primary);
-  font-weight: 900;
-  letter-spacing: -0.03em;
+  font-weight: 780;
+  letter-spacing: -0.052em;
 }
 
 .intro-hero h1 .title-line:nth-child(3) {
-  color: #5f504a;
-  font-weight: 800;
+  color: #b85c66;
+  font-weight: 700;
 }
 
 .intro-hero .lead {
   font-size: 1.02rem;
   color: var(--on-surface-variant);
   line-height: 1.78;
-  margin: 0 0 1.45rem;
+  margin: 0;
   max-width: 520px;
 }
 

--- a/css/intro/hero/responsive.css
+++ b/css/intro/hero/responsive.css
@@ -3,7 +3,12 @@
   .intro-hero {
     grid-template-columns: 1fr;
     min-height: auto;
-    padding-top: 36px;
+    width: min(1120px, calc(100% - 40px));
+    padding-top: 18px;
+  }
+
+  .intro-hero-copy {
+    max-width: 680px;
   }
 }
 
@@ -15,7 +20,13 @@
 
 @media (max-width: 640px) {
   .intro-hero {
-    padding: 24px var(--page-pad-mobile, 16px) 12px;
+    gap: 22px;
+    width: min(100%, calc(100% - 24px));
+    padding: 12px 0 8px;
+  }
+
+  .intro-hero-copy {
+    padding-bottom: 4px;
   }
 
   .intro-hero h1 {
@@ -40,6 +51,10 @@
   .intro-hero-actions .btn-round {
     width: 100%;
     min-height: 54px;
+  }
+
+  .intro-cta-link {
+    width: 100%;
   }
 
   .intro-hero-visual {

--- a/js/i18n/i18n-intro.js
+++ b/js/i18n/i18n-intro.js
@@ -23,20 +23,20 @@
       en: 'LoveTree connects the first scene, heart notes, and moments worth revisiting<br class="pc-only">into one emotional path.'
     },
     'intro.heroTitle1': {
-      ko: '<span class="title-line">첫 순간이 하나의</span><span class="title-line title-accent">러브트리로</span><span class="title-line">이어져요</span>',
-      en: '<span class="title-line">The first spark</span><span class="title-line title-accent">connects into</span><span class="title-line">one LoveTree</span>'
+      ko: '<span class="title-line">러브트리는</span><span class="title-line title-accent">마음이 자라는</span><span class="title-line">기록 공간이에요</span>',
+      en: '<span class="title-line">LoveTree is</span><span class="title-line title-accent">a growing record</span><span class="title-line">of your feelings</span>'
     },
     'intro.heroLead1': {
-      ko: '반했던 장면과 오래 남은 마음을,<br class="pc-only">감정이 이어진 경로로 천천히 남겨 보세요.',
-      en: 'Slowly document your cherished scenes and lasting thoughts along an emotional path.'
+      ko: '좋아하게 된 순간을 하나씩 이어 붙이며, <br class="pc-only">내 마음이 깊어진 경로를 천천히 보여줍니다.',
+      en: 'Connect the moments you came to love, one by one, and slowly see how your feelings deepened.'
     },
     'intro.heroTitle2': {
-      ko: '<span class="title-line">다시 보고 싶은 장면이</span><span class="title-line title-accent">마음의 가지로</span><span class="title-line">자라나요</span>',
-      en: '<span class="title-line">Scenes you want to revisit</span><span class="title-line title-accent">grow into branches</span><span class="title-line">of the heart</span>'
+      ko: '<span class="title-line">흩어진 순간을</span><span class="title-line title-accent">감정의 가지로</span><span class="title-line">이어 보여줘요</span>',
+      en: '<span class="title-line">Scattered moments</span><span class="title-line title-accent">connect as branches</span><span class="title-line">of feeling</span>'
     },
     'intro.heroLead2': {
-      ko: '스쳐간 순간 하나가 오래 머무는 마음이 되도록,<br class="pc-only">나만의 러브트리에 담아 보세요.',
-      en: 'Capture fleeting moments into your own LoveTree, letting them linger in your heart.'
+      ko: '첫 장면과 마음 메모, 다시 보고 싶은 순간을 <br class="pc-only">하나의 러브트리 안에서 차분히 따라가요.',
+      en: 'Follow first scenes, heart notes, and moments worth revisiting inside one LoveTree.'
     },
     'intro.heroPrimaryCta': {
       ko: '내 러브트리 시작하기',

--- a/tests/contracts/intro-home-hero-alignment-contract.test.cjs
+++ b/tests/contracts/intro-home-hero-alignment-contract.test.cjs
@@ -1,0 +1,122 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const homeLayoutCss = fs.readFileSync(path.join(ROOT, 'css', 'index', 'layout.css'), 'utf8');
+const homeResponsiveCss = fs.readFileSync(path.join(ROOT, 'css', 'index', 'responsive.css'), 'utf8');
+const homeComponentsCss = fs.readFileSync(path.join(ROOT, 'css', 'index', 'components.css'), 'utf8');
+const introHeroBaseCss = fs.readFileSync(path.join(ROOT, 'css', 'intro', 'hero', 'base.css'), 'utf8');
+const introHeroLayoutCss = fs.readFileSync(path.join(ROOT, 'css', 'intro', 'hero', 'layout.css'), 'utf8');
+const introHeroResponsiveCss = fs.readFileSync(path.join(ROOT, 'css', 'intro', 'hero', 'responsive.css'), 'utf8');
+const introI18n = fs.readFileSync(path.join(ROOT, 'js', 'i18n', 'i18n-intro.js'), 'utf8');
+
+function assertSharedRule({ homeCss, introCss, rule, label }) {
+  assert.match(homeCss, rule, `home must keep ${label}`);
+  assert.match(introCss, rule, `intro must match home ${label}`);
+}
+
+test('intro hero uses distinct explanatory copy instead of duplicating home hero copy', () => {
+  assert.match(introI18n, /러브트리는/);
+  assert.match(introI18n, /마음이 자라는/);
+  assert.match(introI18n, /기록 공간이에요/);
+  assert.match(introI18n, /내 마음이 깊어진 경로를 천천히 보여줍니다/);
+
+  assert.doesNotMatch(introI18n, /첫 순간이 하나의/);
+  assert.doesNotMatch(introI18n, /반했던 장면과 오래 남은 마음을/);
+  assert.doesNotMatch(introI18n, /마음을,<br class="pc-only">감정이/);
+});
+
+test('intro hero desktop shell follows home hero layout rhythm', () => {
+  assertSharedRule({
+    homeCss: homeLayoutCss,
+    introCss: introHeroBaseCss,
+    rule: /grid-template-columns:\s*minmax\(0,\s*1\.05fr\)\s+minmax\(420px,\s*0\.95fr\)/,
+    label: 'desktop hero grid columns',
+  });
+
+  assertSharedRule({
+    homeCss: homeLayoutCss,
+    introCss: introHeroBaseCss,
+    rule: /padding:\s*28px\s+0\s+24px/,
+    label: 'desktop hero padding',
+  });
+
+  assertSharedRule({
+    homeCss: homeLayoutCss,
+    introCss: introHeroBaseCss,
+    rule: /min-height:\s*min\(820px,\s*calc\(100vh - 108px\)\)/,
+    label: 'desktop hero minimum height',
+  });
+});
+
+test('intro hero mobile title and lead sizing stay aligned with home', () => {
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /font-size:\s*clamp\(2\.25rem,\s*10vw,\s*2\.8rem\)/,
+    label: 'mobile title font size',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /line-height:\s*1\.04/,
+    label: 'mobile title line height',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /font-size:\s*0\.96rem/,
+    label: 'mobile lead font size',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /line-height:\s*1\.72/,
+    label: 'mobile lead line height',
+  });
+});
+
+test('intro hero mobile spacing and CTA sizing stay aligned with home', () => {
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /gap:\s*22px/,
+    label: 'mobile hero gap',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /padding:\s*12px\s+0\s+8px/,
+    label: 'mobile hero padding',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /margin-top:\s*20px/,
+    label: 'mobile CTA top margin',
+  });
+
+  assertSharedRule({
+    homeCss: homeResponsiveCss,
+    introCss: introHeroResponsiveCss,
+    rule: /min-height:\s*54px/,
+    label: 'mobile CTA minimum height',
+  });
+
+  assert.match(homeComponentsCss, /\.home-v3-actions\s+\.btn-round\s*{[\s\S]*?font-size:\s*1rem/);
+  assert.match(introHeroLayoutCss, /\.intro-hero-actions\s+\.btn-round,[\s\S]*?font-size:\s*1rem/);
+});
+
+test('intro hero line color and weight semantics match the home hero', () => {
+  assert.match(introHeroLayoutCss, /\.intro-hero h1 \.title-line:nth-child\(1\)\s*{[\s\S]*?color:\s*var\(--on-surface-variant\);[\s\S]*?font-weight:\s*700/);
+  assert.match(introHeroLayoutCss, /\.intro-hero h1 \.title-accent\s*{[\s\S]*?color:\s*var\(--primary\);[\s\S]*?font-weight:\s*780/);
+  assert.match(introHeroLayoutCss, /\.intro-hero h1 \.title-line:nth-child\(3\)\s*{[\s\S]*?color:\s*#b85c66;[\s\S]*?font-weight:\s*700/);
+  assert.doesNotMatch(introHeroLayoutCss, /\.intro-hero h1\s*{[\s\S]*?font-weight:\s*900/);
+});


### PR DESCRIPTION
Closes #2411

Summary:
- update intro hero copy so the intro page explains what LoveTree is instead of repeating the home hero copy
- align intro hero desktop/mobile shell, typography, line color/weight semantics, lead spacing, and CTA rhythm with the home hero
- keep the intro visual tree and lower intro sections unchanged
- add a contract that locks home/intro hero mobile typography and spacing alignment

Scope:
- UI copy/CSS/contract only
- no shared header refactor
- no scrollbar-gutter/global layout change
- no Browse/Search/DB/API behavior change

Tests:
- add `tests/contracts/intro-home-hero-alignment-contract.test.cjs`