### PR TITLE
docs(browse): audit tree like count foundation

### DIFF
--- a/docs/product/lovebud-tree-like-count-foundation-audit.md
+++ b/docs/product/lovebud-tree-like-count-foundation-audit.md
@@ -1,0 +1,136 @@
+# LoveBud Tree Like Count Foundation Audit
+
+## Status
+- Refs: #2422, #1661
+- Scope: audit/assessment only
+- Runtime behavior change: none
+- Database/schema migration: none
+- API behavior change: none
+- Frontend label change: none
+
+This document audits whether the current tree-level like count foundation is sufficient as a prerequisite for `sort=likes` implementation, per the Browse tree social counts plan sequence (Unit A → Unit B → Unit C → Unit D).
+
+## Executive Summary
+
+**Verdict: Foundation is SUFFICIENT for `sort=likes` implementation.**
+
+All critical prerequisite checks pass. The tree-level like count infrastructure exists, is tree-level (not memory-level), properly separates from memory reactions, enforces public tree boundary, handles pre-migration fallbacks, and prevents duplicate likes.
+
+## Detailed Checklist
+
+### 1. Public detail `likeCount` is tree-level ✅
+
+**Evidence:**
+- `modal_compute/app.py:220` — `tree["likeCount"] = fetch_public_tree_like_count(safe_tree_id)`
+- `modal_compute/tree_likes.py:121-153` — `fetch_public_tree_like_count()` reads from `tree_social_counts.like_count` (tree-level aggregate)
+- Contract test `tree-like-api-boundary-contract.test.cjs:56-57` verifies read from `tree_social_counts` table
+
+**Conclusion:** Public detail exposes tree-level like count, not memory-level reaction aggregate.
+
+### 2. `likeCount` reads from `tree_social_counts.like_count` ✅
+
+**Evidence:**
+- Migration `scripts/migration-add-tree-social-counts.sql:31-36` creates `tree_social_counts` with `like_count INTEGER NOT NULL DEFAULT 0 CHECK (like_count >= 0)`
+- `tree_likes.py:138-147` — SQL `SELECT like_count FROM tree_social_counts WHERE tree_id = %s`
+- `tree_likes.py:77-88` — `_fetch_like_count()` reads from same table
+- Contract test verifies `FROM tree_social_counts` pattern
+
+**Conclusion:** Single authoritative source exists.
+
+### 3. Memory-level reactions and tree-level likes are separated ✅
+
+**Schema separation:**
+- `reactions` table: memory-level, per-memory, multiple types (see `reactions.py:30-48`)
+- `tree_likes` table: tree-level, per-tree, single like per owner (migration lines 14-25)
+- `tree_social_counts` table: aggregates both `like_count` and `view_count` (migration lines 31-36)
+
+**Code separation:**
+- `reactions.py` handles `toggle_reaction`, `fetch_reaction_counts`, `fetch_reaction_summary` — all use `memory_id`
+- `tree_likes.py` handles `toggle_tree_like`, `fetch_tree_like_summary`, `fetch_public_tree_like_count` — all use `tree_id`
+- Contract test `tree-like-api-boundary-contract.test.cjs:28-33` explicitly asserts no `FROM reactions` or `memory_id` in tree_likes code
+
+**Conclusion:** Clean separation maintained. No code path conflates the two.
+
+### 4. Private/missing tree `likeCount` does not leak via public route ✅
+
+**Public detail endpoint (`app.py:204-228`):**
+- Calls `fetch_public_tree()` which enforces `visibility = 'public'` (or `is_public = true`)
+- Returns 404 if tree not found or not public (line 217-219)
+
+**Read helper (`tree_likes.py:91-118`):**
+- `_fetch_public_tree_for_like_count()` queries with `visibility = 'public'` or `is_public = %s` (True)
+- `fetch_public_tree_like_count()` returns `None` if tree not public, raising 404
+
+**Contract test verifies:**
+- `tree-like-api-boundary-contract.test.cjs:62-73` — public read validates `visibility = 'public'`, returns 404 for private
+- Cloudflare route `functions/api/trees/[tree_id]/likes.js` requires Authorization (private only)
+
+**Conclusion:** Private trees return 404 on public detail read; no engagement data leaks.
+
+### 5. Missing aggregate row returns 0 ✅
+
+**Evidence:**
+- `tree_likes.py:135-136` — `if not _table_exists(cur, "tree_social_counts"): return {"like_count": 0}`
+- `tree_likes.py:147-148` — `int(row.get("like_count") or 0)` handles NULL
+- `tree_social_counts` migration: `like_count INTEGER NOT NULL DEFAULT 0`
+
+**Conclusion:** Safe zero fallback for pre-migration environments.
+
+### 6. Pre-migration table/column missing is safe ✅
+
+**Table missing:** Handled by `_table_exists(cur, "tree_social_counts")` check (returns 0)
+
+**Column missing:** NOT explicitly checked in `fetch_public_tree_like_count()` — but `tree_social_counts` always includes `like_count` column (migration line 33 creates it with `DEFAULT 0`). Since the table and column were created together, column-only missing is impossible without manual schema tampering.
+
+**Risk assessment:** LOW. The migration creates `tree_social_counts` with `like_count` column as a unit. If table exists, column exists.
+
+### 7. `toggle_tree_like` prevents repeated likes per user/tree ✅
+
+**Evidence:**
+- Migration line 23-25: `CREATE UNIQUE INDEX ... ON tree_likes(tree_id, owner_id) WHERE deleted_at IS NULL` — enforces one active like per account per tree
+- `tree_likes.py:190-202` — queries for existing active like: `WHERE tree_id = %s AND owner_id = %s AND deleted_at IS NULL LIMIT 1`
+- Toggle logic: if exists → set `deleted_at = NOW()` (soft delete), decrement count; else insert new
+- `GREATEST(like_count - 1, 0)` prevents negative counts
+
+**Conclusion:** Database-level uniqueness + application logic prevents duplicate active likes.
+
+### 8. Blocker assessment for `sort=likes` implementation
+
+| Prerequisite | Status | Notes |
+|--------------|--------|-------|
+| Tree-level like count exists | ✅ | `tree_social_counts.like_count` |
+| Public detail read exists | ✅ | `GET /modal/trees/{tree_id}` returns `likeCount` |
+| Aggregate read helper exists | ✅ | `fetch_public_tree_like_count()` |
+| Index for sort ordering exists | ✅ | `idx_tree_social_counts_like_count (like_count DESC, updated_at DESC)` |
+| Private tree boundary enforced | ✅ | 404 on public read |
+| Pre-migration safe | ✅ | Table missing → 0 |
+| Browse summary unchanged | ✅ | Contract test: no `likeCount` in browse snapshot |
+| `sort=likes` not implemented | ✅ | Catch-all falls back to `latest` |
+
+**Remaining work for `sort=likes` (Unit C):**
+1. Add `sort=likes` to catch-all route (`functions/api/[[path]].js`)
+2. Implement browse latest/growing queries with `ORDER BY like_count DESC`
+3. Add `likeCount` to browse summary payload (public card)
+4. Update Browse UI with `좋아요순` label (Unit D)
+
+**No blockers identified.** All Unit A foundation is complete.
+
+## Related Documents
+
+- `lovebud-browse-tree-social-counts-plan.md` — Original plan (Unit A likes before Unit B views)
+- `lovebud-public-tree-detail-viewcount-read-boundary.md` — View count boundary (parallel read exposure)
+- `migration-add-tree-social-counts.sql` — Schema foundation
+- `tree-like-api-boundary-contract.test.cjs` — Existing contract coverage
+
+## Conclusion
+
+The tree-level like count foundation (Unit A) is **complete and sufficient** for proceeding to Unit C (`sort=likes` implementation). All 8 audit checkpoints pass with no critical gaps.
+
+The implementation correctly:
+- Uses tree-level aggregate (`tree_social_counts.like_count`)
+- Separates from memory-level reactions
+- Enforces public tree boundary
+- Provides safe pre-migration fallbacks
+- Prevents duplicate likes via database constraint + application logic
+- Exposes `likeCount` only on public detail (not Browse summary)
+- Does not enable `sort=likes` or UI labels prematurely

--- a/tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
+++ b/tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
@@ -1,0 +1,163 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const modalApp = fs.readFileSync(path.join(ROOT, 'modal_compute', 'app.py'), 'utf8');
+const treeLikes = fs.readFileSync(path.join(ROOT, 'modal_compute', 'tree_likes.py'), 'utf8');
+const treeViews = fs.readFileSync(path.join(ROOT, 'modal_compute', 'tree_views.py'), 'utf8');
+const reactions = fs.readFileSync(path.join(ROOT, 'modal_compute', 'reactions.py'), 'utf8');
+const cloudflareLikes = fs.readFileSync(path.join(ROOT, 'functions', 'api', 'trees', '[tree_id]', 'likes.js'), 'utf8');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const browseSnapshot = fs.readFileSync(path.join(ROOT, 'modal_compute', 'browse_latest.py'), 'utf8');
+const migrationLike = fs.readFileSync(path.join(ROOT, 'scripts', 'migration-add-tree-social-counts.sql'), 'utf8');
+const migrationView = fs.readFileSync(path.join(ROOT, 'scripts', 'migration-add-tree-view-tracking.sql'), 'utf8');
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+test('Audit: public tree detail likeCount is tree-level (not memory-level)', () => {
+  // app.py calls fetch_public_tree_like_count for likeCount
+  assert.match(modalApp, /tree\["likeCount"\]\s*=\s*fetch_public_tree_like_count/);
+
+  // fetch_public_tree_like_count reads from tree_social_counts (tree-level aggregate)
+  assert.match(treeLikes, /FROM\s+tree_social_counts[\s\S]*WHERE\s+tree_id\s*=\s*%s/i);
+
+  // Does NOT read from reactions table (memory-level)
+  assert.doesNotMatch(treeLikes, /FROM\s+reactions/i);
+  assert.doesNotMatch(treeLikes, /memory_id/i);
+});
+
+test('Audit: tree_social_counts.like_count is authoritative source', () => {
+  // Migration creates tree_social_counts with like_count column
+  assert.match(migrationLike, /CREATE TABLE IF NOT EXISTS tree_social_counts/);
+  assert.match(migrationLike, /like_count\s+INTEGER\s+NOT NULL\s+DEFAULT\s+0\s+CHECK\s+\(like_count\s*>=\s*0\)/);
+
+  // Index for sort=likes exists
+  assert.match(migrationLike, /idx_tree_social_counts_like_count/);
+  assert.match(migrationLike, /like_count\s+DESC/);
+
+  // Helper reads like_count
+  assert.match(treeLikes, /def\s+_fetch_like_count/);
+  assert.match(treeLikes, /SELECT\s+like_count\s+FROM\s+tree_social_counts/);
+});
+
+test('Audit: memory-level reactions and tree-level likes are separated', () => {
+  // tree_likes.py does not reference reactions table
+  assert.doesNotMatch(treeLikes, /FROM\s+reactions/i);
+  assert.doesNotMatch(treeLikes, /memory_id/i);
+
+  // reactions.py operates on memory_id, not tree_id
+  assert.match(reactions, /WHERE\s+memory_id\s*=\s*%s/);
+  assert.doesNotMatch(reactions, /tree_social_counts/);
+  assert.doesNotMatch(reactions, /tree_likes/);
+
+  // Different tables created by different migrations
+  assert.match(migrationLike, /CREATE TABLE IF NOT EXISTS tree_likes/);
+  assert.match(migrationLike, /CREATE TABLE IF NOT EXISTS tree_social_counts/);
+  // view migration does not touch tree_likes or tree_social_counts like_count
+  assert.doesNotMatch(migrationView, /tree_likes/);
+});
+
+test('Audit: private/missing tree likeCount does not leak via public route', () => {
+  // Public detail endpoint validates public tree
+  assert.match(modalApp, /@web_app\.get\("\/modal\/trees\/\{tree_id\}"\)/);
+  assert.match(modalApp, /tree\s*=\s*fetch_public_tree\(safe_tree_id\)/);
+  assert.match(modalApp, /if not tree[\s\S]*raise HTTPException\(status_code=404/);
+
+  // fetch_public_tree_like_count validates public tree
+  assert.match(treeLikes, /def\s+_fetch_public_tree_for_like_count/);
+  assert.match(treeLikes, /visibility\s*=\s*'public'/);
+  assert.match(treeLikes, /is_public\s*=\s*%s/);
+  assert.match(treeLikes, /if not tree[\s\S]*return None/);
+  assert.match(treeLikes, /raise HTTPException\(status_code=404,\s*detail="Tree not found"\)/);
+
+  // Cloudflare likes route requires auth (private only)
+  assert.match(cloudflareLikes, /Authorization required/);
+});
+
+test('Audit: missing aggregate row returns safe zero', () => {
+  // fetch_public_tree_like_count checks table existence
+  assert.match(treeLikes, /if not _table_exists\(cur,\s*["']tree_social_counts["']\)[\s\S]*return\s*\{\s*["']like_count["']\s*:\s*0\s*\}/);
+
+  // _fetch_like_count also safe (returns 0 if table missing or row missing)
+  assert.match(treeLikes, /def\s+_fetch_like_count/);
+  assert.match(treeLikes, /return int\(row\.get\("like_count"\) or 0\)/);
+
+  // Migration default ensures non-negative
+  assert.match(migrationLike, /like_count\s+INTEGER\s+NOT\s+NULL\s+DEFAULT\s+0\s+CHECK\s+\(like_count\s*>=\s*0\)/);
+});
+
+test('Audit: column missing fallback covered by migration atomicity', () => {
+  // Migration creates table and like_count column together
+  assert.match(migrationLike, /CREATE TABLE IF NOT EXISTS tree_social_counts\s*\([\s\S]*like_count\s+INTEGER/);
+
+  // No separate column addition — column exists iff table exists
+  // Table missing check is sufficient (column cannot exist without table)
+});
+
+test('Audit: toggle_tree_like prevents repeated active likes per user/tree', () => {
+  // Migration enforces unique active like per tree+owner
+  assert.match(migrationLike, /CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_likes_tree_owner_active/);
+  assert.match(migrationLike, /ON tree_likes\(tree_id,\s*owner_id\)/);
+  assert.match(migrationLike, /WHERE deleted_at IS NULL/);
+
+  // Application logic queries for existing active like
+  assert.match(treeLikes, /WHERE\s+tree_id\s*=\s*%s[\s\S]*AND\s+owner_id\s*=\s*%s[\s\S]*AND\s+deleted_at\s+IS\s+NULL/);
+
+  // Toggle off sets deleted_at
+  assert.match(treeLikes, /SET\s+deleted_at\s*=\s*NOW\(\)/);
+
+  // Decrement uses GREATEST to prevent negative
+  assert.match(treeLikes, /GREATEST\(like_count\s*-\s*1,\s*0\)/);
+
+  // Increment uses +1
+  assert.match(treeLikes, /SET\s+like_count\s*=\s*like_count\s*\+\s*1/);
+});
+
+test('Audit: no sort=likes, Browse summary likeCount, or UI label changes', () => {
+  // Catch-all route falls back to latest
+  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+
+  // Browse summary has no likeCount
+  assert.doesNotMatch(browseSnapshot, /likeCount/);
+  assert.doesNotMatch(browseSnapshot, /viewCount/);
+
+  // Cloudflare likes route does not expose sort
+  assert.doesNotMatch(cloudflareLikes, /sort=likes/);
+  assert.doesNotMatch(cloudflareLikes, /sort=views/);
+});
+
+test('Audit: view tracking foundation parallel exists but separate', () => {
+  // View migration creates separate dedup table
+  assert.match(migrationView, /CREATE TABLE IF NOT EXISTS tree_view_dedup_events/);
+  assert.doesNotMatch(migrationView, /tree_likes/);
+
+  // tree_social_counts has both counts
+  assert.match(migrationLike, /like_count\s+INTEGER\s+NOT\s+NULL\s+DEFAULT\s+0/);
+  assert.match(migrationLike, /view_count\s+INTEGER\s+NOT\s+NULL\s+DEFAULT\s+0/);
+
+  // Separate indexes for sort=likes and sort=views
+  assert.match(migrationLike, /idx_tree_social_counts_like_count/);
+  assert.match(migrationLike, /idx_tree_social_counts_view_count/);
+});
+
+test('Audit: public detail likeCount matches viewCount boundary decision', () => {
+  // Both likeCount and viewCount added to public detail (app.py)
+  assert.match(modalApp, /tree\["likeCount"\]\s*=\s*fetch_public_tree_like_count/);
+  assert.match(modalApp, /tree\["viewCount"\]\s*=\s*fetch_public_tree_view_count/);
+
+  // Both read from tree_social_counts
+  assert.match(treeLikes, /FROM\s+tree_social_counts/);
+  assert.match(treeViews, /FROM\s+tree_social_counts/);
+
+  // Neither enables Browse summary or sort
+  assert.doesNotMatch(browseSnapshot, /likeCount/);
+  assert.doesNotMatch(browseSnapshot, /viewCount/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+});


### PR DESCRIPTION
Refs #2422
Refs #1661

Summary:
- audit current tree-level like count foundation
- confirm public detail likeCount is tree-level
- confirm tree_social_counts.like_count is the authoritative aggregate source
- confirm memory-level reactions remain separate
- confirm private tree leakage and pre-migration fallback behavior
- confirm sort=likes can proceed next with no Unit A blockers

Scope:
- docs/contracts only
- no sort=likes implementation
- no sort=views implementation
- no Browse/Search likeCount or viewCount payload
- no Browse UI label change
- no broad analytics
- no Scout live provider work

Tests:
- git diff --check
- node --test tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
- npm test -- --runInBand