### PR TITLE
feat(browse): add public tree view count boundary

### DIFF
--- a/functions/api/trees/[tree_id]/views.js
+++ b/functions/api/trees/[tree_id]/views.js
@@ -1,0 +1,116 @@
+function stripTrailingSlash(value) {
+  return String(value || '').replace(/\/$/, '');
+}
+
+const REQUEST_ID_HEADER = 'x-lovebud-request-id';
+const MODAL_FETCH_TIMEOUT_MS = 25000;
+
+function generateRequestId() {
+  return 'req-' + crypto.randomUUID();
+}
+
+function getOrCreateRequestId(request) {
+  const existing = request.headers.get(REQUEST_ID_HEADER);
+  return existing || generateRequestId();
+}
+
+function buildModalUnavailableResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Modal backend unavailable' }), {
+    status: 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-degraded': 'modal-unavailable',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildModalTimeoutResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Modal upstream timeout' }), {
+    status: 504,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'modal',
+      'x-lovebud-route-status': 'modal-timeout',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildMethodNotAllowedResponse(requestId) {
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+    status: 405,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-lovebud-upstream': 'cloudflare',
+      'x-lovebud-route-status': 'method-not-allowed',
+      allow: 'POST',
+      [REQUEST_ID_HEADER]: requestId
+    }
+  });
+}
+
+function buildModalUrl(request, env) {
+  const modalBaseUrl = stripTrailingSlash(env.MODAL_BASE_URL);
+  if (!modalBaseUrl) return null;
+  const url = new URL(request.url);
+  const parts = url.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+  const treeId = parts[2] || '';
+  if (!treeId) return null;
+  const target = new URL(modalBaseUrl);
+  target.pathname = `/modal/public/trees/${encodeURIComponent(decodeURIComponent(treeId))}/views`;
+  return target;
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), MODAL_FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function proxyTreeView(request, env) {
+  const method = request.method.toUpperCase();
+  const requestId = getOrCreateRequestId(request);
+  if (method !== 'POST') return buildMethodNotAllowedResponse(requestId);
+
+  const modalUrl = buildModalUrl(request, env || {});
+  if (!modalUrl) return buildModalUnavailableResponse(requestId);
+
+  const headers = {
+    accept: 'application/json',
+    'content-type': request.headers.get('content-type') || 'application/json',
+    [REQUEST_ID_HEADER]: requestId
+  };
+
+  try {
+    const response = await fetchWithTimeout(modalUrl.toString(), {
+      method: 'POST',
+      headers,
+      body: request.body
+    });
+    const responseHeaders = new Headers(response.headers);
+    responseHeaders.set('x-lovebud-upstream', 'modal');
+    responseHeaders.set(REQUEST_ID_HEADER, requestId);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders
+    });
+  } catch (error) {
+    if (error.name === 'AbortError') return buildModalTimeoutResponse(requestId);
+    return buildModalUnavailableResponse(requestId);
+  }
+}
+
+export async function onRequestPost(context) {
+  return proxyTreeView(context.request, context.env || {});
+}
+
+export async function onRequest(context) {
+  return proxyTreeView(context.request, context.env || {});
+}

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -51,6 +51,7 @@ from modal_compute.tree_likes import (
     fetch_tree_like_summary,
     fetch_public_tree_like_count,
 )
+from modal_compute.tree_views import record_public_tree_view
 from modal_compute.comments import (
     create_comment,
     fetch_comments,
@@ -219,6 +220,34 @@ def get_public_tree_detail(
         tree["likeCount"] = fetch_public_tree_like_count(safe_tree_id)
         logger.log_success(status_code=200)
         return tree
+    except HTTPException:
+        raise
+    except Exception:
+        logger.log_error(status_code=500, error_category="UNEXPECTED_ERROR")
+        raise
+
+
+@web_app.post("/modal/public/trees/{tree_id}/views")
+async def post_public_tree_view(
+    tree_id: str,
+    request: Request,
+    x_lovebud_request_id: str | None = Header(default=None),
+) -> dict:
+    logger = RequestLogger(
+        request_id=x_lovebud_request_id,
+        route="/modal/public/trees/id/views",
+        method="POST",
+    )
+    try:
+        payload = await parse_json_body(request)
+        result = record_public_tree_view(
+            tree_id,
+            payload.get("actorKey", ""),
+            payload.get("actorKind", "anonymous"),
+            payload.get("source", "public_tree_detail"),
+        )
+        logger.log_success(status_code=200)
+        return result
     except HTTPException:
         raise
     except Exception:

--- a/modal_compute/tree_views.py
+++ b/modal_compute/tree_views.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from modal_compute.db import get_db_connection, run_db_with_retry
+from modal_compute.validation import validate_required_uuid
+
+_ALLOWED_ACTOR_KINDS = {"authenticated", "anonymous"}
+_ALLOWED_VIEW_SOURCES = {"public_tree_detail", "public_tree_card_open"}
+
+
+def _table_exists(cur, table_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = %s
+        ) AS "exists"
+        """,
+        (table_name,),
+    )
+    row = cur.fetchone()
+    return bool(row and row.get("exists"))
+
+
+def _table_has_column(cur, table_name: str, column_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = %s
+              AND column_name = %s
+        ) AS "exists"
+        """,
+        (table_name, column_name),
+    )
+    row = cur.fetchone()
+    return bool(row and row.get("exists"))
+
+
+def _fetch_public_tree_for_view_count(cur, tree_id: str) -> dict[str, Any] | None:
+    if _table_has_column(cur, "trees", "visibility"):
+        cur.execute(
+            """
+            SELECT id
+            FROM trees
+            WHERE id = %s
+              AND visibility = 'public'
+            LIMIT 1
+            """,
+            (tree_id,),
+        )
+        return cur.fetchone()
+
+    if _table_has_column(cur, "trees", "is_public"):
+        cur.execute(
+            """
+            SELECT id
+            FROM trees
+            WHERE id = %s
+              AND is_public = %s
+            LIMIT 1
+            """,
+            (tree_id, True),
+        )
+        return cur.fetchone()
+
+    return None
+
+
+def _ensure_tree_social_counts(cur, tree_id: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO tree_social_counts (tree_id, like_count, view_count, updated_at)
+        VALUES (%s, 0, 0, NOW())
+        ON CONFLICT (tree_id) DO NOTHING
+        """,
+        (tree_id,),
+    )
+
+
+def _fetch_view_count(cur, tree_id: str) -> int:
+    if not _table_exists(cur, "tree_social_counts"):
+        return 0
+
+    cur.execute(
+        """
+        SELECT view_count
+        FROM tree_social_counts
+        WHERE tree_id = %s
+        LIMIT 1
+        """,
+        (tree_id,),
+    )
+    row = cur.fetchone()
+    return int(row.get("view_count") or 0) if row else 0
+
+
+def _normalize_actor_key(actor_key: str) -> str:
+    normalized = str(actor_key or "").strip()
+    if not normalized or len(normalized) > 128:
+        raise HTTPException(status_code=400, detail="Invalid view actor key")
+    return normalized
+
+
+def _normalize_actor_kind(actor_kind: str) -> str:
+    normalized = str(actor_kind or "anonymous").strip()
+    if normalized not in _ALLOWED_ACTOR_KINDS:
+        raise HTTPException(status_code=400, detail="Invalid view actor kind")
+    return normalized
+
+
+def _normalize_view_source(source: str) -> str:
+    normalized = str(source or "public_tree_detail").strip()
+    if normalized not in _ALLOWED_VIEW_SOURCES:
+        raise HTTPException(status_code=400, detail="Invalid view source")
+    return normalized
+
+
+def record_public_tree_view(
+    tree_id: str,
+    actor_key: str,
+    actor_kind: str = "anonymous",
+    source: str = "public_tree_detail",
+) -> dict[str, Any]:
+    safe_tree_id = validate_required_uuid(tree_id, "treeId")
+    safe_actor_key = _normalize_actor_key(actor_key)
+    safe_actor_kind = _normalize_actor_kind(actor_kind)
+    safe_source = _normalize_view_source(source)
+
+    def operation() -> dict[str, Any] | None:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                tree = _fetch_public_tree_for_view_count(cur, safe_tree_id)
+                if not tree:
+                    return None
+
+                if not _table_exists(cur, "tree_social_counts") or not _table_exists(cur, "tree_view_dedup_events"):
+                    return {"treeId": safe_tree_id, "counted": False, "viewCount": _fetch_view_count(cur, safe_tree_id)}
+
+                _ensure_tree_social_counts(cur, safe_tree_id)
+                cur.execute(
+                    """
+                    INSERT INTO tree_view_dedup_events (
+                        id,
+                        tree_id,
+                        actor_key,
+                        actor_kind,
+                        counted_window_start,
+                        source,
+                        created_at
+                    )
+                    VALUES (
+                        gen_random_uuid(),
+                        %s,
+                        %s,
+                        %s,
+                        date_trunc('day', NOW()),
+                        %s,
+                        NOW()
+                    )
+                    ON CONFLICT (tree_id, actor_key, counted_window_start) DO NOTHING
+                    RETURNING id
+                    """,
+                    (safe_tree_id, safe_actor_key, safe_actor_kind, safe_source),
+                )
+                inserted = cur.fetchone() is not None
+
+                if inserted:
+                    cur.execute(
+                        """
+                        UPDATE tree_social_counts
+                        SET view_count = view_count + 1,
+                            updated_at = NOW()
+                        WHERE tree_id = %s
+                        """,
+                        (safe_tree_id,),
+                    )
+
+                view_count = _fetch_view_count(cur, safe_tree_id)
+                conn.commit()
+                return {"treeId": safe_tree_id, "counted": inserted, "viewCount": view_count}
+
+    result = run_db_with_retry(operation)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    return result

--- a/modal_compute/tree_views.py
+++ b/modal_compute/tree_views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from fastapi import HTTPException
@@ -157,7 +158,7 @@ def record_public_tree_view(
                         created_at
                     )
                     VALUES (
-                        gen_random_uuid(),
+                        %s,
                         %s,
                         %s,
                         %s,
@@ -168,7 +169,7 @@ def record_public_tree_view(
                     ON CONFLICT (tree_id, actor_key, counted_window_start) DO NOTHING
                     RETURNING id
                     """,
-                    (safe_tree_id, safe_actor_key, safe_actor_kind, safe_source),
+                    (str(uuid.uuid4()), safe_tree_id, safe_actor_key, safe_actor_kind, safe_source),
                 )
                 inserted = cur.fetchone() is not None
 

--- a/tests/contracts/tree-view-api-boundary-contract.test.cjs
+++ b/tests/contracts/tree-view-api-boundary-contract.test.cjs
@@ -1,0 +1,68 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const modalApp = fs.readFileSync(path.join(ROOT, 'modal_compute', 'app.py'), 'utf8');
+const treeViews = fs.readFileSync(path.join(ROOT, 'modal_compute', 'tree_views.py'), 'utf8');
+const cloudflareRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', 'trees', '[tree_id]', 'views.js'), 'utf8');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const browseSnapshot = fs.readFileSync(path.join(ROOT, 'modal_compute', 'browse_latest.py'), 'utf8');
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+test('Modal app exposes public tree view count route only for POST', () => {
+  assert.match(modalApp, /from\s+modal_compute\.tree_views\s+import\s+record_public_tree_view/);
+  assert.match(modalApp, /@web_app\.post\("\/modal\/public\/trees\/\{tree_id\}\/views"\)/);
+  assert.match(modalApp, /async\s+def\s+post_public_tree_view\(/);
+  assert.match(modalApp, /payload\s*=\s*await\s+parse_json_body\(request\)/);
+  assert.match(modalApp, /record_public_tree_view\([\s\S]*payload\.get\("actorKey",\s*""\)[\s\S]*payload\.get\("actorKind",\s*"anonymous"\)[\s\S]*payload\.get\("source",\s*"public_tree_detail"\)/);
+  assert.doesNotMatch(modalApp, /@web_app\.get\("\/modal\/public\/trees\/\{tree_id\}\/views"\)/);
+});
+
+test('tree view repository writes only privacy-scoped dedup and aggregate view count', () => {
+  assert.match(treeViews, /def\s+record_public_tree_view\(/);
+  assert.match(treeViews, /tree_view_dedup_events/);
+  assert.match(treeViews, /tree_social_counts/);
+  assert.match(treeViews, /ON\s+CONFLICT\s+\(tree_id,\s*actor_key,\s*counted_window_start\)\s+DO\s+NOTHING/i);
+  assert.match(treeViews, /SET\s+view_count\s*=\s*view_count\s*\+\s*1/i);
+  assert.match(treeViews, /"counted"/);
+  assert.match(treeViews, /"viewCount"/);
+  assert.doesNotMatch(treeViews, /raw_ip/i);
+  assert.doesNotMatch(treeViews, /user_agent/i);
+  assert.doesNotMatch(treeViews, /fingerprint/i);
+  assert.doesNotMatch(treeViews, /referrer/i);
+  assert.doesNotMatch(treeViews, /request_headers/i);
+});
+
+test('tree view repository enforces public tree boundary and allowed sources', () => {
+  const normalized = compact(treeViews);
+  assert.match(treeViews, /visibility\s*=\s*'public'/);
+  assert.match(treeViews, /is_public\s*=\s+%s/);
+  assert.match(treeViews, /HTTPException\(status_code=404,\s*detail="Tree not found"\)/);
+  assert.match(treeViews, /_ALLOWED_VIEW_SOURCES\s*=\s*\{"public_tree_detail",\s*"public_tree_card_open"\}/);
+  assert.match(treeViews, /_ALLOWED_ACTOR_KINDS\s*=\s*\{"authenticated",\s*"anonymous"\}/);
+  assert.match(normalized, /ifnormalizednotin_allowed_view_sources/);
+  assert.match(normalized, /ifnormalizednotin_allowed_actor_kinds/);
+});
+
+test('Cloudflare tree view route proxies POST only to Modal public route without auth requirement', () => {
+  assert.match(cloudflareRoute, /export\s+async\s+function\s+onRequestPost/);
+  assert.match(cloudflareRoute, /method\s*!==\s*'POST'/);
+  assert.match(cloudflareRoute, /allow:\s*'POST'/);
+  assert.match(cloudflareRoute, /\/modal\/public\/trees\/\$\{encodeURIComponent\(decodeURIComponent\(treeId\)\)\}\/views/);
+  assert.match(cloudflareRoute, /body:\s*request\.body/);
+  assert.doesNotMatch(cloudflareRoute, /Authorization required/);
+  assert.doesNotMatch(cloudflareRoute, /\/modal\/browse\/latest/);
+  assert.doesNotMatch(cloudflareRoute, /sort=views/);
+});
+
+test('Unit B2 still does not enable Browse sort or public Browse viewCount payload', () => {
+  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  assert.doesNotMatch(browseSnapshot, /"viewCount"/);
+});


### PR DESCRIPTION
Refs #1661

Summary:
- add Unit B2 public tree view count repository/API boundary
- add `modal_compute/tree_views.py` with public-tree-only view recording
- add Modal route `POST /modal/public/trees/{tree_id}/views`
- add Cloudflare Pages proxy route `POST /api/trees/:tree_id/views`
- enforce duplicate suppression through `tree_view_dedup_events`
- increment only `tree_social_counts.view_count` when a new dedup row is inserted
- restrict sources to `public_tree_detail` and `public_tree_card_open`
- restrict actor kinds to `authenticated` and `anonymous`
- keep missing/private trees hidden as 404 on the public view boundary

Scope:
- no `sort=views`
- no `sort=likes`
- no Browse `viewCount` payload
- no Browse UI label change
- no broad analytics
- no raw IP/user-agent/fingerprint/referrer/header storage

Tests:
- add `tests/contracts/tree-view-api-boundary-contract.test.cjs`
- preserve guards that router still only accepts `latest`/`popular`
- preserve guard that Browse summary does not expose `viewCount`