### PR TITLE
feat(viewer): record public tree detail view event

### DIFF
--- a/js/viewer/public-tree-viewer.js
+++ b/js/viewer/public-tree-viewer.js
@@ -14,6 +14,8 @@
     if (window[MARKER]) return;
     window[MARKER] = true;
 
+    const VIEW_ACTOR_KEY_STORAGE = 'lovebud_public_tree_view_actor_key_v1';
+
     // Selectors
     const SEL = {
         treeShell: '#viewerTreeShell',
@@ -43,6 +45,7 @@
     let currentTree = null;
     let currentMemories = [];
     let selectedMemoryId = null;
+    let viewEventSentForTreeId = null;
 
     // i18n helper
     function t(key, fallbackKo, fallbackEn) {
@@ -89,6 +92,52 @@
     function getCurrentLocale() {
         const locale = window.i18n?.currentLang || 'ko';
         return String(locale).toLowerCase().startsWith('en') ? 'en' : 'ko';
+    }
+
+    function createRandomViewActorKey() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return 'anon-' + window.crypto.randomUUID();
+        }
+        return 'anon-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+    }
+
+    function getOrCreateViewActorKey() {
+        try {
+            const stored = window.localStorage?.getItem(VIEW_ACTOR_KEY_STORAGE);
+            if (stored) return stored;
+            const created = createRandomViewActorKey();
+            window.localStorage?.setItem(VIEW_ACTOR_KEY_STORAGE, created);
+            return created;
+        } catch (error) {
+            return createRandomViewActorKey();
+        }
+    }
+
+    function buildTreeViewEndpoint(treeId) {
+        return '/api/trees/' + encodeURIComponent(treeId) + '/views';
+    }
+
+    function recordPublicTreeView(treeId) {
+        if (!treeId || viewEventSentForTreeId === treeId) return;
+        viewEventSentForTreeId = treeId;
+
+        const actorKey = getOrCreateViewActorKey();
+        const payload = JSON.stringify({
+            actorKey,
+            actorKind: 'anonymous',
+            source: 'public_tree_detail'
+        });
+
+        fetch(buildTreeViewEndpoint(treeId), {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json'
+            },
+            body: payload,
+            keepalive: true
+        }).catch((error) => {
+            console.warn('[viewer] tree view count failed:', error);
+        });
     }
 
     // Render helpers
@@ -158,6 +207,7 @@
 
             renderTree();
             renderPreview(); // show first moment
+            recordPublicTreeView(treeId);
         } catch (error) {
             console.error('[viewer] load failed:', error);
             renderError();

--- a/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
+++ b/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
@@ -1,0 +1,63 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const viewer = fs.readFileSync(path.join(ROOT, 'js', 'viewer', 'public-tree-viewer.js'), 'utf8');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const browseSnapshot = fs.readFileSync(path.join(ROOT, 'modal_compute', 'browse_latest.py'), 'utf8');
+
+function getFunctionBlock(source, functionName) {
+  const start = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(start, -1, `${functionName} function must exist`);
+  const nextFunction = source.indexOf('\n    function ', start + 1);
+  return source.slice(start, nextFunction === -1 ? source.length : nextFunction);
+}
+
+test('public tree viewer records view event only after successful detail render', () => {
+  assert.match(viewer, /const\s+VIEW_ACTOR_KEY_STORAGE\s*=\s*'lovebud_public_tree_view_actor_key_v1'/);
+  assert.match(viewer, /let\s+viewEventSentForTreeId\s*=\s*null/);
+
+  const initViewer = getFunctionBlock(viewer, 'initViewer');
+  assert.match(initViewer, /const\s+memories\s*=\s*await\s+loadPublicMemories\(treeId\)/);
+  assert.match(initViewer, /if\s*\(!memories\s*\|\|\s*memories\.length\s*===\s*0\)\s*\{[\s\S]*renderEmpty\(\);[\s\S]*return;/);
+  assert.match(initViewer, /renderTree\(\);/);
+  assert.match(initViewer, /renderPreview\(\);/);
+  assert.match(initViewer, /recordPublicTreeView\(treeId\);/);
+});
+
+test('public tree viewer uses privacy-preserving anonymous actor key', () => {
+  assert.match(viewer, /function\s+createRandomViewActorKey\(/);
+  assert.match(viewer, /crypto\.randomUUID/);
+  assert.match(viewer, /anon-/);
+  assert.match(viewer, /window\.localStorage\?\.getItem\(VIEW_ACTOR_KEY_STORAGE\)/);
+  assert.match(viewer, /window\.localStorage\?\.setItem\(VIEW_ACTOR_KEY_STORAGE,\s*created\)/);
+  assert.doesNotMatch(viewer, /userAgent/);
+  assert.doesNotMatch(viewer, /document\.cookie/);
+  assert.doesNotMatch(viewer, /navigator\.platform/);
+  assert.doesNotMatch(viewer, /fingerprint/i);
+  assert.doesNotMatch(viewer, /referrer/i);
+});
+
+test('public tree viewer sends public_tree_detail event once per loaded tree', () => {
+  const recordBlock = getFunctionBlock(viewer, 'recordPublicTreeView');
+
+  assert.match(recordBlock, /if\s*\(!treeId\s*\|\|\s*viewEventSentForTreeId\s*===\s*treeId\)\s*return/);
+  assert.match(recordBlock, /viewEventSentForTreeId\s*=\s*treeId/);
+  assert.match(recordBlock, /actorKind:\s*'anonymous'/);
+  assert.match(recordBlock, /source:\s*'public_tree_detail'/);
+  assert.match(recordBlock, /fetch\(buildTreeViewEndpoint\(treeId\),\s*\{/);
+  assert.match(recordBlock, /method:\s*'POST'/);
+  assert.match(recordBlock, /keepalive:\s*true/);
+  assert.match(recordBlock, /\.catch\(\(error\)\s*=>\s*\{/);
+});
+
+test('public tree view event endpoint is not wired to Browse or Search sort', () => {
+  assert.match(viewer, /function\s+buildTreeViewEndpoint\(treeId\)/);
+  assert.match(viewer, /\/api\/trees\/[^']*\/views/);
+  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  assert.doesNotMatch(browseSnapshot, /"viewCount"/);
+});

--- a/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
+++ b/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
@@ -54,8 +54,10 @@ test('public tree viewer sends public_tree_detail event once per loaded tree', (
 });
 
 test('public tree view event endpoint is not wired to Browse or Search sort', () => {
-  assert.match(viewer, /function\s+buildTreeViewEndpoint\(treeId\)/);
-  assert.match(viewer, /\/api\/trees\/[^']*\/views/);
+  const endpointBlock = getFunctionBlock(viewer, 'buildTreeViewEndpoint');
+  assert.match(endpointBlock, /'\/api\/trees\/'\s*\+/);
+  assert.match(endpointBlock, /encodeURIComponent\(treeId\)/);
+  assert.match(endpointBlock, /\+\s*'\/views'/);
   assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
   assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
   assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);


### PR DESCRIPTION
Refs #1661

Summary:
- wire the public tree viewer to record a tree-level view event after successful public tree detail render
- call `POST /api/trees/:tree_id/views` with `source: public_tree_detail`
- create a privacy-preserving anonymous actor key in localStorage
- send at most one view event per loaded tree per page lifecycle
- fire-and-forget the view event without blocking viewer rendering

Scope:
- public tree viewer only
- no Browse/Search summary callsite wiring
- no prefetch/cache wiring
- no `sort=views`
- no `sort=likes`
- no Browse `viewCount` payload
- no Browse UI label change
- no raw IP/user-agent/fingerprint/referrer/header storage

Tests:
- add `tests/contracts/public-tree-view-event-wiring-contract.test.cjs`
- guard that event recording happens only after successful memories load/render path
- guard anonymous actor key behavior
- guard no Browse/Search sort or payload exposure