### PR TITLE
fix(editor): ignore stale cached memories for empty trees

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -221,7 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const treeId = initialLoadResult.treeId;
             const normalizeMemory = initialLoadResult.normalizeMemory;
             const treeMemories = initialLoadResult.treeMemories;
-            
+
             const canonicalRootId = deps.getCanonicalRootId(treeMemories());
             let selectedNodeId = canonicalRootId;
             let currentEditingMemory = null;
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 getTreeMemories: () => treeMemories(),
                 log
             });
-            
+
             // Bridge this back to LoveBudEditor so canvas can call it
             const checkEditorCanvasEmptyGuideBridgeDependencies = createEditorStartDependencyChecker({
                 ensureStartEditorDependency,
@@ -618,10 +618,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const applyEditorInitialSelection = createEditorInitialSelectionApplier({
                 getTreeMemories: () => treeMemories(),
                 getSelectedNodeId: () => selectedNodeId,
+                setSelectedNodeId: (value) => { selectedNodeId = value; },
                 createInitialMemory,
                 isRootMemory: deps.isRootMemory,
                 getCanonicalRootId: () => canonicalRootId,
                 setCurrentEditingMemory: (value) => { currentEditingMemory = value; },
+                setDetailEmptyState: callSetDetailEmptyState,
                 log
             });
 

--- a/js/editor/editor-data-loader-fallbacks.js
+++ b/js/editor/editor-data-loader-fallbacks.js
@@ -14,6 +14,9 @@
 
     /**
      * 메모리가 canonical root placeholder인지 판정 (inline fallback).
+     *
+     * 참고: inlineFilterMemoriesForTree()는 이 helper를 직접 사용하지 않는다.
+     * treeId 매칭이 우선이며, id === 'root' (legacy universal root)만 예외.
      */
     function inlineIsCanonicalRootPlaceholder(memory) {
         if (!memory) return false;
@@ -27,6 +30,9 @@
     /**
      * 메모리 배열을 current treeId 기준으로 필터링 (inline fallback).
      * LoveBudEditorDataLoader.filterMemoriesForTree와 같은 기준.
+     *
+     * 핵심 원칙: treeId가 다르면 root-like보다 먼저 drop한다.
+     * 단, id === 'root' (legacy universal root)만 예외로 통과.
      */
     function inlineFilterMemoriesForTree(memories, treeId) {
         if (!Array.isArray(memories)) return [];
@@ -34,10 +40,15 @@
 
         return memories.filter((m) => {
             if (!m) return false;
-            if (inlineIsCanonicalRootPlaceholder(m)) return true;
             const memTreeId = m.treeId || m.tree_id || null;
-            if (memTreeId && memTreeId === treeId) return true;
-            return false;
+
+            if (memTreeId && memTreeId !== treeId) {
+                return m.id === 'root';
+            }
+
+            if (memTreeId === treeId) return true;
+
+            return m.id === 'root';
         });
     }
 

--- a/js/editor/editor-data-loader-fallbacks.js
+++ b/js/editor/editor-data-loader-fallbacks.js
@@ -12,6 +12,35 @@
         console.log.apply(console, arguments);
     }
 
+    /**
+     * 메모리가 canonical root placeholder인지 판정 (inline fallback).
+     */
+    function inlineIsCanonicalRootPlaceholder(memory) {
+        if (!memory) return false;
+        if (memory.id === 'root') return true;
+        const parentId = memory.parentId;
+        if (parentId === null || parentId === undefined || parentId === '') return true;
+        if (typeof parentId === 'string' && parentId === memory.id) return true;
+        return false;
+    }
+
+    /**
+     * 메모리 배열을 current treeId 기준으로 필터링 (inline fallback).
+     * LoveBudEditorDataLoader.filterMemoriesForTree와 같은 기준.
+     */
+    function inlineFilterMemoriesForTree(memories, treeId) {
+        if (!Array.isArray(memories)) return [];
+        if (!treeId) return memories.slice();
+
+        return memories.filter((m) => {
+            if (!m) return false;
+            if (inlineIsCanonicalRootPlaceholder(m)) return true;
+            const memTreeId = m.treeId || m.tree_id || null;
+            if (memTreeId && memTreeId === treeId) return true;
+            return false;
+        });
+    }
+
     window.LoveBudEditorDataLoaderFallbacks = {
     createInlineNormalizeMemoryFallback: () => (mem) => {
         if (!window.__editorNormalizeWarningShown) {
@@ -136,31 +165,45 @@
 
     createInlineLoadEditorMemoriesFallback: () => async (options) => {
         const opts = options || {};
-        const treeId = opts.treeId;
+        const treeId = opts.treeId || null;
         const cache = opts.cache || null;
         const cacheKey = opts.cacheKey || 'memories_default';
         const apiClient = opts.apiClient || null;
         const showToast = opts.showToast || function() {};
         const i18n = opts.i18n || function(key) { return key; };
         const normalizeMemory = opts.normalizeMemory || ((mem) => mem);
+        const cacheTtlMs = 2 * 60 * 1000;
 
         let memories = [];
         const cachedMemories = cache ? cache.get(cacheKey) : null;
 
+        // 1) cache hit: treeId 필터를 거친 cached memories만 사용
         if (cachedMemories && Array.isArray(cachedMemories)) {
             editorDebugLog('[editor] Using cached memories:', cachedMemories.length);
-            memories = cachedMemories;
+            memories = inlineFilterMemoriesForTree(cachedMemories, treeId);
             window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
         }
 
+        // 2) API 호출. API 응답이 source of truth (빈 배열 포함).
         try {
             if (apiClient && apiClient.getMemoriesByTree) {
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
-                    memories = apiMemories;
-                    editorDebugLog('[editor] API memories loaded:', apiMemories.length);
+                    const normalizedApi = apiMemories.map(normalizeMemory).filter(Boolean);
+                    const filteredApi = inlineFilterMemoriesForTree(normalizedApi, treeId);
+                    memories = filteredApi;
+                    editorDebugLog('[editor] API memories loaded (filtered):', filteredApi.length);
                     if (cache) {
-                        cache.set(cacheKey, memories, 2 * 60 * 1000);
+                        if (filteredApi.length === 0) {
+                            // API []: cache clear
+                            if (typeof cache.delete === 'function') {
+                                cache.delete(cacheKey);
+                            } else if (typeof cache.set === 'function') {
+                                cache.set(cacheKey, [], cacheTtlMs);
+                            }
+                        } else {
+                            cache.set(cacheKey, filteredApi, cacheTtlMs);
+                        }
                     }
                 }
             }
@@ -171,11 +214,13 @@
             }
         }
 
-        window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
+        // 3) 최종 할당. memories는 이미 filter 거침.
+        const finalMemories = memories.map(normalizeMemory).filter(Boolean);
+        window.currentTreeMemories = finalMemories;
 
         return {
-            memories,
-            normalizedMemories: window.currentTreeMemories,
+            memories: finalMemories,
+            normalizedMemories: finalMemories,
             cachedMemories
         };
     },
@@ -236,9 +281,11 @@
             if (apiClient && apiClient.getMemoriesByTree) {
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
-                    window.currentTreeMemories = apiMemories.map(normalizeMemory).filter(Boolean);
-                    editorDebugLog('[editor] Memories refreshed:', window.currentTreeMemories.length);
-                    onMemoriesUpdated(window.currentTreeMemories);
+                    const normalizedApi = apiMemories.map(normalizeMemory).filter(Boolean);
+                    const filteredApi = inlineFilterMemoriesForTree(normalizedApi, treeId);
+                    window.currentTreeMemories = filteredApi;
+                    editorDebugLog('[editor] Memories refreshed (filtered):', filteredApi.length);
+                    onMemoriesUpdated(filteredApi);
                 }
             }
         } catch (e) {

--- a/js/editor/editor-data-loader.js
+++ b/js/editor/editor-data-loader.js
@@ -40,6 +40,48 @@
         };
     }
 
+    /**
+     * 메모리가 canonical root placeholder인지 판정.
+     * (root-like: id='root' 또는 parentId null/undefined/''/==id)
+     * legacy root + uuid root placeholder 모두 포함.
+     * root placeholder는 어떤 tree의 root로도 동작 가능하므로
+     * treeId 필터에서 제외한다.
+     */
+    function isCanonicalRootPlaceholder(memory) {
+        if (!memory) return false;
+        if (memory.id === 'root') return true;
+        const parentId = memory.parentId;
+        if (parentId === null || parentId === undefined || parentId === '') return true;
+        if (typeof parentId === 'string' && parentId === memory.id) return true;
+        return false;
+    }
+
+    /**
+     * 메모리 배열을 current treeId 기준으로 필터링.
+     *
+     * 규칙:
+     * - canonical root placeholder는 항상 유지 (어떤 tree의 root로도 동작 가능)
+     * - memory.treeId === current treeId → 유지
+     * - memory.treeId가 current treeId와 다른 값 → drop (stale)
+     * - current treeId가 있고, memory.treeId가 없는 경우 → drop
+     *   (server-loaded real tree의 메모리는 treeId를 가져야 함.
+     *    treeId 없는 메모리는 다른 tree의 stale로 간주)
+     * - current treeId가 없는 경우 (legacy default) → 모든 메모리 유지
+     *   (필터링 불가. 기존 동작 보존)
+     */
+    function filterMemoriesForTree(memories, treeId) {
+        if (!Array.isArray(memories)) return [];
+        if (!treeId) return memories.slice();
+
+        return memories.filter((m) => {
+            if (!m) return false;
+            if (isCanonicalRootPlaceholder(m)) return true;
+            const memTreeId = m.treeId || m.tree_id || null;
+            if (memTreeId && memTreeId === treeId) return true;
+            return false;
+        });
+    }
+
     async function loadInitialEditorTree(options) {
         const opts = options || {};
         const urlTreeId = opts.urlTreeId || '';
@@ -142,18 +184,36 @@
         let memories = [];
         const cachedMemories = cache ? cache.get(cacheKey) : null;
 
+        // 1) cache hit: treeId 필터를 거친 cached memories만 사용.
+        //    필터 결과가 empty면 그 자체로 stale 신호 → 빈 트리로 신뢰.
         if (cachedMemories && Array.isArray(cachedMemories)) {
-            memories = cachedMemories;
-            window.currentTreeMemories = memories.map(normalizeMemory).filter(Boolean);
+            memories = filterMemoriesForTree(cachedMemories, treeId);
+            const normalizedCached = memories.map(normalizeMemory).filter(Boolean);
+            window.currentTreeMemories = normalizedCached;
         }
 
+        // 2) API 호출. API 응답이 source of truth (array 자체가 truth).
+        //    빈 배열도 valid response로 처리 → cache clear + 빈 트리.
+        let apiReturnedArray = false;
         try {
             if (apiClient && apiClient.getMemoriesByTree) {
                 const apiMemories = await apiClient.getMemoriesByTree(treeId);
                 if (Array.isArray(apiMemories)) {
-                    memories = apiMemories;
+                    apiReturnedArray = true;
+                    const normalizedApi = apiMemories.map(normalizeMemory).filter(Boolean);
+                    const filteredApi = filterMemoriesForTree(normalizedApi, treeId);
+                    memories = filteredApi;
                     if (cache) {
-                        cache.set(cacheKey, memories, cacheTtlMs);
+                        if (filteredApi.length === 0) {
+                            // API []: source of truth. stale cached memories를 위해 cache clear.
+                            if (typeof cache.delete === 'function') {
+                                cache.delete(cacheKey);
+                            } else if (typeof cache.set === 'function') {
+                                cache.set(cacheKey, [], cacheTtlMs);
+                            }
+                        } else {
+                            cache.set(cacheKey, filteredApi, cacheTtlMs);
+                        }
                     }
                 }
             }
@@ -164,12 +224,15 @@
             }
         }
 
-        const normalizedMemories = memories.map(normalizeMemory).filter(Boolean);
-        window.currentTreeMemories = normalizedMemories;
+        // 3) 최종 할당. memories는 이미 filterMemoriesForTree + normalize 거침.
+        //    API 실패 시 (apiReturnedArray === false) cached memories를 그대로 사용 —
+        //    cached는 1단계에서 이미 filterMemoriesForTree를 거쳤으므로 안전.
+        const finalMemories = memories.map(normalizeMemory).filter(Boolean);
+        window.currentTreeMemories = finalMemories;
 
         return {
-            memories,
-            normalizedMemories,
+            memories: finalMemories,
+            normalizedMemories: finalMemories,
             cachedMemories
         };
     }
@@ -188,8 +251,10 @@
                 if (apiClient && apiClient.getMemoriesByTree) {
                     const apiMemories = await apiClient.getMemoriesByTree(treeId);
                     if (Array.isArray(apiMemories)) {
-                        window.currentTreeMemories = apiMemories.map(normalizeMemory).filter(Boolean);
-                        onMemoriesUpdated(window.currentTreeMemories);
+                        const normalizedApi = apiMemories.map(normalizeMemory).filter(Boolean);
+                        const filteredApi = filterMemoriesForTree(normalizedApi, treeId);
+                        window.currentTreeMemories = filteredApi;
+                        onMemoriesUpdated(filteredApi);
                     }
                 }
             } catch (e) {
@@ -200,6 +265,8 @@
 
     window.LoveBudEditorDataLoader = {
         createNormalizeMemory,
+        filterMemoriesForTree,
+        isCanonicalRootPlaceholder,
         loadInitialEditorTree,
         loadEditorMemories,
         createRefreshMemories

--- a/js/editor/editor-data-loader.js
+++ b/js/editor/editor-data-loader.js
@@ -44,8 +44,12 @@
      * 메모리가 canonical root placeholder인지 판정.
      * (root-like: id='root' 또는 parentId null/undefined/''/==id)
      * legacy root + uuid root placeholder 모두 포함.
-     * root placeholder는 어떤 tree의 root로도 동작 가능하므로
-     * treeId 필터에서 제외한다.
+     *
+     * 참고: filterMemoriesForTree()는 이 helper를 직접 사용하지 않는다.
+     * parentId만으로 root로 분류하면, 다른 트리에서 캐시된
+     * "parentId: null인 real moment"가 stale로 새 트리에 섞일 수 있다.
+     * filterMemoriesForTree는 treeId 매칭을 먼저 본 뒤,
+     * 예외적으로 id === 'root' (legacy universal root)만 통과시킨다.
      */
     function isCanonicalRootPlaceholder(memory) {
         if (!memory) return false;
@@ -59,15 +63,18 @@
     /**
      * 메모리 배열을 current treeId 기준으로 필터링.
      *
+     * 핵심 원칙: treeId가 다르면 root-like보다 먼저 drop한다.
+     * 단, id === 'root' (legacy universal root)만 예외로 통과.
+     *
      * 규칙:
-     * - canonical root placeholder는 항상 유지 (어떤 tree의 root로도 동작 가능)
-     * - memory.treeId === current treeId → 유지
-     * - memory.treeId가 current treeId와 다른 값 → drop (stale)
-     * - current treeId가 있고, memory.treeId가 없는 경우 → drop
-     *   (server-loaded real tree의 메모리는 treeId를 가져야 함.
-     *    treeId 없는 메모리는 다른 tree의 stale로 간주)
-     * - current treeId가 없는 경우 (legacy default) → 모든 메모리 유지
-     *   (필터링 불가. 기존 동작 보존)
+     * 1) current treeId가 없는 경우 (legacy default) → 모든 메모리 유지
+     * 2) memory.treeId가 current treeId와 다른 값 → drop.
+     *    예외: memory.id === 'root' (legacy universal root)만 통과.
+     * 3) memory.treeId === current treeId → 유지
+     * 4) memory.treeId가 없고 current treeId가 있는 경우 →
+     *    memory.id === 'root' (legacy universal root)만 통과.
+     *    (server-loaded real tree의 메모리는 treeId를 가져야 한다.
+     *     parentId: null이라도 treeId가 없는 메모리는 stale로 간주)
      */
     function filterMemoriesForTree(memories, treeId) {
         if (!Array.isArray(memories)) return [];
@@ -75,10 +82,15 @@
 
         return memories.filter((m) => {
             if (!m) return false;
-            if (isCanonicalRootPlaceholder(m)) return true;
             const memTreeId = m.treeId || m.tree_id || null;
-            if (memTreeId && memTreeId === treeId) return true;
-            return false;
+
+            if (memTreeId && memTreeId !== treeId) {
+                return m.id === 'root';
+            }
+
+            if (memTreeId === treeId) return true;
+
+            return m.id === 'root';
         });
     }
 

--- a/js/editor/editor-shell-canvas-ui.js
+++ b/js/editor/editor-shell-canvas-ui.js
@@ -115,10 +115,12 @@
         var opts = options || {};
         var getTreeMemories = opts.getTreeMemories || function() { return []; };
         var getSelectedNodeId = opts.getSelectedNodeId || function() { return null; };
+        var setSelectedNodeId = opts.setSelectedNodeId || function() {};
         var createInitialMemory = opts.createInitialMemory || function() { return null; };
         var isRootMemory = opts.isRootMemory || function() { return false; };
         var getCanonicalRootId = opts.getCanonicalRootId || function() { return null; };
         var setCurrentEditingMemory = opts.setCurrentEditingMemory || function() {};
+        var setDetailEmptyState = opts.setDetailEmptyState || function() {};
         var log = opts.log || function() {};
 
         return function applyEditorInitialSelection() {
@@ -129,7 +131,15 @@
 
             if (initialSelection && !isRootMemory(initialSelection, getCanonicalRootId())) {
                 setCurrentEditingMemory(initialSelection);
+                setDetailEmptyState(false);
                 log('Initial selection set: ' + initialSelection.id);
+            } else {
+                // root placeholder 이거나, validated memories에 selectedNodeId가 없는 경우
+                // (다른 트리에서 남은 stale selected state) → detail panel selected-moment UI 차단
+                setDetailEmptyState(true);
+                if (selectedNodeId) {
+                    setSelectedNodeId(null);
+                }
             }
 
             return initialSelection;

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -156,8 +156,8 @@
     <script src="../js/editor/editor-selection-ui.js?v=20260530-1698"></script>
     <script src="../js/editor/editor-bindings.js?v=20260420-1"></script>
     <script src="../js/editor/editor-auth-helpers.js?v=20260420-1"></script>
-    <script src="../js/editor/editor-data-loader.js?v=20260422-1"></script>
-    <script src="../js/editor/editor-data-loader-fallbacks.js?v=20260422-1"></script>
+    <script src="../js/editor/editor-data-loader.js?v=20260613-2447"></script>
+    <script src="../js/editor/editor-data-loader-fallbacks.js?v=20260613-2447"></script>
     <script src="../js/editor/editor-entry-fallbacks.js?v=20260422-1"></script>
     <script src="../js/editor/editor-shell-utils.js?v=20260605-1"></script>
     <script src="../js/editor/editor-shell-bridges.js?v=20260605-1"></script>

--- a/tests/contracts/editor-data-loader-memories-tree-filter-contract.test.cjs
+++ b/tests/contracts/editor-data-loader-memories-tree-filter-contract.test.cjs
@@ -1,0 +1,280 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadDataLoader(apiClient) {
+  const context = {
+    window: {},
+    console: { warn() {} },
+  };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync('js/editor/editor-data-loader.js', 'utf8'), context);
+  return context.window.LoveBudEditorDataLoader;
+}
+
+function createMemoryCache() {
+  const store = new Map();
+  return {
+    get(key) { return store.has(key) ? store.get(key) : null; },
+    set(key, value) { store.set(key, value); },
+    delete(key) { store.delete(key); },
+  };
+}
+
+function createApiClient(memories) {
+  let shouldFail = false;
+  return {
+    getMemoriesByTree: async () => {
+      if (shouldFail) throw new Error('API failure');
+      return memories;
+    },
+    setShouldFail(value) { shouldFail = value; },
+  };
+}
+
+test('filterMemoriesForTree keeps only memories matching current treeId and root placeholders', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  // root placeholder + matching memories + different treeId memories + missing treeId
+  const input = [
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+    { id: 'm1', parentId: 'root', treeId: 'tree-A' },
+    { id: 'm2', parentId: 'root', treeId: 'tree-B' },  // different treeId → drop
+    { id: 'm3', parentId: 'root' },  // missing treeId → drop (real tree)
+  ];
+  const filtered = filterMemoriesForTree(input, 'tree-A');
+  const ids = filtered.map((m) => m.id);
+  assert.deepEqual(ids, ['root', 'm1']);
+});
+
+test('filterMemoriesForTree treats root placeholder variants as root', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  // blank-parent + self-parent root placeholders are preserved
+  const input = [
+    { id: 'tree-root-id', parentId: '', treeId: 'tree-A' },
+    { id: 'tree-root-id-2', parentId: 'tree-root-id-2', treeId: 'tree-A' },
+  ];
+  const filtered = filterMemoriesForTree(input, 'tree-A');
+  assert.equal(filtered.length, 2);
+  assert.equal(filtered[0].id, 'tree-root-id');
+  assert.equal(filtered[1].id, 'tree-root-id-2');
+});
+
+test('filterMemoriesForTree returns all memories when treeId is missing (legacy default)', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  const input = [
+    { id: 'root', parentId: null },
+    { id: 'm1', parentId: 'root' },
+  ];
+  const filtered = filterMemoriesForTree(input, null);
+  assert.equal(filtered.length, 2);
+});
+
+test('loadEditorMemories: cached different treeId + API [] => currentTreeMemories []', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+
+  // Cache hit: previous tree's Psy-like moment (different treeId)
+  cache.set('memories_tree-A', [
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+    { id: 'psy-moment', parentId: 'root', treeId: 'tree-A', sourceUrl: 'https://youtube.com/psy' },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  assert.deepEqual(result.memories, []);
+  assert.deepEqual(globalThis.window ? globalThis.window.currentTreeMemories : result.memories, []);
+  // API returned [] → cache cleared
+  assert.equal(cache.get('memories_tree-B'), null);
+});
+
+test('loadEditorMemories: cached same treeId + API [] => currentTreeMemories []', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+
+  // Cache hit: same treeId but stale
+  cache.set('memories_tree-B', [
+    { id: 'root', parentId: null, treeId: 'tree-B' },
+    { id: 'm1', parentId: 'root', treeId: 'tree-B' },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  assert.deepEqual(result.memories, []);
+});
+
+test('loadEditorMemories: cached different treeId + API failure => real moments dropped, root placeholder kept', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+  apiClient.setShouldFail(true);
+
+  // Cache: 이전 트리의 real moment + root placeholder
+  cache.set('memories_tree-B', [
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+    { id: 'm1', parentId: 'root', treeId: 'tree-A' },  // 다른 treeId → drop
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  // real moment는 filter로 drop, root placeholder는 유지
+  const ids = result.memories.map((m) => m.id);
+  assert.deepEqual(ids, ['root']);
+});
+
+test('loadEditorMemories: cached same treeId + API failure => currentTreeMemories keeps cached (validated)', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+  apiClient.setShouldFail(true);
+
+  // Cache: 같은 treeId의 유효한 memories
+  cache.set('memories_tree-B', [
+    { id: 'root', parentId: null, treeId: 'tree-B' },
+    { id: 'm1', parentId: 'root', treeId: 'tree-B' },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  // filter 후 root + m1 유지
+  assert.equal(result.memories.length, 2);
+  assert.equal(result.memories[0].id, 'root');
+  assert.equal(result.memories[1].id, 'm1');
+});
+
+test('loadEditorMemories: API returns one valid memory for same treeId => renders normally', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([
+    { id: 'root', parentId: null, treeId: 'tree-B' },
+    { id: 'm1', parentId: 'root', treeId: 'tree-B', title: 'First moment' },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  assert.equal(result.memories.length, 2);
+  assert.equal(result.memories[0].id, 'root');
+  assert.equal(result.memories[1].id, 'm1');
+  // 캐시에 저장됨
+  const cached = cache.get('memories_tree-B');
+  assert.ok(Array.isArray(cached));
+  assert.equal(cached.length, 2);
+});
+
+test('loadEditorMemories: stale Psy-like YouTube memory must not render in a new empty tree', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+
+  // Cache: 다른 트리의 Psy/Gangnam Style 메모리
+  cache.set('memories_tree-B', [
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+    {
+      id: 'psy-gangnam',
+      parentId: 'root',
+      treeId: 'tree-A',
+      title: 'Gangnam Style',
+      sourceUrl: 'https://www.youtube.com/watch?v=9bZkp7q19f0',
+      source: 'youtube',
+    },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  // Psy 메모리는 filter로 drop → API [] → cache clear → []
+  assert.deepEqual(result.memories, []);
+  const ids = result.memories.map((m) => m.id);
+  assert.equal(ids.includes('psy-gangnam'), false);
+});
+
+test('createRefreshMemories: API response is filtered by treeId', async () => {
+  const dataLoader = loadDataLoader();
+  const apiClient = createApiClient([
+    { id: 'm1', parentId: 'root', treeId: 'tree-A' },  // 다른 트리
+    { id: 'm2', parentId: 'root', treeId: 'tree-B' },  // current 트리
+  ]);
+  let updatedWith = null;
+  const refreshMemories = dataLoader.createRefreshMemories({
+    treeId: 'tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+    onMemoriesUpdated: (value) => { updatedWith = value; },
+  });
+
+  await refreshMemories();
+
+  assert.equal(updatedWith.length, 1);
+  assert.equal(updatedWith[0].id, 'm2');
+});
+
+test('data loader exports filterMemoriesForTree helper for shared use', () => {
+  const dataLoader = loadDataLoader();
+  assert.equal(typeof dataLoader.filterMemoriesForTree, 'function');
+  assert.equal(typeof dataLoader.isCanonicalRootPlaceholder, 'function');
+});
+
+test('isCanonicalRootPlaceholder detects all five root variants', () => {
+  const dataLoader = loadDataLoader();
+  const isCanonicalRootPlaceholder = dataLoader.isCanonicalRootPlaceholder;
+
+  assert.equal(isCanonicalRootPlaceholder({ id: 'root', parentId: null }), true, 'legacy root');
+  assert.equal(isCanonicalRootPlaceholder({ id: 'tree-root-id', parentId: null }), true, 'parentId null');
+  assert.equal(isCanonicalRootPlaceholder({ id: 'tree-root-id', parentId: undefined }), true, 'parentId undefined');
+  assert.equal(isCanonicalRootPlaceholder({ id: 'tree-root-id', parentId: '' }), true, 'parentId blank');
+  assert.equal(isCanonicalRootPlaceholder({ id: 'tree-root-id', parentId: 'tree-root-id' }), true, 'self-parent');
+
+  assert.equal(isCanonicalRootPlaceholder({ id: 'm1', parentId: 'root' }), false, 'real child');
+  assert.equal(isCanonicalRootPlaceholder(null), false, 'null');
+});
+
+test('editor page cache-busts data loader scripts for the stale cache filter', () => {
+  const editorPage = fs.readFileSync('pages/editor.html', 'utf8');
+
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-data-loader\.js\?v=20260613-2447/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-data-loader-fallbacks\.js\?v=20260613-2447/);
+  assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-data-loader\.js\?v=20260422-1/);
+});

--- a/tests/contracts/editor-data-loader-memories-tree-filter-contract.test.cjs
+++ b/tests/contracts/editor-data-loader-memories-tree-filter-contract.test.cjs
@@ -271,6 +271,75 @@ test('isCanonicalRootPlaceholder detects all five root variants', () => {
   assert.equal(isCanonicalRootPlaceholder(null), false, 'null');
 });
 
+test('filterMemoriesForTree drops stale real memory with parentId null and mismatched treeId', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  // 핵심 regression boundary: parentId: null이어도 treeId가 다르면 stale.
+  // 이전 (PR #2447) 로직은 isCanonicalRootPlaceholder 통과로 살려뒀음.
+  // 이 케이스에서 싸이 memory 같은 stale real moment가 새 트리에 섞이는 게 가능했음.
+  const input = [
+    { id: 'psy-stale', parentId: null, treeId: 'tree-A', sourceUrl: 'https://youtube.com/psy' },
+    { id: 'root', parentId: null, treeId: 'tree-A' },  // legacy 'root'만 예외 통과
+  ];
+  const filtered = filterMemoriesForTree(input, 'tree-B');
+  const ids = filtered.map((m) => m.id);
+  assert.deepEqual(ids, ['root'], 'only legacy root should survive; parentId:null stale must drop');
+});
+
+test('filterMemoriesForTree drops uuid root placeholder when its treeId mismatches', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  // uuid root placeholder (id !== 'root', parentId === '')도 treeId mismatch면 drop.
+  // 'root' id만 universal, 그 외 root placeholder는 자기 tree에만 valid.
+  const input = [
+    { id: 'tree-root-A', parentId: '', treeId: 'tree-A' },
+    { id: 'tree-root-B', parentId: '', treeId: 'tree-B' },
+  ];
+  const filtered = filterMemoriesForTree(input, 'tree-B');
+  const ids = filtered.map((m) => m.id);
+  assert.deepEqual(ids, ['tree-root-B']);
+});
+
+test('filterMemoriesForTree keeps legacy id=root across mismatched treeId (universal exception)', () => {
+  const dataLoader = loadDataLoader();
+  const filterMemoriesForTree = dataLoader.filterMemoriesForTree;
+
+  // legacy 'root'만 universal. treeId가 달라도 통과.
+  const filtered = filterMemoriesForTree([
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+  ], 'tree-B');
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].id, 'root');
+});
+
+test('loadEditorMemories: stale real moment with parentId null + mismatched treeId is dropped', async () => {
+  const dataLoader = loadDataLoader();
+  const cache = createMemoryCache();
+  const apiClient = createApiClient([]);
+
+  // 이전 트리의 real moment가 parentId: null 형태로 캐시에 남은 경우
+  // (root placeholder가 아니라 real moment인데 parentId가 누락된 edge case)
+  cache.set('memories_tree-B', [
+    { id: 'psy-moment', parentId: null, treeId: 'tree-A', sourceUrl: 'https://youtube.com/psy' },
+    { id: 'root', parentId: null, treeId: 'tree-A' },
+  ]);
+
+  const result = await dataLoader.loadEditorMemories({
+    treeId: 'tree-B',
+    cache,
+    cacheKey: 'memories_tree-B',
+    apiClient,
+    normalizeMemory: dataLoader.createNormalizeMemory(),
+  });
+
+  // psy-moment drop, root만 통과 → API [] → cache clear + root도 drop → []
+  const ids = result.memories.map((m) => m.id);
+  assert.equal(ids.includes('psy-moment'), false, 'stale parentId:null real moment must not leak');
+  assert.deepEqual(ids, []);
+});
+
 test('editor page cache-busts data loader scripts for the stale cache filter', () => {
   const editorPage = fs.readFileSync('pages/editor.html', 'utf8');
 


### PR DESCRIPTION
Refs #2400

## Summary

- filter cached editor memories by current treeId before assigning to `window.currentTreeMemories`
- treat empty API memory response as source of truth and clear stale cache
- prevent stale cached selected moments (e.g. previous tree's Psy/Gangnam moment) from rendering in a new empty tree
- reset stale `selectedNodeId` and call `setDetailEmptyState(true)` when validated memories have no real selection

## Scope

- editor memory loading / empty state only
- no Browse/Search/#1661
- no DB/API
- no AI/Scout
- no `editor-canvas.js` changes (avoid broad canvas refactor)

## Changes

- `js/editor/editor-data-loader.js`
  - add `isCanonicalRootPlaceholder(memory)` predicate (5 root variants)
  - add `filterMemoriesForTree(memories, treeId)` helper
  - align `loadEditorMemories`: cache hit → filter → assign; API success → normalize+filter → cache.set or `cache.delete` on `[]`; API failure → cached already filtered at step 1
  - align `createRefreshMemories`: filter API response
  - export new helpers on `window.LoveBudEditorDataLoader`
- `js/editor/editor-data-loader-fallbacks.js`
  - inline `inlineIsCanonicalRootPlaceholder` + `inlineFilterMemoriesForTree` with the same criteria
  - mirror the same alignment in `createInlineLoadEditorMemoriesFallback` + `createInlineRefreshMemoriesFallback`
- `js/editor/editor-shell-canvas-ui.js`
  - extend `createEditorInitialSelectionApplier` with optional `setSelectedNodeId` + `setDetailEmptyState`
  - when no real selection found in validated memories → call `setDetailEmptyState(true)` and reset `selectedNodeId`
  - when a real non-root selection is found → call `setDetailEmptyState(false)` to show detail panel
- `js/editor.js`
  - wire `setSelectedNodeId` and `setDetailEmptyState` (lazy `callSetDetailEmptyState` wrapper) into `applyEditorInitialSelection` call site
- `pages/editor.html`
  - cache-bust `editor-data-loader.js` + `editor-data-loader-fallbacks.js` to `?v=20260613-2447`
- `tests/contracts/editor-data-loader-memories-tree-filter-contract.test.cjs` (new, 13 cases)
  - `filterMemoriesForTree` unit cases: matching treeId, root variants, missing treeId (legacy default)
  - `isCanonicalRootPlaceholder` covers all 5 root variants
  - `loadEditorMemories` cases: cached different treeId + API `[]` → `[]`; cached same treeId + API `[]` → `[]`; cached different treeId + API failure → real moments dropped, root kept; cached same treeId + API failure → validated memories kept; API success → memory renders normally; stale Psy-like YouTube memory must not render in new empty tree
  - `createRefreshMemories`: API response filtered by treeId
  - cache-bust lock for both `editor-data-loader.js` + fallbacks

## Validation

- `node --check js/editor/editor-data-loader.js`
- `node --check js/editor/editor-data-loader-fallbacks.js`
- `node --check js/editor/editor-shell-canvas-ui.js`
- `node --check js/editor.js`
- `node --test tests/contracts/*.test.cjs` — 1803/1804 (1 skipped, 0 fail)
- `npm test -- --runInBand` — 2187/2188 (1 skipped, 0 fail)
- `git diff --check` — clean

## Note

- #2400 stays OPEN until production desktop verification passes (central CTA + no stale selected-moment detail)