### PR TITLE
fix(editor): restore auth start dependency wiring

### DIFF
--- a/js/editor/editor-entry-dependencies.js
+++ b/js/editor/editor-entry-dependencies.js
@@ -108,6 +108,9 @@
         const buildTreeLoadErrorCopy = editorPageHelpers.buildTreeLoadErrorCopy;
         if (typeof buildTreeLoadErrorCopy !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy');
 
+        const registerEditorAuthStart = editorPageHelpers.registerEditorAuthStart;
+        if (typeof registerEditorAuthStart !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.registerEditorAuthStart');
+
         const applyEditorShellCopy = shellHelpers.applyEditorShellCopy;
         if (typeof applyEditorShellCopy !== 'function') return stopMissing(windowRef, 'LoveBudEditorShellHelpers.applyEditorShellCopy');
 
@@ -175,6 +178,7 @@
                 getYouTubeInputErrorMessage,
                 renderTreeLoadError,
                 buildTreeLoadErrorCopy,
+                registerEditorAuthStart,
                 applyEditorShellCopy,
                 createPrepareEditorShell,
                 nextMemoryIdFromMemories: editorTreeHelpers.nextMemoryIdFromMemories,

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -19,82 +19,6 @@ function sourceIndex(sources, needle) {
   return sources.findIndex((src) => src.includes(needle));
 }
 
-function loadEntryDependencies() {
-  const context = { window: {}, console: { error() {} }, Object };
-  vm.createContext(context);
-  vm.runInContext(read('js/editor/editor-entry-dependencies.js'), context);
-  return context.window.LoveBudEditorEntryDependencies.resolveEditorEntryDependencies;
-}
-
-function createReadyWindow() {
-  const noop = function() {};
-  return {
-    LoveBudEditorDataLoaderFallbacks: {},
-    LoveBudEditorEntryFallbacks: {},
-    LoveBudEditorShellHelpers: {
-      createInlineShowToastFallback: () => noop,
-      getI18n: () => ((key) => key),
-      getEditorBasePath: noop,
-      getYouTubeInputErrorMessageFallback: noop,
-      applyEditorShellCopy: noop,
-      createEditorDebugReporter: noop,
-      getHttpStatus: noop,
-      markEditorReady: noop,
-      applyEditorEditabilityState: noop,
-      createEditorStartupDependencyWaiter: noop,
-      exposeCanvasEmptyGuideUpdater: noop,
-      exposeDetailPanelUpdater: noop,
-      createSelectedMomentFocusHandler: noop,
-      createSidebarTreeActionsUpdater: noop,
-      createMemoryActionsReadinessWrapper: noop,
-      createCurrentMomentDetailOpener: noop,
-      createSaveStatusOrchestrationFallback: noop,
-      exposeRefreshMemoriesBridge: noop,
-      resolveSaveStatusTimeFormatter: noop,
-    },
-    LoveBudEditorUtils: {
-      findRootMemory: noop,
-      getCanonicalRootId: noop,
-      isRootMemory: noop,
-    },
-    LoveBudEditorHelpers: {
-      safeI18nText: noop,
-      resolveHintText: noop,
-      resolveTreeTitleText: noop,
-      resolveInfoText: noop,
-      escapeHtml: noop,
-      safeUrl: noop,
-      resolveMemoryThumbnail: noop,
-    },
-    LoveBudEditorSaveStatus: {},
-    LoveBudEditorPageHelpers: {
-      redirectToEditorLogin: noop,
-      getMyTreesHref: noop,
-      renderTreeLoadError: noop,
-      buildTreeLoadErrorCopy: noop,
-      registerEditorAuthStart: noop,
-    },
-    LoveBudEditorTreeHelpers: {
-      syncCurrentTreeData: noop,
-      resolveParentIdForCreate: noop,
-      nextMemoryIdFromMemories: noop,
-    },
-    LoveBudEditorSelectionUI: {},
-    LoveBudEditorBindings: {},
-    LoveBudEditorPageEventBindings: { bindEditorPageEvents: noop },
-    LoveBudEditorDataLoader: {},
-    LoveBudEditorInitialLoadFlow: { runEditorInitialLoadFlow: noop },
-    LoveBudEditorRefreshSaveRuntime: { createEditorRefreshSaveRuntime: noop },
-    LoveBudEditorStartupContext: { createEditorStartupContext: noop },
-    LoveBudEditorAuthHelpers: {
-      readConfirmedAuthCache: () => ({ uid: 'u1' }),
-      hasConfirmedSessionUser: () => true,
-    },
-    LoveBudEditorShellCopyApplier: { createPrepareEditorShell: noop },
-    LoveBudEditorDomRefsBuilder: { createEditorDomRefs: noop },
-  };
-}
-
 test('editor entry dependencies helper loads before editor entry', () => {
   const sources = scriptSources();
   const dependencyHelper = sourceIndex(sources, 'js/editor/editor-entry-dependencies.js');
@@ -178,31 +102,11 @@ test('entry dependencies helper preserves shell copy side effect before prepare 
   assert.ok(applyIndex < prepareIndex, 'shell copy must apply before prepareEditorShell is returned');
 });
 
-test('entry dependency resolver exposes auth start helper required by editor entry', () => {
-  const resolveEditorEntryDependencies = loadEntryDependencies();
-  const windowRef = createReadyWindow();
-  const result = resolveEditorEntryDependencies({ windowRef });
+test('entry dependencies helper wires auth start helper required by editor entry', () => {
+  const helper = read('js/editor/editor-entry-dependencies.js');
 
-  assert.equal(result.status, 'ready');
-  assert.equal(
-    result.deps.registerEditorAuthStart,
-    windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart,
-    'resolver must pass through LoveBudEditorPageHelpers.registerEditorAuthStart'
-  );
-});
-
-test('entry dependency resolver stops with auth start helper message when missing', () => {
-  const resolveEditorEntryDependencies = loadEntryDependencies();
-  const windowRef = createReadyWindow();
-  delete windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart;
-
-  const result = resolveEditorEntryDependencies({ windowRef });
-
-  assert.equal(result.status, 'stopped');
-  assert.deepEqual(windowRef.LoveBudEditorDebug.errors, [
-    {
-      msg: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
-      error: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
-    },
-  ]);
+  assert.match(helper, /const\s+registerEditorAuthStart\s*=\s*editorPageHelpers\.registerEditorAuthStart;/);
+  assert.match(helper, /typeof\s+registerEditorAuthStart\s*!==\s*'function'/);
+  assert.match(helper, /LoveBudEditorPageHelpers\.registerEditorAuthStart/);
+  assert.match(helper, /\n\s*registerEditorAuthStart,\n/);
 });

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -19,6 +19,82 @@ function sourceIndex(sources, needle) {
   return sources.findIndex((src) => src.includes(needle));
 }
 
+function loadEntryDependencies() {
+  const context = { window: {}, console: { error() {} }, Object };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-entry-dependencies.js'), context);
+  return context.window.LoveBudEditorEntryDependencies.resolveEditorEntryDependencies;
+}
+
+function createReadyWindow() {
+  const noop = function() {};
+  return {
+    LoveBudEditorDataLoaderFallbacks: {},
+    LoveBudEditorEntryFallbacks: {},
+    LoveBudEditorShellHelpers: {
+      createInlineShowToastFallback: () => noop,
+      getI18n: () => ((key) => key),
+      getEditorBasePath: noop,
+      getYouTubeInputErrorMessageFallback: noop,
+      applyEditorShellCopy: noop,
+      createEditorDebugReporter: noop,
+      getHttpStatus: noop,
+      markEditorReady: noop,
+      applyEditorEditabilityState: noop,
+      createEditorStartupDependencyWaiter: noop,
+      exposeCanvasEmptyGuideUpdater: noop,
+      exposeDetailPanelUpdater: noop,
+      createSelectedMomentFocusHandler: noop,
+      createSidebarTreeActionsUpdater: noop,
+      createMemoryActionsReadinessWrapper: noop,
+      createCurrentMomentDetailOpener: noop,
+      createSaveStatusOrchestrationFallback: noop,
+      exposeRefreshMemoriesBridge: noop,
+      resolveSaveStatusTimeFormatter: noop,
+    },
+    LoveBudEditorUtils: {
+      findRootMemory: noop,
+      getCanonicalRootId: noop,
+      isRootMemory: noop,
+    },
+    LoveBudEditorHelpers: {
+      safeI18nText: noop,
+      resolveHintText: noop,
+      resolveTreeTitleText: noop,
+      resolveInfoText: noop,
+      escapeHtml: noop,
+      safeUrl: noop,
+      resolveMemoryThumbnail: noop,
+    },
+    LoveBudEditorSaveStatus: {},
+    LoveBudEditorPageHelpers: {
+      redirectToEditorLogin: noop,
+      getMyTreesHref: noop,
+      renderTreeLoadError: noop,
+      buildTreeLoadErrorCopy: noop,
+      registerEditorAuthStart: noop,
+    },
+    LoveBudEditorTreeHelpers: {
+      syncCurrentTreeData: noop,
+      resolveParentIdForCreate: noop,
+      nextMemoryIdFromMemories: noop,
+    },
+    LoveBudEditorSelectionUI: {},
+    LoveBudEditorBindings: {},
+    LoveBudEditorPageEventBindings: { bindEditorPageEvents: noop },
+    LoveBudEditorDataLoader: {},
+    LoveBudEditorInitialLoadFlow: { runEditorInitialLoadFlow: noop },
+    LoveBudEditorRefreshSaveRuntime: { createEditorRefreshSaveRuntime: noop },
+    LoveBudEditorStartupContext: { createEditorStartupContext: noop },
+    LoveBudEditorAuthHelpers: {
+      readConfirmedAuthCache: () => ({ uid: 'u1' }),
+      hasConfirmedSessionUser: () => true,
+    },
+    LoveBudEditorShellCopyApplier: { createPrepareEditorShell: noop },
+    LoveBudEditorDomRefsBuilder: { createEditorDomRefs: noop },
+  };
+}
+
 test('editor entry dependencies helper loads before editor entry', () => {
   const sources = scriptSources();
   const dependencyHelper = sourceIndex(sources, 'js/editor/editor-entry-dependencies.js');
@@ -78,6 +154,7 @@ test('entry dependencies helper preserves bootstrap missing-helper messages', ()
     'LoveBudEditorHelpers.escapeHtml',
     'LoveBudEditorPageHelpers.renderTreeLoadError',
     'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy',
+    'LoveBudEditorPageHelpers.registerEditorAuthStart',
     'LoveBudEditorShellHelpers.applyEditorShellCopy',
     'LoveBudEditorShellCopyApplier.createPrepareEditorShell',
     'LoveBudEditorShellHelpers.createEditorDebugReporter'
@@ -99,4 +176,33 @@ test('entry dependencies helper preserves shell copy side effect before prepare 
   assert.notEqual(applyIndex, -1, 'applyEditorShellCopy side effect must remain');
   assert.notEqual(prepareIndex, -1, 'prepareEditorShell creation must remain');
   assert.ok(applyIndex < prepareIndex, 'shell copy must apply before prepareEditorShell is returned');
+});
+
+test('entry dependency resolver exposes auth start helper required by editor entry', () => {
+  const resolveEditorEntryDependencies = loadEntryDependencies();
+  const windowRef = createReadyWindow();
+  const result = resolveEditorEntryDependencies({ windowRef });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(
+    result.deps.registerEditorAuthStart,
+    windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart,
+    'resolver must pass through LoveBudEditorPageHelpers.registerEditorAuthStart'
+  );
+});
+
+test('entry dependency resolver stops with auth start helper message when missing', () => {
+  const resolveEditorEntryDependencies = loadEntryDependencies();
+  const windowRef = createReadyWindow();
+  delete windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart;
+
+  const result = resolveEditorEntryDependencies({ windowRef });
+
+  assert.equal(result.status, 'stopped');
+  assert.deepEqual(windowRef.LoveBudEditorDebug.errors, [
+    {
+      msg: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
+      error: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
+    },
+  ]);
 });


### PR DESCRIPTION
Closes #2413

Summary:
- pass `LoveBudEditorPageHelpers.registerEditorAuthStart` through `resolveEditorEntryDependencies()` as `deps.registerEditorAuthStart`
- add an explicit missing-helper guard for the auth start dependency in the resolver
- extend `editor-entry-dependencies` contract coverage for both ready and missing-helper paths

Scope:
- editor bootstrap dependency wiring only
- no #1661 Browse/Search tree-level social count changes
- no DB/API/sort/view/like changes
- no CSP inline script cleanup

Tests:
- update `tests/contracts/editor-entry-dependencies-contract.test.cjs`