### PR TITLE
docs(browse): decide final social sort labels

### DIFF
--- a/docs/product/lovebud-browse-final-social-sort-labels-decision.md
+++ b/docs/product/lovebud-browse-final-social-sort-labels-decision.md
@@ -1,0 +1,107 @@
+# LoveBud Browse Final Social Sort Labels Decision
+
+## Status
+
+- Refs: #2433, #1661, #608
+- Unit: D — Final Browse UI update (social sort labels)
+- Scope: product decision / contract only — no runtime behavior change in this slice
+- Runtime behavior change: none
+- Database/schema migration: none
+- API behavior change: none
+- Frontend label change: none (this defines the boundary for future UI PR)
+
+This document locks the final visible sort labels for the Browse page after Units A, B, C are complete.
+
+## Relationship to Existing Decisions
+
+This document extends and must not override:
+
+- `lovebud-browse-tree-social-counts-plan.md` — Units A, B, C, D split and target labels
+- `lovebud-browse-tree-view-count-policy.md` — view count policy, sort/UI hold until Unit D
+- `lovebud-browse-sort-views-readiness-audit.md` — audit confirming Units A–C readiness
+- `lovebud-public-tree-detail-viewcount-read-boundary.md` — public detail `viewCount` read exposure
+- `BROWSE_POPULAR_SORT_SEMANTICS.md` — current `인기순` is a memory-count proxy, not real popularity
+- `BROWSE_SORT_DEFINITION.md` — decision criteria for sort labels
+- `lovebud-browse-sort-views-readiness-audit.md` — confirms `sort=views` backend is ready
+
+## Current Backend Reality (Post Units A–C)
+
+| Sort value | Backend ordering | Signal source | Implementation status |
+|------------|------------------|---------------|----------------------|
+| `latest` | `t.created_at DESC` | Tree creation time | ✅ Active |
+| `popular` | `public_memory_count DESC, t.created_at DESC` | Public memory count (proxy) | ✅ Active |
+| `likes` | `s.like_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC` | Tree-level likes (real engagement) | ✅ Active (Unit C) |
+| `views` | `s.view_count DESC, t.updated_at DESC, t.created_at DESC, t.id ASC` | Tree-level views (real engagement) | ✅ Active (Unit C) |
+
+**Key change from baseline**: `sort=likes` and `sort=views` now have **real engagement signals** (tree-level like count, tree-level view count) backed by `tree_social_counts` aggregate table. The previous `popular` sort was a memory-count proxy; it is no longer the only engagement-adjacent option.
+
+## Product Decision: Final Visible Sort Label Set
+
+The Browse page shall expose exactly three user-facing sort labels:
+
+| Visible label | Internal sort value | Signal | Honesty assessment |
+|---------------|---------------------|--------|---------------------|
+| **최신순** | `latest` | Tree creation time | ✅ Honest — clear meaning |
+| **조회순** | `views` | Tree-level view count (24h dedup, public trees only) | ✅ Honest — real engagement signal |
+| **좋아요순** | `likes` | Tree-level like count (authenticated, one per account per tree) | ✅ Honest — real engagement signal |
+
+### `인기순` (current `popular` label) disposition
+
+**Decision**: Remove `인기순` from the visible sort control.
+
+**Rationale**:
+
+1. **It is a proxy, not popularity**: `popular` orders by public memory count, which correlates with tree completeness but does not measure user engagement (views, likes, shares, comments, dwell time). The `BROWSE_POPULAR_SORT_SEMANTICS.md` explicitly recommended renaming or hiding it.
+
+2. **Real engagement signals now exist**: With `조회순` (views) and `좋아요순` (likes) both backed by real tree-level engagement aggregates, the user has genuine popularity-adjacent options. Keeping a weak proxy alongside real signals creates confusion and dilutes trust.
+
+3. **Three is a clean UX set**: "Recency / Views / Likes" maps cleanly to the three fundamental discovery dimensions: newness, passive engagement, active endorsement. Adding a fourth proxy label adds cognitive load without proportional value.
+
+4. **No data loss**: The `popular` sort value remains supported in the API (it still works and produces the same memory-count ordering). It is simply not surfaced in the visible control. Advanced users or future features can still access it via direct URL if needed.
+
+## Migration Path for `popular`
+
+- **API**: `sort=popular` continues to work, ordering by `public_memory_count DESC, t.created_at DESC` with eligibility `public_memory_count >= 3`. No breaking change.
+- **Frontend**: The visible sort control (dropdown/tabs) removes the `인기순` option. The control shows only `최신순` / `조회순` / `좋아요순`.
+- **URL state**: If a user has `?sort=popular` in their URL or saved state, the backend still honors it. The frontend should not highlight a "selected" state for a label that no longer exists in the control — treat it as "custom/other" or default to `최신순` display.
+- **Future**: If a true curation/editorial score is implemented, it can be added as a fourth label with an honest name (e.g., `큐레이션순`, `추천순`).
+
+## Hard Scope Boundaries for the Follow-up UI PR
+
+The follow-up UI implementation PR (Unit D execution) must NOT touch:
+
+1. **Backend sort logic** — `latest`, `popular`, `likes`, `views` ordering all stay as-is.
+2. **API contract** — no new sort values, no changes to fallback behavior.
+3. **Browse summary payload** — still no `viewCount` or `likeCount` in summary (policy boundary from Unit B-read).
+4. **Private tree boundary** — `sort=views` and `sort=likes` must continue to only rank public trees (already enforced in SQL).
+5. **Dedup policy** — 24-hour per-actor view dedup unchanged; one like per account per tree unchanged.
+6. **Analytics prohibition** — no raw IP / user-agent / fingerprint / referrer / header collection.
+
+The UI PR scope is strictly: update the visible sort control labels and their mapping to internal sort values.
+
+## Implementation Gates for the Unit D UI PR
+
+A future PR that implements the visible label change must include contract coverage for:
+
+- Visible sort control shows exactly three options: `최신순`, `조회순`, `좋아요순`.
+- `최신순` maps to `sort=latest`.
+- `조회순` maps to `sort=views`.
+- `좋아요순` maps to `sort=likes`.
+- `인기순` is not present in the visible control.
+- `sort=popular` still works via direct URL (not a regression).
+- Mobile (375px) and desktop Browse remain usable.
+- No restricted runtime values printed in reports.
+
+## Acceptance for This Decision Slice
+
+This decision slice is complete when:
+
+- The final three-label decision is recorded.
+- The `인기순` disposition is explicit.
+- The hard scope boundaries for the follow-up UI PR are defined.
+- Implementation gates are defined.
+- Runtime behavior remains unchanged (this is a docs-only decision).
+
+## Closure Note for #1661 and #608
+
+This decision slice does not close #1661 or #608 by itself. It finalizes the product label decision that enables the Unit D UI implementation PR. #1661 should remain open until the UI implementation is complete. #608 can be closed when the UI PR implements this decision (Outcome B from BROWSE_SORT_DEFINITION.md — rename/remove the misleading label).

--- a/docs/product/product_index.md
+++ b/docs/product/product_index.md
@@ -23,6 +23,9 @@
 | [BROWSE_POPULAR_SORT_SEMANTICS.md](BROWSE_POPULAR_SORT_SEMANTICS.md) | Browse `popular` sort의 현재 memory-count proxy 의미와 v0.1 표시 정책 방향 |
 | [lovebud-browse-tree-social-counts-plan.md](lovebud-browse-tree-social-counts-plan.md) | #1661 tree-level Browse social counts foundation plan — storage model, likes-before-views order, duplicate view policy, and follow-up split |
 | [lovebud-browse-tree-view-count-policy.md](lovebud-browse-tree-view-count-policy.md) | #1661 Unit B tree-level view count policy — countable event boundary, duplicate suppression, privacy-safe actor key, and sort/UI hold |
+| [lovebud-browse-sort-views-readiness-audit.md](lovebud-browse-sort-views-readiness-audit.md) | #1661 Unit C sort=views readiness audit — confirms backend prerequisites for `sort=views` runtime implementation |
+| [lovebud-public-tree-detail-viewcount-read-boundary.md](lovebud-public-tree-detail-viewcount-read-boundary.md) | #1661 Unit B-read public tree detail `viewCount` read exposure boundary — narrow endpoint decision |
+| [lovebud-browse-final-social-sort-labels-decision.md](lovebud-browse-final-social-sort-labels-decision.md) | #1661 Unit D final Browse social sort labels decision — `최신순` / `조회순` / `좋아요순`, `인기순` disposition |
 | [READ_ONLY_LOVETREE_VIEWER_PLAN.md](READ_ONLY_LOVETREE_VIEWER_PLAN.md) | read-only LoveTree viewer의 route, public-safe data, viewer/editor separation, interaction, privacy guardrail 계획 |
 | [VERTICAL_TREE_LAYOUT_DECISION.md](VERTICAL_TREE_LAYOUT_DECISION.md) | Editor와 read-only viewer의 세로형 tree-growth layout 채택 결정, desktop/mobile 원칙, phased rollout 기준 |
 | [BROWSE_TREE_FIRST_DISCOVERY_PLAN.md](BROWSE_TREE_FIRST_DISCOVERY_PLAN.md) | Browse를 tree-first public LoveTree discovery로 발전시키기 위한 card/감상허브/viewer route semantics 계획 |
@@ -123,26 +126,29 @@ Strong primary CTAs require Ready status and valid runtime verification when Aut
 5. **BROWSE_POPULAR_SORT_SEMANTICS.md** — Browse `popular` sort의 현재 의미와 v0.1 표시 정책 방향
 6. **lovebud-browse-tree-social-counts-plan.md** — #1661 tree-level Browse social counts planning, storage model, likes-before-views order, duplicate view policy
 7. **lovebud-browse-tree-view-count-policy.md** — #1661 Unit B tree-level view count policy, counted event boundary, duplicate suppression, privacy-safe keys, and sort/UI hold
-8. **READ_ONLY_LOVETREE_VIEWER_PLAN.md** — read-only LoveTree viewer route/data/viewer-editor separation 계획
-9. **VERTICAL_TREE_LAYOUT_DECISION.md** — 세로형 tree-growth layout 채택 결정
-10. **BROWSE_TREE_FIRST_DISCOVERY_PLAN.md** — Browse tree-first discovery와 viewer route semantics 계획
-11. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
-12. **PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md** — public viewer social placeholder 배치 및 phasing 계획
-13. **TREE_LEVEL_COMMENTS_READ_CONTRACT.md** — tree-level comments read scope, parent-tree guard, public-safe response, empty/error state contract
-14. **MOMENT_LEVEL_COMMENTS_READ_CONTRACT.md** — moment-level comments read scope, parent-tree guard, target-moment guard, public-safe response, empty/error state contract
-15. **V01_CTA_EXPOSURE_POLICY.md** — v0.1 unfinished/partial action 노출 기준과 CTA readiness 분류 정책
-16. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
-17. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
-18. **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
-19. **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
-20. **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
-21. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
-22. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
-23. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
-24. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
-25. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
-26. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
-27. **필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md**
+8. **lovebud-browse-sort-views-readiness-audit.md** — #1661 Unit C sort=views readiness audit — confirms backend prerequisites for `sort=views` runtime implementation
+9. **lovebud-public-tree-detail-viewcount-read-boundary.md** — #1661 Unit B-read public tree detail `viewCount` read exposure boundary — narrow endpoint decision
+10. **lovebud-browse-final-social-sort-labels-decision.md** — #1661 Unit D final Browse social sort labels decision — `최신순` / `조회순` / `좋아요순`, `인기순` disposition
+11. **READ_ONLY_LOVETREE_VIEWER_PLAN.md** — read-only LoveTree viewer route/data/viewer-editor separation 계획
+12. **VERTICAL_TREE_LAYOUT_DECISION.md** — 세로형 tree-growth layout 채택 결정
+13. **BROWSE_TREE_FIRST_DISCOVERY_PLAN.md** — Browse tree-first discovery와 viewer route semantics 계획
+14. **TREE_MOMENT_SOCIAL_MODEL.md** — tree-level / moment-level social scope, permissions, moderation, data model planning
+15. **PUBLIC_VIEWER_SOCIAL_PLACEHOLDER_PLAN.md** — public viewer social placeholder 배치 및 phasing 계획
+16. **TREE_LEVEL_COMMENTS_READ_CONTRACT.md** — tree-level comments read scope, parent-tree guard, public-safe response, empty/error state contract
+17. **MOMENT_LEVEL_COMMENTS_READ_CONTRACT.md** — moment-level comments read scope, parent-tree guard, target-moment guard, public-safe response, empty/error state contract
+18. **V01_CTA_EXPOSURE_POLICY.md** — v0.1 unfinished/partial action 노출 기준과 CTA readiness 분류 정책
+19. **MOMENT_TIMELINE_PLAN.md** — cue-based Moment Timeline 계획
+20. **YOUTUBE_SEGMENT_PLAYER_POC_SCOPE.md** — YouTube segment player PoC scope and verification criteria
+21. **YOUTUBE_SEGMENT_PLAYER_POC_TEST_MATRIX.md** — YouTube segment player PoC test matrix and browser verification requirements
+22. **YOUTUBE_SEGMENT_PLAYER_POC_RUNTIME_NOTES.md** — YouTube segment player PoC runtime observations and limitations
+23. **YOUTUBE_SEGMENT_PLAYER_POC_BROWSER_VERIFICATION.md** — YouTube segment player PoC browser verification evidence and feasibility decision
+24. **MOMENT_CAPTURE_UI_DESIGN.md** — Moment capture UI flow 설계
+25. **MOMENT_TIMELINE_REORDER_DESIGN.md** — Moment Timeline reorder / sequence editor 설계
+26. **UI_COPY_DIET_GUIDE.md** — 전역 UI 카피 다이어트 기준
+27. **MVP_SCOPE.md** — MVP 범위 및 In/Out of Scope
+28. **USER_FLOW.md** — 사용자 여정 및 핵심 플로우
+29. **PRODUCT_BRIEF.md** — 현재 실행 기준 요약
+30. **필요시 DATA_NAMING_RULE.md, READONLY_SHARE_SCOPE.md**
 
 ## 참조
 - 전체 문서 인덱스: `../doc_index.md`

--- a/tests/contracts/browse-final-social-sort-labels-decision-contract.test.cjs
+++ b/tests/contracts/browse-final-social-sort-labels-decision-contract.test.cjs
@@ -1,0 +1,188 @@
+// Browse Final Social Sort Labels Decision — contract test
+// Locks the decision in docs/product/lovebud-browse-final-social-sort-labels-decision.md
+// Refs #2433, #1661, #608
+
+const assert = require('node:assert');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const docsDir = path.join(__dirname, '..', '..', 'docs', 'product');
+const decisionDoc = path.join(docsDir, 'lovebud-browse-final-social-sort-labels-decision.md');
+
+// Helper to read file content
+function readDoc(p) {
+  return fs.readFileSync(p, 'utf8');
+}
+
+test('Decision document exists', () => {
+  assert.ok(fs.existsSync(decisionDoc), `Expected ${decisionDoc} to exist`);
+});
+
+test('Decision document records three final labels', () => {
+  const content = readDoc(decisionDoc);
+  // Must explicitly state the three labels
+  assert.match(content, /최신순/);
+  assert.match(content, /조회순/);
+  assert.match(content, /좋아요순/);
+});
+
+test('Decision document maps labels to correct sort values', () => {
+  const content = readDoc(decisionDoc);
+  // Verify mapping table or explicit statements
+  assert.match(content, /최신순.*latest|latest.*최신순/);
+  assert.match(content, /조회순.*views|views.*조회순/);
+  assert.match(content, /좋아요순.*likes|likes.*좋아요순/);
+});
+
+test('Decision document explicitly disposes of 인기순', () => {
+  const content = readDoc(decisionDoc);
+  // Must have explicit decision about 인기순
+  assert.match(content, /인기순/);
+  // Must state it is removed/hidden from visible control
+  assert.match(content, /제거|숨김|not present|not surfaced|disposition|removed|hidden/i);
+});
+
+test('Decision document preserves popular API support', () => {
+  const content = readDoc(decisionDoc);
+  // popular sort value must still work via API
+  assert.match(content, /popular.*작동|popular.*works|popular.*supported|API.*popular|continues to work/i);
+});
+
+test('Decision document reaffirms hard scope boundaries for Unit D UI PR', () => {
+  const content = readDoc(decisionDoc);
+  // Must list boundaries that UI PR must not touch
+  const boundaryKeywords = [
+    'backend sort logic',
+    'API contract',
+    'Browse summary payload',
+    'private tree boundary',
+    'dedup policy',
+    'analytics prohibition'
+  ];
+  for (const kw of boundaryKeywords) {
+    assert.match(content, new RegExp(kw, 'i'), `Missing boundary keyword: ${kw}`);
+  }
+});
+
+test('Decision document records implementation gates for Unit D UI PR', () => {
+  const content = readDoc(decisionDoc);
+  // Must have implementation gates section
+  assert.match(content, /Implementation Gates|implementation gates/i);
+  const gateKeywords = [
+    '정확히 세 개|exactly three|three options',
+    '최신순.*조회순.*좋아요순|조회순.*좋아요순.*최신순|좋아요순.*최신순.*조회순',
+    'mobile.*375px|375px.*mobile',
+    'desktop'
+  ];
+  for (const kw of gateKeywords) {
+    assert.match(content, new RegExp(kw, 'i'), `Missing gate keyword: ${kw}`);
+  }
+});
+
+test('Decision document does not authorize runtime changes', () => {
+  const content = readDoc(decisionDoc);
+  // Must be clear this is docs-only decision
+  assert.match(content, /docs-only|docs only|문서만|런타임.*변경.*없음|no runtime.*change|Runtime behavior remains unchanged/i);
+});
+
+test('Decision document references all parent decisions', () => {
+  const content = readDoc(decisionDoc);
+  const requiredRefs = [
+    'lovebud-browse-tree-social-counts-plan',
+    'lovebud-browse-tree-view-count-policy',
+    'lovebud-browse-sort-views-readiness-audit',
+    'lovebud-public-tree-detail-viewcount-read-boundary',
+    'BROWSE_POPULAR_SORT_SEMANTICS',
+    'BROWSE_SORT_DEFINITION'
+  ];
+  for (const ref of requiredRefs) {
+    assert.match(content, new RegExp(ref, 'i'), `Missing parent reference: ${ref}`);
+  }
+});
+
+test('Decision document records closure note for #1661 and #608', () => {
+  const content = readDoc(decisionDoc);
+  assert.match(content, /#1661/);
+  assert.match(content, /#608/);
+  assert.match(content, /does not close|남아있|remain open/i);
+});
+
+// Runtime locking assertions — these must fail if the codebase drifts
+test('Runtime locking: visitor-viewer-panels.js does not yet have 조회순/좋아요순', () => {
+  const filePath = path.join(__dirname, '..', '..', 'js', 'visitor-viewer', 'visitor-viewer-panels.js');
+  const content = fs.readFileSync(filePath, 'utf8');
+  // 조회순 and 좋아요순 should NOT be present yet (this is a pre-UI decision contract)
+  assert.doesNotMatch(content, /조회순/);
+  assert.doesNotMatch(content, /좋아요순/);
+  // 인기순 and 최신순 should still be present (current baseline)
+  assert.match(content, /인기순/);
+  assert.match(content, /최신순/);
+});
+
+test('Runtime locking: search-ui.js does not yet have 조회순/좋아요순', () => {
+  const filePath = path.join(__dirname, '..', '..', 'js', 'search', 'search-ui.js');
+  const content = fs.readFileSync(filePath, 'utf8');
+  // 조회순 and 좋아요순 should NOT be present yet
+  assert.doesNotMatch(content, /조회순/);
+  assert.doesNotMatch(content, /좋아요순/);
+  // 최신순 should be present
+  assert.match(content, /최신순/);
+});
+
+test('Runtime locking: catch-all route still accepts popular and maps unsupported to latest', () => {
+  const filePath = path.join(__dirname, '..', '..', 'functions', 'api', '[[path]].js');
+  const content = fs.readFileSync(filePath, 'utf8');
+  // popular must still be in the ternary
+  assert.match(content, /popular/);
+  // unsupported values must fall back to latest
+  assert.match(content, /latest/);
+  // likes and views must be in the ternary (post Unit C)
+  assert.match(content, /likes/);
+  assert.match(content, /views/);
+});
+
+test('Runtime locking: modal app safe_sort set includes latest, popular, likes, views', () => {
+  const filePath = path.join(__dirname, '..', '..', 'modal_compute', 'app.py');
+  const content = fs.readFileSync(filePath, 'utf8');
+  assert.match(content, /latest/);
+  assert.match(content, /popular/);
+  assert.match(content, /likes/);
+  assert.match(content, /views/);
+  // safe_sort set should contain all four
+  assert.match(content, /safe_sort.*=.*{.*latest.*popular.*likes.*views|safe_sort.*=.*{.*views.*likes.*popular.*latest/);
+});
+
+test('Runtime locking: public_reads order_clause branches for likes and views exist', () => {
+  const filePath = path.join(__dirname, '..', '..', 'modal_compute', 'public_reads.py');
+  const content = fs.readFileSync(filePath, 'utf8');
+  // likes branch
+  assert.match(content, /like_count.*DESC.*updated_at.*DESC.*created_at.*DESC.*id.*ASC|order_clause.*likes/);
+  // views branch
+  assert.match(content, /view_count.*DESC.*updated_at.*DESC.*created_at.*DESC.*id.*ASC|order_clause.*views/);
+});
+
+test('Runtime locking: no viewCount or likeCount in Browse summary payload', () => {
+  // The Browse summary payload must not expose viewCount or likeCount.
+  // The SQL query may select s.view_count for sort=views ordering, but
+  // normalize_row() with include_like_count=True only adds likeCount.
+  // viewCount is never added to the result.
+  const filePath = path.join(__dirname, '..', '..', 'modal_compute', 'validation.py');
+  const content = fs.readFileSync(filePath, 'utf8');
+  
+  // normalize_row should not add viewCount
+  assert.doesNotMatch(content, /result\[\"viewCount\"\]|result\['viewCount'\]/);
+  
+  // include_like_count only adds likeCount
+  assert.match(content, /include_like_count/);
+  assert.match(content, /result\[\"likeCount\"\]/);
+});
+
+test('Runtime locking: tree_social_counts has view_count and like_count indexes', () => {
+  const filePath = path.join(__dirname, '..', '..', 'scripts', 'migration-add-tree-social-counts.sql');
+  const content = fs.readFileSync(filePath, 'utf8');
+  assert.match(content, /idx_tree_social_counts_view_count/);
+  assert.match(content, /idx_tree_social_counts_like_count/);
+  assert.match(content, /view_count.*DESC.*updated_at.*DESC/);
+  assert.match(content, /like_count.*DESC.*updated_at.*DESC/);
+});


### PR DESCRIPTION
Refs #2433
Refs #1661

Summary:
- document final Browse social sort label decision
- keep this as docs/contracts only
- defer frontend implementation to a later Unit D PR

Validation:
- git diff --check
- node --test tests/contracts/browse-final-social-sort-labels-decision-contract.test.cjs
- npm test -- --runInBand

Result: 2125 pass, 0 fail, 1 skipped.