### PR TITLE
fix(editor): show empty guide for root-only trees

### DIFF
--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -5,6 +5,14 @@
         const getTreeMemories = options && options.getTreeMemories;
         const log = options && options.log;
 
+        function isRootLikeMemory(memory) {
+            return !!(memory && (memory.id === 'root' || memory.parentId === null || memory.parentId === undefined));
+        }
+
+        function hasVisibleMoment(memories) {
+            return Array.isArray(memories) && memories.some((memory) => memory && !isRootLikeMemory(memory));
+        }
+
         return function updateCanvasEmptyGuide() {
             const guide = document.getElementById('canvasEmptyGuide');
             if (!guide) {
@@ -15,7 +23,7 @@
             }
 
             const memories = typeof getTreeMemories === 'function' ? getTreeMemories() : [];
-            const hasMoments = memories.length > 0;
+            const hasMoments = hasVisibleMoment(memories);
 
             if (typeof log === 'function') {
                 log(`Updating empty guide visibility. hasMoments=${hasMoments}`);

--- a/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
+++ b/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
@@ -5,6 +5,7 @@ const test = require('node:test');
 const editorSource = fs.readFileSync('js/editor.js', 'utf8');
 const shellHelpersSource = fs.readFileSync('js/editor/editor-shell-helpers.js', 'utf8');
 const shellCanvasUISource = fs.readFileSync('js/editor/editor-shell-canvas-ui.js', 'utf8');
+const emptyGuideUISource = fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8');
 
 test('canvas ui fix editor shell helpers expose canvas empty guide updater factory', () => {
   assert.match(shellCanvasUISource, /createEditorCanvasEmptyGuideUpdater:\s*function\(options\)/);
@@ -15,6 +16,15 @@ test('canvas ui fix canvas empty guide updater preserves helper call', () => {
   assert.match(shellCanvasUISource, /return emptyGuideUIHelper\.createCanvasEmptyGuideUpdater\({/);
   assert.match(shellCanvasUISource, /getTreeMemories:\s*getTreeMemories/);
   assert.match(shellCanvasUISource, /log:\s*log/);
+});
+
+test('canvas empty guide updater counts only non-root moments as visible moments', () => {
+  assert.match(emptyGuideUISource, /function isRootLikeMemory\(memory\)/);
+  assert.match(emptyGuideUISource, /memory\.id === 'root' \|\| memory\.parentId === null \|\| memory\.parentId === undefined/);
+  assert.match(emptyGuideUISource, /function hasVisibleMoment\(memories\)/);
+  assert.match(emptyGuideUISource, /memories\.some\(\(memory\) => memory && !isRootLikeMemory\(memory\)\)/);
+  assert.match(emptyGuideUISource, /const hasMoments = hasVisibleMoment\(memories\);/);
+  assert.doesNotMatch(emptyGuideUISource, /const hasMoments = memories\.length > 0;/);
 });
 
 test('canvas ui fix canvas empty guide updater preserves warning fallback', () => {


### PR DESCRIPTION
Refs #2400

Summary:
- show the central canvas empty guide when the loaded tree only has a root/placeholder memory
- treat only non-root memories as visible moments for empty guide visibility
- keep the guide hidden once a real non-root moment exists
- strengthen the canvas empty guide updater contract so it cannot regress to `memories.length > 0`

Scope:
- UI empty-state logic only
- no backend/API/DB changes
- no Browse/Search social count changes
- no #1661 implementation changes

Validation:
- targeted contract update: `tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs`