### PR TITLE
feat(api): add Browse sort=likes backend support

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -79,7 +79,11 @@ function isBrowseSummaryRequest(request) {
 
 function buildBrowseCacheRequest(request) {
   const url = new URL(request.url);
-  const sort = url.searchParams.get('sort') === 'popular' ? 'popular' : 'latest';
+  const sort = url.searchParams.get('sort') === 'popular'
+    ? 'popular'
+    : url.searchParams.get('sort') === 'likes'
+      ? 'likes'
+      : 'latest';
   const limit = Math.min(Math.max(Number(url.searchParams.get('limit') || 12) || 12, 1), 60);
   const cacheUrl = new URL(url.origin);
   cacheUrl.pathname = '/__cache/community/trees';
@@ -104,7 +108,11 @@ function buildModalUrl(request, env) {
 
   if (path === '/api/community/trees' && sourceUrl.searchParams.get('view') === 'summary') {
     const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 12) || 12, 1), 60);
-    const sort = sourceUrl.searchParams.get('sort') === 'popular' ? 'popular' : 'latest';
+    const sort = sourceUrl.searchParams.get('sort') === 'popular'
+      ? 'popular'
+      : sourceUrl.searchParams.get('sort') === 'likes'
+        ? 'likes'
+        : 'latest';
     target.pathname = '/modal/browse/latest';
     target.searchParams.set('limit', String(limit));
     target.searchParams.set('sort', sort);

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -119,7 +119,7 @@ def get_latest_browse_snapshot(
         method="GET",
     )
     try:
-        safe_sort = sort if sort in {"latest", "popular"} else "latest"
+        safe_sort = sort if sort in {"latest", "popular", "likes"} else "latest"
         result = fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)
         logger.log_success(status_code=200)
         return result

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -165,17 +165,23 @@ def _normalize_legacy_memory_row(node: dict[str, Any], tree_id: str, row: dict[s
 def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") -> list[dict[str, Any]]:
     """Fetch the latest public tree snapshots using a robust join-lateral query.
     Falls back to legacy trees.payload format if memories table is missing.
+    Supports sort="latest" (created_at DESC), sort="popular" (memory_count DESC),
+    and sort="likes" (like_count DESC).
     """
 
     order_clause = "t.created_at DESC"
     if sort == "popular":
         order_clause = "c.memory_count DESC, t.created_at DESC"
+    elif sort == "likes":
+        order_clause = "s.like_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC"
 
     modern_query = """
         SELECT
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
             c.all_tags,
+            s.like_count,
+            s.view_count,
             m.thumbnail as raw_thumbnail,
             m.source_url as raw_source_url
         FROM trees t
@@ -190,6 +196,11 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
             GROUP BY tree_id
             HAVING count(*) >= 3
         ) c ON t.id = c.tree_id
+        LEFT JOIN (
+            -- Social counts: like_count, view_count
+            SELECT tree_id, like_count, view_count
+            FROM tree_social_counts
+        ) s ON t.id = s.tree_id
         LEFT JOIN LATERAL (
             -- Representative Snapshot: Latest memory with visual data
             SELECT thumbnail, source_url
@@ -274,6 +285,8 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
                         "theme": "LoveTree",
                         "timeRange": "",
                         "representativeMemorySourceUrl": rep_source_url or "",
+                        "likeCount": 0,
+                        "viewCount": 0,
                     })
                     if len(result) >= limit:
                         break
@@ -292,6 +305,8 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
             c.all_tags,
+            s.like_count,
+            s.view_count,
             m.thumbnail as raw_thumbnail,
             m.source_url as raw_source_url
         FROM trees t
@@ -305,6 +320,11 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
             GROUP BY tree_id
             HAVING count(*) BETWEEN 1 AND 2
         ) c ON t.id = c.tree_id
+        LEFT JOIN (
+            -- Social counts: like_count, view_count
+            SELECT tree_id, like_count, view_count
+            FROM tree_social_counts
+        ) s ON t.id = s.tree_id
         LEFT JOIN LATERAL (
             SELECT thumbnail, source_url
             FROM memories
@@ -401,6 +421,8 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
                         "theme": "LoveTree",
                         "timeRange": "",
                         "representativeMemorySourceUrl": rep_source_url or "",
+                        "likeCount": 0,
+                        "viewCount": 0,
                     })
                     if len(result) >= limit:
                         break

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -181,7 +181,6 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
             c.memory_count,
             c.all_tags,
             s.like_count,
-            s.view_count,
             m.thumbnail as raw_thumbnail,
             m.source_url as raw_source_url
         FROM trees t
@@ -197,8 +196,8 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
             HAVING count(*) >= 3
         ) c ON t.id = c.tree_id
         LEFT JOIN (
-            -- Social counts: like_count, view_count
-            SELECT tree_id, like_count, view_count
+            -- Social counts: like_count
+            SELECT tree_id, like_count
             FROM tree_social_counts
         ) s ON t.id = s.tree_id
         LEFT JOIN LATERAL (
@@ -231,7 +230,7 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
                     rows = cur.fetchall()
                     q_duration = (time.time() - q_start) * 1000
                     print(f"[LoveBudModal] Latest browse query took {q_duration:.2f}ms (limit={limit})")
-                    return [normalize_row(row) for row in rows]
+                    return [normalize_row(row, include_like_count=True) for row in rows]
 
                 # Fallback: legacy schema (name/is_public/payload)
                 has_name = _table_has_column(cur, "trees", "name")
@@ -285,8 +284,6 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
                         "theme": "LoveTree",
                         "timeRange": "",
                         "representativeMemorySourceUrl": rep_source_url or "",
-                        "likeCount": 0,
-                        "viewCount": 0,
                     })
                     if len(result) >= limit:
                         break
@@ -305,8 +302,6 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
             c.all_tags,
-            s.like_count,
-            s.view_count,
             m.thumbnail as raw_thumbnail,
             m.source_url as raw_source_url
         FROM trees t
@@ -320,11 +315,6 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
             GROUP BY tree_id
             HAVING count(*) BETWEEN 1 AND 2
         ) c ON t.id = c.tree_id
-        LEFT JOIN (
-            -- Social counts: like_count, view_count
-            SELECT tree_id, like_count, view_count
-            FROM tree_social_counts
-        ) s ON t.id = s.tree_id
         LEFT JOIN LATERAL (
             SELECT thumbnail, source_url
             FROM memories
@@ -357,12 +347,7 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
                     rows = cur.fetchall()
                     q_duration = (time.time() - q_start) * 1000
                     print(f"[LoveBudModal] [TIMING] SQL execution took {q_duration:.2f}ms (limit={limit})")
-                    
-                    map_start = time.time()
-                    res = [normalize_row(row, stage_override="growing") for row in rows]
-                    map_duration = (time.time() - map_start) * 1000
-                    print(f"[LoveBudModal] [TIMING] Result mapping/normalization took {map_duration:.2f}ms")
-                    return res
+                    return [normalize_row(row, stage_override="growing") for row in rows]
 
                 # Fallback: legacy schema (name/is_public/payload)
                 has_name = _table_has_column(cur, "trees", "name")
@@ -421,8 +406,6 @@ def fetch_growing_public_tree_snapshots(limit: int = 6) -> list[dict[str, Any]]:
                         "theme": "LoveTree",
                         "timeRange": "",
                         "representativeMemorySourceUrl": rep_source_url or "",
-                        "likeCount": 0,
-                        "viewCount": 0,
                     })
                     if len(result) >= limit:
                         break

--- a/modal_compute/validation.py
+++ b/modal_compute/validation.py
@@ -114,7 +114,7 @@ def normalize_tree_row(
     return tree
 
 
-def normalize_row(row: dict[str, Any], *, stage_override: str | None = None) -> dict[str, Any]:
+def normalize_row(row: dict[str, Any], *, stage_override: str | None = None, include_like_count: bool = False) -> dict[str, Any]:
     """Normalize a combined DB row into a browse-friendly snapshot."""
     memory_count = row.get("memory_count", 0) or 0
     emotion_tags = parse_tags(row.get("all_tags"))
@@ -126,7 +126,7 @@ def normalize_row(row: dict[str, Any], *, stage_override: str | None = None) -> 
     created_at = _to_isoformat(row.get("created_at"))
     updated_at = _to_isoformat(row.get("updated_at"))
 
-    return {
+    result = {
         "id": str(row["id"]),
         "title": row.get("title") or "나의 Lovetree",
         "visibility": row.get("visibility") or "public",
@@ -139,9 +139,10 @@ def normalize_row(row: dict[str, Any], *, stage_override: str | None = None) -> 
         "theme": "LoveTree",
         "timeRange": "",
         "representativeMemorySourceUrl": raw_source_url or "",
-        "likeCount": row.get("like_count", 0) or 0,
-        "viewCount": row.get("view_count", 0) or 0,
     }
+    if include_like_count:
+        result["likeCount"] = row.get("like_count", 0) or 0
+    return result
 
 
 def validate_visibility(value: Any, default: str = "private") -> str:

--- a/modal_compute/validation.py
+++ b/modal_compute/validation.py
@@ -139,6 +139,8 @@ def normalize_row(row: dict[str, Any], *, stage_override: str | None = None) -> 
         "theme": "LoveTree",
         "timeRange": "",
         "representativeMemorySourceUrl": raw_source_url or "",
+        "likeCount": row.get("like_count", 0) or 0,
+        "viewCount": row.get("view_count", 0) or 0,
     }
 
 

--- a/tests/contracts/browse-sort-likes-backend-contract.test.cjs
+++ b/tests/contracts/browse-sort-likes-backend-contract.test.cjs
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const modalApp = fs.readFileSync(path.join(ROOT, 'modal_compute', 'app.py'), 'utf8');
+const publicReads = fs.readFileSync(path.join(ROOT, 'modal_compute', 'public_reads.py'), 'utf8');
+const browseSnapshot = fs.readFileSync(path.join(ROOT, 'modal_compute', 'browse_latest.py'), 'utf8');
+
+function compact(value) {
+  return value.replace(/\s+/g, '').toLowerCase();
+}
+
+test('Catch-all route accepts sort=likes and maps to modal', () => {
+  // buildBrowseCacheRequest handles likes - ternary operator uses ? value for true branches
+  assert.match(catchAllRoute, /buildBrowseCacheRequest/);
+  assert.match(catchAllRoute, /===.*popular/);
+  assert.match(catchAllRoute, /===.*likes/);
+  assert.match(catchAllRoute, /\?\s*['"]popular['"]/);
+  assert.match(catchAllRoute, /\?\s*['"]likes['"]/);
+
+  // buildModalUrl handles likes for community/trees - ternary with nested ternary
+  assert.match(catchAllRoute, /sourceUrl\.searchParams\.get\(["']sort["']\).*===.*popular/);
+  assert.match(catchAllRoute, /sourceUrl\.searchParams\.get\(["']sort["']\).*===.*likes/);
+  assert.match(catchAllRoute, /\?\s*['"]popular['"]/);
+  assert.match(catchAllRoute, /\?\s*['"]likes['"]/);
+
+  // Final fallback is : 'latest'
+  assert.match(catchAllRoute, /:\s*['"]latest['"]/);
+});
+
+test('Modal app validates sort=likes in browse/latest endpoint', () => {
+  assert.match(modalApp, /safe_sort\s*=\s*sort\s+if\s+sort\s+in\s+\{[\s\S]*"latest"[\s\S]*"popular"[\s\S]*"likes"[\s\S]*\}/);
+});
+
+test('Public reads fetch_latest_public_tree_snapshots supports sort=likes', () => {
+  // Function signature and docstring
+  assert.match(publicReads, /def\s+fetch_latest_public_tree_snapshots\(/);
+  assert.match(publicReads, /sort=["']likes["']/);
+
+  // Order clause for likes
+  assert.match(publicReads, /elif\s+sort\s*==\s*["']likes["']/);
+  assert.match(publicReads, /s\.like_count\s+DESC/);
+
+  // Tie-breakers: updated_at DESC, created_at DESC, id ASC
+  assert.match(publicReads, /t\.updated_at\s+DESC/);
+  assert.match(publicReads, /t\.created_at\s+DESC/);
+  assert.match(publicReads, /t\.id\s+ASC/);
+
+  // Join with tree_social_counts
+  assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
+  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
+  assert.match(publicReads, /FROM\s+tree_social_counts/);
+  assert.match(publicReads, /s\s+ON\s+t\.id\s*=\s*s\.tree_id/);
+
+  // Select like_count and view_count in modern query
+  assert.match(publicReads, /s\.like_count,/);
+  assert.match(publicReads, /s\.view_count,/);
+});
+
+test('Normalize row includes likeCount and viewCount from modern query', () => {
+  // validation.py normalize_row includes likeCount/viewCount
+  const validation = fs.readFileSync(path.join(ROOT, 'modal_compute', 'validation.py'), 'utf8');
+  assert.match(validation, /"likeCount":\s*row\.get\(["']like_count["'],\s*0\)\s+or\s+0/);
+  assert.match(validation, /"viewCount":\s*row\.get\(["']view_count["'],\s*0\)\s+or\s+0/);
+});
+
+test('Growing public tree snapshots also includes likeCount/viewCount', () => {
+  // Growing modern query joins tree_social_counts
+  assert.match(publicReads, /def\s+fetch_growing_public_tree_snapshots/);
+  assert.match(publicReads, /s\.like_count,/);
+  assert.match(publicReads, /s\.view_count,/);
+  assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
+  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
+  assert.match(publicReads, /FROM\s+tree_social_counts/);
+
+  // Growing legacy fallback includes likeCount/viewCount
+  assert.match(publicReads, /"likeCount":\s*0,/);
+  assert.match(publicReads, /"viewCount":\s*0,/);
+});
+
+test('Browse sort=views remains unsupported (falls back to latest)', () => {
+  // Catch-all still only accepts popular and likes as non-latest
+  assert.match(catchAllRoute, /===.*popular/);
+  assert.match(catchAllRoute, /===.*likes/);
+  
+  // No views handling
+  assert.doesNotMatch(catchAllRoute, /===.*views/);
+  assert.doesNotMatch(catchAllRoute, /\?\s*['"]views['"]/);
+
+  // Modal app still rejects views
+  assert.doesNotMatch(modalApp, /["']views["']/);
+});
+
+test('Popular sort behavior preserved (memory_count)', () => {
+  // Popular still uses memory_count
+  assert.match(publicReads, /if\s+sort\s*==\s*["']popular["']/);
+  assert.match(publicReads, /c\.memory_count\s+DESC/);
+  assert.match(publicReads, /c\.memory_count\s+DESC,\s*t\.created_at\s+DESC/);
+
+  // Catch-all still accepts popular
+  assert.match(catchAllRoute, /===.*popular/);
+  assert.match(catchAllRoute, /\?\s*['"]popular['"]/);
+});
+
+test('Latest sort behavior preserved (created_at)', () => {
+  // Default latest uses created_at DESC
+  assert.match(publicReads, /order_clause\s*=\s*["']t\.created_at\s+DESC["']/);
+  assert.doesNotMatch(publicReads, /order_clause\s*=\s*["']t\.updated_at\s+DESC["']/);
+});

--- a/tests/contracts/browse-sort-likes-backend-contract.test.cjs
+++ b/tests/contracts/browse-sort-likes-backend-contract.test.cjs
@@ -49,43 +49,51 @@ test('Public reads fetch_latest_public_tree_snapshots supports sort=likes', () =
   assert.match(publicReads, /t\.created_at\s+DESC/);
   assert.match(publicReads, /t\.id\s+ASC/);
 
-  // Join with tree_social_counts
+  // Join with tree_social_counts (only like_count)
   assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
-  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
+  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count/);
   assert.match(publicReads, /FROM\s+tree_social_counts/);
   assert.match(publicReads, /s\s+ON\s+t\.id\s*=\s*s\.tree_id/);
 
-  // Select like_count and view_count in modern query
+  // Select like_count but NOT view_count in modern query
   assert.match(publicReads, /s\.like_count,/);
-  assert.match(publicReads, /s\.view_count,/);
+  assert.doesNotMatch(publicReads, /s\.view_count,/);
 });
 
-test('Normalize row includes likeCount and viewCount from modern query', () => {
-  // validation.py normalize_row includes likeCount/viewCount
+test('Normalize row includes likeCount from modern query but NOT viewCount', () => {
+  // validation.py normalize_row includes likeCount conditionally
   const validation = fs.readFileSync(path.join(ROOT, 'modal_compute', 'validation.py'), 'utf8');
-  assert.match(validation, /"likeCount":\s*row\.get\(["']like_count["'],\s*0\)\s+or\s+0/);
-  assert.match(validation, /"viewCount":\s*row\.get\(["']view_count["'],\s*0\)\s+or\s+0/);
+  assert.match(validation, /result\["likeCount"\]\s*=\s*row\.get\(["']like_count["'],\s*0\)\s+or\s+0/);
+  assert.doesNotMatch(validation, /"viewCount"/);
+
+  // include_like_count parameter exists
+  assert.match(validation, /include_like_count:\s*bool\s*=\s*False/);
 });
 
-test('Growing public tree snapshots also includes likeCount/viewCount', () => {
-  // Growing modern query joins tree_social_counts
+test('Growing public tree snapshots does NOT include social counts join', () => {
+  // Growing modern query does NOT join tree_social_counts
   assert.match(publicReads, /def\s+fetch_growing_public_tree_snapshots/);
-  assert.match(publicReads, /s\.like_count,/);
-  assert.match(publicReads, /s\.view_count,/);
-  assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
-  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
-  assert.match(publicReads, /FROM\s+tree_social_counts/);
 
-  // Growing legacy fallback includes likeCount/viewCount
-  assert.match(publicReads, /"likeCount":\s*0,/);
-  assert.match(publicReads, /"viewCount":\s*0,/);
+  // The growing function's modern_query should NOT have s.like_count
+  const growingSection = publicReads.substring(
+    publicReads.indexOf('fetch_growing_public_tree_snapshots'),
+    publicReads.indexOf('def fetch_public_memories')
+  );
+  assert.doesNotMatch(growingSection, /s\.like_count,/);
+  assert.doesNotMatch(growingSection, /s\.view_count,/);
+  assert.doesNotMatch(growingSection, /LEFT JOIN.*Social counts/);
+  assert.doesNotMatch(growingSection, /FROM\s+tree_social_counts/);
+
+  // Growing legacy fallback does NOT include likeCount/viewCount
+  assert.doesNotMatch(growingSection, /"likeCount":\s*0,/);
+  assert.doesNotMatch(growingSection, /"viewCount":\s*0,/);
 });
 
 test('Browse sort=views remains unsupported (falls back to latest)', () => {
   // Catch-all still only accepts popular and likes as non-latest
   assert.match(catchAllRoute, /===.*popular/);
   assert.match(catchAllRoute, /===.*likes/);
-  
+
   // No views handling
   assert.doesNotMatch(catchAllRoute, /===.*views/);
   assert.doesNotMatch(catchAllRoute, /\?\s*['"]views['"]/);

--- a/tests/contracts/browse-tree-social-counts-plan-contract.test.cjs
+++ b/tests/contracts/browse-tree-social-counts-plan-contract.test.cjs
@@ -76,12 +76,15 @@ test('browse tree social counts plan splits follow-up units and preserves UI/API
   assert.match(content, /This planning slice does not close #1661/);
 });
 
-test('current router still only permits latest or popular summary sort', () => {
+test('current router accepts latest, popular, and likes summary sort (views still falls back)', () => {
   const router = read(routerPath);
 
-  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(router, /sort'\) === 'views'/);
-  assert.doesNotMatch(router, /sort'\) === 'likes'/);
+  // sort=likes is now supported as a summary sort (multiline ternary)
+  assert.match(router, /'likes'\s*\?\s*'likes'\s*:\s*'latest'/);
+  // sort=popular still supported
+  assert.match(router, /'popular'\s*\?\s*'popular'/);
+  // sort=views must NOT be accepted; it must fall back
+  assert.doesNotMatch(router, /sort'\)\s*===\s*'views'/);
 });
 
 test('current browse snapshot remains memory-count centered without tree social counts', () => {

--- a/tests/contracts/browse-tree-view-count-policy-contract.test.cjs
+++ b/tests/contracts/browse-tree-view-count-policy-contract.test.cjs
@@ -73,12 +73,13 @@ test('tree view count policy holds sort and UI changes', () => {
   assert.match(content, /This Unit B policy slice does not close #1661/);
 });
 
-test('current router still does not accept views or likes sort', () => {
+test('current router accepts latest, popular, and likes sort (views still rejected)', () => {
   const router = read(routerPath);
 
-  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(router, /sort'\) === 'views'/);
-  assert.doesNotMatch(router, /sort'\) === 'likes'/);
+  // sort=likes is now supported (Unit C, multiline ternary)
+  assert.match(router, /'likes'\s*\?\s*'likes'/);
+  // sort=views must remain rejected (Unit B policy)
+  assert.doesNotMatch(router, /sort'\)\s*===\s*'views'/);
 });
 
 test('current Browse summary remains without tree view count payload', () => {

--- a/tests/contracts/migration-tree-social-counts-contract.test.cjs
+++ b/tests/contracts/migration-tree-social-counts-contract.test.cjs
@@ -35,12 +35,15 @@ test('tree social counts migration creates aggregate counts table', () => {
   assert.match(sql, /updated_at\s+TIMESTAMP\s+WITH\s+TIME\s+ZONE\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)/i);
 });
 
-test('tree social counts migration prepares future count indexes without changing router behavior', () => {
+test('tree social counts migration prepares count indexes (sort=likes is now supported as Unit C)', () => {
   assert.match(sql, /idx_tree_social_counts_like_count/i);
   assert.match(sql, /ON\s+tree_social_counts\(like_count\s+DESC,\s*updated_at\s+DESC\)/i);
   assert.match(sql, /idx_tree_social_counts_view_count/i);
   assert.match(sql, /ON\s+tree_social_counts\(view_count\s+DESC,\s*updated_at\s+DESC\)/i);
-  assert.match(router, /url\.searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
+  // sort=likes is now supported in router (Unit C runtime slice, multiline ternary)
+  assert.match(router, /'likes'\s*\?\s*'likes'/);
+  // sort=views must remain unsupported
+  assert.doesNotMatch(router, /sort'\)\s*===\s*'views'/);
 });
 
 test('tree social counts migration keeps scope narrow', () => {

--- a/tests/contracts/modal-public-read-routes-contract.test.cjs
+++ b/tests/contracts/modal-public-read-routes-contract.test.cjs
@@ -72,7 +72,8 @@ test('modal public read handlers call their current helper functions', () => {
 
   const latestHandler = extractDecoratedHandler(content, '@web_app.get("/modal/browse/latest")', 'get_latest_browse_snapshot');
   assert.ok(hasString(latestHandler, 'fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)'));
-  assert.ok(hasString(latestHandler, 'safe_sort = sort if sort in {"latest", "popular"} else "latest"'));
+  // safe_sort must accept latest, popular, and likes (Unit C)
+  assert.ok(hasString(latestHandler, 'safe_sort = sort if sort in {"latest", "popular", "likes"} else "latest"'));
 
   const growingHandler = extractDecoratedHandler(content, '@web_app.get("/modal/browse/growing")', 'get_growing_browse_snapshot');
   assert.ok(hasString(growingHandler, 'fetch_growing_public_tree_snapshots(limit=limit)'));
@@ -98,7 +99,9 @@ test('modal public read helpers preserve public visibility filters and normaliza
   const latestHelper = extractPythonFunction(content, 'fetch_latest_public_tree_snapshots');
   assert.ok(hasString(latestHelper, "t.visibility = 'public'"));
   assert.ok(hasString(latestHelper, "WHERE visibility = 'public'"));
-  assert.ok(hasString(latestHelper, 'normalize_row(row)'));
+  // latest Browse summary: likeCount opt-in, viewCount forbidden
+  assert.ok(hasString(latestHelper, 'normalize_row(row, include_like_count=True)'));
+  assert.ok(!hasString(latestHelper, '"viewCount"'), 'latest helper must not emit viewCount in payload');
   assert.ok(hasString(latestHelper, 'HAVING count(*) >= 3'));
   assert.ok(hasString(latestHelper, 'has_memories'));
   assert.ok(hasString(latestHelper, '_table_exists(cur, "memories")'));
@@ -108,7 +111,11 @@ test('modal public read helpers preserve public visibility filters and normaliza
   const growingHelper = extractPythonFunction(content, 'fetch_growing_public_tree_snapshots');
   assert.ok(hasString(growingHelper, "t.visibility = 'public'"));
   assert.ok(hasString(growingHelper, "WHERE visibility = 'public'"));
+  // growing Browse summary: must NOT include social counts (Unit C scope discipline)
   assert.ok(hasString(growingHelper, 'normalize_row(row, stage_override="growing")'));
+  assert.ok(!hasString(growingHelper, 'include_like_count'), 'growing helper must not include likeCount');
+  assert.ok(!hasString(growingHelper, 's.like_count'), 'growing helper must not join like_count');
+  assert.ok(!hasString(growingHelper, 's.view_count'), 'growing helper must not join view_count');
   assert.ok(hasString(growingHelper, 'HAVING count(*) BETWEEN 1 AND 2'));
   assert.ok(hasString(growingHelper, 'has_memories'));
   assert.ok(hasString(growingHelper, '_table_exists'));

--- a/tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
+++ b/tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
@@ -59,11 +59,11 @@ test('Browse summary must not include viewCount in payload', () => {
   // (browse_latest.py handles both latest and growing via imports)
 });
 
-test('Browse/Search sort must not support sort=views', () => {
-  // Catch-all route falls back to latest for unsupported sorts
-  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+test('Browse/Search sort supports latest/popular/likes; sort=views still falls back', () => {
+  // sort=views must still be unsupported
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
+  // sort=likes is now supported (Unit C, multiline ternary)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
 });
 
 test('Public tree detail boundary: private trees must not leak viewCount', () => {

--- a/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
+++ b/tests/contracts/public-tree-view-event-wiring-contract.test.cjs
@@ -53,13 +53,15 @@ test('public tree viewer sends public_tree_detail event once per loaded tree', (
   assert.match(recordBlock, /\.catch\(\(error\)\s*=>\s*\{/);
 });
 
-test('public tree view event endpoint is not wired to Browse or Search sort', () => {
+test('public tree view event endpoint is wired (sort=likes is supported, sort=views is not)', () => {
   const endpointBlock = getFunctionBlock(viewer, 'buildTreeViewEndpoint');
   assert.match(endpointBlock, /'\/api\/trees\/'\s*\+/);
   assert.match(endpointBlock, /encodeURIComponent\(treeId\)/);
   assert.match(endpointBlock, /\+\s*'\/views'/);
-  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+  // sort=likes is now supported in router (Unit C, multiline ternary)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
+  // sort=views remains unsupported
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
+  // viewCount still forbidden in Browse summary
   assert.doesNotMatch(browseSnapshot, /"viewCount"/);
 });

--- a/tests/contracts/tree-like-api-boundary-contract.test.cjs
+++ b/tests/contracts/tree-like-api-boundary-contract.test.cjs
@@ -83,10 +83,11 @@ test('Cloudflare tree like route proxies only authenticated GET and POST to Moda
   assert.doesNotMatch(cloudflareRoute, /sort=views/);
 });
 
-test('Unit A3 does not enable Browse sort or public Browse count payloads', () => {
-  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
-  assert.doesNotMatch(browseSnapshot, /likeCount/);
+test('Unit A3 enables likeCount in latest Browse summary; sort=likes is now supported (Unit C)', () => {
+  // sort=likes is now supported in router (Unit C runtime slice, multiline ternary)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
+  // sort=views remains unsupported
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
+  // viewCount still forbidden in Browse summary (Unit B policy)
   assert.doesNotMatch(browseSnapshot, /viewCount/);
 });

--- a/tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
+++ b/tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
@@ -117,18 +117,17 @@ test('Audit: toggle_tree_like prevents repeated active likes per user/tree', () 
   assert.match(treeLikes, /SET\s+like_count\s*=\s*like_count\s*\+\s*1/);
 });
 
-test('Audit: no sort=likes, Browse summary likeCount, or UI label changes', () => {
-  // Catch-all route falls back to latest
-  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+test('Audit: sort=likes is now enabled; UI labels and viewCount summary are still forbidden', () => {
+  // sort=likes is now enabled (Unit C)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
+  // sort=views remains unsupported
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
 
-  // Browse summary has no likeCount
-  assert.doesNotMatch(browseSnapshot, /likeCount/);
+  // viewCount still forbidden in Browse summary (Unit B policy)
   assert.doesNotMatch(browseSnapshot, /viewCount/);
 
-  // Cloudflare likes route does not expose sort
-  assert.doesNotMatch(cloudflareLikes, /sort=likes/);
+  // likeCount is now allowed in latest Browse summary (Unit C, opt-in)
+  // but Browse UI labels are still forbidden (Unit D slice)
   assert.doesNotMatch(cloudflareLikes, /sort=views/);
 });
 
@@ -146,7 +145,7 @@ test('Audit: view tracking foundation parallel exists but separate', () => {
   assert.match(migrationLike, /idx_tree_social_counts_view_count/);
 });
 
-test('Audit: public detail likeCount matches viewCount boundary decision', () => {
+test('Audit: public detail likeCount matches viewCount boundary decision; sort=likes is now enabled (Unit C)', () => {
   // Both likeCount and viewCount added to public detail (app.py)
   assert.match(modalApp, /tree\["likeCount"\]\s*=\s*fetch_public_tree_like_count/);
   assert.match(modalApp, /tree\["viewCount"\]\s*=\s*fetch_public_tree_view_count/);
@@ -155,9 +154,10 @@ test('Audit: public detail likeCount matches viewCount boundary decision', () =>
   assert.match(treeLikes, /FROM\s+tree_social_counts/);
   assert.match(treeViews, /FROM\s+tree_social_counts/);
 
-  // Neither enables Browse summary or sort
-  assert.doesNotMatch(browseSnapshot, /likeCount/);
+  // viewCount still forbidden in Browse summary (Unit B policy boundary)
   assert.doesNotMatch(browseSnapshot, /viewCount/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
+  // sort=views still unsupported
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
+  // sort=likes is now enabled (Unit C runtime slice)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
 });

--- a/tests/contracts/tree-view-api-boundary-contract.test.cjs
+++ b/tests/contracts/tree-view-api-boundary-contract.test.cjs
@@ -60,9 +60,11 @@ test('Cloudflare tree view route proxies POST only to Modal public route without
   assert.doesNotMatch(cloudflareRoute, /sort=views/);
 });
 
-test('Unit B2 still does not enable Browse sort or public Browse viewCount payload', () => {
-  assert.match(catchAllRoute, /searchParams\.get\('sort'\) === 'popular' \? 'popular' : 'latest'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'views'/);
-  assert.doesNotMatch(catchAllRoute, /sort'\) === 'likes'/);
+test('Unit B2 still does not enable sort=views or public Browse viewCount payload (sort=likes is now supported as Unit C)', () => {
+  // sort=views still forbidden (Unit B policy boundary)
+  assert.doesNotMatch(catchAllRoute, /sort'\)\s*===\s*'views'/);
+  // sort=likes is now supported (Unit C runtime slice, multiline ternary)
+  assert.match(catchAllRoute, /'likes'\s*\?\s*'likes'/);
+  // viewCount still forbidden in Browse summary (Unit B policy boundary)
   assert.doesNotMatch(browseSnapshot, /"viewCount"/);
 });


### PR DESCRIPTION
Refs #2426
Refs #1661

## Summary

- Add backend/API support for `/api/community/trees?view=summary&sort=likes`.
- Sort public Browse summary rows by tree-level `tree_social_counts.like_count DESC` with deterministic tie-breakers.
- Keep `sort=views` unsupported/fallback.
- Keep Browse UI labels unchanged.
- Keep `popular` behavior as the existing memory-count proxy.
- Keep Browse/Search summary `viewCount` out of the payload.
- Keep growing Browse snapshots out of this social-count slice.

## Validation

Reported local validation:

```bash
git diff --check
node --test tests/contracts/browse-sort-likes-backend-contract.test.cjs
node --test tests/contracts/browse-tree-social-counts-plan-contract.test.cjs
node --test tests/contracts/browse-tree-view-count-policy-contract.test.cjs
node --test tests/contracts/migration-tree-social-counts-contract.test.cjs
node --test tests/contracts/modal-public-read-routes-contract.test.cjs
node --test tests/contracts/public-tree-view-event-wiring-contract.test.cjs
node --test tests/contracts/tree-like-api-boundary-contract.test.cjs
node --test tests/contracts/tree-like-count-foundation-audit-contract.test.cjs
node --test tests/contracts/tree-view-api-boundary-contract.test.cjs
node --test tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
```

No Scout live provider/fetch/network work.