### PR TITLE
fix(editor): hide selected-moment detail panel until moment selected

### DIFF
--- a/js/editor/templates/editor-detail-edit-mode-template.js
+++ b/js/editor/templates/editor-detail-edit-mode-template.js
@@ -1,6 +1,6 @@
 export function buildDetailEditModeTemplate() {
     return `
-            <div id="detailEditMode" class="editor-hidden-initial">
+            <div id="detailEditMode" class="editor-hidden-initial" style="display: none;">
                 <div class="editor-form-stack editor-form-stack-compact">
                     <label id="editTitleLabel" class="editor-form-label">...</label>
                     <input type="text" id="editTitleInput" class="editor-form-input" placeholder="...">

--- a/js/editor/templates/editor-detail-view-mode-template.js
+++ b/js/editor/templates/editor-detail-view-mode-template.js
@@ -1,6 +1,6 @@
 export function buildDetailViewModeTemplate() {
     return `
-            <div id="detailViewMode" class="editor-hidden-initial">
+            <div id="detailViewMode" class="editor-hidden-initial" style="display: none;">
                 <div class="editor-tree-meta-section" aria-hidden="true">
                     <div class="editor-section-eyebrow" id="detailTreeStatusLabel">현재 트리</div>
                     <div id="detailTreeMetaMount"></div>

--- a/tests/contracts/editor-detail-edit-mode-template-contract.test.cjs
+++ b/tests/contracts/editor-detail-edit-mode-template-contract.test.cjs
@@ -19,6 +19,7 @@ test('Detail Edit Mode template helper exists and contains markup', () => {
     assert.ok(helperCode.includes('id="deleteMemoryBtn"'), 'must include delete btn id');
 
     assert.ok(helperCode.includes('editor-hidden-initial'), 'must include editor-hidden-initial class');
+    assert.match(helperCode, /id="detailEditMode"[^>]*style="display:\s*none;"/, 'detail edit mode root must be initially hidden');
     assert.ok(helperCode.includes('editor-form-stack'), 'must include editor-form-stack class');
     assert.ok(helperCode.includes('editor-form-input'), 'must include editor-form-input class');
     assert.ok(helperCode.includes('editor-form-textarea'), 'must include editor-form-textarea class');

--- a/tests/contracts/editor-detail-view-mode-template-contract.test.cjs
+++ b/tests/contracts/editor-detail-view-mode-template-contract.test.cjs
@@ -23,6 +23,7 @@ test('Detail View Mode template helper exists and contains markup', () => {
     assert.ok(helperCode.includes('id="lastSavedTime"'), 'must include last saved time id');
     
     assert.ok(helperCode.includes('class="editor-hidden-initial"'), 'must include editor-hidden-initial class');
+    assert.match(helperCode, /id="detailViewMode"[^>]*style="display:\s*none;"/, 'detail view mode root must be initially hidden');
     assert.ok(helperCode.includes('class="editor-current-moment-card"'), 'must include editor-current-moment-card class');
     assert.ok(helperCode.includes('class="editor-moment-actions-card"'), 'must include editor-moment-actions-card class');
     assert.ok(helperCode.includes('class="editor-moment-info-card"'), 'must include editor-moment-info-card class');

--- a/tests/contracts/editor-empty-detail-panel-contract.test.cjs
+++ b/tests/contracts/editor-empty-detail-panel-contract.test.cjs
@@ -15,7 +15,7 @@ test('editor detail panel hides selected-memory UI when no memory is selected', 
   assert.match(source, /if \(isEmptyState\) \{[\s\S]*?setDetailEmptyState\(true\);[\s\S]*?return;[\s\S]*?\}/);
   assert.match(source, /if \(reactionsCard && isEmpty\) reactionsCard\.style\.display = 'none';/);
   assert.match(source, /if \(isEmptyState \|\| !data\?\.id \|\| isRootMemory\(data, canonicalRootId\)\) \{[\s\S]*?reactionsCard\.style\.display = 'none';/);
-  assert.match(source, /const thumbnail = resolveMemoryThumbnail\(data\);[\s\S]*?if \(thumbnail\) \{[\s\S]*?\} else \{[\s\S]*?clearDetailMedia\(\);[\s\S]*?\}/);
+  assert.match(source, /const viewMode = document\.getElementById\('detailViewMode'\);[\s\S]*?const editMode = document\.getElementById\('detailEditMode'\);[\s\S]*?if \(viewMode\) viewMode\.style\.display = isEmpty \? 'none' : 'block';[\s\S]*?if \(editMode\) editMode\.style\.display = 'none';/);
   assert.match(source, /id="detailEmptyStartBtn"/);
   assert.match(source, /formatI18nText\('create_first_moment', '첫 순간 만들기'\)/);
 });


### PR DESCRIPTION
Refs #2400

- Add explicit display:none to detailViewMode template root
- Add explicit display:none to detailEditMode template root
- Keep setDetailEmptyState(false) as the show path for selected moments
- Strengthen template contracts for initial hidden state
- Strengthen empty-detail-panel contract to lock selected-moment UI hiding

CI: local tests pass (2144 pass, 0 fail, 1 skipped)