### PR TITLE
fix(editor): show empty guide for root placeholder variants

### DIFF
--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -6,7 +6,13 @@
         const log = options && options.log;
 
         function isRootLikeMemory(memory) {
-            return !!(memory && (memory.id === 'root' || memory.parentId === null || memory.parentId === undefined));
+            if (!memory) return false;
+            const parentId = memory.parentId;
+            return memory.id === 'root'
+                || parentId === null
+                || parentId === undefined
+                || parentId === ''
+                || parentId === memory.id;
         }
 
         function hasVisibleMoment(memories) {

--- a/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
+++ b/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
@@ -20,7 +20,7 @@ test('canvas ui fix canvas empty guide updater preserves helper call', () => {
 
 test('canvas empty guide updater counts only non-root moments as visible moments', () => {
   assert.match(emptyGuideUISource, /function isRootLikeMemory\(memory\)/);
-  assert.match(emptyGuideUISource, /memory\.id === 'root' \|\| memory\.parentId === null \|\| memory\.parentId === undefined/);
+  assert.match(emptyGuideUISource, /memory\.id === 'root'\s*\|\|\s*parentId === null\s*\|\|\s*parentId === undefined/);
   assert.match(emptyGuideUISource, /function hasVisibleMoment\(memories\)/);
   assert.match(emptyGuideUISource, /memories\.some\(\(memory\) => memory && !isRootLikeMemory\(memory\)\)/);
   assert.match(emptyGuideUISource, /const hasMoments = hasVisibleMoment\(memories\);/);

--- a/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
@@ -29,7 +29,7 @@ function createGuide() {
   };
 }
 
-test('empty guide runtime shows guide for root-only tree memories', () => {
+function assertGuideVisibleFor(memories) {
   const guide = createGuide();
   const documentRef = {
     getElementById(id) {
@@ -38,31 +38,29 @@ test('empty guide runtime shows guide for root-only tree memories', () => {
   };
   const emptyGuideUI = loadEmptyGuideUI(documentRef);
   const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
-    getTreeMemories: () => [{ id: 'root', parentId: null, title: 'LoveTree' }],
+    getTreeMemories: () => memories,
     log() {},
   });
 
   updateCanvasEmptyGuide();
 
   assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+}
+
+test('empty guide runtime shows guide for root-only tree memories', () => {
+  assertGuideVisibleFor([{ id: 'root', parentId: null, title: 'LoveTree' }]);
 });
 
 test('empty guide runtime shows guide for uuid root-only tree memories', () => {
-  const guide = createGuide();
-  const documentRef = {
-    getElementById(id) {
-      return id === 'canvasEmptyGuide' ? guide : null;
-    },
-  };
-  const emptyGuideUI = loadEmptyGuideUI(documentRef);
-  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
-    getTreeMemories: () => [{ id: 'tree-root-id', parentId: null, title: 'LoveTree' }],
-    log() {},
-  });
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: null, title: 'LoveTree' }]);
+});
 
-  updateCanvasEmptyGuide();
+test('empty guide runtime shows guide for blank-parent root placeholder', () => {
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: '', title: 'LoveTree' }]);
+});
 
-  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+test('empty guide runtime shows guide for self-parent root placeholder', () => {
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: 'tree-root-id', title: 'LoveTree' }]);
 });
 
 test('empty guide runtime hides guide when a non-root moment exists', () => {


### PR DESCRIPTION
Refs #2400

Summary:
- treat blank-parent and self-parent root placeholders as root-like for central empty guide visibility
- keep the central empty guide visible until a real non-root moment exists
- add runtime contract coverage for blank-parent and self-parent root-only trees

Why:
- desktop can have no visible first-moment CTA while mobile still shows the bottom action bar
- the empty guide updater was only recognizing null/undefined parent roots and legacy id=root roots

Scope:
- editor empty-guide UI logic and tests only
- no backend/API/DB changes
- no Browse/Search social count changes
- no AI/Scout changes

Validation:
- CI required before merge