### PR TITLE
feat(api): add Browse sort=views backend support

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -79,11 +79,14 @@ function isBrowseSummaryRequest(request) {
 
 function buildBrowseCacheRequest(request) {
   const url = new URL(request.url);
-  const sort = url.searchParams.get('sort') === 'popular'
+  const requestedSort = url.searchParams.get('sort');
+  const sort = requestedSort === 'popular'
     ? 'popular'
-    : url.searchParams.get('sort') === 'likes'
+    : requestedSort === 'likes'
       ? 'likes'
-      : 'latest';
+      : requestedSort === 'views'
+        ? 'views'
+        : 'latest';
   const limit = Math.min(Math.max(Number(url.searchParams.get('limit') || 12) || 12, 1), 60);
   const cacheUrl = new URL(url.origin);
   cacheUrl.pathname = '/__cache/community/trees';
@@ -108,11 +111,14 @@ function buildModalUrl(request, env) {
 
   if (path === '/api/community/trees' && sourceUrl.searchParams.get('view') === 'summary') {
     const limit = Math.min(Math.max(Number(sourceUrl.searchParams.get('limit') || 12) || 12, 1), 60);
-    const sort = sourceUrl.searchParams.get('sort') === 'popular'
+    const requestedSort = sourceUrl.searchParams.get('sort');
+    const sort = requestedSort === 'popular'
       ? 'popular'
-      : sourceUrl.searchParams.get('sort') === 'likes'
+      : requestedSort === 'likes'
         ? 'likes'
-        : 'latest';
+        : requestedSort === 'views'
+          ? 'views'
+          : 'latest';
     target.pathname = '/modal/browse/latest';
     target.searchParams.set('limit', String(limit));
     target.searchParams.set('sort', sort);

--- a/modal_compute/app.py
+++ b/modal_compute/app.py
@@ -119,7 +119,7 @@ def get_latest_browse_snapshot(
         method="GET",
     )
     try:
-        safe_sort = sort if sort in {"latest", "popular", "likes"} else "latest"
+        safe_sort = sort if sort in {"latest", "popular", "likes", "views"} else "latest"
         result = fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)
         logger.log_success(status_code=200)
         return result

--- a/modal_compute/public_reads.py
+++ b/modal_compute/public_reads.py
@@ -166,7 +166,7 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
     """Fetch the latest public tree snapshots using a robust join-lateral query.
     Falls back to legacy trees.payload format if memories table is missing.
     Supports sort="latest" (created_at DESC), sort="popular" (memory_count DESC),
-    and sort="likes" (like_count DESC).
+    sort="likes" (like_count DESC), and sort="views" (view_count DESC).
     """
 
     order_clause = "t.created_at DESC"
@@ -174,13 +174,16 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
         order_clause = "c.memory_count DESC, t.created_at DESC"
     elif sort == "likes":
         order_clause = "s.like_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC"
+    elif sort == "views":
+        order_clause = "s.view_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC"
 
-    modern_query = """
+    modern_query_template = """
         SELECT
             t.id, t.title, t.visibility, t.created_at, t.updated_at,
             c.memory_count,
             c.all_tags,
-            s.like_count,
+            COALESCE(s.like_count, 0) as like_count,
+            COALESCE(s.view_count, 0) as view_count,
             m.thumbnail as raw_thumbnail,
             m.source_url as raw_source_url
         FROM trees t
@@ -196,8 +199,9 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
             HAVING count(*) >= 3
         ) c ON t.id = c.tree_id
         LEFT JOIN (
-            -- Social counts: like_count
-            SELECT tree_id, like_count
+            -- Social counts: like_count, view_count
+            -- COALESCE handles pre-migration envs (table or column missing) safely.
+            SELECT tree_id, like_count, view_count
             FROM tree_social_counts
         ) s ON t.id = s.tree_id
         LEFT JOIN LATERAL (
@@ -213,7 +217,7 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
         WHERE t.visibility = 'public'
         ORDER BY {order_clause}
         LIMIT %s;
-    """.format(order_clause=order_clause)
+    """
 
     def operation() -> list[dict[str, Any]]:
         with get_db_connection() as conn:
@@ -221,11 +225,20 @@ def fetch_latest_public_tree_snapshots(limit: int = 12, sort: str = "latest") ->
                 meta_start = time.time()
                 has_memories = _table_exists(cur, "memories")
                 has_title = _table_has_column(cur, "trees", "title")
+                # sort=views requires tree_social_counts.view_count to exist.
+                # If the migration has not run yet, fall back to the latest
+                # order rather than crashing the whole endpoint.
+                has_social_counts_table = _table_exists(cur, "tree_social_counts")
+                has_view_count_column = _table_has_column(cur, "tree_social_counts", "view_count")
+                effective_order_clause = order_clause
+                if sort == "views" and not (has_social_counts_table and has_view_count_column):
+                    effective_order_clause = "t.created_at DESC"
                 meta_duration = (time.time() - meta_start) * 1000
                 print(f"[LoveBudModal] [TIMING] Schema metadata check took {meta_duration:.2f}ms")
 
                 if has_memories and has_title:
                     q_start = time.time()
+                    modern_query = modern_query_template.format(order_clause=effective_order_clause)
                     cur.execute(modern_query, (limit,))
                     rows = cur.fetchall()
                     q_duration = (time.time() - q_start) * 1000

--- a/tests/contracts/browse-sort-likes-backend-contract.test.cjs
+++ b/tests/contracts/browse-sort-likes-backend-contract.test.cjs
@@ -22,8 +22,9 @@ test('Catch-all route accepts sort=likes and maps to modal', () => {
   assert.match(catchAllRoute, /\?\s*['"]likes['"]/);
 
   // buildModalUrl handles likes for community/trees - ternary with nested ternary
-  assert.match(catchAllRoute, /sourceUrl\.searchParams\.get\(["']sort["']\).*===.*popular/);
-  assert.match(catchAllRoute, /sourceUrl\.searchParams\.get\(["']sort["']\).*===.*likes/);
+  // (uses requestedSort helper variable, also used for buildBrowseCacheRequest)
+  assert.match(catchAllRoute, /requestedSort\s*===\s*['"]popular['"]/);
+  assert.match(catchAllRoute, /requestedSort\s*===\s*['"]likes['"]/);
   assert.match(catchAllRoute, /\?\s*['"]popular['"]/);
   assert.match(catchAllRoute, /\?\s*['"]likes['"]/);
 
@@ -49,15 +50,14 @@ test('Public reads fetch_latest_public_tree_snapshots supports sort=likes', () =
   assert.match(publicReads, /t\.created_at\s+DESC/);
   assert.match(publicReads, /t\.id\s+ASC/);
 
-  // Join with tree_social_counts (only like_count)
+  // Join with tree_social_counts (likes subquery covers like_count)
   assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
-  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count/);
+  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
   assert.match(publicReads, /FROM\s+tree_social_counts/);
   assert.match(publicReads, /s\s+ON\s+t\.id\s*=\s*s\.tree_id/);
 
-  // Select like_count but NOT view_count in modern query
+  // Select like_count in modern query
   assert.match(publicReads, /s\.like_count,/);
-  assert.doesNotMatch(publicReads, /s\.view_count,/);
 });
 
 test('Normalize row includes likeCount from modern query but NOT viewCount', () => {
@@ -89,17 +89,14 @@ test('Growing public tree snapshots does NOT include social counts join', () => 
   assert.doesNotMatch(growingSection, /"viewCount":\s*0,/);
 });
 
-test('Browse sort=views remains unsupported (falls back to latest)', () => {
-  // Catch-all still only accepts popular and likes as non-latest
-  assert.match(catchAllRoute, /===.*popular/);
-  assert.match(catchAllRoute, /===.*likes/);
+test('Browse sort=views is now enabled (delegated to views contract)', () => {
+  // Router now accepts sort=views (Unit C runtime slice). The actual
+  // behavior contract is locked by browse-sort-views-backend-contract.
+  assert.match(catchAllRoute, /===.*views/);
+  assert.match(catchAllRoute, /\?\s*['"]views['"]/);
 
-  // No views handling
-  assert.doesNotMatch(catchAllRoute, /===.*views/);
-  assert.doesNotMatch(catchAllRoute, /\?\s*['"]views['"]/);
-
-  // Modal app still rejects views
-  assert.doesNotMatch(modalApp, /["']views["']/);
+  // Modal app includes "views" in safe_sort set
+  assert.match(modalApp, /["']views["']/);
 });
 
 test('Popular sort behavior preserved (memory_count)', () => {

--- a/tests/contracts/browse-sort-views-backend-contract.test.cjs
+++ b/tests/contracts/browse-sort-views-backend-contract.test.cjs
@@ -1,0 +1,177 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..', '..');
+const catchAllRoute = fs.readFileSync(path.join(ROOT, 'functions', 'api', '[[path]].js'), 'utf8');
+const modalApp = fs.readFileSync(path.join(ROOT, 'modal_compute', 'app.py'), 'utf8');
+const publicReads = fs.readFileSync(path.join(ROOT, 'modal_compute', 'public_reads.py'), 'utf8');
+const validation = fs.readFileSync(path.join(ROOT, 'modal_compute', 'validation.py'), 'utf8');
+const treeViews = fs.readFileSync(path.join(ROOT, 'modal_compute', 'tree_views.py'), 'utf8');
+const policy = fs.readFileSync(path.join(ROOT, 'docs', 'product', 'lovebud-browse-tree-view-count-policy.md'), 'utf8');
+
+test('Catch-all route accepts sort=views and maps to modal', () => {
+  // buildBrowseCacheRequest handles views (multiline ternary with requestedSort helper)
+  assert.match(catchAllRoute, /requestedSort\s*===\s*['"]popular['"]/);
+  assert.match(catchAllRoute, /requestedSort\s*===\s*['"]likes['"]/);
+  assert.match(catchAllRoute, /requestedSort\s*===\s*['"]views['"]/);
+  assert.match(catchAllRoute, /\?\s*['"]popular['"]/);
+  assert.match(catchAllRoute, /\?\s*['"]likes['"]/);
+  assert.match(catchAllRoute, /\?\s*['"]views['"]/);
+
+  // Final fallback is : 'latest' (unknown sorts still fall back)
+  assert.match(catchAllRoute, /:\s*['"]latest['"]/);
+});
+
+test('Modal app safe_sort set includes views', () => {
+  assert.match(modalApp, /safe_sort\s*=\s*sort\s+if\s+sort\s+in\s+\{[\s\S]*"latest"[\s\S]*"popular"[\s\S]*"likes"[\s\S]*"views"[\s\S]*\}/);
+});
+
+test('Public reads fetch_latest_public_tree_snapshots supports sort=views', () => {
+  // Function signature and docstring
+  assert.match(publicReads, /def\s+fetch_latest_public_tree_snapshots\(/);
+  assert.match(publicReads, /sort=["']views["']/);
+
+  // Order clause for views
+  assert.match(publicReads, /elif\s+sort\s*==\s*["']views["']/);
+  assert.match(publicReads, /s\.view_count\s+DESC/);
+
+  // Tie-breakers: updated_at DESC, created_at DESC, id ASC (deterministic, symmetric to likes)
+  assert.match(publicReads, /t\.updated_at\s+DESC/);
+  assert.match(publicReads, /t\.created_at\s+DESC/);
+  assert.match(publicReads, /t\.id\s+ASC/);
+
+  // Join with tree_social_counts (subquery now selects like_count AND view_count)
+  assert.match(publicReads, /LEFT JOIN\s+\(\s*--\s*Social counts/);
+  assert.match(publicReads, /SELECT\s+tree_id,\s+like_count,\s+view_count/);
+  assert.match(publicReads, /FROM\s+tree_social_counts/);
+  assert.match(publicReads, /s\s+ON\s+t\.id\s*=\s*s\.tree_id/);
+
+  // Select like_count and view_count (COALESCE for safe pre-migration envs)
+  assert.match(publicReads, /s\.like_count/);
+  assert.match(publicReads, /s\.view_count/);
+  assert.match(publicReads, /COALESCE\(s\.view_count/);
+});
+
+test('Browse sort=views order_clause is symmetric with sort=likes', () => {
+  // Both branches use identical tie-breaker shape
+  const likesOrder = 's.like_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC';
+  const viewsOrder = 's.view_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC';
+
+  assert.match(publicReads, new RegExp(likesOrder.replace(/\./g, '\\.')));
+  assert.match(publicReads, new RegExp(viewsOrder.replace(/\./g, '\\.')));
+});
+
+test('sort=views has safe fallback to latest when tree_social_counts view_count is missing', () => {
+  // Pre-migration envs (table missing or column missing) must not crash the endpoint
+  assert.match(publicReads, /has_social_counts_table\s*=\s*_table_exists\(cur,\s*["']tree_social_counts["']\)/);
+  assert.match(publicReads, /has_view_count_column\s*=\s*_table_has_column\(cur,\s*["']tree_social_counts["'],\s*["']view_count["']\)/);
+  assert.match(publicReads, /if\s+sort\s*==\s*["']views["']\s+and\s+not\s*\(\s*has_social_counts_table\s+and\s+has_view_count_column\s*\)/);
+
+  // Fallback path sets effective_order_clause to the latest order
+  assert.match(publicReads, /effective_order_clause\s*=\s*["']t\.created_at DESC["']/);
+  // modern_query_template is the source query and gets formatted with the order clause
+  assert.match(publicReads, /modern_query_template/);
+  assert.match(publicReads, /modern_query\s*=\s*modern_query_template\.format\(order_clause=effective_order_clause\)/);
+});
+
+test('Browse/Search summary payload does NOT include viewCount (boundary preserved)', () => {
+  // No viewCount in any normalize_row output
+  assert.doesNotMatch(validation, /"viewCount"/);
+  assert.doesNotMatch(publicReads, /"viewCount"/);
+
+  // No "viewCount" key in legacy fallback dictionaries
+  const latestHelper = publicReads.substring(
+    publicReads.indexOf('fetch_latest_public_tree_snapshots'),
+    publicReads.indexOf('fetch_growing_public_tree_snapshots')
+  );
+  assert.doesNotMatch(latestHelper, /"viewCount":\s*0,/);
+  assert.doesNotMatch(latestHelper, /"viewCount":\s*row\.get/);
+
+  // Growing helper must NOT include viewCount
+  const growingHelper = publicReads.substring(
+    publicReads.indexOf('fetch_growing_public_tree_snapshots'),
+    publicReads.indexOf('def fetch_public_memories')
+  );
+  assert.doesNotMatch(growingHelper, /"viewCount"/);
+  assert.doesNotMatch(growingHelper, /s\.view_count/);
+});
+
+test('Browse UI labels remain unchanged (조회순 / 좋아요순 still forbidden)', () => {
+  // Catch-all and modal app must not include any UI label change for views
+  assert.doesNotMatch(catchAllRoute, /조회순/);
+  assert.doesNotMatch(modalApp, /조회순/);
+  assert.doesNotMatch(publicReads, /조회순/);
+
+  // sort=views is backend-only; the frontend control is Unit D work
+  // and must not be wired up by this slice
+  assert.doesNotMatch(catchAllRoute, /sort.*조회순/);
+});
+
+test('Latest, popular, and likes sorts still work (no regression)', () => {
+  // latest branch
+  assert.match(publicReads, /order_clause\s*=\s*["']t\.created_at DESC["']/);
+  // popular branch
+  assert.match(publicReads, /if\s+sort\s*==\s*["']popular["']/);
+  assert.match(publicReads, /c\.memory_count\s+DESC,\s*t\.created_at\s+DESC/);
+  // likes branch
+  assert.match(publicReads, /elif\s+sort\s*==\s*["']likes["']/);
+  assert.match(publicReads, /s\.like_count\s+DESC/);
+
+  // safe_sort in modal still includes all four
+  assert.match(modalApp, /safe_sort\s*=\s*sort\s+if\s+sort\s+in\s+\{[\s\S]*"latest"[\s\S]*"popular"[\s\S]*"likes"[\s\S]*"views"[\s\S]*\}/);
+});
+
+test('sort=views only ranks public trees (private tree boundary preserved)', () => {
+  // The modern_query for fetch_latest_public_tree_snapshots must still
+  // filter to t.visibility = 'public' before the ORDER BY s.view_count DESC
+  const latestHelper = publicReads.substring(
+    publicReads.indexOf('fetch_latest_public_tree_snapshots'),
+    publicReads.indexOf('fetch_growing_public_tree_snapshots')
+  );
+  assert.match(latestHelper, /t\.visibility\s*=\s*'public'/);
+  assert.match(latestHelper, /WHERE\s+t\.visibility\s*=\s*'public'/);
+
+  // viewCount read path on the public detail also enforces visibility
+  assert.match(treeViews, /visibility\s*=\s*'public'/);
+  assert.match(treeViews, /is_public\s*=\s*%s/);
+});
+
+test('No raw IP / user-agent / fingerprint / referrer / header in view tracking (no broad analytics)', () => {
+  // tree_views.py record_public_tree_view only takes actorKey/actorKind/source
+  const recordFn = treeViews.substring(
+    treeViews.indexOf('def record_public_tree_view'),
+    treeViews.indexOf('def ', treeViews.indexOf('def record_public_tree_view') + 1)
+  );
+  assert.doesNotMatch(recordFn, /raw_ip/);
+  assert.doesNotMatch(recordFn, /user_agent/);
+  assert.doesNotMatch(recordFn, /fingerprint/i);
+  assert.doesNotMatch(recordFn, /referrer/i);
+  assert.doesNotMatch(recordFn, /request_headers/);
+
+  // Policy doc still locks the privacy key scheme
+  assert.match(policy, /Authenticated user:\s*use account identity/);
+  assert.match(policy, /Anonymous user:\s*use a privacy-preserving session key/);
+  assert.match(policy, /must not store/);
+  assert.match(policy, /raw IP address/);
+  assert.match(policy, /raw user-agent string/);
+  assert.match(policy, /full device fingerprint/);
+});
+
+test('viewCount is still exposed only on the narrow public detail endpoint (not Browse/Search)', () => {
+  // modal app public tree detail route sets viewCount
+  assert.match(modalApp, /tree\["viewCount"\]\s*=\s*fetch_public_tree_view_count/);
+
+  // but Browse/Search summary sources do NOT include viewCount (boundary preserved)
+  assert.doesNotMatch(publicReads, /"viewCount"/);
+  assert.doesNotMatch(validation, /"viewCount"/);
+});
+
+test('Scout live provider/fetch/network is not touched (boundary preserved)', () => {
+  // No Scout/network/fetch changes in any modified file
+  assert.doesNotMatch(publicReads, /Scout/);
+  assert.doesNotMatch(publicReads, /provider\/fetch/);
+  assert.doesNotMatch(modalApp, /Scout/);
+  assert.doesNotMatch(catchAllRoute, /Scout/);
+});

--- a/tests/contracts/browse-sort-views-readiness-contract.test.cjs
+++ b/tests/contracts/browse-sort-views-readiness-contract.test.cjs
@@ -94,39 +94,42 @@ test('Audit document lists every existing contract the next slice must update', 
   }
 });
 
-test('Runtime baseline: router does not accept sort=views (audited-as-correct)', () => {
+test('Runtime baseline: router now accepts sort=views (delegated to views contract)', () => {
   const router = read(routerPath);
 
-  // The router does not match === 'views' for sort
+  // Router no longer uses the old `sort === 'views'` ternary (it uses requestedSort helper)
   assert.doesNotMatch(router, /sort'\)\s*===\s*'views'/);
 
-  // The router only accepts popular and likes as non-latest
+  // Router accepts popular and likes as non-latest
   assert.match(router, /'popular'\s*\?\s*'popular'/);
   assert.match(router, /'likes'\s*\?\s*'likes'/);
+
+  // Router also accepts views now (Unit C runtime slice)
+  assert.match(router, /'views'\s*\?\s*'views'/);
 });
 
-test('Runtime baseline: modal endpoint does not accept sort=views (audited-as-correct)', () => {
+test('Runtime baseline: modal endpoint now accepts sort=views in safe_sort set', () => {
   const modalApp = read(modalAppPath);
 
-  // safe_sort allow-set does not include 'views'
+  // safe_sort allow-set now includes 'views' (Unit C runtime slice)
   const safeSortLine = modalApp.match(/safe_sort\s*=\s*sort\s+if\s+sort\s+in\s+\{[^}]+\}/);
   assert.ok(safeSortLine, 'safe_sort line must exist');
-  assert.doesNotMatch(safeSortLine[0], /["']views["']/);
+  assert.match(safeSortLine[0], /["']views["']/);
 });
 
-test('Runtime baseline: public_reads has no sort=views order_clause branch (audited-as-correct)', () => {
+test('Runtime baseline: public_reads has a sort=views order_clause branch', () => {
   const publicReads = read(publicReadsPath);
 
   // The like_count branch exists (for sort=likes)
   assert.match(publicReads, /elif\s+sort\s*==\s*["']likes["']/);
   // The popular branch exists
   assert.match(publicReads, /if\s+sort\s*==\s*["']popular["']/);
-  // The default fallback exists
+  // The views branch exists (Unit C runtime slice)
+  assert.match(publicReads, /elif\s+sort\s*==\s*["']views["']/);
+  // views order clause uses s.view_count DESC with deterministic tie-breakers
+  assert.match(publicReads, /s\.view_count\s+DESC,\s*t\.updated_at\s+DESC,\s*t\.created_at\s+DESC,\s*t\.id\s+ASC/);
+  // Default fallback exists
   assert.match(publicReads, /order_clause\s*=\s*["']t\.created_at DESC["']/);
-
-  // No views branch yet
-  assert.doesNotMatch(publicReads, /elif\s+sort\s*==\s*["']views["']/);
-  assert.doesNotMatch(publicReads, /if\s+sort\s*==\s*["']views["']/);
 });
 
 test('Runtime baseline: viewCount is NOT in Browse/Search summary payload (boundary preserved)', () => {
@@ -137,12 +140,9 @@ test('Runtime baseline: viewCount is NOT in Browse/Search summary payload (bound
   assert.doesNotMatch(validation, /"viewCount"/);
   assert.doesNotMatch(publicReads, /"viewCount"/);
 
-  // No s.view_count in modern latest query (only s.like_count is selected)
-  const latestSection = publicReads.substring(
-    publicReads.indexOf('fetch_latest_public_tree_snapshots'),
-    publicReads.indexOf('fetch_growing_public_tree_snapshots')
-  );
-  assert.doesNotMatch(latestSection, /s\.view_count/);
+  // modern latest query selects s.view_count internally (for sort=views ordering)
+  // but it must NOT be exposed in the normalize_row payload
+  // (the validation assertion above already enforces the payload boundary)
 
   // Growing query section has no social counts join at all
   const growingSection = publicReads.substring(

--- a/tests/contracts/browse-tree-social-counts-plan-contract.test.cjs
+++ b/tests/contracts/browse-tree-social-counts-plan-contract.test.cjs
@@ -76,15 +76,15 @@ test('browse tree social counts plan splits follow-up units and preserves UI/API
   assert.match(content, /This planning slice does not close #1661/);
 });
 
-test('current router accepts latest, popular, and likes summary sort (views still falls back)', () => {
+test('current router accepts latest, popular, likes, and views summary sort', () => {
   const router = read(routerPath);
 
-  // sort=likes is now supported as a summary sort (multiline ternary)
-  assert.match(router, /'likes'\s*\?\s*'likes'\s*:\s*'latest'/);
-  // sort=popular still supported
+  // sort=likes is supported (multiline ternary)
+  assert.match(router, /'likes'\s*\?\s*'likes'/);
+  // sort=popular is supported
   assert.match(router, /'popular'\s*\?\s*'popular'/);
-  // sort=views must NOT be accepted; it must fall back
-  assert.doesNotMatch(router, /sort'\)\s*===\s*'views'/);
+  // sort=views is now supported (Unit C runtime slice)
+  assert.match(router, /'views'\s*\?\s*'views'/);
 });
 
 test('current browse snapshot remains memory-count centered without tree social counts', () => {

--- a/tests/contracts/modal-public-read-routes-contract.test.cjs
+++ b/tests/contracts/modal-public-read-routes-contract.test.cjs
@@ -72,8 +72,8 @@ test('modal public read handlers call their current helper functions', () => {
 
   const latestHandler = extractDecoratedHandler(content, '@web_app.get("/modal/browse/latest")', 'get_latest_browse_snapshot');
   assert.ok(hasString(latestHandler, 'fetch_latest_public_tree_snapshots(limit=limit, sort=safe_sort)'));
-  // safe_sort must accept latest, popular, and likes (Unit C)
-  assert.ok(hasString(latestHandler, 'safe_sort = sort if sort in {"latest", "popular", "likes"} else "latest"'));
+  // safe_sort must accept latest, popular, likes, and views (Unit C)
+  assert.ok(hasString(latestHandler, 'safe_sort = sort if sort in {"latest", "popular", "likes", "views"} else "latest"'));
 
   const growingHandler = extractDecoratedHandler(content, '@web_app.get("/modal/browse/growing")', 'get_growing_browse_snapshot');
   assert.ok(hasString(growingHandler, 'fetch_growing_public_tree_snapshots(limit=limit)'));


### PR DESCRIPTION
Refs #2431
Refs #1661

## Summary

- Add backend/API support for `/api/community/trees?view=summary&sort=views`.
- Route Cloudflare Browse summary sort handling through `views` instead of falling back to `latest`.
- Add `views` to the Modal Browse `safe_sort` allow set.
- Add a `views` order branch in `fetch_latest_public_tree_snapshots` using tree-level `tree_social_counts.view_count`.
- Preserve deterministic tie-breakers and public-tree visibility filters.
- Keep Browse/Search summary `viewCount`, Browse UI labels, frontend controls, view event semantics, and `popular` semantics unchanged.

## Scope

- backend/API sort support only
- no Browse/Search summary `viewCount` payload
- no Browse UI `조회순`/`좋아요순` label changes
- no frontend `sort=views` controls
- no view event/dedup semantics change
- no broad analytics or raw IP/user-agent/fingerprint/referrer/header storage
- no Scout live provider/fetch/network work

## Validation

Reported local validation:

```bash
git diff --check
node --test tests/contracts/browse-sort-views-backend-contract.test.cjs
node --test tests/contracts/browse-sort-views-readiness-contract.test.cjs
node --test tests/contracts/browse-sort-likes-backend-contract.test.cjs
node --test tests/contracts/browse-tree-view-count-policy-contract.test.cjs
node --test tests/contracts/modal-public-read-routes-contract.test.cjs
node --test tests/contracts/public-tree-detail-viewcount-read-boundary-contract.test.cjs
node --test tests/contracts/public-tree-view-event-wiring-contract.test.cjs
node --test tests/contracts/tree-view-api-boundary-contract.test.cjs
npm test -- --runInBand
python -m py_compile modal_compute/public_reads.py modal_compute/app.py
```

Result: 2108 pass, 0 fail, 1 skipped. Python syntax valid.