### PR TITLE
fix(editor): align root placeholder handling for empty guide

### DIFF
--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -1,11 +1,22 @@
 (function () {
     const emptyGuideUI = window.LoveBudEditorEmptyGuideUI || {};
 
+    // Root helper 공통 predicate를 우선 사용 (editor-root-helpers.js)
+    // fallback은 root helper와 같은 기준 (5가지 케이스)
+    const rootUtils = (typeof window !== 'undefined' && window.LoveBudEditorUtils) || {};
+    const sharedIsRootLikeMemory = typeof rootUtils.isRootLikeMemory === 'function'
+        ? rootUtils.isRootLikeMemory
+        : null;
+
     emptyGuideUI.createCanvasEmptyGuideUpdater = function(options) {
         const getTreeMemories = options && options.getTreeMemories;
         const log = options && options.log;
 
+        // local fallback — root helper와 같은 기준 (5가지 케이스)
         function isRootLikeMemory(memory) {
+            if (sharedIsRootLikeMemory) {
+                return sharedIsRootLikeMemory(memory);
+            }
             if (!memory) return false;
             const parentId = memory.parentId;
             return memory.id === 'root'

--- a/js/editor/editor-root-helpers.js
+++ b/js/editor/editor-root-helpers.js
@@ -1,53 +1,92 @@
 /**
  * editor-root-helpers.js
- * 
+ *
  * 러브트리 에디터 - Root Memory 식별 및 관리 헬퍼
- * 
+ *
  * 책임:
  * - Root memory 식별 (parentId === null 기반)
  * - Canonical root ID 계산
  * - Root 관련 유틸리티 함수 제공
- * 
+ *
  * 의존성: 없음 (순수 함수들만 제공)
  * 사용처: editor.js, 추후 다른 트리 관련 페이지에서 재사용 가능
- * 
- * @version 1.0.0
+ *
+ * @version 1.1.0
  * @since 2026-04-18
+ * @updated 2026-06-13
  */
 
 (function() {
     'use strict';
 
     /**
+     * Root-like memory 판정 (공통 predicate)
+     *
+     * 메모리가 root placeholder로 간주되어야 하는지 판정한다.
+     * 5가지 케이스 모두 root-like로 본다:
+     *   1) memory.id === 'root'             — legacy root
+     *   2) memory.parentId === null         — 정식 root (parentId 미설정)
+     *   3) memory.parentId === undefined    — 정식 root (parentId 미설정)
+     *   4) memory.parentId === ''           — blank-parent root placeholder
+     *   5) memory.parentId === memory.id    — self-parent root placeholder
+     *
+     * 이 predicate는 empty guide visibility, canvas detail, root helper
+     * selection 등 모든 root 판정 경로에서 공통으로 사용된다.
+     *
+     * @param {Object} memory - memory 객체
+     * @returns {boolean} - root-like 여부
+     */
+    const isRootLikeMemory = (memory) => {
+        if (!memory) return false;
+        const parentId = memory.parentId;
+        return memory.id === 'root'
+            || parentId === null
+            || parentId === undefined
+            || parentId === ''
+            || parentId === memory.id;
+    };
+
+    /**
      * Root memory 식별
-     * 
+     *
      * 규칙:
-     * 1) parentId === null인 노드 중 createdAt이 가장 오래된 것 (진짜 root)
-     * 2) id === 'root' (legacy root compatibility)
-     * 
+     * 1) root-like 노드 (`isRootLikeMemory`) 중 id === 'root' 우선
+     *    (legacy root compatibility: parentId: null인 real child가 있어도
+     *     'root'를 canonical root로 선택)
+     * 2) id === 'root'가 없으면 root-like 노드 중 createdAt 가장 오래된 것
+     * 3) root-like 노드가 없으면 null
+     *
      * @param {Array} memories - memory 객체 배열
      * @returns {Object|null} - root memory 객체 또는 null
      */
     const findRootMemory = (memories) => {
         if (!Array.isArray(memories)) return null;
-        
-        // 1순위: parentId === null인 노드 중 createdAt이 가장 오래된 것 (진짜 root)
-        const parentNullNodes = memories.filter(m => m.parentId === null || m.parentId === undefined);
-        
-        if (parentNullNodes.length === 1) {
-            return parentNullNodes[0];
-        } else if (parentNullNodes.length > 1) {
-            // 여러 개면 createdAt 기준으로 가장 오래된 것이 진짜 root
-            const oldest = parentNullNodes.sort((a, b) => {
-                const aTime = a.createdAt || a.timestamp || '9999';
-                const bTime = b.createdAt || b.timestamp || '9999';
-                return new Date(aTime) - new Date(bTime);
-            })[0];
-            return oldest;
+
+        // 1순위: root-like 노드 필터 (5가지 케이스 모두 포함)
+        const rootLikeNodes = memories.filter(isRootLikeMemory);
+
+        if (rootLikeNodes.length === 0) {
+            return null;
         }
-        
-        // 2순위: id === 'root' (legacy root compatibility)
-        return memories.find(m => m.id === 'root');
+
+        // 2순위: legacy 'root' 우선 (parentId: null인 real child 오인 방지)
+        const legacyRoot = rootLikeNodes.find(m => m.id === 'root');
+        if (legacyRoot) {
+            return legacyRoot;
+        }
+
+        // 3순위: root-like가 하나면 그게 root
+        if (rootLikeNodes.length === 1) {
+            return rootLikeNodes[0];
+        }
+
+        // 4순위: 여러 개면 createdAt 기준으로 가장 오래된 것이 진짜 root
+        const oldest = rootLikeNodes.slice().sort((a, b) => {
+            const aTime = a.createdAt || a.timestamp || '9999';
+            const bTime = b.createdAt || b.timestamp || '9999';
+            return new Date(aTime) - new Date(bTime);
+        })[0];
+        return oldest;
     };
 
     /**
@@ -91,14 +130,15 @@
 
     /**
      * 러브트리 유틸리티 객체
-     * 
+     *
      * 전역 노출: window.LoveBudEditorUtils
      */
     const LoveBudEditorUtils = {
         findRootMemory,
         getRootId,
         getCanonicalRootId,
-        isRootMemory
+        isRootMemory,
+        isRootLikeMemory
     };
 
     // 전역 노출

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -88,7 +88,7 @@
     <script type="module" src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260531-1494"></script>
     <script type="module" src="../js/editor/templates/editor-detail-edit-mode-template.js?v=20260531-1494"></script>
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
-    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260526-1"></script>
@@ -125,7 +125,7 @@
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
-    <script src="../js/editor/editor-empty-guide-ui.js?v=20260612-2441"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260613-2446"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
     <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>

--- a/pages/public-canvas.html
+++ b/pages/public-canvas.html
@@ -49,7 +49,7 @@
 
     <!-- Canvas core modules -->
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
-    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>

--- a/pages/view.html
+++ b/pages/view.html
@@ -41,7 +41,7 @@
     <script src="../js/viewer/public-viewer-detail-empty-state-template.js?v=20260526-1"></script>
     <script src="../js/viewer/public-viewer-detail-view-mode-template.js?v=20260526-1"></script>
 
-    <script src="../js/editor/editor-root-helpers.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>

--- a/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
@@ -10,8 +10,13 @@ function loadEmptyGuideUI(documentRef) {
     console: { warn() {} },
   };
   vm.createContext(context);
+  // Root helper 공통 predicate를 우선 사용하므로 root helpers도 함께 로드
+  vm.runInContext(fs.readFileSync('js/editor/editor-root-helpers.js', 'utf8'), context);
   vm.runInContext(fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8'), context);
-  return context.window.LoveBudEditorEmptyGuideUI;
+  return {
+    rootUtils: context.window.LoveBudEditorUtils,
+    emptyGuideUI: context.window.LoveBudEditorEmptyGuideUI,
+  };
 }
 
 function createGuide() {
@@ -36,7 +41,7 @@ function assertGuideVisibleFor(memories) {
       return id === 'canvasEmptyGuide' ? guide : null;
     },
   };
-  const emptyGuideUI = loadEmptyGuideUI(documentRef);
+  const { emptyGuideUI } = loadEmptyGuideUI(documentRef);
   const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
     getTreeMemories: () => memories,
     log() {},
@@ -45,6 +50,24 @@ function assertGuideVisibleFor(memories) {
   updateCanvasEmptyGuide();
 
   assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+}
+
+function assertGuideHiddenFor(memories) {
+  const guide = createGuide();
+  const documentRef = {
+    getElementById(id) {
+      return id === 'canvasEmptyGuide' ? guide : null;
+    },
+  };
+  const { emptyGuideUI } = loadEmptyGuideUI(documentRef);
+  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => memories,
+    log() {},
+  });
+
+  updateCanvasEmptyGuide();
+
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
 }
 
 test('empty guide runtime shows guide for root-only tree memories', () => {
@@ -63,30 +86,157 @@ test('empty guide runtime shows guide for self-parent root placeholder', () => {
   assertGuideVisibleFor([{ id: 'tree-root-id', parentId: 'tree-root-id', title: 'LoveTree' }]);
 });
 
+test('empty guide runtime shows guide when only legacy root exists with real child having parentId null', () => {
+  // legacy { id: 'root' } + real child whose parentId === null
+  // real child는 root-like로 분류되지만, legacy root가 canonical root.
+  // real child는 root-like 이므로 가이드는 여전히 visible (real moment 아님).
+  assertGuideVisibleFor([
+    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'real-child', parentId: null, title: 'First real moment' },
+  ]);
+});
+
 test('empty guide runtime hides guide when a non-root moment exists', () => {
+  assertGuideHiddenFor([
+    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'moment-1', parentId: 'root', title: 'First moment' },
+  ]);
+});
+
+test('empty guide runtime hides guide when uuid root placeholder has a non-root child', () => {
+  // blank-parent root placeholder + real child with proper parentId
+  assertGuideHiddenFor([
+    { id: 'tree-root-id', parentId: '', title: 'LoveTree' },
+    { id: 'moment-1', parentId: 'tree-root-id', title: 'First moment' },
+  ]);
+});
+
+test('empty guide runtime hides guide when self-parent root placeholder has a non-root child', () => {
+  assertGuideHiddenFor([
+    { id: 'tree-root-id', parentId: 'tree-root-id', title: 'LoveTree' },
+    { id: 'moment-1', parentId: 'tree-root-id', title: 'First moment' },
+  ]);
+});
+
+test('root helper findRootMemory picks legacy root over real child with parentId null', () => {
+  const documentRef = { getElementById() { return null; } };
+  const { rootUtils } = loadEmptyGuideUI(documentRef);
+  const root = rootUtils.findRootMemory([
+    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'real-child', parentId: null, title: 'First real moment' },
+  ]);
+  assert.equal(root && root.id, 'root');
+});
+
+test('root helper findRootMemory picks blank-parent root placeholder', () => {
+  const documentRef = { getElementById() { return null; } };
+  const { rootUtils } = loadEmptyGuideUI(documentRef);
+  const root = rootUtils.findRootMemory([
+    { id: 'tree-root-id', parentId: '', title: 'LoveTree' },
+  ]);
+  assert.equal(root && root.id, 'tree-root-id');
+});
+
+test('root helper findRootMemory picks self-parent root placeholder', () => {
+  const documentRef = { getElementById() { return null; } };
+  const { rootUtils } = loadEmptyGuideUI(documentRef);
+  const root = rootUtils.findRootMemory([
+    { id: 'tree-root-id', parentId: 'tree-root-id', title: 'LoveTree' },
+  ]);
+  assert.equal(root && root.id, 'tree-root-id');
+});
+
+test('root helper getCanonicalRootId matches root placeholder variants', () => {
+  const documentRef = { getElementById() { return null; } };
+  const { rootUtils } = loadEmptyGuideUI(documentRef);
+
+  assert.equal(rootUtils.getCanonicalRootId([{ id: 'root', parentId: null }]), 'root');
+  assert.equal(rootUtils.getCanonicalRootId([{ id: 'tree-root-id', parentId: null }]), 'tree-root-id');
+  assert.equal(rootUtils.getCanonicalRootId([{ id: 'tree-root-id', parentId: '' }]), 'tree-root-id');
+  assert.equal(rootUtils.getCanonicalRootId([{ id: 'tree-root-id', parentId: 'tree-root-id' }]), 'tree-root-id');
+  assert.equal(rootUtils.getCanonicalRootId([
+    { id: 'root', parentId: null },
+    { id: 'real-child', parentId: null },
+  ]), 'root');
+});
+
+test('root helper isRootLikeMemory agrees with empty guide isRootLikeMemory fallback on all variants', () => {
+  const documentRef = { getElementById() { return null; } };
+  const { rootUtils, emptyGuideUI } = loadEmptyGuideUI(documentRef);
+
+  // 5가지 root-like variant — 둘 다 true
+  const rootLikeVariants = [
+    { id: 'root', parentId: null },
+    { id: 'tree-root-id', parentId: null },
+    { id: 'tree-root-id', parentId: '' },
+    { id: 'tree-root-id', parentId: 'tree-root-id' },
+  ];
+  rootLikeVariants.forEach((memory) => {
+    assert.equal(rootUtils.isRootLikeMemory(memory), true, `root helper should treat ${JSON.stringify(memory)} as root-like`);
+  });
+
+  // empty guide는 root helper의 공통 predicate를 위임해서 사용한다.
+  // 5가지 root-like variant에 대해 root helper와 같은 결과를 내야 한다.
+  // 빈 가이드 isRootLikeMemory는 closure 내부 함수이므로 간접 검증:
+  // root helper와 같은 메모리 셋에 대해 같은 가시성 결과를 내야 한다.
   const guide = createGuide();
-  const documentRef = {
-    getElementById(id) {
-      return id === 'canvasEmptyGuide' ? guide : null;
-    },
-  };
-  const emptyGuideUI = loadEmptyGuideUI(documentRef);
-  const updateCanvasEmptyGuide = emptyGuideUI.createCanvasEmptyGuideUpdater({
+  const docRef = { getElementById(id) { return id === 'canvasEmptyGuide' ? guide : null; } };
+  const ctx = { window: {}, document: docRef, console: { warn() {} } };
+  vm.createContext(ctx);
+  vm.runInContext(fs.readFileSync('js/editor/editor-root-helpers.js', 'utf8'), ctx);
+  vm.runInContext(fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8'), ctx);
+  const updateCanvasEmptyGuide = ctx.window.LoveBudEditorEmptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => rootLikeVariants,
+    log() {},
+  });
+  updateCanvasEmptyGuide();
+  // 모든 root-like면 가이드는 visible (real moment 없음)
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+
+  // real child 추가 시 가이드 hidden — root helper의 hasVisibleMoment과 같은 결과
+  const guide2 = createGuide();
+  const docRef2 = { getElementById(id) { return id === 'canvasEmptyGuide' ? guide2 : null; } };
+  const ctx2 = { window: {}, document: docRef2, console: { warn() {} } };
+  vm.createContext(ctx2);
+  vm.runInContext(fs.readFileSync('js/editor/editor-root-helpers.js', 'utf8'), ctx2);
+  vm.runInContext(fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8'), ctx2);
+  const update2 = ctx2.window.LoveBudEditorEmptyGuideUI.createCanvasEmptyGuideUpdater({
     getTreeMemories: () => [
-      { id: 'root', parentId: null, title: 'LoveTree' },
-      { id: 'moment-1', parentId: 'root', title: 'First moment' },
+      { id: 'root', parentId: null },
+      { id: 'real-child', parentId: 'root' },  // parentId: 'root' → not root-like
     ],
     log() {},
   });
+  update2();
+  assert.equal(guide2.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
 
+test('empty guide UI does not redefine its own local isRootLikeMemory when root helper is missing — fallback keeps same criteria', () => {
+  // root helpers 로드하지 않은 컨텍스트에서 empty guide UI만 로드
+  // → local fallback이 동작해야 하며, 같은 5가지 기준으로 판정해야 한다
+  const guide = createGuide();
+  const documentRef = {
+    getElementById(id) { return id === 'canvasEmptyGuide' ? guide : null; },
+  };
+  const context = { window: {}, document: documentRef, console: { warn() {} } };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync('js/editor/editor-empty-guide-ui.js', 'utf8'), context);
+
+  const updateCanvasEmptyGuide = context.window.LoveBudEditorEmptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => [
+      { id: 'tree-root-id', parentId: '' },
+      { id: 'tree-root-id', parentId: 'tree-root-id' },
+    ],
+    log() {},
+  });
   updateCanvasEmptyGuide();
-
-  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+  // fallback도 같은 기준이므로 가이드 visible
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
 });
 
 test('editor page cache-busts empty guide runtime script', () => {
   const editorPage = fs.readFileSync('pages/editor.html', 'utf8');
 
-  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260612-2441/);
-  assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260523-1276/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260613-2446/);
+  assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260612-2441/);
 });

--- a/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
+++ b/tests/contracts/editor-root-helper-required-boundary-contract.test.cjs
@@ -42,6 +42,7 @@ test('root helpers export root utilities and editor utils preserve the namespace
   assert.equal(typeof context.window.LoveBudEditorUtils.getRootId, 'function');
   assert.equal(typeof context.window.LoveBudEditorUtils.getCanonicalRootId, 'function');
   assert.equal(typeof context.window.LoveBudEditorUtils.isRootMemory, 'function');
+  assert.equal(typeof context.window.LoveBudEditorUtils.isRootLikeMemory, 'function');
 
   const rootFindRootMemory = context.window.LoveBudEditorUtils.findRootMemory;
   vm.runInContext(read('js/editor/editor-utils.js'), context);
@@ -52,6 +53,92 @@ test('root helpers export root utilities and editor utils preserve the namespace
   const editorUtils = read('js/editor/editor-utils.js');
   assert.match(editorUtils, /const\s+utils\s*=\s*window\.LoveBudEditorUtils\s*\|\|\s*\{\}/);
   assert.match(editorUtils, /window\.LoveBudEditorUtils\s*=\s*utils/);
+});
+
+test('root helper isRootLikeMemory covers all five root placeholder variants', () => {
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  const isRootLike = context.window.LoveBudEditorUtils.isRootLikeMemory;
+
+  // 5가지 root-like variant — 모두 true
+  assert.equal(isRootLike({ id: 'root', parentId: null }), true, 'legacy root');
+  assert.equal(isRootLike({ id: 'tree-root-id', parentId: null }), true, 'parentId null');
+  assert.equal(isRootLike({ id: 'tree-root-id', parentId: undefined }), true, 'parentId undefined');
+  assert.equal(isRootLike({ id: 'tree-root-id', parentId: '' }), true, 'parentId blank');
+  assert.equal(isRootLike({ id: 'tree-root-id', parentId: 'tree-root-id' }), true, 'self-parent');
+
+  // non-root는 false
+  assert.equal(isRootLike({ id: 'moment-1', parentId: 'root' }), false, 'real child of root');
+  assert.equal(isRootLike({ id: 'moment-1', parentId: 'tree-root-id' }), false, 'real child of uuid root');
+  assert.equal(isRootLike(null), false, 'null is not root-like');
+  assert.equal(isRootLike(undefined), false, 'undefined is not root-like');
+  // 빈 객체는 parentId === undefined로 root-like (지시서 3번 케이스)
+  assert.equal(isRootLike({ id: 'tree-root-id' }), true, 'parentId undefined is root-like');
+});
+
+test('root helper findRootMemory aligns with isRootLikeMemory for all placeholder variants', () => {
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  const { findRootMemory, getCanonicalRootId } = context.window.LoveBudEditorUtils;
+
+  // 5가지 root-only 케이스 — 각자 자신이 root
+  assert.equal(findRootMemory([{ id: 'root', parentId: null }])?.id, 'root');
+  assert.equal(findRootMemory([{ id: 'tree-root-id', parentId: null }])?.id, 'tree-root-id');
+  assert.equal(findRootMemory([{ id: 'tree-root-id', parentId: undefined }])?.id, 'tree-root-id');
+  assert.equal(findRootMemory([{ id: 'tree-root-id', parentId: '' }])?.id, 'tree-root-id');
+  assert.equal(findRootMemory([{ id: 'tree-root-id', parentId: 'tree-root-id' }])?.id, 'tree-root-id');
+
+  // getCanonicalRootId도 같은 root를 가리킴
+  assert.equal(getCanonicalRootId([{ id: 'tree-root-id', parentId: '' }]), 'tree-root-id');
+  assert.equal(getCanonicalRootId([{ id: 'tree-root-id', parentId: 'tree-root-id' }]), 'tree-root-id');
+});
+
+test('root helper findRootMemory prefers legacy root over real child with parentId null', () => {
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  const { findRootMemory, getCanonicalRootId } = context.window.LoveBudEditorUtils;
+
+  // memories에 { id: 'root' }가 있고, real child가 parentId: null인 경우
+  // → legacy 'root'가 canonical root. real child를 root로 오인하면 안 됨.
+  const memories = [
+    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'real-child', parentId: null, title: 'First real moment' },
+  ];
+  const root = findRootMemory(memories);
+  assert.equal(root?.id, 'root', 'legacy root must win over real child with parentId null');
+  assert.equal(getCanonicalRootId(memories), 'root');
+});
+
+test('root helper findRootMemory returns null for memories with no root-like node', () => {
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  const { findRootMemory } = context.window.LoveBudEditorUtils;
+
+  // 모든 메모리가 실제 child (parentId가 다른 노드) — root-like 없음
+  assert.equal(findRootMemory([
+    { id: 'moment-1', parentId: 'root' },
+    { id: 'moment-2', parentId: 'root' },
+  ]), null);
+
+  // 빈 배열
+  assert.equal(findRootMemory([]), null);
+  // 비-배열
+  assert.equal(findRootMemory(null), null);
+  assert.equal(findRootMemory(undefined), null);
+});
+
+test('root helpers load before editor empty guide UI script', () => {
+  const sources = scriptSources();
+  const rootHelpers = sourceIndex(sources, 'js/editor/editor-root-helpers.js');
+  const emptyGuideUI = sourceIndex(sources, 'js/editor/editor-empty-guide-ui.js');
+
+  assert.notEqual(rootHelpers, -1, 'editor-root-helpers.js must be loaded');
+  assert.notEqual(emptyGuideUI, -1, 'editor-empty-guide-ui.js must be loaded');
+  assert.ok(rootHelpers < emptyGuideUI, 'root helpers must load before empty guide UI');
 });
 
 test('editor entry requires preloaded root helper utilities through deps without inline fallbacks', () => {


### PR DESCRIPTION
Refs #2400

## Summary

- align editor root placeholder detection between root helpers and empty guide visibility
- treat blank-parent (`parentId: ''`) and self-parent (`parentId === id`) root placeholders consistently
- keep empty guide hidden once a real non-root moment exists
- legacy `{ id: 'root' }` is preferred as canonical root over a real child with `parentId: null`

## Scope

- editor empty state / root helper UI runtime only
- no backend / API / DB changes
- no Browse / Search / #1661 changes
- no AI / Scout changes

## Changes

- `js/editor/editor-root-helpers.js`
  - add `isRootLikeMemory(memory)` common predicate (5 variants)
  - align `findRootMemory()` to filter via `isRootLikeMemory` and prefer legacy `id === 'root'`
  - export `isRootLikeMemory` on `window.LoveBudEditorUtils`
- `js/editor/editor-empty-guide-ui.js`
  - delegate to root helper's `isRootLikeMemory` first
  - local fallback kept, same 5-variant criteria
- `pages/editor.html`, `pages/public-canvas.html`, `pages/view.html`
  - cache-bust `editor-root-helpers.js` and `editor-empty-guide-ui.js` to `?v=20260613-2446`
- `tests/contracts/editor-empty-guide-runtime-contract.test.cjs`
  - add cases: 5 root variants visible, legacy-root + real-child visible, root+child hidden, uuid-root+child hidden, self-parent+child hidden, root-helper parity, fallback parity, cache-bust
- `tests/contracts/editor-root-helper-required-boundary-contract.test.cjs`
  - lock `isRootLikeMemory` export, 5-variant coverage, placeholder alignment, legacy-root preference, no-root-like → null, root-helper loads before empty-guide UI

## Validation

- `node --check js/editor/editor-root-helpers.js`
- `node --check js/editor/editor-empty-guide-ui.js`
- `node --test tests/contracts/*.test.cjs` — 1790/1791 (1 skipped, 0 fail)
- `npm test -- --runInBand` — 2174/2175 (1 skipped, 0 fail)
- `git diff --check` — clean
- CI: `verify-static`, `Cloudflare Pages`, `GitGuardian Security Checks` all expected to pass

## Note

- #2400 stays OPEN until production desktop verification