### PR TITLE
feat(api): add public tree detail viewCount read field

### DIFF
--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -51,7 +51,7 @@ from modal_compute.tree_likes import (
     fetch_tree_like_summary,
     fetch_public_tree_like_count,
 )
-from modal_compute.tree_views import record_public_tree_view
+from modal_compute.tree_views import record_public_tree_view, fetch_public_tree_view_count
 from modal_compute.comments import (
     create_comment,
     fetch_comments,
@@ -218,6 +218,7 @@ def get_public_tree_detail(
             logger.log_error(status_code=404, error_category="NOT_FOUND")
             raise HTTPException(status_code=404, detail="Tree not found")
         tree["likeCount"] = fetch_public_tree_like_count(safe_tree_id)
+        tree["viewCount"] = fetch_public_tree_view_count(safe_tree_id)
         logger.log_success(status_code=200)
         return tree
     except HTTPException:

--- a/modal_compute/tree_views.py
+++ b/modal_compute/tree_views.py
@@ -141,6 +141,9 @@ def fetch_public_tree_view_count(tree_id: str) -> int:
                 if not _table_exists(cur, "tree_social_counts"):
                     return {"view_count": 0}
 
+                if not _table_has_column(cur, "tree_social_counts", "view_count"):
+                    return {"view_count": 0}
+
                 cur.execute(
                     """
                     SELECT view_count

--- a/modal_compute/tree_views.py
+++ b/modal_compute/tree_views.py
@@ -124,6 +124,41 @@ def _normalize_view_source(source: str) -> str:
     return normalized
 
 
+def fetch_public_tree_view_count(tree_id: str) -> int:
+    """Read the public tree-level view count without creating aggregate rows.
+
+    Missing tree_social_counts remains a safe zero-count fallback so public tree detail
+    reads keep working before the migration is applied in a runtime environment.
+    """
+
+    def operation() -> dict[str, Any] | None:
+        with get_db_connection() as conn:
+            with conn.cursor() as cur:
+                tree = _fetch_public_tree_for_view_count(cur, tree_id)
+                if not tree:
+                    return None
+
+                if not _table_exists(cur, "tree_social_counts"):
+                    return {"view_count": 0}
+
+                cur.execute(
+                    """
+                    SELECT view_count
+                    FROM tree_social_counts
+                    WHERE tree_id = %s
+                    LIMIT 1
+                    """,
+                    (tree_id,),
+                )
+                row = cur.fetchone()
+                return {"view_count": int(row.get("view_count") or 0) if row else 0}
+
+    result = run_db_with_retry(operation)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Tree not found")
+    return int(result.get("view_count") or 0)
+
+
 def record_public_tree_view(
     tree_id: str,
     actor_key: str,

--- a/tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
+++ b/tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
@@ -15,15 +15,38 @@ function compact(value) {
   return value.replace(/\s+/g, '').toLowerCase();
 }
 
-test('Public tree detail read boundary: viewCount allowed in detail, not in Browse summary', () => {
+test('Public tree detail read boundary: viewCount implemented in detail, not in Browse summary', () => {
+  // modal_app imports fetch_public_tree_view_count
+  assert.match(modalApp, /from\s+modal_compute\.tree_views\s+import\s+[^\n]*fetch_public_tree_view_count/);
+
   // Detail endpoint exists and returns likeCount (pattern for viewCount)
   assert.match(modalApp, /@web_app\.get\("\/modal\/trees\/\{tree_id\}"\)/);
   assert.match(modalApp, /fetch_public_tree_like_count/);
   assert.match(modalApp, /tree\["likeCount"\]\s*=\s*fetch_public_tree_like_count/);
 
-  // Public reads fetches tree and normalizes - future PR should add viewCount here
-  assert.match(publicReads, /def\s+fetch_public_tree\(/);
-  assert.match(publicReads, /normalize_tree_row/);
+  // Public detail route now sets tree["viewCount"] = fetch_public_tree_view_count(safe_tree_id)
+  assert.match(modalApp, /tree\["viewCount"\]\s*=\s*fetch_public_tree_view_count/);
+});
+
+test('fetch_public_tree_view_count helper exists with table and column missing fallbacks', () => {
+  // Helper function exists
+  assert.match(treeViews, /def\s+fetch_public_tree_view_count\(/);
+
+  // Helper checks _table_exists(cur, "tree_social_counts")
+  assert.match(treeViews, /_table_exists\(cur,\s*["']tree_social_counts["']\)/);
+
+  // Helper checks _table_has_column(cur, "tree_social_counts", "view_count")
+  assert.match(treeViews, /_table_has_column\(cur,\s*["']tree_social_counts["'],\s*["']view_count["']\)/);
+
+  // Helper returns safe zero when table missing
+  assert.match(treeViews, /if not _table_exists.*tree_social_counts[\s\S]*?return\s*\{\s*["']view_count["']\s*:\s*0\s*\}/);
+
+  // Helper returns safe zero when column missing
+  assert.match(treeViews, /if not _table_has_column.*view_count[\s\S]*?return\s*\{\s*["']view_count["']\s*:\s*0\s*\}/);
+
+  // Helper validates public tree boundary
+  assert.match(treeViews, /_fetch_public_tree_for_view_count/);
+  assert.match(treeViews, /visibility\s*=\s*'public'/);
 });
 
 test('Browse summary must not include viewCount in payload', () => {
@@ -57,7 +80,7 @@ test('Public tree detail boundary: private trees must not leak viewCount', () =>
   assert.match(treeViews, /is_public\s*=\s*%s/);
 });
 
-test('View count infrastructure exists for future detail read exposure', () => {
+test('View count infrastructure exists for detail read exposure', () => {
   // Aggregate table column exists in tree_views
   assert.match(treeViews, /tree_social_counts/);
   assert.match(treeViews, /view_count/);


### PR DESCRIPTION
Refs #2420
Refs #1661

Summary:
- add viewCount to the public tree detail response only
- read from tree_social_counts.view_count with safe zero fallback
- keep private/missing tree 404 behavior
- strengthen contract coverage for the public-detail-only read boundary

Scope:
- public tree detail read field only
- no Browse/Search summary viewCount
- no sort=views or sort=likes
- no Browse UI label change
- no broad analytics
- no Scout live provider work

Tests:
- git diff --check
- node --test tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
- node --test tests/contracts/tree-view-api-boundary-contract.test.cjs
- npm test -- --runInBand