### PR TITLE
fix(editor): restore auth start dependency wiring

### DIFF
--- a/js/editor/editor-entry-dependencies.js
+++ b/js/editor/editor-entry-dependencies.js
@@ -68,6 +68,9 @@
         const redirectToEditorLogin = editorPageHelpers.redirectToEditorLogin;
         if (typeof redirectToEditorLogin !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.redirectToEditorLogin');
 
+        const registerEditorAuthStart = editorPageHelpers.registerEditorAuthStart;
+        if (typeof registerEditorAuthStart !== 'function') return stopMissing(windowRef, 'LoveBudEditorPageHelpers.registerEditorAuthStart');
+
         const safeI18nText = editorHelpers.safeI18nText;
         const resolveHintText = editorHelpers.resolveHintText;
         const resolveTreeTitleText = editorHelpers.resolveTreeTitleText;
@@ -164,6 +167,7 @@
                 i18n,
                 getEditorBasePath,
                 redirectToEditorLogin,
+                registerEditorAuthStart,
                 safeI18nText,
                 resolveHintText,
                 resolveTreeTitleText,

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -19,97 +19,6 @@ function sourceIndex(sources, needle) {
   return sources.findIndex((src) => src.includes(needle));
 }
 
-function noop() {}
-
-function buildReadyWindowRef(overrides = {}) {
-  const registerEditorAuthStart = overrides.registerEditorAuthStart || noop;
-
-  return {
-    LoveBudEditorDataLoaderFallbacks: {},
-    LoveBudEditorEntryFallbacks: {},
-    LoveBudEditorShellHelpers: {
-      createInlineShowToastFallback: () => noop,
-      getI18n: () => ((key) => key),
-      getEditorBasePath: () => 'pages/',
-      getYouTubeInputErrorMessageFallback: () => 'invalid',
-      applyEditorShellCopy: noop,
-      createEditorDebugReporter: () => ({ log: noop, reportError: noop }),
-      createEditorStartupDependencyWaiter: noop,
-      exposeCanvasEmptyGuideUpdater: noop,
-      exposeDetailPanelUpdater: noop,
-      createSelectedMomentFocusHandler: noop,
-      createSidebarTreeActionsUpdater: noop,
-      createMemoryActionsReadinessWrapper: noop,
-      createCurrentMomentDetailOpener: noop,
-      createSaveStatusOrchestrationFallback: noop,
-      exposeRefreshMemoriesBridge: noop,
-      resolveSaveStatusTimeFormatter: noop,
-      markEditorReady: noop,
-      applyEditorEditabilityState: noop,
-      getHttpStatus: noop,
-    },
-    LoveBudEditorUtils: {
-      findRootMemory: noop,
-      getCanonicalRootId: noop,
-      isRootMemory: noop,
-    },
-    LoveBudEditorHelpers: {
-      safeI18nText: noop,
-      resolveHintText: noop,
-      resolveTreeTitleText: noop,
-      resolveInfoText: noop,
-      escapeHtml: noop,
-      safeUrl: noop,
-      resolveMemoryThumbnail: noop,
-    },
-    LoveBudEditorSaveStatus: {},
-    LoveBudEditorPageHelpers: {
-      redirectToEditorLogin: noop,
-      registerEditorAuthStart,
-      getMyTreesHref: noop,
-      renderTreeLoadError: noop,
-      buildTreeLoadErrorCopy: noop,
-    },
-    LoveBudEditorTreeHelpers: {
-      syncCurrentTreeData: noop,
-      resolveParentIdForCreate: noop,
-      nextMemoryIdFromMemories: noop,
-    },
-    LoveBudEditorSelectionUI: {},
-    LoveBudEditorBindings: {},
-    LoveBudEditorPageEventBindings: {
-      bindEditorPageEvents: noop,
-    },
-    LoveBudEditorDataLoader: {},
-    LoveBudEditorInitialLoadFlow: {
-      runEditorInitialLoadFlow: noop,
-    },
-    LoveBudEditorRefreshSaveRuntime: {
-      createEditorRefreshSaveRuntime: noop,
-    },
-    LoveBudEditorStartupContext: {
-      createEditorStartupContext: noop,
-    },
-    LoveBudEditorAuthHelpers: {
-      readConfirmedAuthCache: () => null,
-      hasConfirmedSessionUser: () => false,
-    },
-    LoveBudEditorShellCopyApplier: {
-      createPrepareEditorShell: noop,
-    },
-    LoveBudEditorDomRefsBuilder: {
-      createEditorDomRefs: noop,
-    },
-  };
-}
-
-function loadResolver() {
-  const context = { window: {}, console: { error() {} }, Object };
-  vm.createContext(context);
-  vm.runInContext(read('js/editor/editor-entry-dependencies.js'), context);
-  return context.window.LoveBudEditorEntryDependencies.resolveEditorEntryDependencies;
-}
-
 test('editor entry dependencies helper loads before editor entry', () => {
   const sources = scriptSources();
   const dependencyHelper = sourceIndex(sources, 'js/editor/editor-entry-dependencies.js');
@@ -160,31 +69,12 @@ test('editor entry delegates dependency resolution to helper', () => {
   assert.match(editor, /createEditorStartDependencyChecker\s*=\s*deps\.shellHelpers\.createEditorStartDependencyChecker/);
 });
 
-test('entry dependencies resolver exposes registerEditorAuthStart expected by editor entry', () => {
-  const registerEditorAuthStart = noop;
-  const resolveEditorEntryDependencies = loadResolver();
-  const result = resolveEditorEntryDependencies({
-    windowRef: buildReadyWindowRef({ registerEditorAuthStart }),
-  });
+test('entry dependencies helper wires registerEditorAuthStart required by editor entry', () => {
+  const helper = read('js/editor/editor-entry-dependencies.js');
 
-  assert.equal(result.status, 'ready');
-  assert.equal(result.deps.registerEditorAuthStart, registerEditorAuthStart);
-});
-
-test('entry dependencies resolver stops when registerEditorAuthStart is missing', () => {
-  const errors = [];
-  const resolveEditorEntryDependencies = loadResolver();
-  const windowRef = buildReadyWindowRef({ registerEditorAuthStart: undefined });
-  delete windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart;
-  windowRef.LoveBudEditorDebug = { logs: [], errors };
-
-  const result = resolveEditorEntryDependencies({ windowRef });
-
-  assert.equal(result.status, 'stopped');
-  assert.deepEqual(errors, [{
-    msg: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
-    error: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
-  }]);
+  assert.match(helper, /const\s+registerEditorAuthStart\s*=\s*editorPageHelpers\.registerEditorAuthStart/);
+  assert.match(helper, /typeof\s+registerEditorAuthStart\s*!==\s*'function'\)\s*return\s+stopMissing\(windowRef,\s*'LoveBudEditorPageHelpers\.registerEditorAuthStart'\)/);
+  assert.match(helper, /redirectToEditorLogin,\s*\n\s*registerEditorAuthStart,\s*\n\s*safeI18nText/);
 });
 
 test('entry dependencies helper preserves bootstrap missing-helper messages', () => {

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -19,6 +19,97 @@ function sourceIndex(sources, needle) {
   return sources.findIndex((src) => src.includes(needle));
 }
 
+function noop() {}
+
+function buildReadyWindowRef(overrides = {}) {
+  const registerEditorAuthStart = overrides.registerEditorAuthStart || noop;
+
+  return {
+    LoveBudEditorDataLoaderFallbacks: {},
+    LoveBudEditorEntryFallbacks: {},
+    LoveBudEditorShellHelpers: {
+      createInlineShowToastFallback: () => noop,
+      getI18n: () => ((key) => key),
+      getEditorBasePath: () => 'pages/',
+      getYouTubeInputErrorMessageFallback: () => 'invalid',
+      applyEditorShellCopy: noop,
+      createEditorDebugReporter: () => ({ log: noop, reportError: noop }),
+      createEditorStartupDependencyWaiter: noop,
+      exposeCanvasEmptyGuideUpdater: noop,
+      exposeDetailPanelUpdater: noop,
+      createSelectedMomentFocusHandler: noop,
+      createSidebarTreeActionsUpdater: noop,
+      createMemoryActionsReadinessWrapper: noop,
+      createCurrentMomentDetailOpener: noop,
+      createSaveStatusOrchestrationFallback: noop,
+      exposeRefreshMemoriesBridge: noop,
+      resolveSaveStatusTimeFormatter: noop,
+      markEditorReady: noop,
+      applyEditorEditabilityState: noop,
+      getHttpStatus: noop,
+    },
+    LoveBudEditorUtils: {
+      findRootMemory: noop,
+      getCanonicalRootId: noop,
+      isRootMemory: noop,
+    },
+    LoveBudEditorHelpers: {
+      safeI18nText: noop,
+      resolveHintText: noop,
+      resolveTreeTitleText: noop,
+      resolveInfoText: noop,
+      escapeHtml: noop,
+      safeUrl: noop,
+      resolveMemoryThumbnail: noop,
+    },
+    LoveBudEditorSaveStatus: {},
+    LoveBudEditorPageHelpers: {
+      redirectToEditorLogin: noop,
+      registerEditorAuthStart,
+      getMyTreesHref: noop,
+      renderTreeLoadError: noop,
+      buildTreeLoadErrorCopy: noop,
+    },
+    LoveBudEditorTreeHelpers: {
+      syncCurrentTreeData: noop,
+      resolveParentIdForCreate: noop,
+      nextMemoryIdFromMemories: noop,
+    },
+    LoveBudEditorSelectionUI: {},
+    LoveBudEditorBindings: {},
+    LoveBudEditorPageEventBindings: {
+      bindEditorPageEvents: noop,
+    },
+    LoveBudEditorDataLoader: {},
+    LoveBudEditorInitialLoadFlow: {
+      runEditorInitialLoadFlow: noop,
+    },
+    LoveBudEditorRefreshSaveRuntime: {
+      createEditorRefreshSaveRuntime: noop,
+    },
+    LoveBudEditorStartupContext: {
+      createEditorStartupContext: noop,
+    },
+    LoveBudEditorAuthHelpers: {
+      readConfirmedAuthCache: () => null,
+      hasConfirmedSessionUser: () => false,
+    },
+    LoveBudEditorShellCopyApplier: {
+      createPrepareEditorShell: noop,
+    },
+    LoveBudEditorDomRefsBuilder: {
+      createEditorDomRefs: noop,
+    },
+  };
+}
+
+function loadResolver() {
+  const context = { window: {}, console: { error() {} }, Object };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-entry-dependencies.js'), context);
+  return context.window.LoveBudEditorEntryDependencies.resolveEditorEntryDependencies;
+}
+
 test('editor entry dependencies helper loads before editor entry', () => {
   const sources = scriptSources();
   const dependencyHelper = sourceIndex(sources, 'js/editor/editor-entry-dependencies.js');
@@ -69,6 +160,33 @@ test('editor entry delegates dependency resolution to helper', () => {
   assert.match(editor, /createEditorStartDependencyChecker\s*=\s*deps\.shellHelpers\.createEditorStartDependencyChecker/);
 });
 
+test('entry dependencies resolver exposes registerEditorAuthStart expected by editor entry', () => {
+  const registerEditorAuthStart = noop;
+  const resolveEditorEntryDependencies = loadResolver();
+  const result = resolveEditorEntryDependencies({
+    windowRef: buildReadyWindowRef({ registerEditorAuthStart }),
+  });
+
+  assert.equal(result.status, 'ready');
+  assert.equal(result.deps.registerEditorAuthStart, registerEditorAuthStart);
+});
+
+test('entry dependencies resolver stops when registerEditorAuthStart is missing', () => {
+  const errors = [];
+  const resolveEditorEntryDependencies = loadResolver();
+  const windowRef = buildReadyWindowRef({ registerEditorAuthStart: undefined });
+  delete windowRef.LoveBudEditorPageHelpers.registerEditorAuthStart;
+  windowRef.LoveBudEditorDebug = { logs: [], errors };
+
+  const result = resolveEditorEntryDependencies({ windowRef });
+
+  assert.equal(result.status, 'stopped');
+  assert.deepEqual(errors, [{
+    msg: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
+    error: 'LoveBudEditorPageHelpers.registerEditorAuthStart missing',
+  }]);
+});
+
 test('entry dependencies helper preserves bootstrap missing-helper messages', () => {
   const helper = read('js/editor/editor-entry-dependencies.js');
 
@@ -76,6 +194,7 @@ test('entry dependencies helper preserves bootstrap missing-helper messages', ()
     'LoveBudEditorUtils.findRootMemory',
     'LoveBudEditorHelpers.safeI18nText',
     'LoveBudEditorHelpers.escapeHtml',
+    'LoveBudEditorPageHelpers.registerEditorAuthStart',
     'LoveBudEditorPageHelpers.renderTreeLoadError',
     'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy',
     'LoveBudEditorShellHelpers.applyEditorShellCopy',


### PR DESCRIPTION
Closes #2413

Summary:
- wire `editorPageHelpers.registerEditorAuthStart` through `resolveEditorEntryDependencies()` as `deps.registerEditorAuthStart`
- fail fast with the existing bootstrap missing-helper message when the auth start helper is unavailable
- extend the editor entry dependency contract to verify the helper is exposed and the missing-helper path is preserved

Scope:
- editor bootstrap dependency wiring only
- no Browse/Search tree social counts changes
- no DB/API changes
- no CSP inline script cleanup
- no broader editor refactor

Tests:
- update `tests/contracts/editor-entry-dependencies-contract.test.cjs`