### PR TITLE
fix(editor): bust empty detail panel cache

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -138,7 +138,7 @@
     <script src="../js/editor/editor-detail-inline-edit.js?v=20260504-627"></script>
     <script src="../js/editor/editor-detail-sidebar-status-boundary.js?v=20260504-772"></script>
     <script src="../js/editor/editor-detail-ui-builders.js?v=20260503-1"></script>
-    <script src="../js/editor/editor-detail-ui.js?v=20260504-627"></script>
+    <script src="../js/editor/editor-detail-ui.js?v=20260612-2400"></script>
     <script src="../js/editor/editor-detail-channel-link.js?v=20260517-1"></script>
     <script src="../js/editor/editor-memory-actions.js?v=20260508-635"></script>
     <script src="../js/editor/editor-memory-form-mode.js?v=20260510-999"></script>

--- a/tests/contracts/editor-empty-detail-panel-contract.test.cjs
+++ b/tests/contracts/editor-empty-detail-panel-contract.test.cjs
@@ -4,6 +4,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const detailUiPath = path.join(__dirname, '..', '..', 'js', 'editor', 'editor-detail-ui.js');
+const editorPagePath = path.join(__dirname, '..', '..', 'pages', 'editor.html');
 
 test('editor detail panel hides selected-memory UI when no memory is selected', () => {
   const source = fs.readFileSync(detailUiPath, 'utf8');
@@ -17,4 +18,11 @@ test('editor detail panel hides selected-memory UI when no memory is selected', 
   assert.match(source, /const thumbnail = resolveMemoryThumbnail\(data\);[\s\S]*?if \(thumbnail\) \{[\s\S]*?\} else \{[\s\S]*?clearDetailMedia\(\);[\s\S]*?\}/);
   assert.match(source, /id="detailEmptyStartBtn"/);
   assert.match(source, /formatI18nText\('create_first_moment', '첫 순간 만들기'\)/);
+});
+
+test('editor page cache-busts the empty detail panel UI script', () => {
+  const editorPage = fs.readFileSync(editorPagePath, 'utf8');
+
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-detail-ui\.js\?v=20260612-2400/);
+  assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-detail-ui\.js\?v=20260504-627/);
 });


### PR DESCRIPTION
Refs #2400

Summary:
- bump `editor-detail-ui.js` script version in `pages/editor.html` so the empty detail panel fix is loaded on the live editor page
- add contract coverage to keep the editor page off the stale `20260504-627` detail UI bundle

Scope:
- UI/cache-bust only
- no backend/API/DB changes
- no Browse/Search social count changes
- no #1661 implementation changes

Validation:
- targeted contract update: `tests/contracts/editor-empty-detail-panel-contract.test.cjs`