### PR TITLE
test(editor): verify empty guide runtime visibility

### DIFF
--- a/pages/editor.html
+++ b/pages/editor.html
@@ -125,7 +125,7 @@
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
-    <script src="../js/editor/editor-empty-guide-ui.js?v=20260523-1276"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260612-2441"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
     <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>

--- a/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
@@ -85,3 +85,10 @@ test('empty guide runtime hides guide when a non-root moment exists', () => {
 
   assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
 });
+
+test('editor page cache-busts empty guide runtime script', () => {
+  const editorPage = fs.readFileSync('pages/editor.html', 'utf8');
+
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260612-2441/);
+  assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260523-1276/);
+});

--- a/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
@@ -1,0 +1,87 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadEmptyGuideUI(documentRef) {
+  const context = {
+    window: {},
+    document: documentRef,
+    console: { warn() {} },
+  };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8'), context);
+  return context.window.LoveBudEditorEmptyGuideUI;
+}
+
+function createGuide() {
+  const classes = new Set(['editor-canvas-empty-guide-hidden']);
+  return {
+    classList: {
+      toggle(name, force) {
+        if (force) classes.add(name);
+        else classes.delete(name);
+      },
+      contains(name) {
+        return classes.has(name);
+      },
+    },
+  };
+}
+
+test('empty guide runtime shows guide for root-only tree memories', () => {
+  const guide = createGuide();
+  const documentRef = {
+    getElementById(id) {
+      return id === 'canvasEmptyGuide' ? guide : null;
+    },
+  };
+  const emptyGuideUI = loadEmptyGuideUI(documentRef);
+  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => [{ id: 'root', parentId: null, title: 'LoveTree' }],
+    log() {},
+  });
+
+  updateCanvasEmptyGuide();
+
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('empty guide runtime shows guide for uuid root-only tree memories', () => {
+  const guide = createGuide();
+  const documentRef = {
+    getElementById(id) {
+      return id === 'canvasEmptyGuide' ? guide : null;
+    },
+  };
+  const emptyGuideUI = loadEmptyGuideUI(documentRef);
+  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => [{ id: 'tree-root-id', parentId: null, title: 'LoveTree' }],
+    log() {},
+  });
+
+  updateCanvasEmptyGuide();
+
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('empty guide runtime hides guide when a non-root moment exists', () => {
+  const guide = createGuide();
+  const documentRef = {
+    getElementById(id) {
+      return id === 'canvasEmptyGuide' ? guide : null;
+    },
+  };
+  const emptyGuideUI = loadEmptyGuideUI(documentRef);
+  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => [
+      { id: 'root', parentId: null, title: 'LoveTree' },
+      { id: 'moment-1', parentId: 'root', title: 'First moment' },
+    ],
+    log() {},
+  });
+
+  updateCanvasEmptyGuide();
+
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});


### PR DESCRIPTION
Refs #2400

Summary:
- add runtime contract coverage for the empty guide updater using a minimal DOM classList mock
- verify root-only trees show the central empty guide
- verify non-root moments keep the central empty guide hidden
- bump editor-empty-guide-ui.js script version in pages/editor.html so the live editor loads the fixed runtime
- lock the cache-bust URL so it cannot regress to the stale 20260523-1276 URL

Scope:
- UI empty-guide runtime and cache-bust only
- no backend/API/DB changes
- no Browse/Search social count changes
- no #1661 implementation changes

Validation:
- CI required before merge