### PR TITLE
fix(editor): distinguish rootless real moments from root placeholders

### DIFF
--- a/js/editor/editor-empty-guide-ui.js
+++ b/js/editor/editor-empty-guide-ui.js
@@ -2,32 +2,74 @@
     const emptyGuideUI = window.LoveBudEditorEmptyGuideUI || {};
 
     // Root helper 공통 predicate를 우선 사용 (editor-root-helpers.js)
-    // fallback은 root helper와 같은 기준 (5가지 케이스)
+    // fallback은 root helper와 같은 기준 (PR #2448 정밀화: real content-aware)
     const rootUtils = (typeof window !== 'undefined' && window.LoveBudEditorUtils) || {};
     const sharedIsRootLikeMemory = typeof rootUtils.isRootLikeMemory === 'function'
         ? rootUtils.isRootLikeMemory
         : null;
+    const sharedHasRealMomentContent = typeof rootUtils.hasRealMomentContent === 'function'
+        ? rootUtils.hasRealMomentContent
+        : null;
+
+    // inline fallback — root helper와 같은 ROOT_PLACEHOLDER_TITLES 집합
+    const ROOT_PLACEHOLDER_TITLES = new Set([
+        'root', 'Root', 'ROOT',
+        '루트',
+        '새 트리', '새 러브트리', '새 트리입니다', '새 러브트리입니다',
+        'untitled', 'Untitled', 'UNTITLED',
+        '새 moment', '새 순간', 'root placeholder'
+    ]);
 
     emptyGuideUI.createCanvasEmptyGuideUpdater = function(options) {
         const getTreeMemories = options && options.getTreeMemories;
         const log = options && options.log;
 
-        // local fallback — root helper와 같은 기준 (5가지 케이스)
+        // local fallback — root helper와 같은 기준 (PR #2448 정밀화)
+        function hasRealMomentContent(memory) {
+            if (sharedHasRealMomentContent) {
+                return sharedHasRealMomentContent(memory);
+            }
+            if (!memory) return false;
+            if (memory.sourceUrl && String(memory.sourceUrl).trim()) return true;
+            if (memory.source && String(memory.source).trim()) return true;
+            if (memory.thumbnail && String(memory.thumbnail).trim()) return true;
+            if (memory.memo && String(memory.memo).trim()) return true;
+            if (memory.quote && String(memory.quote).trim()) return true;
+            if (Array.isArray(memory.emotionTags) && memory.emotionTags.length > 0) return true;
+            const title = memory.title ? String(memory.title).trim() : '';
+            if (title && !ROOT_PLACEHOLDER_TITLES.has(title)) return true;
+            return false;
+        }
+
         function isRootLikeMemory(memory) {
             if (sharedIsRootLikeMemory) {
                 return sharedIsRootLikeMemory(memory);
             }
             if (!memory) return false;
             const parentId = memory.parentId;
-            return memory.id === 'root'
-                || parentId === null
-                || parentId === undefined
-                || parentId === ''
-                || parentId === memory.id;
+            if (memory.id === 'root') return true;
+            if (parentId === '') return true;
+            if (parentId === memory.id) return true;
+            if (parentId === null || parentId === undefined) {
+                return !hasRealMomentContent(memory);
+            }
+            return false;
         }
 
         function hasVisibleMoment(memories) {
-            return Array.isArray(memories) && memories.some((memory) => memory && !isRootLikeMemory(memory));
+            if (!Array.isArray(memories)) return false;
+            return memories.some((memory) => {
+                if (!memory) return false;
+                // hard-coded root placeholder는 real content가 있어도 root
+                // (PR #2448: id='root', parentId='', parentId===id)
+                if (memory.id === 'root') return false;
+                if (memory.parentId === '') return false;
+                if (memory.parentId === memory.id) return false;
+                // 그 외 (parentId null/undefined 또는 parentId가 다른 노드):
+                // real content가 있으면 visible moment
+                if (hasRealMomentContent(memory)) return true;
+                return false;
+            });
         }
 
         return function updateCanvasEmptyGuide() {

--- a/js/editor/editor-root-helpers.js
+++ b/js/editor/editor-root-helpers.js
@@ -11,7 +11,7 @@
  * 의존성: 없음 (순수 함수들만 제공)
  * 사용처: editor.js, 추후 다른 트리 관련 페이지에서 재사용 가능
  *
- * @version 1.1.0
+ * @version 1.2.0
  * @since 2026-04-18
  * @updated 2026-06-13
  */
@@ -20,18 +20,74 @@
     'use strict';
 
     /**
+     * Root placeholder에서 흔히 사용되는 기본 title 집합.
+     * hasRealMomentContent()에서 "title만 있는 memory"가
+     * placeholder인지 real moment인지 구분하는 데 사용된다.
+     */
+    const ROOT_PLACEHOLDER_TITLES = new Set([
+        'root', 'Root', 'ROOT',
+        '루트',
+        '새 트리', '새 러브트리', '새 트리입니다', '새 러브트리입니다',
+        'untitled', 'Untitled', 'UNTITLED',
+        '새 moment', '새 순간', 'root placeholder'
+    ]);
+
+    /**
+     * memory에 "실제 표시 가능한 moment content"가 있는지 검사.
+     *
+     * PR #2448에서 도입. parentId === null/undefined인 memory가
+     * root placeholder로 오인되는 false positive를 막기 위해 사용된다.
+     *
+     * strong signal (하나라도 truthy → real moment):
+     *   - sourceUrl (YouTube/외부 URL)
+     *   - source   ('YouTube', '텍스트' 등)
+     *   - thumbnail
+     *   - memo
+     *   - quote
+     *   - emotionTags (비어있지 않은 배열)
+     *
+     * weak signal:
+     *   - title이 비어있지 않고 ROOT_PLACEHOLDER_TITLES에 없는 경우
+     *     → root placeholder가 아닌 "유저가 입력한 의미있는 제목"으로 보고 real moment로 본다.
+     *
+     * @param {Object} memory - memory 객체
+     * @returns {boolean} - real moment content 존재 여부
+     */
+    const hasRealMomentContent = (memory) => {
+        if (!memory) return false;
+
+        if (memory.sourceUrl && String(memory.sourceUrl).trim()) return true;
+        if (memory.source && String(memory.source).trim()) return true;
+        if (memory.thumbnail && String(memory.thumbnail).trim()) return true;
+        if (memory.memo && String(memory.memo).trim()) return true;
+        if (memory.quote && String(memory.quote).trim()) return true;
+        if (Array.isArray(memory.emotionTags) && memory.emotionTags.length > 0) return true;
+
+        const title = memory.title ? String(memory.title).trim() : '';
+        if (title && !ROOT_PLACEHOLDER_TITLES.has(title)) return true;
+
+        return false;
+    };
+
+    /**
      * Root-like memory 판정 (공통 predicate)
      *
      * 메모리가 root placeholder로 간주되어야 하는지 판정한다.
-     * 5가지 케이스 모두 root-like로 본다:
-     *   1) memory.id === 'root'             — legacy root
-     *   2) memory.parentId === null         — 정식 root (parentId 미설정)
-     *   3) memory.parentId === undefined    — 정식 root (parentId 미설정)
-     *   4) memory.parentId === ''           — blank-parent root placeholder
-     *   5) memory.parentId === memory.id    — self-parent root placeholder
+     *
+     * 규칙 (PR #2448에서 정밀화):
+     *   1) memory.id === 'root'                    → root (legacy root)
+     *   2) memory.parentId === ''                  → blank-parent root placeholder
+     *   3) memory.parentId === memory.id           → self-parent root placeholder
+     *   4) memory.parentId === null/undefined:
+     *      - hasRealMomentContent(memory) === true  → real moment (root 아님)
+     *      - 그 외                                   → root-like (legacy placeholder 호환)
      *
      * 이 predicate는 empty guide visibility, canvas detail, root helper
      * selection 등 모든 root 판정 경로에서 공통으로 사용된다.
+     *
+     * signature는 (memory) → boolean으로 유지되며, PR #2447의
+     * filterMemoriesForTree()는 이 helper를 직접 사용하지 않는다
+     * (treeId 매칭을 최우선으로 본다).
      *
      * @param {Object} memory - memory 객체
      * @returns {boolean} - root-like 여부
@@ -39,11 +95,18 @@
     const isRootLikeMemory = (memory) => {
         if (!memory) return false;
         const parentId = memory.parentId;
-        return memory.id === 'root'
-            || parentId === null
-            || parentId === undefined
-            || parentId === ''
-            || parentId === memory.id;
+
+        // 무조건 root
+        if (memory.id === 'root') return true;
+        if (parentId === '') return true;
+        if (parentId === memory.id) return true;
+
+        // parentId null/undefined는 content-aware
+        if (parentId === null || parentId === undefined) {
+            return !hasRealMomentContent(memory);
+        }
+
+        return false;
     };
 
     /**
@@ -62,7 +125,7 @@
     const findRootMemory = (memories) => {
         if (!Array.isArray(memories)) return null;
 
-        // 1순위: root-like 노드 필터 (5가지 케이스 모두 포함)
+        // 1순위: root-like 노드 필터 (정밀화된 4가지 케이스)
         const rootLikeNodes = memories.filter(isRootLikeMemory);
 
         if (rootLikeNodes.length === 0) {
@@ -91,7 +154,7 @@
 
     /**
      * Root ID 반환 (없으면 'root' fallback - backward compatibility)
-     * 
+     *
      * @param {Array} memories - memory 객체 배열
      * @returns {string} - root ID 또는 'root'
      */
@@ -102,12 +165,12 @@
 
     /**
      * Canonical root 계산 (현재 메모리 배열 기준, 항상 fresh)
-     * 
+     *
      * 규칙:
-     * 1) parentId === null 우선
+     * 1) parentId === null 우선 (단, real content가 없는 placeholder만)
      * 2) id === 'root' (legacy root compatibility)
      * 3) 없으면 'root' fallback
-     * 
+     *
      * @param {Array} memories - memory 객체 배열
      * @returns {string} - canonical root ID
      */
@@ -118,7 +181,7 @@
 
     /**
      * memory가 지정된 root ID와 같은지 확인
-     * 
+     *
      * @param {Object} mem - memory 객체
      * @param {string} rootId - root ID
      * @returns {boolean}
@@ -138,7 +201,8 @@
         getRootId,
         getCanonicalRootId,
         isRootMemory,
-        isRootLikeMemory
+        isRootLikeMemory,
+        hasRealMomentContent
     };
 
     // 전역 노출

--- a/pages/editor.html
+++ b/pages/editor.html
@@ -88,7 +88,7 @@
     <script type="module" src="../js/editor/templates/editor-detail-view-mode-template.js?v=20260531-1494"></script>
     <script type="module" src="../js/editor/templates/editor-detail-edit-mode-template.js?v=20260531-1494"></script>
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
-    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260526-1"></script>
@@ -125,7 +125,7 @@
     <script src="../js/editor/editor-utils.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-save-status-ui.js?v=20260523-1276"></script>
     <script src="../js/editor/editor-sidebar-ui.js?v=20260523-1276"></script>
-    <script src="../js/editor/editor-empty-guide-ui.js?v=20260613-2446"></script>
+    <script src="../js/editor/editor-empty-guide-ui.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-canvas-geometry.js?v=20260502-1"></script>
     <script src="../js/editor/editor-canvas-layout-storage.js?v=20260522-1277"></script>
     <script src="../js/editor/editor-canvas-layout-transition.js?v=20260524-1"></script>
@@ -163,9 +163,9 @@
     <script src="../js/editor/editor-shell-bridges.js?v=20260605-1"></script>
     <script src="../js/editor/editor-shell-guards.js?v=20260605-1"></script>
     <script src="../js/editor/editor-shell-startup.js?v=20260605-1"></script>
-    <script src="../js/editor/editor-shell-canvas-ui.js?v=20260605-3"></script>
-    <script src="../js/editor/editor-shell-memory.js?v=20260605-3"></script>
-    <script src="../js/editor/editor-shell-helpers.js?v=20260605-3"></script>
+    <script src="../js/editor/editor-shell-canvas-ui.js?v=20260613-2448"></script>
+    <script src="../js/editor/editor-shell-memory.js?v=20260613-2448"></script>
+    <script src="../js/editor/editor-shell-helpers.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-shell-copy-applier.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-dom-refs-builder.js?v=20260522-1276"></script>
     <script src="../js/editor/editor-startup-context.js?v=20260530-1698"></script>
@@ -183,7 +183,7 @@
     <script src="../js/scout/scout-suggestion-endpoint-client.js?v=20260606-4"></script>
     <script src="../js/scout/scout-suggestion-source-selector.js?v=20260606-1"></script>
 
-    <script src="../js/editor.js?v=20260612-2400"></script>
+    <script src="../js/editor.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-i18n-refresh.js?v=20260422-2"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>

--- a/pages/public-canvas.html
+++ b/pages/public-canvas.html
@@ -49,7 +49,7 @@
 
     <!-- Canvas core modules -->
     <script src="../js/editor/editor-dom-selectors.js?v=20260428-1"></script>
-    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-layout-helpers.js?v=20260503-1"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>

--- a/pages/view.html
+++ b/pages/view.html
@@ -41,7 +41,7 @@
     <script src="../js/viewer/public-viewer-detail-empty-state-template.js?v=20260526-1"></script>
     <script src="../js/viewer/public-viewer-detail-view-mode-template.js?v=20260526-1"></script>
 
-    <script src="../js/editor/editor-root-helpers.js?v=20260613-2446"></script>
+    <script src="../js/editor/editor-root-helpers.js?v=20260613-2448"></script>
     <script src="../js/editor/editor-canvas-layout.js?v=20260507-655"></script>
     <script src="../js/editor/editor-canvas-node.js?v=20260420-1"></script>
     <script src="../js/editor/editor-canvas-interaction.js?v=20260507-655"></script>

--- a/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
+++ b/tests/contracts/editor-canvas-empty-guide-updater-contract.test.cjs
@@ -18,13 +18,26 @@ test('canvas ui fix canvas empty guide updater preserves helper call', () => {
   assert.match(shellCanvasUISource, /log:\s*log/);
 });
 
-test('canvas empty guide updater counts only non-root moments as visible moments', () => {
+test('canvas empty guide updater counts list-aware real moments as visible moments (PR #2448)', () => {
+  // PR #2448: hard-coded root placeholder (id='root', parentId='', parentId===id) 제외 후
+  // hasRealMomentContent로 content-aware 판정
   assert.match(emptyGuideUISource, /function isRootLikeMemory\(memory\)/);
-  assert.match(emptyGuideUISource, /memory\.id === 'root'\s*\|\|\s*parentId === null\s*\|\|\s*parentId === undefined/);
+  assert.match(emptyGuideUISource, /function hasRealMomentContent\(memory\)/);
+  // hard-coded root placeholder 분기
+  assert.match(emptyGuideUISource, /memory\.id === 'root'/);
+  assert.match(emptyGuideUISource, /memory\.parentId === ''/);
+  assert.match(emptyGuideUISource, /memory\.parentId === memory\.id/);
+  // parentId null/undefined + real content-aware 분기
+  assert.match(emptyGuideUISource, /parentId === null \|\| parentId === undefined/);
+  assert.match(emptyGuideUISource, /return !hasRealMomentContent\(memory\)/);
   assert.match(emptyGuideUISource, /function hasVisibleMoment\(memories\)/);
-  assert.match(emptyGuideUISource, /memories\.some\(\(memory\) => memory && !isRootLikeMemory\(memory\)\)/);
   assert.match(emptyGuideUISource, /const hasMoments = hasVisibleMoment\(memories\);/);
   assert.doesNotMatch(emptyGuideUISource, /const hasMoments = memories\.length > 0;/);
+  // PR #2446의 단순 !isRootLikeMemory 단독 체크는 사라짐
+  assert.doesNotMatch(
+    emptyGuideUISource,
+    /memories\.some\(\(memory\) => memory && !isRootLikeMemory\(memory\)\)/,
+  );
 });
 
 test('canvas ui fix canvas empty guide updater preserves warning fallback', () => {

--- a/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-runtime-contract.test.cjs
@@ -71,28 +71,65 @@ function assertGuideHiddenFor(memories) {
 }
 
 test('empty guide runtime shows guide for root-only tree memories', () => {
-  assertGuideVisibleFor([{ id: 'root', parentId: null, title: 'LoveTree' }]);
+  // id === 'root' 이므로 무조건 root-like, 가이드 visible.
+  // (PR #2448: title은 root-like 판정에 무관 — id='root'가 hard-coded root)
+  assertGuideVisibleFor([{ id: 'root', parentId: null }]);
 });
 
 test('empty guide runtime shows guide for uuid root-only tree memories', () => {
-  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: null, title: 'LoveTree' }]);
+  // parentId: null + content 없음 → root-like (legacy placeholder) → 가이드 visible
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: null }]);
 });
 
 test('empty guide runtime shows guide for blank-parent root placeholder', () => {
-  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: '', title: 'LoveTree' }]);
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: '' }]);
 });
 
 test('empty guide runtime shows guide for self-parent root placeholder', () => {
-  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: 'tree-root-id', title: 'LoveTree' }]);
+  assertGuideVisibleFor([{ id: 'tree-root-id', parentId: 'tree-root-id' }]);
 });
 
-test('empty guide runtime shows guide when only legacy root exists with real child having parentId null', () => {
-  // legacy { id: 'root' } + real child whose parentId === null
-  // real child는 root-like로 분류되지만, legacy root가 canonical root.
-  // real child는 root-like 이므로 가이드는 여전히 visible (real moment 아님).
+test('empty guide runtime shows guide when only legacy root exists with placeholder child having parentId null', () => {
+  // legacy { id: 'root' } + child whose parentId === null
+  // child는 real moment content가 없으므로 placeholder로 간주되어 root-like.
+  // legacy root가 canonical root이고, child도 root-like이므로 가이드는 visible.
+  // (PR #2448: child에 real moment content가 있으면 real moment로 분류되어 hidden — 별도 test로 lock)
   assertGuideVisibleFor([
-    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'root', parentId: null },
+    { id: 'real-child', parentId: null },
+  ]);
+});
+
+test('empty guide runtime hides guide when real child with title/content exists alongside legacy root', () => {
+  // PR #2448 핵심 회귀 방지: real child가 real moment content (title)를 가지면
+  // parentId: null이라도 root placeholder로 오인하면 안 됨.
+  // → legacy root + real child(with title) → real child는 visible moment → 가이드 hidden
+  assertGuideHiddenFor([
+    { id: 'root', parentId: null },
     { id: 'real-child', parentId: null, title: 'First real moment' },
+  ]);
+});
+
+test('empty guide runtime hides guide for PSY-like real moment with parentId null (production case)', () => {
+  // production에서 발견된 케이스:
+  // 트리에 PSY memory 1개 (parentId:null + sourceUrl + thumbnail + title)
+  // → root placeholder가 아닌 real moment → 가이드 hidden
+  assertGuideHiddenFor([
+    {
+      id: '19ad873f-53f1-4ad8-8317-69219b9e2199',
+      parentId: null,
+      title: 'PSY - GANGNAM STYLE(강남스타일) M/V',
+      source: 'YouTube',
+      sourceUrl: 'https://www.youtube.com/embed/9bZkp7q19f0',
+      thumbnail: 'https://img.youtube.com/vi/9bZkp7q19f0/mqdefault.jpg',
+    },
+  ]);
+});
+
+test('empty guide runtime shows guide for empty root placeholder with no real content', () => {
+  // 모든 content 필드가 비어있는 root placeholder는 그대로 root로 본다.
+  assertGuideVisibleFor([
+    { id: 'tree-root-id', parentId: null },
   ]);
 });
 
@@ -194,6 +231,7 @@ test('root helper isRootLikeMemory agrees with empty guide isRootLikeMemory fall
   assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
 
   // real child 추가 시 가이드 hidden — root helper의 hasVisibleMoment과 같은 결과
+  // (PR #2448: real child는 real moment content가 있어야 visible로 인정)
   const guide2 = createGuide();
   const docRef2 = { getElementById(id) { return id === 'canvasEmptyGuide' ? guide2 : null; } };
   const ctx2 = { window: {}, document: docRef2, console: { warn() {} } };
@@ -203,7 +241,7 @@ test('root helper isRootLikeMemory agrees with empty guide isRootLikeMemory fall
   const update2 = ctx2.window.LoveBudEditorEmptyGuideUI.createCanvasEmptyGuideUpdater({
     getTreeMemories: () => [
       { id: 'root', parentId: null },
-      { id: 'real-child', parentId: 'root' },  // parentId: 'root' → not root-like
+      { id: 'real-child', parentId: 'root', title: 'First real moment' },  // parentId: 'root' + title → real
     ],
     log() {},
   });
@@ -237,6 +275,6 @@ test('empty guide UI does not redefine its own local isRootLikeMemory when root 
 test('editor page cache-busts empty guide runtime script', () => {
   const editorPage = fs.readFileSync('pages/editor.html', 'utf8');
 
-  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260613-2446/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260613-2448/);
   assert.doesNotMatch(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260612-2441/);
 });

--- a/tests/contracts/editor-empty-guide-ui-real-moment-integration-contract.test.cjs
+++ b/tests/contracts/editor-empty-guide-ui-real-moment-integration-contract.test.cjs
@@ -1,0 +1,184 @@
+/**
+ * editor-empty-guide-ui-real-moment-integration-contract.test.cjs
+ *
+ * PR #2448: empty guide UI integration contract.
+ *
+ * - editor-empty-guide-ui.js가 hasRealMomentContent를 통해
+ *   list-aware "real visible moment" 판정을 함을 source-level로 lock.
+ * - inline fallback이 root helper와 같은 ROOT_PLACEHOLDER_TITLES 집합을 가진
+ *   real-content 검사를 포함함을 lock.
+ * - canvasEmptyGuide hide/show 로직이 hasVisibleMoment 결과를 반영함을
+ *   integration test로 lock.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+function createGuide() {
+  const classes = new Set();
+  return {
+    classList: {
+      toggle(name, force) {
+        if (force) classes.add(name);
+        else classes.delete(name);
+      },
+      contains(name) {
+        return classes.has(name);
+      },
+    },
+    _classes: classes,
+  };
+}
+
+function loadAll(documentRef) {
+  const context = { window: {}, document: documentRef, console: { warn() {} } };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  vm.runInContext(read('js/editor/editor-empty-guide-ui.js'), context);
+  return context;
+}
+
+function runUpdate(memories) {
+  const guide = createGuide();
+  const doc = { getElementById: (id) => (id === 'canvasEmptyGuide' ? guide : null) };
+  const ctx = loadAll(doc);
+  const update = ctx.window.LoveBudEditorEmptyGuideUI.createCanvasEmptyGuideUpdater({
+    getTreeMemories: () => memories,
+    log() {},
+  });
+  update();
+  return guide;
+}
+
+test('empty guide UI source uses hasRealMomentContent for list-aware visible moment detection', () => {
+  const source = read('js/editor/editor-empty-guide-ui.js');
+
+  // hasRealMomentContent를 import하거나 정의해야 함
+  assert.match(source, /hasRealMomentContent/);
+
+  // hasVisibleMoment 안에 isRootLikeMemory 단독 체크만 있지 않고,
+  // hasRealMomentContent를 함께 봐야 함
+  const hasVisibleMomentMatch = source.match(/function\s+hasVisibleMoment[\s\S]*?\n\s{4}\}/);
+  assert.ok(hasVisibleMomentMatch, 'hasVisibleMoment function must exist');
+  const body = hasVisibleMomentMatch[0];
+  assert.match(body, /hasRealMomentContent/, 'hasVisibleMoment must consult hasRealMomentContent');
+});
+
+test('empty guide UI source defines inline ROOT_PLACEHOLDER_TITLES fallback aligned with root helper', () => {
+  const source = read('js/editor/editor-empty-guide-ui.js');
+
+  // inline fallback이 root helper와 같은 placeholder title set을 가져야 함
+  assert.match(source, /ROOT_PLACEHOLDER_TITLES/);
+  // placeholder 기본명 일부
+  assert.match(source, /['"]root['"]/);
+  assert.match(source, /['"]루트['"]/);
+  assert.match(source, /['"]새 트리['"]/);
+});
+
+test('integration: PSY-like single moment → empty guide hidden (production regression guard)', () => {
+  const guide = runUpdate([{
+    id: '19ad873f-...',
+    parentId: null,
+    title: 'PSY - GANGNAM STYLE(강남스타일) M/V',
+    source: 'YouTube',
+    sourceUrl: 'https://www.youtube.com/embed/9bZkp7q19f0',
+    thumbnail: 'https://img.youtube.com/vi/9bZkp7q19f0/mqdefault.jpg',
+  }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: real moment with text content only (memo) → empty guide hidden', () => {
+  const guide = runUpdate([{
+    id: 'm1',
+    parentId: null,
+    memo: '오늘 본 첫 순간',
+  }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: real moment with quote only → empty guide hidden', () => {
+  const guide = runUpdate([{
+    id: 'm1',
+    parentId: null,
+    quote: '인상 깊은 말',
+  }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: real moment with emotionTags only → empty guide hidden', () => {
+  const guide = runUpdate([{
+    id: 'm1',
+    parentId: null,
+    emotionTags: ['joy', 'first'],
+  }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: empty placeholder (no content) → empty guide visible', () => {
+  const guide = runUpdate([{ id: 'tree-root', parentId: null }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('integration: placeholder title only ("root", "루트", "새 트리") → empty guide visible', () => {
+  const titles = ['root', 'Root', '루트', '새 트리', '새 러브트리', 'untitled'];
+  titles.forEach((title) => {
+    const guide = runUpdate([{ id: 'm1', parentId: null, title }]);
+    assert.equal(
+      guide.classList.contains('editor-canvas-empty-guide-hidden'),
+      false,
+      `placeholder title "${title}" must not trigger hidden`,
+    );
+  });
+});
+
+test('integration: real moment with meaningful title → empty guide hidden', () => {
+  const guide = runUpdate([{ id: 'm1', parentId: null, title: 'PSY - GANGNAM STYLE' }]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: legacy root + real child (with title) → empty guide hidden', () => {
+  // PR #2448 핵심: real child with title → 가이드 hidden
+  const guide = runUpdate([
+    { id: 'root', parentId: null },
+    { id: 'real-child', parentId: null, title: 'First real moment' },
+  ]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), true);
+});
+
+test('integration: legacy root + placeholder child (no content) → empty guide visible', () => {
+  // PR #2446 호환: 둘 다 root-like → visible
+  const guide = runUpdate([
+    { id: 'root', parentId: null },
+    { id: 'real-child', parentId: null },
+  ]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('integration: blank-parent root placeholder → empty guide visible even with real content on it', () => {
+  // PR #2448: blank-parent는 무조건 root placeholder (real content 있어도)
+  const guide = runUpdate([
+    { id: 'tree-root', parentId: '', title: 'PSY', sourceUrl: 'x' },
+  ]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('integration: self-parent root placeholder → empty guide visible even with real content on it', () => {
+  const guide = runUpdate([
+    { id: 'tree-root', parentId: 'tree-root', sourceUrl: 'x' },
+  ]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});
+
+test('integration: empty array → empty guide visible', () => {
+  const guide = runUpdate([]);
+  assert.equal(guide.classList.contains('editor-canvas-empty-guide-hidden'), false);
+});

--- a/tests/contracts/editor-entry-dependencies-contract.test.cjs
+++ b/tests/contracts/editor-entry-dependencies-contract.test.cjs
@@ -219,6 +219,7 @@ test('lazy let stubs are declared strictly before detailUI wiring', () => {
 test('editor page cache-busts editor.js for the lazy wrapper fix', () => {
   const editorPage = read('pages/editor.html');
 
-  assert.match(editorPage, /\.\.\/js\/editor\.js\?v=20260612-2400/);
+  // PR #2448: editor.js cache-bust 갱신
+  assert.match(editorPage, /\.\.\/js\/editor\.js\?v=20260613-2448/);
   assert.doesNotMatch(editorPage, /\.\.\/js\/editor\.js\?v=20260502-1/);
 });

--- a/tests/contracts/editor-root-helper-real-moment-boundary-contract.test.cjs
+++ b/tests/contracts/editor-root-helper-real-moment-boundary-contract.test.cjs
@@ -1,0 +1,218 @@
+/**
+ * editor-root-helper-real-moment-boundary-contract.test.cjs
+ *
+ * PR #2448: "rootless real moments vs root placeholders" 핵심 invariant lock.
+ *
+ * editor-root-helpers.js의 hasRealMomentContent, isRootLikeMemory, findRootMemory
+ * 가 PR #2448의 real-content-aware 기준으로 동작함을 lock.
+ *
+ * 핵심 규칙:
+ *   - id === 'root'               → 무조건 root-like
+ *   - parentId === ''              → 무조건 root-like (blank-parent placeholder)
+ *   - parentId === memory.id       → 무조건 root-like (self-parent placeholder)
+ *   - parentId === null/undefined:
+ *     - hasRealMomentContent(m) === true  → real moment (root 아님)
+ *     - hasRealMomentContent(m) === false → root-like (legacy placeholder)
+ *
+ * filterMemoriesForTree() (PR #2447)는 이 helper를 직접 사용하지 않고
+ * treeId 매칭을 최우선으로 한다는 invariant도 함께 lock.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+function loadRootHelpers() {
+  const context = { window: {} };
+  vm.createContext(context);
+  vm.runInContext(read('js/editor/editor-root-helpers.js'), context);
+  return context.window.LoveBudEditorUtils;
+}
+
+test('hasRealMomentContent detects real moment from each strong signal', () => {
+  const utils = loadRootHelpers();
+  assert.equal(typeof utils.hasRealMomentContent, 'function');
+
+  // sourceUrl
+  assert.equal(utils.hasRealMomentContent({ sourceUrl: 'https://youtu.be/abc' }), true);
+  // source
+  assert.equal(utils.hasRealMomentContent({ source: 'YouTube' }), true);
+  // thumbnail
+  assert.equal(utils.hasRealMomentContent({ thumbnail: 'https://img/abc.jpg' }), true);
+  // memo
+  assert.equal(utils.hasRealMomentContent({ memo: 'some memo' }), true);
+  // quote
+  assert.equal(utils.hasRealMomentContent({ quote: 'some quote' }), true);
+  // emotionTags (non-empty)
+  assert.equal(utils.hasRealMomentContent({ emotionTags: ['joy'] }), true);
+  assert.equal(utils.hasRealMomentContent({ emotionTags: [] }), false);
+});
+
+test('hasRealMomentContent detects real moment from meaningful title', () => {
+  const utils = loadRootHelpers();
+
+  // 의미있는 title은 real moment
+  assert.equal(utils.hasRealMomentContent({ title: 'PSY - GANGNAM STYLE' }), true);
+  assert.equal(utils.hasRealMomentContent({ title: '첫 순간' }), true);
+
+  // placeholder 기본명은 real 아님
+  assert.equal(utils.hasRealMomentContent({ title: 'root' }), false);
+  assert.equal(utils.hasRealMomentContent({ title: '루트' }), false);
+  assert.equal(utils.hasRealMomentContent({ title: '새 트리' }), false);
+  assert.equal(utils.hasRealMomentContent({ title: 'untitled' }), false);
+
+  // 빈 title은 real 아님
+  assert.equal(utils.hasRealMomentContent({ title: '' }), false);
+  assert.equal(utils.hasRealMomentContent({ title: '   ' }), false);
+  assert.equal(utils.hasRealMomentContent({}), false);
+  assert.equal(utils.hasRealMomentContent(null), false);
+  assert.equal(utils.hasRealMomentContent(undefined), false);
+});
+
+test('isRootLikeMemory always returns true for hard-coded root placeholders', () => {
+  const utils = loadRootHelpers();
+
+  // id === 'root' — content 무관, 무조건 root
+  assert.equal(utils.isRootLikeMemory({ id: 'root', parentId: null, title: 'PSY' }), true);
+  assert.equal(utils.isRootLikeMemory({ id: 'root', parentId: null, sourceUrl: 'x' }), true);
+  // blank-parent
+  assert.equal(utils.isRootLikeMemory({ id: 'uuid', parentId: '', title: 'PSY' }), true);
+  // self-parent
+  assert.equal(utils.isRootLikeMemory({ id: 'uuid', parentId: 'uuid', sourceUrl: 'x' }), true);
+});
+
+test('isRootLikeMemory treats parentId null with real content as real moment (not root)', () => {
+  const utils = loadRootHelpers();
+
+  // PSY 케이스 (production 발견)
+  const psy = {
+    id: '19ad873f-...',
+    parentId: null,
+    title: 'PSY - GANGNAM STYLE(강남스타일) M/V',
+    source: 'YouTube',
+    sourceUrl: 'https://www.youtube.com/embed/9bZkp7q19f0',
+    thumbnail: 'https://img.youtube.com/vi/9bZkp7q19f0/mqdefault.jpg',
+  };
+  assert.equal(utils.isRootLikeMemory(psy), false, 'PSY-like with real content must not be root-like');
+
+  // parentId: undefined + sourceUrl
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: undefined, sourceUrl: 'x' }), false);
+  // parentId: null + memo
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, memo: 'note' }), false);
+  // parentId: null + emotionTags
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, emotionTags: ['joy'] }), false);
+  // parentId: null + meaningful title only
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, title: '내가 본 첫 순간' }), false);
+});
+
+test('isRootLikeMemory keeps parentId null as root when no real content exists (legacy placeholder)', () => {
+  const utils = loadRootHelpers();
+
+  // parentId null + 모든 content 비어있음 → root-like (legacy placeholder)
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null }), true);
+  // 빈 title도 root-like
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, title: '' }), true);
+  // placeholder 기본명 title도 root-like
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, title: 'root' }), true);
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, title: '루트' }), true);
+  // whitespace만
+  assert.equal(utils.isRootLikeMemory({ id: 'm1', parentId: null, title: '   ' }), true);
+});
+
+test('findRootMemory returns null for PSY-like single real moment (no root placeholder)', () => {
+  const utils = loadRootHelpers();
+
+  const psy = {
+    id: '19ad873f-...',
+    parentId: null,
+    title: 'PSY - GANGNAM STYLE',
+    sourceUrl: 'https://youtu.be/abc',
+  };
+  // PSY는 root-like 아님 → findRootMemory는 null
+  assert.equal(utils.findRootMemory([psy]), null);
+  assert.equal(utils.getCanonicalRootId([psy]), 'root', 'no root-like → fallback to "root" string');
+});
+
+test('findRootMemory keeps legacy root as canonical even when real child exists with title', () => {
+  const utils = loadRootHelpers();
+
+  const memories = [
+    { id: 'root', parentId: null, title: 'LoveTree' },
+    { id: 'real-child', parentId: null, title: 'First real moment' },
+  ];
+  // root-like nodes = [root] (real-child는 real)
+  // legacy root 우선
+  assert.equal(utils.findRootMemory(memories)?.id, 'root');
+  assert.equal(utils.getCanonicalRootId(memories), 'root');
+});
+
+test('findRootMemory picks blank-parent / self-parent root placeholders regardless of content', () => {
+  const utils = loadRootHelpers();
+
+  // blank-parent + real content여도 root placeholder
+  const blank = { id: 'tree-root', parentId: '', title: 'PSY', sourceUrl: 'x' };
+  assert.equal(utils.findRootMemory([blank])?.id, 'tree-root');
+
+  // self-parent + real content여도 root placeholder
+  const self = { id: 'tree-root', parentId: 'tree-root', sourceUrl: 'x' };
+  assert.equal(utils.findRootMemory([self])?.id, 'tree-root');
+});
+
+test('isRootLikeMemory signature preserved (memory → boolean) for backward compat', () => {
+  const utils = loadRootHelpers();
+
+  // signature: takes 1 arg, returns boolean
+  assert.equal(utils.isRootLikeMemory.length, 1);
+  assert.equal(typeof utils.isRootLikeMemory({ id: 'root' }), 'boolean');
+  assert.equal(typeof utils.isRootLikeMemory(null), 'boolean');
+});
+
+test('editor-data-loader.js filterMemoriesForTree does NOT use isRootLikeMemory directly (PR #2447 invariant)', () => {
+  const dataLoader = read('js/editor/editor-data-loader.js');
+
+  // PR #2447 invariant: filterMemoriesForTree는 treeId 매칭을 최우선으로 본다.
+  // hasRealMomentContent/isRootLikeMemory/isCanonicalRootPlaceholder를 직접 호출하면 안 됨.
+  // 함수 본문에서 .filter(isCanonicalRootPlaceholder ...) 같은 패턴이 없어야 함.
+  const fnMatch = dataLoader.match(/function\s+filterMemoriesForTree[\s\S]*?\n\s{4}\}/);
+  if (fnMatch) {
+    const body = fnMatch[0];
+    assert.doesNotMatch(body, /isCanonicalRootPlaceholder\s*\(/);
+    assert.doesNotMatch(body, /isRootLikeMemory\s*\(/);
+    assert.doesNotMatch(body, /hasRealMomentContent\s*\(/);
+  } else {
+    // 함수 본문을 못 찾으면 fail-safe로 isRootLikeMemory 호출이 없는지만 확인
+    assert.doesNotMatch(dataLoader, /isRootLikeMemory\s*\(\s*memories?\b/);
+  }
+});
+
+test('editor page cache-busts root helpers to PR #2448 version', () => {
+  const editorPage = read('pages/editor.html');
+  const publicCanvas = read('pages/public-canvas.html');
+  const viewPage = read('pages/view.html');
+
+  // 셋 다 editor-root-helpers.js?v=20260613-2448 이상
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-root-helpers\.js\?v=20260613-2448/);
+  assert.match(publicCanvas, /\.\.\/js\/editor\/editor-root-helpers\.js\?v=20260613-2448/);
+  assert.match(viewPage, /\.\.\/js\/editor\/editor-root-helpers\.js\?v=20260613-2448/);
+
+  // editor.html: editor-shell-canvas-ui도 PR #2448로 bust (PR #2447 누락 보강)
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-shell-canvas-ui\.js\?v=20260613-2448/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-shell-memory\.js\?v=20260613-2448/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-shell-helpers\.js\?v=20260613-2448/);
+  assert.match(editorPage, /\.\.\/js\/editor\.js\?v=20260613-2448/);
+  assert.match(editorPage, /\.\.\/js\/editor\/editor-empty-guide-ui\.js\?v=20260613-2448/);
+
+  // 2446 stale 못 들어가게
+  assert.doesNotMatch(editorPage, /editor-root-helpers\.js\?v=20260613-2446/);
+  assert.doesNotMatch(editorPage, /editor-empty-guide-ui\.js\?v=20260613-2446/);
+  assert.doesNotMatch(editorPage, /editor-shell-canvas-ui\.js\?v=20260605/);
+  assert.doesNotMatch(editorPage, /editor\.js\?v=20260612-2400/);
+});


### PR DESCRIPTION
Refs #2400

## Summary
- tighten `isRootLikeMemory` to treat `parentId: null/undefined` as root placeholder only when no real moment content (`sourceUrl`/`source`/`thumbnail`/`memo`/`quote`/`emotionTags`/meaningful `title`) exists
- align empty guide visibility on list-aware 'real moment' detection so rootless first moments (e.g. PSY/Gangnam case) no longer trigger the empty guide
- add `hasRealMomentContent` helper for content-aware root placeholder discrimination
- bump cache-bust to `?v=20260613-2448` for editor-root-helpers, editor-empty-guide-ui, editor-shell-canvas-ui, editor-shell-memory, editor-shell-helpers, editor.js (and editor-root-helpers in public-canvas.html / view.html)

## Scope
- editor root helper + empty guide UI + cache-bust only
- no backend/API/DB changes
- no Browse/Search/#1661 changes
- no AI/Scout changes
- PR #2447's `filterMemoriesForTree` invariant (treeId-first) preserved unchanged
- `isRootLikeMemory(memory)` signature preserved (memory → boolean)

## Production regression case
```
currentTreeData.id: b7558695-9f7c-49c1-8263-040a9c6ed24a
currentTreeMemories[0]:
  id: 19ad873f-... (PSY - GANGNAM STYLE)
  parentId: null
  sourceUrl: https://www.youtube.com/embed/9bZkp7q19f0
  thumbnail: https://img.youtube.com/vi/9bZkp7q19f0/mqdefault.jpg
```
Before PR #2448: `isRootLikeMemory(psy) = true`, `getCanonicalRootId = psy.id`, `canvasEmptyGuide.hidden = false` (false positive)
After PR #2448: `isRootLikeMemory(psy) = false`, `findRootMemory = null`, `canvasEmptyGuide.hidden = true`

## Validation
- `node --check js/editor/editor-root-helpers.js` ✓
- `node --check js/editor/editor-empty-guide-ui.js` ✓
- `node --test tests/contracts/editor-empty-guide-runtime-contract.test.cjs` (17 cases, 0 fail)
- `node --test tests/contracts/editor-root-helper-real-moment-boundary-contract.test.cjs` (12 cases, 0 fail)
- `node --test tests/contracts/editor-empty-guide-ui-real-moment-integration-contract.test.cjs` (14 cases, 0 fail)
- `node --test tests/contracts/editor-root-helper-required-boundary-contract.test.cjs` (9 cases, 0 fail)
- `npm test -- --runInBand` — 2219/2220 pass (1 skipped, 0 fail)
- `git diff --check` — clean
- PR #2447 invariant (treeId-first filterMemoriesForTree) preserved unchanged