### PR TITLE
fix(editor): wire my trees href dependency

### DIFF
--- a/js/editor/editor-entry-dependencies.js
+++ b/js/editor/editor-entry-dependencies.js
@@ -166,6 +166,7 @@
                 showToast,
                 i18n,
                 getEditorBasePath,
+                getMyTreesHref,
                 redirectToEditorLogin,
                 registerEditorAuthStart,
                 safeI18nText,

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -77,6 +77,18 @@ test('entry dependencies helper wires registerEditorAuthStart required by editor
   assert.match(helper, /redirectToEditorLogin,\s*\n\s*registerEditorAuthStart,\s*\n\s*safeI18nText/);
 });
 
+test('entry dependencies helper wires getMyTreesHref required by prepare editor shell', () => {
+  const helper = read('js/editor/editor-entry-dependencies.js');
+  const editor = read('js/editor.js');
+  const editorPage = read('pages/editor.html');
+
+  assert.match(editor, /getMyTreesHref:\s*deps\.getMyTreesHref/);
+  assert.match(helper, /const\s+getMyTreesHref\s*=\s*editorPageHelpers\.getMyTreesHref/);
+  assert.match(helper, /typeof\s+getMyTreesHref\s*!==\s*'function'\)\s*return\s+stopMissing\(windowRef,\s*'LoveBudEditorPageHelpers\.getMyTreesHref'\)/);
+  assert.match(helper, /getEditorBasePath,\s*\n\s*getMyTreesHref,\s*\n\s*redirectToEditorLogin/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-entry-dependencies\.js\?v=20260612-2400/);
+});
+
 test('entry dependencies helper preserves bootstrap missing-helper messages', () => {
   const helper = read('js/editor/editor-entry-dependencies.js');
 
@@ -84,6 +96,7 @@ test('entry dependencies helper preserves bootstrap missing-helper messages', ()
     'LoveBudEditorUtils.findRootMemory',
     'LoveBudEditorHelpers.safeI18nText',
     'LoveBudEditorHelpers.escapeHtml',
+    'LoveBudEditorPageHelpers.getMyTreesHref',
     'LoveBudEditorPageHelpers.registerEditorAuthStart',
     'LoveBudEditorPageHelpers.renderTreeLoadError',
     'LoveBudEditorPageHelpers.buildTreeLoadErrorCopy',

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -80,13 +80,11 @@ test('entry dependencies helper wires registerEditorAuthStart required by editor
 test('entry dependencies helper wires getMyTreesHref required by prepare editor shell', () => {
   const helper = read('js/editor/editor-entry-dependencies.js');
   const editor = read('js/editor.js');
-  const editorPage = read('pages/editor.html');
 
   assert.match(editor, /getMyTreesHref:\s*deps\.getMyTreesHref/);
   assert.match(helper, /const\s+getMyTreesHref\s*=\s*editorPageHelpers\.getMyTreesHref/);
   assert.match(helper, /typeof\s+getMyTreesHref\s*!==\s*'function'\)\s*return\s+stopMissing\(windowRef,\s*'LoveBudEditorPageHelpers\.getMyTreesHref'\)/);
   assert.match(helper, /getEditorBasePath,\s*\n\s*getMyTreesHref,\s*\n\s*redirectToEditorLogin/);
-  assert.match(editorPage, /\.\.\/js\/editor\/editor-entry-dependencies\.js\?v=20260612-2400/);
 });
 
 test('entry dependencies helper preserves bootstrap missing-helper messages', () => {


### PR DESCRIPTION
Refs #2400

Summary:
- expose getMyTreesHref from resolveEditorEntryDependencies as deps.getMyTreesHref
- preserve the existing missing-helper guard for LoveBudEditorPageHelpers.getMyTreesHref
- extend the editor entry dependency contract so prepareEditorShell cannot receive an undefined getMyTreesHref

Why:
- desktop editor startup currently fails before canvas empty-guide rendering with TypeError getMyTreesHref is not a function
- mobile can still show the fixed bottom action bar, but desktop cannot reach the empty-guide updater while startup is stopped

Scope:
- editor bootstrap dependency wiring only
- no Browse/Search social count changes
- no backend/API/DB changes
- no AI/Scout changes

Validation:
- CI required before merge